### PR TITLE
Enable Sveltos Drift Detection

### DIFF
--- a/api/v1alpha1/multiclusterservice_types.go
+++ b/api/v1alpha1/multiclusterservice_types.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -92,6 +93,13 @@ type ServiceSpec struct {
 	StopOnConflict bool `json:"stopOnConflict,omitempty"`
 	// Reload instances via rolling upgrade when a ConfigMap/Secret mounted as volume is modified.
 	Reload bool `json:"reload,omitempty"`
+
+	// +kubebuilder:default:=Continuous
+	// +kubebuilder:validation:Enum:=OneTime;Continuous;ContinuousWithDriftDetection;DryRun
+
+	SyncMode        string                            `json:"syncMode,omitempty"`
+	IgnoreDrift     []libsveltosv1beta1.PatchSelector `json:"ignoreDrift,omitempty"`
+	DriftExclusions []sveltosv1beta1.DriftExclusion   `json:"driftExclusions,omitempty"`
 }
 
 // MultiClusterServiceSpec defines the desired state of MultiClusterService

--- a/api/v1alpha1/multiclusterservice_types.go
+++ b/api/v1alpha1/multiclusterservice_types.go
@@ -97,9 +97,12 @@ type ServiceSpec struct {
 	// +kubebuilder:default:=Continuous
 	// +kubebuilder:validation:Enum:=OneTime;Continuous;ContinuousWithDriftDetection;DryRun
 
-	SyncMode        string                            `json:"syncMode,omitempty"`
-	IgnoreDrift     []libsveltosv1beta1.PatchSelector `json:"ignoreDrift,omitempty"`
-	DriftExclusions []sveltosv1beta1.DriftExclusion   `json:"driftExclusions,omitempty"`
+	// SyncMode specifies how services are synced in the target cluster.
+	SyncMode string `json:"syncMode,omitempty"`
+	// DriftIgnore specifies resources to ignore for drift detection.
+	DriftIgnore []libsveltosv1beta1.PatchSelector `json:"driftIgnore,omitempty"`
+	// DriftExclusions specifies specific configurations of resources to ignore for drift detection.
+	DriftExclusions []sveltosv1beta1.DriftExclusion `json:"driftExclusions,omitempty"`
 }
 
 // MultiClusterServiceSpec defines the desired state of MultiClusterService

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fluxcd/helm-controller/api/v2"
 	apiv1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/projectsveltos/addon-controller/api/v1beta1"
+	apiv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -1320,6 +1321,18 @@ func (in *ServiceSpec) DeepCopyInto(out *ServiceSpec) {
 		in, out := &in.TemplateResourceRefs, &out.TemplateResourceRefs
 		*out = make([]v1beta1.TemplateResourceRef, len(*in))
 		copy(*out, *in)
+	}
+	if in.IgnoreDrift != nil {
+		in, out := &in.IgnoreDrift, &out.IgnoreDrift
+		*out = make([]apiv1beta1.PatchSelector, len(*in))
+		copy(*out, *in)
+	}
+	if in.DriftExclusions != nil {
+		in, out := &in.DriftExclusions, &out.DriftExclusions
+		*out = make([]v1beta1.DriftExclusion, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1322,8 +1322,8 @@ func (in *ServiceSpec) DeepCopyInto(out *ServiceSpec) {
 		*out = make([]v1beta1.TemplateResourceRef, len(*in))
 		copy(*out, *in)
 	}
-	if in.IgnoreDrift != nil {
-		in, out := &in.IgnoreDrift, &out.IgnoreDrift
+	if in.DriftIgnore != nil {
+		in, out := &in.DriftIgnore, &out.DriftIgnore
 		*out = make([]apiv1beta1.PatchSelector, len(*in))
 		copy(*out, *in)
 	}

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -528,7 +528,7 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, mc *kc
 			),
 			PolicyRefs:      getProjectPolicyRefs(mc, cred),
 			SyncMode:        mc.Spec.ServiceSpec.SyncMode,
-			IgnoreDrift:     mc.Spec.ServiceSpec.IgnoreDrift,
+			DriftIgnore:     mc.Spec.ServiceSpec.DriftIgnore,
 			DriftExclusions: mc.Spec.ServiceSpec.DriftExclusions,
 		}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile Profile: %w", err)

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -526,7 +526,10 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, mc *kc
 			TemplateResourceRefs: append(
 				getProjectTemplateResourceRefs(mc, cred), mc.Spec.ServiceSpec.TemplateResourceRefs...,
 			),
-			PolicyRefs: getProjectPolicyRefs(mc, cred),
+			PolicyRefs:      getProjectPolicyRefs(mc, cred),
+			SyncMode:        mc.Spec.ServiceSpec.SyncMode,
+			IgnoreDrift:     mc.Spec.ServiceSpec.IgnoreDrift,
+			DriftExclusions: mc.Spec.ServiceSpec.DriftExclusions,
 		}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile Profile: %w", err)
 	}

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -139,6 +139,9 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 			StopOnConflict:       mcs.Spec.ServiceSpec.StopOnConflict,
 			Reload:               mcs.Spec.ServiceSpec.Reload,
 			TemplateResourceRefs: mcs.Spec.ServiceSpec.TemplateResourceRefs,
