### PR TITLE
Set default values for OpenStack resources 

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,12 +4,12 @@ metadata:
   name: openstack-dev
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-0-0-1
+  template: openstack-standalone-cp-0-0-2
   credential: openstack-cluster-identity-cred
   config:
     controlPlaneNumber: 1
     workersNumber: 1
-    controlPlane:
+    controlplane:
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
       image:
         filter:
@@ -19,4 +19,11 @@ spec:
       image:
         filter:
           name: ${OPENSTACK_IMAGE_NAME}
+    externalNetwork:
+      filter:
+        name: "public"
     authURL: ${OS_AUTH_URL}
+    identityRef:
+      name: "openstack-cloud-config"
+      cloudName: "openstack"
+      region: ${OS_REGION_NAME}


### PR DESCRIPTION
Without these default values, cluster provisioning will not proceed. The defaults provided here are used by OpenStackCluster, OpenStackMachine. 

This is similar to how the other providers are currently set up.

