### PR TITLE
Remove second checkout for e2e tests workflow

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -170,7 +170,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup kubectl
         uses: azure/setup-kubectl@v4
-      - uses: actions/checkout@v4
       - name: Run E2E tests
         env:
           GINKGO_LABEL_FILTER: 'provider:cloud'


### PR DESCRIPTION
This is forcing tests to be always on main.
With actions approval it doesn't make much sense