+			SyncMode:             mcs.Spec.ServiceSpec.SyncMode,
+			IgnoreDrift:          mcs.Spec.ServiceSpec.IgnoreDrift,
+			DriftExclusions:      mcs.Spec.ServiceSpec.DriftExclusions,
 		}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile ClusterProfile: %w", err)
 	}

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -140,7 +140,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 			Reload:               mcs.Spec.ServiceSpec.Reload,
 			TemplateResourceRefs: mcs.Spec.ServiceSpec.TemplateResourceRefs,
 			SyncMode:             mcs.Spec.ServiceSpec.SyncMode,
-			IgnoreDrift:          mcs.Spec.ServiceSpec.IgnoreDrift,
+			DriftIgnore:          mcs.Spec.ServiceSpec.DriftIgnore,
 			DriftExclusions:      mcs.Spec.ServiceSpec.DriftExclusions,
 		}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile ClusterProfile: %w", err)

--- a/internal/sveltos/profile.go
+++ b/internal/sveltos/profile.go
@@ -32,7 +32,7 @@ import (
 	"github.com/K0rdent/kcm/internal/utils"
 )
 
-const DrifIgnorePatch = `- op: add
+const driftIgnorePatch = `- op: add
   path: /metadata/annotations/projectsveltos.io~1driftDetectionIgnore
   value: ok`
 
@@ -43,7 +43,7 @@ type ReconcileProfileOpts struct {
 	HelmChartOpts        []HelmChartOpts
 	TemplateResourceRefs []sveltosv1beta1.TemplateResourceRef
 	PolicyRefs           []sveltosv1beta1.PolicyRef
-	IgnoreDrift          []libsveltosv1beta1.PatchSelector
+	DriftIgnore          []libsveltosv1beta1.PatchSelector
 	DriftExclusions      []sveltosv1beta1.DriftExclusion
 	Priority             int32
 	StopOnConflict       bool
@@ -252,10 +252,10 @@ func GetSpec(opts *ReconcileProfileOpts) (*sveltosv1beta1.Spec, error) {
 		DriftExclusions:      opts.DriftExclusions,
 	}
 
-	for _, target := range opts.IgnoreDrift {
+	for _, target := range opts.DriftIgnore {
 		spec.Patches = append(spec.Patches, libsveltosv1beta1.Patch{
 			Target: &target,
-			Patch:  DrifIgnorePatch,
+			Patch:  driftIgnorePatch,
 		})
 	}
 

--- a/internal/sveltos/profile.go
+++ b/internal/sveltos/profile.go
@@ -32,12 +32,19 @@ import (
 	"github.com/K0rdent/kcm/internal/utils"
 )
 
+const DrifIgnorePatch = `- op: add
+  path: /metadata/annotations/projectsveltos.io~1driftDetectionIgnore
+  value: ok`
+
 type ReconcileProfileOpts struct {
 	OwnerReference       *metav1.OwnerReference
+	SyncMode             string
 	LabelSelector        metav1.LabelSelector
 	HelmChartOpts        []HelmChartOpts
 	TemplateResourceRefs []sveltosv1beta1.TemplateResourceRef
 	PolicyRefs           []sveltosv1beta1.PolicyRef
+	IgnoreDrift          []libsveltosv1beta1.PatchSelector
+	DriftExclusions      []sveltosv1beta1.DriftExclusion
 	Priority             int32
 	StopOnConflict       bool
 	Reload               bool
@@ -239,8 +246,17 @@ func GetSpec(opts *ReconcileProfileOpts) (*sveltosv1beta1.Spec, error) {
 		ContinueOnConflict:   !opts.StopOnConflict,
 		HelmCharts:           make([]sveltosv1beta1.HelmChart, 0, len(opts.HelmChartOpts)),
 		Reloader:             opts.Reload,
+		SyncMode:             sveltosv1beta1.SyncMode(opts.SyncMode),
 		TemplateResourceRefs: opts.TemplateResourceRefs,
 		PolicyRefs:           opts.PolicyRefs,
+		DriftExclusions:      opts.DriftExclusions,
+	}
+
+	for _, target := range opts.IgnoreDrift {
+		spec.Patches = append(spec.Patches, libsveltosv1beta1.Patch{
+			Target: &target,
+			Patch:  DrifIgnorePatch,
+		})
 	}
 
 	for _, hc := range opts.HelmChartOpts {

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
@@ -79,6 +79,8 @@ spec:
                 description: ServiceSpec is spec related to deployment of services.
                 properties:
                   driftExclusions:
+                    description: DriftExclusions specifies specific configurations
+                      of resources to ignore for drift detection.
                     items:
                       properties:
                         paths:
@@ -133,7 +135,9 @@ spec:
                       - paths
                       type: object
                     type: array
-                  ignoreDrift:
+                  driftIgnore:
+                    description: DriftIgnore specifies resources to ignore for drift
+                      detection.
                     items:
                       properties:
                         annotationSelector:
@@ -271,6 +275,8 @@ spec:
                     type: boolean
                   syncMode:
                     default: Continuous
+                    description: SyncMode specifies how services are synced in the
+                      target cluster.
                     enum:
                     - OneTime
                     - Continuous

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
@@ -78,6 +78,103 @@ spec:
               serviceSpec:
                 description: ServiceSpec is spec related to deployment of services.
                 properties:
+                  driftExclusions:
+                    items:
+                      properties:
+                        paths:
+                          description: Paths is a slice of JSON6902 paths to exclude
+                            from configuration drift evaluation.
+                          items:
+                            type: string
+                          type: array
+                        target:
+                          description: Target points to the resources that the paths
+                            refers to.
+                          properties:
+                            annotationSelector:
+                              description: |-
+                                AnnotationSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource annotations.
+                              type: string
+                            group:
+                              description: |-
+                                Group is the API group to select resources from.
+                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the API Group to select resources from.
+                                Together with Group and Version it is capable of unambiguously
+                                identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource labels.
+                              type: string
+                            name:
+                              description: Name to match resources with.
+                              type: string
+                            namespace:
+                              description: Namespace to select resources from.
+                              type: string
+                            version:
+                              description: |-
+                                Version of the API Group to select resources from.
+                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  ignoreDrift:
+                    items:
+                      properties:
+                        annotationSelector:
+                          description: |-
+                            AnnotationSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource annotations.
+                          type: string
+                        group:
+                          description: |-
+                            Group is the API group to select resources from.
+                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the API Group to select resources from.
+                            Together with Group and Version it is capable of unambiguously
+                            identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        labelSelector:
+                          description: |-
+                            LabelSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource labels.
+                          type: string
+                        name:
+                          description: Name to match resources with.
+                          type: string
+                        namespace:
+                          description: Namespace to select resources from.
+                          type: string
+                        version:
+                          description: |-
+                            Version of the API Group to select resources from.
+                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                      type: object
+                    type: array
                   priority:
                     default: 100
                     description: |-
@@ -172,6 +269,14 @@ spec:
                       By default the remaining services will be deployed even if conflict is detected.
                       If set to true, the deployment will stop after encountering the first conflict.
                     type: boolean
+                  syncMode:
+                    default: Continuous
+                    enum:
+                    - OneTime
+                    - Continuous
+                    - ContinuousWithDriftDetection
+                    - DryRun
+                    type: string
                   templateResourceRefs:
                     description: |-
                       TemplateResourceRefs is a list of resources to collect from the management cluster,

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -91,6 +91,8 @@ spec:
                 description: ServiceSpec is spec related to deployment of services.
                 properties:
                   driftExclusions:
+                    description: DriftExclusions specifies specific configurations
+                      of resources to ignore for drift detection.
                     items:
                       properties:
                         paths:
@@ -145,7 +147,9 @@ spec:
                       - paths
                       type: object
                     type: array
-                  ignoreDrift:
+                  driftIgnore:
+                    description: DriftIgnore specifies resources to ignore for drift
+                      detection.
                     items:
                       properties:
                         annotationSelector:
@@ -283,6 +287,8 @@ spec:
                     type: boolean
                   syncMode:
                     default: Continuous
+                    description: SyncMode specifies how services are synced in the
+                      target cluster.
                     enum:
                     - OneTime
                     - Continuous

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -90,6 +90,103 @@ spec:
               serviceSpec:
                 description: ServiceSpec is spec related to deployment of services.
                 properties:
+                  driftExclusions:
+                    items:
+                      properties:
+                        paths:
+                          description: Paths is a slice of JSON6902 paths to exclude
+                            from configuration drift evaluation.
+                          items:
+                            type: string
+                          type: array
+                        target:
+                          description: Target points to the resources that the paths
+                            refers to.
+                          properties:
+                            annotationSelector:
+                              description: |-
+                                AnnotationSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource annotations.
+                              type: string
+                            group:
+                              description: |-
+                                Group is the API group to select resources from.
+                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the API Group to select resources from.
+                                Together with Group and Version it is capable of unambiguously
+                                identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                            labelSelector:
+                              description: |-
+                                LabelSelector is a string that follows the label selection expression
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                It matches with the resource labels.
+                              type: string
+                            name:
+                              description: Name to match resources with.
+                              type: string
+                            namespace:
+                              description: Namespace to select resources from.
+                              type: string
+                            version:
+                              description: |-
+                                Version of the API Group to select resources from.
+                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                              type: string
+                          type: object
+                      required:
+                      - paths
+                      type: object
+                    type: array
+                  ignoreDrift:
+                    items:
+                      properties:
+                        annotationSelector:
+                          description: |-
+                            AnnotationSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource annotations.
+                          type: string
+                        group:
+                          description: |-
+                            Group is the API group to select resources from.
+                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the API Group to select resources from.
+                            Together with Group and Version it is capable of unambiguously
+                            identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                        labelSelector:
+                          description: |-
+                            LabelSelector is a string that follows the label selection expression
+                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                            It matches with the resource labels.
+                          type: string
+                        name:
+                          description: Name to match resources with.
+                          type: string
+                        namespace:
+                          description: Namespace to select resources from.
+                          type: string
+                        version:
+                          description: |-
+                            Version of the API Group to select resources from.
+                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                          type: string
+                      type: object
+                    type: array
                   priority:
                     default: 100
                     description: |-
@@ -184,6 +281,14 @@ spec:
                       By default the remaining services will be deployed even if conflict is detected.
                       If set to true, the deployment will stop after encountering the first conflict.
                     type: boolean
+                  syncMode:
+                    default: Continuous
+                    enum:
+                    - OneTime
+                    - Continuous
+                    - ContinuousWithDriftDetection
+                    - DryRun
+                    type: string
                   templateResourceRefs:
                     description: |-
                       TemplateResourceRefs is a list of resources to collect from the management cluster,


### PR DESCRIPTION
# Description
This PR exposes the drift correction functionality of Sveltos via the `ClusterDeployment` and `MultiClusterService` objects by:

1. Introducing `.spec.serviceSpec.syncMode`: Sveltos will automatically deploy a drift-detection-manager on the managed cluster by setting this to `ContinuousWithDriftDetection`.
2. Introducing `.spec.serviceSpec.driftExclusions`: To exclude any particular field of an object from drift detection/correction.
3. Introducing `.spec.serviceSpec.ignoreDrift`: To exclude any object as a whole from drift detection/correction.

# Verification
I created a new managed cluster with the following `ClusterDeployment`:
```yaml
apiVersion: k0rdent.mirantis.com/v1alpha1
kind: ClusterDeployment
metadata:
  name: wali-dev-1
  namespace: kcm-system
