### PR TITLE
Force control plane node to be registered in k8s in standalone case

### DIFF
--- a/templates/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -31,6 +31,8 @@ spec:
                 chartname: aws-cloud-controller-manager/aws-cloud-controller-manager
                 version: "0.0.8"
                 values: |
+                  nodeSelector:
+                    node-role.kubernetes.io/control-plane: "true"
                   args:
                     - --v=2
                     - --cloud-provider=aws


### PR DESCRIPTION
K0s control plane nodes are not listed in kubectl by default:
https://docs.k0sproject.io/v1.28.4+k0s.0/FAQ/#why-doesnt-kubectl-get-nodes-list-the-k0s-controllers