### PR TITLE
Add EKS e2e testing

### DIFF
--- a/config/dev/eks-clusterdeployment.yaml
+++ b/config/dev/eks-clusterdeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     k0rdent.mirantis.com/component: kcm
 spec:
-  template: aws-eks-0-0-3
+  template: aws-eks-0-0-4
   credential: "aws-cluster-identity-cred"
   config:
     region: ${AWS_REGION}

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-eks/templates/awsmanagedcontrolplane.yaml
+++ b/templates/cluster/aws-eks/templates/awsmanagedcontrolplane.yaml
@@ -12,3 +12,6 @@ spec:
   identityRef:
     kind: {{ .Values.clusterIdentity.kind }}
     name: {{ .Values.clusterIdentity.name }}
+  {{- with .Values.addons }}
+  addons: {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/templates/cluster/aws-eks/values.schema.json
+++ b/templates/cluster/aws-eks/values.schema.json
@@ -129,6 +129,39 @@
         }
       }
     },
+    "addons": {
+      "description": "The EKS addons to enable with the EKS cluster",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "version"
+        ],
+        "properties": {
+          "name": {
+            "description": "The name of the addon",
+            "type": "string"
+          },
+          "version": {
+            "description": "The version of the addon to use",
+            "type": "string"
+          },
+          "configuration": {
+            "description": "Optional configuration of the EKS addon in YAML format",
+            "type": "string"
+          },
+          "conflictResolution": {
+            "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none",
+            "type": "string"
+          },
+          "serviceAccountRoleARN": {
+            "description": "ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account",
+            "type": "string"
+          }
+        }
+      }
+    },
     "kubernetes": {
       "description": "Kubernetes parameters",
       "type": "object",

--- a/templates/cluster/aws-eks/values.yaml
+++ b/templates/cluster/aws-eks/values.yaml
@@ -31,6 +31,13 @@ worker:
     org: ""
     baseOS: ""
 
+addons:
+- name: aws-ebs-csi-driver
+  version: v1.37.0-eksbuild.1
+  configuration: |
+    defaultStorageClass:
+      enabled: true
+
 # Kubernetes version
 kubernetes:
   version: v1.30.4

--- a/templates/provider/kcm-templates/files/templates/aws-eks-0-0-4.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-0-0-4.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-eks-0-0-3
+  name: aws-eks-0-0-4
   annotations:
     helm.sh/resource-policy: keep
   labels:
@@ -10,7 +10,7 @@ spec:
   helm:
     chartSpec:
       chart: aws-eks
-      version: 0.0.3
+      version: 0.0.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/test/e2e/clusterdeployment/clusterdeployment.go
+++ b/test/e2e/clusterdeployment/clusterdeployment.go
@@ -48,6 +48,7 @@ type Template string
 const (
 	TemplateAWSStandaloneCP     Template = "aws-standalone-cp"
 	TemplateAWSHostedCP         Template = "aws-hosted-cp"
+	TemplateAWSEKS              Template = "aws-eks"
 	TemplateAzureHostedCP       Template = "azure-hosted-cp"
 	TemplateAzureStandaloneCP   Template = "azure-standalone-cp"
 	TemplateVSphereStandaloneCP Template = "vsphere-standalone-cp"
@@ -60,6 +61,9 @@ var awsStandaloneCPClusterDeploymentTemplateBytes []byte
 
 //go:embed resources/aws-hosted-cp.yaml.tpl
 var awsHostedCPClusterDeploymentTemplateBytes []byte
+
+//go:embed resources/aws-eks.yaml.tpl
+var awsEksClusterDeploymentTemplateBytes []byte
 
 //go:embed resources/azure-standalone-cp.yaml.tpl
 var azureStandaloneCPClusterDeploymentTemplateBytes []byte
@@ -106,6 +110,10 @@ func setClusterName(templateName Template) {
 	if strings.Contains(string(templateName), "hosted") {
 		generatedName = fmt.Sprintf("%s-%s", mcName, "hosted")
 	}
+	// TODO: quick w/a. The cluster names' generator will be refactored in https://github.com/k0rdent/kcm/pull/752
+	if strings.Contains(string(templateName), "eks") {
+		generatedName = fmt.Sprintf("%s-%s", mcName, "eks")
+	}
 
 	GinkgoT().Setenv(EnvVarClusterDeploymentName, generatedName)
 }
@@ -131,6 +139,8 @@ func GetUnstructured(templateName Template) *unstructured.Unstructured {
 			EnvVarAWSSecurityGroupID,
 		})
 		clusterDeploymentTemplateBytes = awsHostedCPClusterDeploymentTemplateBytes
+	case TemplateAWSEKS:
+		clusterDeploymentTemplateBytes = awsEksClusterDeploymentTemplateBytes
 	case TemplateVSphereStandaloneCP:
 		clusterDeploymentTemplateBytes = vsphereStandaloneCPClusterDeploymentTemplateBytes
 	case TemplateVSphereHostedCP:

--- a/test/e2e/clusterdeployment/providervalidator.go
+++ b/test/e2e/clusterdeployment/providervalidator.go
@@ -65,6 +65,15 @@ func NewProviderValidator(template Template, clusterName string, action Validati
 		case TemplateAWSStandaloneCP, TemplateAWSHostedCP:
 			resourcesToValidate["ccm"] = validateCCM
 			resourceOrder = append(resourceOrder, "ccm")
+		case TemplateAWSEKS:
+			resourcesToValidate = map[string]resourceValidationFunc{
+				"clusters":                   validateCluster,
+				"machines":                   validateMachines,
+				"aws-managed-control-planes": validateAWSManagedControlPlanes,
+				"csi-driver":                 validateCSIDriver,
+				"ccm":                        validateCCM,
+			}
+			resourceOrder = []string{"clusters", "machines", "aws-managed-control-planes", "csi-driver", "ccm"}
 		case TemplateAzureStandaloneCP, TemplateAzureHostedCP, TemplateVSphereStandaloneCP:
 			delete(resourcesToValidate, "csi-driver")
 		case TemplateAdoptedCluster:
@@ -76,10 +85,17 @@ func NewProviderValidator(template Template, clusterName string, action Validati
 		resourcesToValidate = map[string]resourceValidationFunc{
 			"clusters":           validateClusterDeleted,
 			"machinedeployments": validateMachineDeploymentsDeleted,
-			"control-planes":     validateK0sControlPlanesDeleted,
 		}
 
-		resourceOrder = []string{"clusters", "machinedeployments", "control-planes"}
+		resourceOrder = []string{"clusters", "machinedeployments"}
+		switch template {
+		case TemplateAWSEKS:
+			resourcesToValidate["aws-managed-control-planes"] = validateAWSManagedControlPlanesDeleted
+			resourceOrder = append(resourceOrder, "aws-managed-control-planes")
+		default:
+			resourcesToValidate["control-planes"] = validateK0sControlPlanesDeleted
+			resourceOrder = append(resourceOrder, "control-planes")
+		}
 	}
 
 	return &ProviderValidator{

--- a/test/e2e/clusterdeployment/resources/aws-eks.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/aws-eks.yaml.tpl
@@ -1,0 +1,13 @@
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ClusterDeployment
+metadata:
+  name: ${CLUSTER_DEPLOYMENT_NAME}
+spec:
+  template: aws-eks-0-0-4
+  credential: ${AWS_CLUSTER_IDENTITY}-cred
+  config:
+    region: ${AWS_REGION}
+    workersNumber: ${WORKERS_NUMBER:=1}
+    publicIP: ${AWS_PUBLIC_IP:=true}
+    worker:
+      instanceType: ${AWS_INSTANCE_TYPE:=t3.small}

--- a/test/e2e/clusterdeployment/validate_deployed.go
+++ b/test/e2e/clusterdeployment/validate_deployed.go
@@ -16,6 +16,7 @@ package clusterdeployment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -27,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/K0rdent/kcm/internal/utils/status"
 	"github.com/K0rdent/kcm/test/e2e/kubeclient"
 	"github.com/K0rdent/kcm/test/utils"
 )
@@ -104,38 +104,52 @@ func validateK0sControlPlanes(ctx context.Context, kc *kubeclient.KubeClient, cl
 		return err
 	}
 
+	var errs error
 	for _, controlPlane := range controlPlanes {
 		if err := utils.ValidateObjectNamePrefix(&controlPlane, clusterName); err != nil {
-			Fail(err.Error())
+			errs = errors.Join(errs, err)
+			continue
 		}
-
-		objKind, objName := status.ObjKindName(&controlPlane)
 
 		// k0s does not use the metav1.Condition type for status.conditions,
 		// instead it uses a custom type so we can't use
 		// ValidateConditionsTrue here, instead we'll check for "ready: true".
-		objStatus, found, err := unstructured.NestedFieldCopy(controlPlane.Object, "status")
-		if !found {
-			return fmt.Errorf("no status found for %s: %s", objKind, objName)
-		}
-		if err != nil {
-			return fmt.Errorf("failed to get status conditions for %s: %s: %w", objKind, objName, err)
-		}
-
-		st, ok := objStatus.(map[string]any)
-		if !ok {
-			return fmt.Errorf("expected K0sControlPlane condition to be type map[string]any, got: %T", objStatus)
-		}
-
-		if _, ok := st["ready"]; !ok {
-			return fmt.Errorf("%s %s has no 'ready' status", objKind, objName)
-		}
-
-		if v, ok := st["ready"].(bool); !ok || !v {
-			return fmt.Errorf("%s %s is not ready, status: %+v", objKind, objName, st)
-		}
+		errs = errors.Join(errs, validateReadyStatus(controlPlane))
 	}
 
+	return errs
+}
+
+func validateAWSManagedControlPlanes(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
+	controlPlanes, err := kc.ListAWSManagedControlPlanes(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+	var errs error
+	for _, controlPlane := range controlPlanes {
+		errs = errors.Join(errs, validateReadyStatus(controlPlane))
+	}
+	return errs
+}
+
+// validateReadyStatus validates if the provided object has ready status
+func validateReadyStatus(obj unstructured.Unstructured) error {
+	name := obj.GetName()
+	kind := obj.GetKind()
+	objStatus, found, err := unstructured.NestedFieldCopy(obj.Object, "status")
+	if err != nil {
+		return fmt.Errorf("failed to get status conditions for %s: %s: %w", kind, name, err)
+	}
+	if !found {
+		return fmt.Errorf("no status found for %s: %s", kind, name)
+	}
+	st, ok := objStatus.(map[string]any)
+	if !ok {
+		return fmt.Errorf("expected %s condition to be type map[string]any, got: %T", kind, objStatus)
+	}
+	if v, ok := st["ready"].(bool); !ok || !v {
+		return fmt.Errorf("%s %s is not ready, status: %+v", kind, name, st)
+	}
 	return nil
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -77,7 +77,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	if !noCleanup() {
+	if cleanup() {
 		By("collecting logs from local controllers")
 		kc := kubeclient.NewFromLocal(internalutils.DefaultSystemNamespace)
 		collectLogArtifacts(kc, "")
@@ -236,11 +236,6 @@ func collectLogArtifacts(kc *kubeclient.KubeClient, clusterName string, provider
 	}
 }
 
-func noCleanup() bool {
-	noCleanup := os.Getenv(clusterdeployment.EnvVarNoCleanup)
-	if noCleanup != "" {
-		By(fmt.Sprintf("skipping After node as %s is set", clusterdeployment.EnvVarNoCleanup))
-	}
-
-	return noCleanup != ""
+func cleanup() bool {
+	return os.Getenv(clusterdeployment.EnvVarNoCleanup) == ""
 }

--- a/test/e2e/kubeclient/kubeclient.go
+++ b/test/e2e/kubeclient/kubeclient.go
@@ -281,6 +281,18 @@ func (kc *KubeClient) ListK0sControlPlanes(
 	}, clusterName)
 }
 
+func (kc *KubeClient) ListAWSManagedControlPlanes(
+	ctx context.Context, clusterName string,
+) ([]unstructured.Unstructured, error) {
+	GinkgoHelper()
+
+	return kc.listResource(ctx, schema.GroupVersionResource{
+		Group:    "controlplane.cluster.x-k8s.io",
+		Version:  "v1beta2",
+		Resource: "awsmanagedcontrolplanes",
+	}, clusterName)
+}
+
 func (kc *KubeClient) ListClusterTemplates(ctx context.Context) ([]unstructured.Unstructured, error) {
 	client := kc.GetDynamicClient(schema.GroupVersionResource{
 		Group:    v1alpha1.GroupVersion.Group,

--- a/test/e2e/kubeclient/kubeclient.go
+++ b/test/e2e/kubeclient/kubeclient.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -244,6 +245,23 @@ func (kc *KubeClient) listResource(
 	return resources.Items, nil
 }
 
+// patchResource patches a specified resource.
+func (kc *KubeClient) patchResource(
+	ctx context.Context,
+	gvr schema.GroupVersionResource,
+	name string,
+	pt types.PatchType,
+	data []byte,
+) (*unstructured.Unstructured, error) {
+	client := kc.GetDynamicClient(gvr, true)
+
+	resource, err := client.Patch(ctx, name, pt, data, metav1.PatchOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to patch %s %s", gvr.Resource, name)
+	}
+	return resource, nil
+}
+
 // ListMachines returns a list of Machine resources for the given cluster.
 func (kc *KubeClient) ListMachines(ctx context.Context, clusterName string) ([]unstructured.Unstructured, error) {
 	GinkgoHelper()
@@ -267,6 +285,22 @@ func (kc *KubeClient) ListMachineDeployments(
 		Version:  "v1beta1",
 		Resource: "machinedeployments",
 	}, clusterName)
+}
+
+// PatchMachineDeployment patches a MachineDeployment resource with the given data.
+func (kc *KubeClient) PatchMachineDeployment(
+	ctx context.Context,
+	name string,
+	pt types.PatchType,
+	data []byte,
+) (*unstructured.Unstructured, error) {
+	GinkgoHelper()
+
+	return kc.patchResource(ctx, schema.GroupVersionResource{
+		Group:    "cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "machinedeployments",
+	}, name, pt, data)
 }
 
 func (kc *KubeClient) ListK0sControlPlanes(

--- a/test/e2e/provider_adopted_test.go
+++ b/test/e2e/provider_adopted_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Adopted Cluster Templates", Label("provider:cloud", "provider:
 	AfterAll(func() {
 		// If we failed collect logs from each of the affiliated controllers
 		// as well as the output of clusterctl to store as artifacts.
-		if CurrentSpecReport().Failed() && !noCleanup() {
+		if CurrentSpecReport().Failed() && cleanup() {
 			if standaloneClient != nil {
 				By("collecting failure logs from hosted controllers")
 				collectLogArtifacts(standaloneClient, clusterName, clusterdeployment.ProviderAWS, clusterdeployment.ProviderCAPI)

--- a/test/e2e/provider_aws_test.go
+++ b/test/e2e/provider_aws_test.go
@@ -16,6 +16,8 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -23,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
 
 	internalutils "github.com/K0rdent/kcm/internal/utils"
 	"github.com/K0rdent/kcm/test/e2e/clusterdeployment"
@@ -210,6 +213,31 @@ var _ = Describe("AWS Templates", Label("provider:cloud", "provider:aws"), Order
 			clusterName,
 			clusterdeployment.ValidationActionDeploy,
 		)
+
+		// TODO: w/a for https://github.com/k0rdent/kcm/issues/907. Remove when the issue is fixed.
+		patch := map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]string{
+					"machineset.cluster.x-k8s.io/skip-preflight-checks": "ControlPlaneIsStable",
+				},
+			},
+		}
+		patchBytes, err := json.Marshal(patch)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() error {
+			mds, err := kc.ListMachineDeployments(context.Background(), clusterName)
+			if err != nil {
+				return err
+			}
+			if len(mds) == 0 {
+				return errors.New("waiting for the MachineDeployment to be created")
+			}
+			_, err = kc.PatchMachineDeployment(context.Background(), mds[0].GetName(), types.MergePatchType, patchBytes)
+			if err != nil {
+				return err
+			}
+			return nil
+		}, 10*time.Minute, 10*time.Second).Should(Succeed(), "Should patch MachineDeployment with \"machineset.cluster.x-k8s.io/skip-preflight-checks\": \"ControlPlaneIsStable\" annotation")
 
 		Eventually(func() error {
 			return deploymentValidator.Validate(context.Background(), kc)

--- a/test/e2e/provider_azure_test.go
+++ b/test/e2e/provider_azure_test.go
@@ -54,7 +54,7 @@ var _ = Context("Azure Templates", Label("provider:cloud", "provider:azure"), Or
 	AfterEach(func() {
 		// If we failed collect logs from each of the affiliated controllers
 		// as well as the output of clusterctl to store as artifacts.
-		if CurrentSpecReport().Failed() && !noCleanup() {
+		if CurrentSpecReport().Failed() && cleanup() {
 			By("collecting failure logs from controllers")
 			if kc != nil {
 				collectLogArtifacts(kc, sdName, clusterdeployment.ProviderAzure, clusterdeployment.ProviderCAPI)

--- a/test/e2e/provider_vsphere_test.go
+++ b/test/e2e/provider_vsphere_test.go
@@ -64,7 +64,7 @@ var _ = Context("vSphere Templates", Label("provider:onprem", "provider:vsphere"
 		// TODO(#473) Add an exterior cleanup mechanism for VSphere like
 		// 'dev-aws-nuke' to clean up resources in the event that the test
 		// fails to do so.
-		if deleteFunc != nil && !noCleanup() {
+		if deleteFunc != nil && cleanup() {
 			deletionValidator := clusterdeployment.NewProviderValidator(
 				clusterdeployment.TemplateVSphereStandaloneCP,
 				clusterName,


### PR DESCRIPTION
This PR introduces the following changes:
1. Added e2e testing to verify the successful deployment of an EKS cluster
2. Enhanced the EKS template to allow deployment of additional add-ons
3. Configured the CSI driver add-on to be enabled by default
4. Workaround for #907 is applied on EKS clusters (created by e2e tests only)

## E2E
E2E testing for EKS deployments is enabled by default and integrated into the AWS provider testing suite. At this time, hosted cluster deployments are not supported for EKS clusters.

Testing Scenario:
1. Deploy an EKS cluster using the default simple configuration
2. Apply workaround for #907 for the MachineDeployment
3. Verify the deployment of all related objects
4. Verify the CSI driver
5. Verify the CCM

P.S. The testing scenario is intentionally kept simple, avoiding complex configurations, as the overall testing strategy is currently under review and subject to potential changes.

Closes #387