spec:
  config:
    clusterIdentity:
      name: aws-cluster-identity
      namespace: kcm-system
    controlPlane:
      amiID: ami-0eb9fdcf0d07bd5ef
      instanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
      instanceType: t3.small
    controlPlaneNumber: 1
    publicIP: true
    region: ca-central-1
    worker:
      amiID: ami-0eb9fdcf0d07bd5ef
      instanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
      instanceType: t3.small
    workersNumber: 1
  credential: aws-cluster-identity-cred
  serviceSpec:
    services:
      - template: ingress-nginx-4-11-0
        name: ingress-nginx
        namespace: ingress-nginx
        values: |
          ingress-nginx:
            controller:
              replicaCount: 3
    priority: 100
    stopOnConflict: false
    syncMode: ContinuousWithDriftDetection
  template: aws-standalone-cp-0-0-5
```
## Sveltos drift-detection-manager installed on managed cluster
Verified that Sveltos automatically installs the drift-detection-manager on the managed cluster when using `syncMode: ContinuousWithDriftDetection`:
```sh
➜  ~ kubectl get pod -A
NAMESPACE        NAME                                        READY   STATUS    RESTARTS   AGE
ingress-nginx    ingress-nginx-controller-86bd747cf9-2gc98   1/1     Running   0          123m
ingress-nginx    ingress-nginx-controller-86bd747cf9-2prlk   1/1     Running   0          123m
ingress-nginx    ingress-nginx-controller-86bd747cf9-bzhb4   1/1     Running   0          123m
kube-system      aws-cloud-controller-manager-cgcnk          1/1     Running   0          124m
kube-system      calico-kube-controllers-6cd7d8cc9f-7vp67    1/1     Running   0          125m
kube-system      calico-node-w22bx                           1/1     Running   0          125m
kube-system      calico-node-z2tsg                           1/1     Running   0          124m
kube-system      coredns-679c655b6f-6mgct                    1/1     Running   0          124m
kube-system      coredns-679c655b6f-qrrc4                    1/1     Running   0          124m
kube-system      ebs-csi-controller-977d5cc56-hztb2          5/5     Running   0          125m
kube-system      ebs-csi-controller-977d5cc56-mj758          5/5     Running   0          125m
kube-system      ebs-csi-node-gj6nj                          3/3     Running   0          124m
kube-system      ebs-csi-node-vqc6n                          3/3     Running   0          125m
kube-system      kube-proxy-kmzcq                            1/1     Running   0          124m
kube-system      kube-proxy-qdkjq                            1/1     Running   0          125m
kube-system      metrics-server-78c4ccbc7f-qxxz4             1/1     Running   0          125m
projectsveltos   drift-detection-manager-6767d5bf67-7dt9x    1/1     Running   0          125m
```

## Verifying that Sveltos corrects drift
I manually edited the `ingress-nginx-controller` Deployment and changed `.spec.replicas=1` to introduce drift. After a few seconds, Sveltos recognized the drift and corrected it as can be seen by the watch on `.spec.replicas` below. **I.e., it starts as 3 then changes to 1 as I manually edit it and then eventually comes back to 3 as Sveltos corrects the drift:**
```sh
➜  ~ kubectl -n ingress-nginx get deployments.apps ingress-nginx-controller -o=jsonpath='{.spec.replicas}' -w
3111333333
```
We can also see 2 of the pods have a younger age as expected:
```sh
➜  ~ kubectl -n ingress-nginx get pod   
NAME                                        READY   STATUS    RESTARTS   AGE
ingress-nginx-controller-86bd747cf9-2wbqz   1/1     Running   0          8m43s
ingress-nginx-controller-86bd747cf9-bzhb4   1/1     Running   0          152m
ingress-nginx-controller-86bd747cf9-tkhmh   1/1     Running   0          8m43s
```

## Verifying that `driftExclusions` work
I used to following drift exclusion in the `ClusterDeployment` object to exclude `.spec.replicas` from drift correction:
```yaml
apiVersion: k0rdent.mirantis.com/v1alpha1
kind: ClusterDeployment
metadata:
  . . .
