### PR TITLE
Provide ability to add labels to `Cluster` object

### DIFF
--- a/api/v1alpha1/clusterdeployment_types.go
+++ b/api/v1alpha1/clusterdeployment_types.go
@@ -15,6 +15,9 @@
 package v1alpha1
 
 import (
+	"encoding/json"
+	"fmt"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,11 +108,39 @@ type ClusterDeployment struct {
 	Status ClusterDeploymentStatus `json:"status,omitempty"`
 }
 
-func (in *ClusterDeployment) HelmValues() (values map[string]any, err error) {
+func (in *ClusterDeployment) HelmValues() (map[string]any, error) {
+	var values map[string]any
+
 	if in.Spec.Config != nil {
-		err = yaml.Unmarshal(in.Spec.Config.Raw, &values)
+		if err := yaml.Unmarshal(in.Spec.Config.Raw, &values); err != nil {
+			return nil, fmt.Errorf("error unmarshalling helm values for clusterTemplate %s: %w", in.Spec.Template, err)
+		}
 	}
-	return values, err
+
+	return values, nil
+}
+
+func (in *ClusterDeployment) SetHelmValues(values map[string]any) error {
+	b, err := json.Marshal(values)
+	if err != nil {
+		return fmt.Errorf("error marshalling helm values for clusterTemplate %s: %w", in.Spec.Template, err)
+	}
+
+	in.Spec.Config = &apiextensionsv1.JSON{Raw: b}
+	return nil
+}
+
+func (in *ClusterDeployment) AddHelmValues(fn func(map[string]any) error) error {
+	values, err := in.HelmValues()
+	if err != nil {
+		return err
+	}
+
+	if err := fn(values); err != nil {
+		return err
+	}
+
+	return in.SetHelmValues(values)
 }
 
 func (in *ClusterDeployment) GetConditions() *[]metav1.Condition {

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -16,7 +16,6 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -31,7 +30,6 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -308,13 +306,21 @@ func (r *ClusterDeploymentReconciler) updateCluster(ctx context.Context, mc *kcm
 		return ctrl.Result{}, nil
 	}
 
-	helmValues, err := setIdentityHelmValues(mc.Spec.Config, cred.Spec.IdentityRef)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("error setting identity values: %w", err)
+	if err := mc.AddHelmValues(func(values map[string]any) error {
+		values["clusterIdentity"] = cred.Spec.IdentityRef
+
+		if _, ok := values["clusterLabels"]; !ok {
+			// Use the ManagedCluster's own labels if not defined.
+			values["clusterLabels"] = mc.GetObjectMeta().GetLabels()
+		}
+
+		return nil
+	}); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	hrReconcileOpts := helm.ReconcileHelmReleaseOpts{
-		Values: helmValues,
+		Values: mc.Spec.Config,
 		OwnerReference: &metav1.OwnerReference{
 			APIVersion: kcm.GroupVersion.String(),
 			Kind:       kcm.ClusterDeploymentKind,
@@ -793,22 +799,6 @@ func (r *ClusterDeploymentReconciler) reconcileCredentialPropagation(ctx context
 	l.Info("CCM credentials reconcile finished")
 
 	return nil
-}
-
-func setIdentityHelmValues(values *apiextensionsv1.JSON, idRef *corev1.ObjectReference) (*apiextensionsv1.JSON, error) {
-	var valuesJSON map[string]any
-	err := json.Unmarshal(values.Raw, &valuesJSON)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling values: %w", err)
-	}
-
-	valuesJSON["clusterIdentity"] = idRef
-	valuesRaw, err := json.Marshal(valuesJSON)
-	if err != nil {
-		return nil, fmt.Errorf("error marshalling values: %w", err)
-	}
-
-	return &apiextensionsv1.JSON{Raw: valuesRaw}, nil
 }
 
 func (r *ClusterDeploymentReconciler) setAvailableUpgrades(ctx context.Context, clusterDeployment *kcm.ClusterDeployment, template *kcm.ClusterTemplate) error {

--- a/templates/cluster/aws-eks/templates/cluster.yaml
+++ b/templates/cluster/aws-eks/templates/cluster.yaml
@@ -2,6 +2,9 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
+  {{- if .Values.clusterLabels }}
+  labels: {{- toYaml .Values.clusterLabels | nindent 4}}
+  {{- end }}
 spec:
   {{- with .Values.clusterNetwork }}
   clusterNetwork:

--- a/templates/cluster/aws-eks/values.yaml
+++ b/templates/cluster/aws-eks/values.yaml
@@ -9,6 +9,8 @@ clusterNetwork:
     cidrBlocks:
       - "10.96.0.0/12"
 
+clusterLabels: {}
+
 # EKS cluster parameters
 region: ""
 sshKeyName: ""

--- a/templates/cluster/aws-hosted-cp/templates/cluster.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/cluster.yaml
@@ -2,6 +2,9 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
+  {{- if .Values.clusterLabels }}
+  labels: {{- toYaml .Values.clusterLabels | nindent 4}}
+  {{- end }}
 spec:
   {{- with .Values.clusterNetwork }}
   clusterNetwork:

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -9,6 +9,8 @@ clusterNetwork:
     cidrBlocks:
       - "10.96.0.0/12"
 
+clusterLabels: {}
+
 # AWS cluster parameters
 vpcID: ""
 region: ""

--- a/templates/cluster/aws-standalone-cp/templates/cluster.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/cluster.yaml
@@ -2,6 +2,9 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
+  {{- if .Values.clusterLabels }}
+  labels: {{- toYaml .Values.clusterLabels | nindent 4}}
+  {{- end }}
 spec:
   {{- with .Values.clusterNetwork }}
   clusterNetwork:

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -10,6 +10,8 @@ clusterNetwork:
     cidrBlocks:
       - "10.96.0.0/12"
 
+clusterLabels: {}
+
 # AWS cluster parameters
 region: ""
 sshKeyName: ""

--- a/templates/cluster/azure-hosted-cp/templates/cluster.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/cluster.yaml
@@ -2,6 +2,9 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
+  {{- if .Values.clusterLabels }}
+  labels: {{- toYaml .Values.clusterLabels | nindent 4}}
+  {{- end }}
 spec:
   {{- with .Values.clusterNetwork }}
   clusterNetwork:

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -10,6 +10,8 @@ clusterNetwork:
     cidrBlocks:
     - "10.96.0.0/12"
 
+clusterLabels: {}
+
 # Azure cluster parameters
 location: ""
 subscriptionID: ""

--- a/templates/cluster/azure-standalone-cp/templates/cluster.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/cluster.yaml
@@ -2,6 +2,9 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
+  {{- if .Values.clusterLabels }}
+  labels: {{- toYaml .Values.clusterLabels | nindent 4}}
+  {{- end }}
 spec:
   {{- with .Values.clusterNetwork }}
   clusterNetwork:

--- a/templates/cluster/azure-standalone-cp/values.yaml
+++ b/templates/cluster/azure-standalone-cp/values.yaml
@@ -10,6 +10,8 @@ clusterNetwork:
     cidrBlocks:
     - "10.96.0.0/12"
 
+clusterLabels: {}
+
 # Azure cluster parameters
 location: ""
 subscriptionID: ""

--- a/templates/cluster/vsphere-hosted-cp/templates/cluster.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/cluster.yaml
@@ -2,6 +2,9 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
+  {{- if .Values.clusterLabels }}
+  labels: {{- toYaml .Values.clusterLabels | nindent 4}}
+  {{- end }}
 spec:
   {{- with .Values.clusterNetwork }}
   clusterNetwork:

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -10,6 +10,8 @@ clusterNetwork:
     cidrBlocks:
     - "10.96.0.0/12"
 
+clusterLabels: {}
+
 # vSphere cluster parameters
 clusterIdentity:
   name: ""

--- a/templates/cluster/vsphere-standalone-cp/templates/cluster.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/cluster.yaml
@@ -2,6 +2,9 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
+  {{- if .Values.clusterLabels }}
+  labels: {{- toYaml .Values.clusterLabels | nindent 4}}
+  {{- end }}
 spec:
   {{- with .Values.clusterNetwork }}
   clusterNetwork:

--- a/templates/cluster/vsphere-standalone-cp/values.yaml
+++ b/templates/cluster/vsphere-standalone-cp/values.yaml
@@ -10,6 +10,8 @@ clusterNetwork:
     cidrBlocks:
     - "10.96.0.0/12"
 
+clusterLabels: {}
+
 # vSphere cluster parameters
 clusterIdentity:
   name: ""


### PR DESCRIPTION
# Description

Provide ability to add labels to the `Cluster` object created when installing a clusterTemplate by:

1. Adding `.Values.ClusterLabels` to all clusterTemplate helm charts.
2. Using `ManagedCluster`'s own labels via the HMC controller if none have been defined in `.Values.ClusterLabels`.

# Testing
As can be seen from the output below, the `.metadata.labels` from `ManagedCluster` have been added to the `Cluster` object:
```sh
➜  ~ kubectl -n hmc-system get managedclusters.hmc.mirantis.com wali-dev-1 --show-labels
NAME         READY   STATUS                    LABELS
wali-dev-1   True    ManagedCluster is ready   labelA=A,labelB=B
➜  ~
➜  ~
➜  ~ kubectl -n hmc-system get cluster --show-labels                                
NAME         CLUSTERCLASS   PHASE         AGE   VERSION   LABELS
wali-dev-1                  Provisioned   13m             app.kubernetes.io/managed-by=Helm,helm.toolkit.fluxcd.io/name=wali-dev-1,helm.toolkit.fluxcd.io/namespace=hmc-system,labelA=A,labelB=B,sveltos-agent=present
```
