### PR TITLE
Fix AWS hosted cluster template networking issue (fixes #788)

### DIFF
--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -58,7 +58,7 @@ spec:
               cloudConfig:
                 enabled: true
                 global:
-                  KubernetesClusterID: {{ .Values.managementClusterName }}
+                  KubernetesClusterID: {{ required ".Values.managementClusterName is required on AWS hosted deployment" .Values.managementClusterName }}
               # Removing the default `node-role.kubernetes.io/control-plane` node selector
               # TODO: it does not work
               nodeSelector:

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -26,11 +26,11 @@ spec:
       extensions:
         helm:
           repositories:
-          - name: aws-cloud-controller-manager
+          - name: mirantis
             {{- if .Values.extensions.chartRepository }}
             url: {{ .Values.extensions.chartRepository }}
             {{- else }}
-            url: https://kubernetes.github.io/cloud-provider-aws
+            url: https://charts.mirantis.com
             {{- end }}
           - name: aws-ebs-csi-driver
             {{- if .Values.extensions.chartRepository }}
@@ -41,8 +41,8 @@ spec:
           charts:
           - name: aws-cloud-controller-manager
             namespace: kube-system
-            chartname: aws-cloud-controller-manager/aws-cloud-controller-manager
-            version: "0.0.8"
+            chartname: mirantis/aws-cloud-controller-manager
+            version: "0.0.9"
             values: |
               image:
                 {{- if .Values.extensions.imageRepository }}
@@ -55,6 +55,10 @@ spec:
                 - --cluster-cidr={{ first .Values.clusterNetwork.pods.cidrBlocks }}
                 - --allocate-node-cidrs=true
                 - --cluster-name={{ include "cluster.name" . }}
+              cloudConfig:
+                enabled: {{ ne .Values.managementClusterName "" }}
+                global:
+                  KubernetesClusterID: {{ .Values.managementClusterName }}
               # Removing the default `node-role.kubernetes.io/control-plane` node selector
               # TODO: it does not work
               nodeSelector:

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -56,7 +56,7 @@ spec:
                 - --allocate-node-cidrs=true
                 - --cluster-name={{ include "cluster.name" . }}
               cloudConfig:
-                enabled: {{ ne .Values.managementClusterName "" }}
+                enabled: true
                 global:
                   KubernetesClusterID: {{ .Values.managementClusterName }}
               # Removing the default `node-role.kubernetes.io/control-plane` node selector

--- a/templates/cluster/aws-hosted-cp/values.schema.json
+++ b/templates/cluster/aws-hosted-cp/values.schema.json
@@ -10,7 +10,8 @@
     "iamInstanceProfile",
     "instanceType",
     "securityGroupIDs",
-    "clusterIdentity"
+    "clusterIdentity",
+    "managementClusterName"
   ],
   "properties": {
     "managementClusterName" : {

--- a/templates/cluster/aws-hosted-cp/values.schema.json
+++ b/templates/cluster/aws-hosted-cp/values.schema.json
@@ -13,6 +13,10 @@
     "clusterIdentity"
   ],
   "properties": {
+    "managementClusterName" : {
+      "description": "The name of the management cluster that this template is being deployed on",
+      "type": "string"
+    },
     "workersNumber": {
       "description": "The number of the worker machines",
       "type": "integer",

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -53,3 +53,6 @@ k0s:
 extensions:
   chartRepository: ""
   imageRepository: ""
+
+# Name of the management cluster that this template is being deployed on
+managementClusterName: ""


### PR DESCRIPTION
This PR adds the ability to set the management cluster name in the AWS hosted template. This is needed because of issue #788. Requires PR https://github.com/Mirantis/helm-charts/pull/2 to be merged and the resulting helm chart to be published. An upstream PR for the change to the chart has been created : https://github.com/kubernetes/cloud-provider-aws/pull/1085.