spec:
  . . .
  serviceSpec:
    services:
      . . .
    priority: 100
    stopOnConflict: false
    syncMode: ContinuousWithDriftDetection
    driftExclusions:
      - paths:
        - "/spec/replicas"
        target:
          kind: Deployment
          name: ingress-nginx-controller
          namespace: ingress-nginx
  . . .
```
Now when I manually edit the replicas to be 1, the number of replicas is not corrected back to 3 as can be seen below:
```sh
➜  ~ kubectl -n ingress-nginx get deployments.apps ingress-nginx-controller -o=jsonpath='{.spec.replicas}' -w
3111
```
We can also verify that this is the case by observing that the "generation" of the `ResourceSummary` has progressed and by seeing the following patch in its spec:
```sh
➜  ~ ksveltos get resourcesummaries.lib.projectsveltos.io kcm-system--p--wali-dev-1-capi-wali-dev-1 -o yaml -w
apiVersion: lib.projectsveltos.io/v1beta1
kind: ResourceSummary
metadata:
  . . .
spec:
  chartResources:
  - chartName: ingress-nginx
    group:
    . . .
    releaseName: ingress-nginx
    releaseNamespace: ingress-nginx
  patches:
  - patch: |-
      - op: remove
        path: /spec/replicas
    target:
      kind: Deployment
      name: ingress-nginx-controller
      namespace: ingress-nginx
