### PR TITLE
update controlplane to controlPlane and add openstackcluster to role

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -9,7 +9,7 @@ spec:
   config:
     controlPlaneNumber: 1
     workersNumber: 1
-    controlplane:
+    controlPlane:
       flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
       image:
         filter:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-dev
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-0-0-2
+  template: openstack-standalone-cp-0-0-3
   credential: openstack-cluster-identity-cred
   config:
     controlPlaneNumber: 1

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
@@ -5,28 +5,28 @@ metadata:
 spec:
   template:
     spec:
-      flavor: {{ .Values.controlplane.flavor }}
+      flavor: {{ .Values.controlPlane.flavor }}
       identityRef:
         name: {{ .Values.identityRef.name }}
         region: {{ .Values.identityRef.region }}
         cloudName: {{ .Values.identityRef.cloudName}}
       image:
         filter:
-          name: {{ .Values.controlplane.image.filter.name }}
-          {{- if .Values.controlplane.image.filter.tags }}
+          name: {{ .Values.controlPlane.image.filter.name }}
+          {{- if .Values.controlPlane.image.filter.tags }}
           tags:
-            {{- range $tag := .Values.controlplane.image.filter.tags }}
+            {{- range $tag := .Values.controlPlane.image.filter.tags }}
             - {{ $tag }}
             {{- end }}
           {{- end }}
-      {{- if gt (len .Values.controlplane.portOpts) 0 }}
+      {{- if gt (len .Values.controlPlane.portOpts) 0 }}
       portOpts:
-        {{ .Values.controlplane.portOpts | toYaml | nindent 8 }}
+        {{ .Values.controlPlane.portOpts | toYaml | nindent 8 }}
       {{- end }}
-      {{- if gt (len .Values.controlplane.securityGroups) 0 }}
+      {{- if gt (len .Values.controlPlane.securityGroups) 0 }}
       securityGroups:
-        {{ .Values.controlplane.securityGroups | toYaml | nindent 8 }}
+        {{ .Values.controlPlane.securityGroups | toYaml | nindent 8 }}
       {{- end }}
-      {{- if not ( .Values.controlplane.sshPublicKey | empty) }}
-      sshKeyName: {{ .Values.controlplane.sshPublicKey }}
+      {{- if not ( .Values.controlPlane.sshPublicKey | empty) }}
+      sshKeyName: {{ .Values.controlPlane.sshPublicKey }}
       {{- end }}

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -6,7 +6,7 @@
     "controlPlaneNumber",
     "workersNumber",
     "identityRef",
-    "controlplane",
+    "controlPlane",
     "worker"
   ],
   "properties": {
@@ -206,7 +206,7 @@
         }
       }
     },
-    "controlplane": {
+    "controlPlane": {
       "type": "object",
       "description": "Configuration of the control plane instances",
       "required": [

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -37,7 +37,7 @@ externalNetwork:
   filter:
     name: ""
 
-controlplane:
+controlPlane:
   sshPublicKey: ""
   providerID: ""
   flavor: ""

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-0-3.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-0-3.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-0-0-2
+  name: openstack-standalone-cp-0-0-3
   annotations:
     helm.sh/resource-policy: keep
   labels:
@@ -10,7 +10,7 @@ spec:
   helm:
     chartSpec:
       chart: openstack-standalone-cp
-      version: 0.0.2
+      version: 0.0.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -140,6 +140,7 @@ rules:
   resources:
   - awsclusters
   - azureclusters
+  - openstackclusters
   - vsphereclusters
   - vspheremachines
   verbs:


### PR DESCRIPTION
This PR updates `controlplane` to `controlPlane` in OpenStack templates to stay consistent with the naming.
It also adds OpenStackCluster to kcm-manager-role.