status:
  helmResourceHashes:
  . . .
```
### Removing the drift exclusion
The drift exclusion can be removed by removing the `.spec.serviceSpec.driftExclusion` field from the `ClusterDeployment` object and re-trigger the drift correction by editing any field in the `ingress-nginx-controller` Deployment. This will force a drift correction and since the drift exclusion has been removed, it will restore the Deployment to it's original spec.

## Verifying that `ignoreDrift` works:
I manually removed the label `app.kubernetes.io/managed-by=Helm` from the deployment and Sveltos corrected it as expected and as can be seen the watch below:
```sh
➜  ~ kubectl -n ingress-nginx get deployments.apps ingress-nginx-controller --show-labels -w
NAME                       READY   UP-TO-DATE   AVAILABLE   AGE    LABELS
ingress-nginx-controller   3/3     3            3           171m   app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-nginx,app.kubernetes.io/managed-by=Helm,app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/part-of=ingress-nginx,app.kubernetes.io/version=1.11.0,helm.sh/chart=ingress-nginx-4.11.0
ingress-nginx-controller   3/3     3            3           172m   app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-nginx,app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/part-of=ingress-nginx,app.kubernetes.io/version=1.11.0,helm.sh/chart=ingress-nginx-4.11.0
ingress-nginx-controller   3/3     3            3           172m   app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-nginx,app.kubernetes.io/managed-by=Helm,app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/part-of=ingress-nginx,app.kubernetes.io/version=1.11.0,helm.sh/chart=ingress-nginx-4.11.0
```
So now let's tell Sveltos to ignore any changes to the `ingress-nginx-controller` Deployment with the following:
```yaml
apiVersion: k0rdent.mirantis.com/v1alpha1
kind: ClusterDeployment
metadata:
  . . .
spec:
  . . .
  serviceSpec:
    services:
      . . .
    priority: 100
    stopOnConflict: false
    syncMode: ContinuousWithDriftDetection
    ignoreDrift:
      - target:
        group: apps
        version: v1
        kind: Deployment
        name: ingress-nginx-controller
        namespace: ingress-nginx
  . . .
```
Now when I manually remove the `app.kubernetes.io/managed-by=Helm` label again, I can observe that Sveltos does not correct the drift:
```sh
➜  ~ kubectl -n ingress-nginx get deployments.apps ingress-nginx-controller --show-labels -w
NAME                       READY   UP-TO-DATE   AVAILABLE   AGE     LABELS
ingress-nginx-controller   3/3     3            3           3h58m   app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-nginx,app.kubernetes.io/managed-by=Helm,app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/part-of=ingress-nginx,app.kubernetes.io/version=1.11.0,helm.sh/chart=ingress-nginx-4.11.0
ingress-nginx-controller   3/3     3            3           3h59m   app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-nginx,app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/part-of=ingress-nginx,app.kubernetes.io/version=1.11.0,helm.sh/chart=ingress-nginx-4.11.0
```
This can also be verified by observing that `ignoreForConfigurationDrift: true` for the object targeted for drift ignore in `ResourceSummary` spec on the managed cluser:
```sh
➜  ~ ksveltos get resourcesummaries.lib.projectsveltos.io kcm-system--p--wali-dev-1-capi-wali-dev-1 -o yaml -w
apiVersion: lib.projectsveltos.io/v1beta1
kind: ResourceSummary
metadata:
  . . .
spec:
  chartResources:
  - chartName: ingress-nginx
    group:
    . . .
    - group: apps
      ignoreForConfigurationDrift: true
      kind: Deployment
      name: ingress-nginx-controller
      namespace: ingress-nginx
      version: v1
    releaseName: ingress-nginx
    releaseNamespace: ingress-nginx
status:
  helmResourceHashes:
  . . .
```
And also by observing that the `projectsveltos.io/driftDetectionIgnore: ok` annotation has been applied to the targeted object:
```sh
➜  ~ kubectl -n ingress-nginx get deployments.apps ingress-nginx-controller -o=jsonpath='{.metadata.annotations}'
{"deployment.kubernetes.io/revision":"1","meta.helm.sh/release-name":"ingress-nginx","meta.helm.sh/release-namespace":"ingress-nginx","projectsveltos.io/driftDetectionIgnore":"ok"}%
```

### Removing the ignore drift:
The ignore drift setting can be removed by removing the `.spec.serviceSpec.ignoreDrift` field from the `ClusterDeployment` object, Sveltos will then automatically re-trigger the drift correction.
