### PR TITLE
Create backups on release upgrade

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -19,7 +19,6 @@ resources:
   version: v1alpha1
 - api:
     crdVersion: v1
-    namespaced: true
   controller: true
   domain: k0rdent.mirantis.com
   group: k0rdent.mirantis.com
@@ -47,7 +46,6 @@ resources:
   version: v1alpha1
 - api:
     crdVersion: v1
-    namespaced: true
   controller: true
   domain: k0rdent.mirantis.com
   group: k0rdent.mirantis.com
@@ -65,7 +63,6 @@ resources:
   version: v1alpha1
 - api:
     crdVersion: v1
-    namespaced: true
   controller: true
   domain: k0rdent.mirantis.com
   group: k0rdent.mirantis.com
@@ -106,7 +103,6 @@ resources:
   version: v1alpha1
 - api:
     crdVersion: v1
-    namespaced: true
   controller: true
   domain: k0rdent.mirantis.com
   group: k0rdent.mirantis.com

--- a/api/v1alpha1/management_backup_types.go
+++ b/api/v1alpha1/management_backup_types.go
@@ -37,6 +37,10 @@ type ManagementBackupSpec struct {
 	// Schedule is a Cron expression defining when to run the scheduled [ManagementBackup].
 	// If not set, the object is considered to be run only once.
 	Schedule string `json:"schedule,omitempty"`
+	// PerformOnManagementUpgrade indicates that a single [ManagementBackup]
+	// should be created and stored in the [ManagementBackup] storage location if not default
+	// before the [Management] release upgrade.
+	PerformOnManagementUpgrade bool `json:"performOnManagementUpgrade,omitempty"`
 }
 
 // ManagementBackupStatus defines the observed state of ManagementBackup
@@ -57,6 +61,11 @@ type ManagementBackupStatus struct {
 // IsSchedule checks if an instance of [ManagementBackup] is schedulable.
 func (s *ManagementBackup) IsSchedule() bool {
 	return s.Spec.Schedule != ""
+}
+
+// IsCompleted checks if the latest underlaying backup has been completed.
+func (s *ManagementBackup) IsCompleted() bool {
+	return s.Status.LastBackup != nil && !s.Status.LastBackup.CompletionTimestamp.IsZero()
 }
 
 // TimestampedBackupName returns the backup name related to scheduled [ManagementBackup] based on the given timestamp.

--- a/internal/controller/accessmanagement_controller.go
+++ b/internal/controller/accessmanagement_controller.go
@@ -53,8 +53,10 @@ func (r *AccessManagementReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	if err := utils.AddKCMComponentLabel(ctx, r.Client, accessMgmt); err != nil {
-		l.Error(err, "adding component label")
+	if updated, err := utils.AddKCMComponentLabel(ctx, r.Client, accessMgmt); updated || err != nil {
+		if err != nil {
+			l.Error(err, "adding component label")
+		}
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/accessmanagement_controller_test.go
+++ b/internal/controller/accessmanagement_controller_test.go
@@ -119,6 +119,7 @@ var _ = Describe("Template Management Controller", func() {
 		am := am.NewAccessManagement(
 			am.WithName(amName),
 			am.WithAccessRules(accessRules),
+			am.WithLabels(kcm.GenericComponentNameLabel, kcm.GenericComponentLabelValueKCM),
 		)
 
 		ctChain := tc.NewClusterTemplateChain(tc.WithName(ctChainName), tc.WithNamespace(systemNamespace.Name), tc.ManagedByKCM())

--- a/internal/controller/backup/reconcile_test.go
+++ b/internal/controller/backup/reconcile_test.go
@@ -1,0 +1,124 @@
+// Copyright 2024
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backup
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+)
+
+const tsFormat = "20060102150405"
+
+func Test_getMostRecentProducedBackup(t *testing.T) {
+	const scheduleName = "test-schedule-name"
+
+	now := time.Now().In(time.UTC)
+
+	timeToTS := func(input time.Time) string {
+		return input.Format(tsFormat)
+	}
+
+	tcases := []struct {
+		name                string
+		genOpts             []createOpt
+		expectedNameTS      string
+		expectedExistsValue bool
+	}{
+		{
+			name:    "no backups from schedule",
+			genOpts: []createOpt{withScheduleLabel("another-schedule")},
+		},
+		{
+			name:    "all backups are in future",
+			genOpts: []createOpt{futureName()},
+		},
+		{
+			name:    "wrong backup name format",
+			genOpts: []createOpt{wrongFormatName()},
+		},
+		{
+			name:                "correct input",
+			expectedNameTS:      timeToTS(now),
+			expectedExistsValue: true,
+		},
+	}
+
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			backups := generateVeleroBackups(t, scheduleName, now, 10, tc.genOpts...)
+
+			actualB, actualExists := getMostRecentProducedBackup(scheduleName, backups)
+			if tc.expectedExistsValue != actualExists {
+				t.Errorf("%s: actual '%v'; want: '%v'", tc.name, actualExists, tc.expectedExistsValue)
+			}
+
+			if tc.expectedExistsValue {
+				actualNameTS := actualB.Name[strings.LastIndexByte(actualB.Name, '-')+1:]
+				if tc.expectedNameTS != actualNameTS {
+					t.Errorf("%s: actual '%v'; want: '%v'", tc.name, actualNameTS, tc.expectedNameTS)
+				}
+			}
+		})
+	}
+}
+
+func futureName() createOpt {
+	return func(b *velerov1.Backup) {
+		rn := time.Duration(rand.Intn(100) * int(time.Minute))
+		future := time.Now().Add(rn)
+		b.Name = b.Name[:strings.LastIndexByte(b.Name, '-')] + "-" + future.Format(tsFormat)
+	}
+}
+
+func wrongFormatName() createOpt {
+	return func(b *velerov1.Backup) {
+		b.Name = b.Name[:strings.LastIndexByte(b.Name, '-')] // trim ts
+	}
+}
+
+func generateVeleroBackups(t *testing.T, scheduleName string, now time.Time, n int, opts ...createOpt) []velerov1.Backup {
+	t.Helper()
+
+	past := now.Add(24 * time.Hour)
+
+	name := func(b *velerov1.Backup) {
+		b.Name = scheduleName + "-" + past.Format(tsFormat)
+	}
+
+	label := func(b *velerov1.Backup) {
+		if b.Labels == nil {
+			b.Labels = make(map[string]string)
+		}
+		b.Labels[scheduleMgmtNameLabel] = scheduleName
+	}
+
+	ret := make([]velerov1.Backup, n)
+	for i := range n {
+		instance := &velerov1.Backup{}
+		name(instance)
+		label(instance)
+		for _, o := range opts {
+			o(instance)
+		}
+		ret[i] = *instance
+		past = past.Add(-24 * time.Hour)
+	}
+
+	return ret
+}

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -152,8 +152,10 @@ func (r *ClusterDeploymentReconciler) reconcileUpdate(ctx context.Context, mc *k
 		return ctrl.Result{}, nil
 	}
 
-	if err := utils.AddKCMComponentLabel(ctx, r.Client, mc); err != nil {
-		l.Error(err, "adding component label")
+	if updated, err := utils.AddKCMComponentLabel(ctx, r.Client, mc); updated || err != nil {
+		if err != nil {
+			l.Error(err, "adding component label")
+		}
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/credential_controller.go
+++ b/internal/controller/credential_controller.go
@@ -47,8 +47,10 @@ func (r *CredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if err := utils.AddKCMComponentLabel(ctx, r.Client, cred); err != nil {
-		l.Error(err, "adding component label")
+	if updated, err := utils.AddKCMComponentLabel(ctx, r.Client, cred); updated || err != nil {
+		if err != nil {
+			l.Error(err, "adding component label")
+		}
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/management_backup_controller.go
+++ b/internal/controller/management_backup_controller.go
@@ -46,7 +46,11 @@ func (r *ManagementBackupReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	return r.internal.ReconcileBackup(ctx, mgmtBackup)
+	res, err := r.internal.ReconcileBackup(ctx, mgmtBackup)
+	if err != nil {
+		l.Error(err, "failed to reconcile managementbackups")
+	}
+	return res, err
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/management_controller_test.go
+++ b/internal/controller/management_controller_test.go
@@ -226,6 +226,7 @@ var _ = Describe("Management Controller", func() {
 			mgmt := &kcmv1.Management{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       mgmtName,
+					Labels:     map[string]string{kcmv1.GenericComponentNameLabel: kcmv1.GenericComponentLabelValueKCM},
 					Finalizers: []string{kcmv1.ManagementFinalizer},
 				},
 				Spec: kcmv1.ManagementSpec{

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -71,11 +71,8 @@ func (r *MultiClusterServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 }
 
 func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs *kcm.MultiClusterService) (_ ctrl.Result, err error) {
-	if utils.AddLabel(mcs, kcm.GenericComponentNameLabel, kcm.GenericComponentLabelValueKCM) {
-		if err := r.Client.Update(ctx, mcs); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to update labels: %w", err)
-		}
-		return ctrl.Result{Requeue: true}, nil // generation has not changed, need explicit requeue
+	if updated, err := utils.AddKCMComponentLabel(ctx, r.Client, mcs); updated || err != nil {
+		return ctrl.Result{Requeue: true}, err // generation has not changed, need explicit requeue
 	}
 
 	// servicesErr is handled separately from err because we do not want

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -79,8 +79,10 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 			return ctrl.Result{}, err
 		}
 
-		if err := utils.AddKCMComponentLabel(ctx, r.Client, release); err != nil {
-			l.Error(err, "adding component label")
+		if updated, err := utils.AddKCMComponentLabel(ctx, r.Client, release); updated || err != nil {
+			if err != nil {
+				l.Error(err, "adding component label")
+			}
 			return ctrl.Result{}, err
 		}
 

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -80,11 +80,11 @@ func (r *ClusterTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	if utils.AddLabel(clusterTemplate, kcm.GenericComponentNameLabel, kcm.GenericComponentLabelValueKCM) {
-		if err := r.Update(ctx, clusterTemplate); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to update labels: %w", err)
+	if updated, err := utils.AddKCMComponentLabel(ctx, r.Client, clusterTemplate); updated || err != nil {
+		if err != nil {
+			l.Error(err, "adding component label")
 		}
-		return ctrl.Result{Requeue: true}, nil // generation has not changed, need explicit requeue
+		return ctrl.Result{Requeue: true}, err // generation has not changed, need explicit requeue
 	}
 
 	result, err := r.ReconcileTemplate(ctx, clusterTemplate)
@@ -121,11 +121,11 @@ func (r *ServiceTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	if utils.AddLabel(serviceTemplate, kcm.GenericComponentNameLabel, kcm.GenericComponentLabelValueKCM) {
-		if err := r.Update(ctx, serviceTemplate); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to update labels: %w", err)
+	if updated, err := utils.AddKCMComponentLabel(ctx, r.Client, serviceTemplate); updated || err != nil {
+		if err != nil {
+			l.Error(err, "adding component label")
 		}
-		return ctrl.Result{Requeue: true}, nil // generation has not changed, need explicit requeue
+		return ctrl.Result{Requeue: true}, err // generation has not changed, need explicit requeue
 	}
 
 	return r.ReconcileTemplate(ctx, serviceTemplate)
@@ -146,11 +146,11 @@ func (r *ProviderTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	if utils.AddLabel(providerTemplate, kcm.GenericComponentNameLabel, kcm.GenericComponentLabelValueKCM) {
-		if err := r.Update(ctx, providerTemplate); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to update labels: %w", err)
+	if updated, err := utils.AddKCMComponentLabel(ctx, r.Client, providerTemplate); updated || err != nil {
+		if err != nil {
+			l.Error(err, "adding component label")
 		}
-		return ctrl.Result{Requeue: true}, nil // generation has not changed, need explicit requeue
+		return ctrl.Result{Requeue: true}, err // generation has not changed, need explicit requeue
 	}
 
 	changed, err := r.setReleaseOwnership(ctx, providerTemplate)

--- a/internal/controller/templatechain_controller.go
+++ b/internal/controller/templatechain_controller.go
@@ -90,8 +90,10 @@ func (r *ServiceTemplateChainReconciler) Reconcile(ctx context.Context, req ctrl
 func (r *TemplateChainReconciler) ReconcileTemplateChain(ctx context.Context, templateChain templateChain) (ctrl.Result, error) {
 	l := ctrl.LoggerFrom(ctx)
 
-	if err := utils.AddKCMComponentLabel(ctx, r.Client, templateChain); err != nil {
-		l.Error(err, "adding component label")
+	if updated, err := utils.AddKCMComponentLabel(ctx, r.Client, templateChain); updated || err != nil {
+		if err != nil {
+			l.Error(err, "adding component label")
+		}
 		return ctrl.Result{}, err
 	}
 

--- a/internal/utils/label.go
+++ b/internal/utils/label.go
@@ -42,12 +42,12 @@ func AddLabel(o client.Object, labelKey, labelValue string) (labelsUpdated bool)
 
 // AddKCMComponentLabel adds the common KCM component label with the kcm value to the given object
 // and updates if it is required.
-func AddKCMComponentLabel(ctx context.Context, cl client.Client, o client.Object) error {
+func AddKCMComponentLabel(ctx context.Context, cl client.Client, o client.Object) (labelsUpdated bool, err error) {
 	if !AddLabel(o, kcmv1.GenericComponentNameLabel, kcmv1.GenericComponentLabelValueKCM) {
-		return nil
+		return false, nil
 	}
 	if err := cl.Update(ctx, o); err != nil {
-		return fmt.Errorf("failed to update %s %s labels: %w", o.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(o), err)
+		return false, fmt.Errorf("failed to update %s %s labels: %w", o.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(o), err)
 	}
-	return nil
+	return true, nil
 }

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_managementbackups.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_managementbackups.yaml
@@ -65,6 +65,12 @@ spec:
           spec:
             description: ManagementBackupSpec defines the desired state of ManagementBackup
             properties:
+              performOnManagementUpgrade:
+                description: |-
+                  PerformOnManagementUpgrade indicates that a single [ManagementBackup]
+                  should be created and stored in the [ManagementBackup] storage location if not default
+                  before the [Management] release upgrade.
+                type: boolean
               schedule:
                 description: |-
                   Schedule is a Cron expression defining when to run the scheduled [ManagementBackup].

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -244,6 +244,12 @@ rules:
   verbs:
   - '*'
 # managementbackups-ctrl
+- apiGroups: # required for autobackup on upgrade
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/test/objects/accessmanagement/accessmanagement.go
+++ b/test/objects/accessmanagement/accessmanagement.go
@@ -50,3 +50,20 @@ func WithAccessRules(accessRules []v1alpha1.AccessRule) Opt {
 		am.Spec.AccessRules = accessRules
 	}
 }
+
+func WithLabels(kv ...string) Opt {
+	return func(am *v1alpha1.AccessManagement) {
+		if am.Labels == nil {
+			am.Labels = make(map[string]string)
+		}
+		if len(kv) == 0 {
+			return
+		}
+		if len(kv)&1 != 0 {
+			panic("expected even number of args")
+		}
+		for i := range len(kv) / 2 {
+			am.Labels[kv[i*2]] = kv[i*2+1]
+		}
+	}
+}


### PR DESCRIPTION
* add new flag to scheduled backups to enable autobackups during
  upgrades
* create auto backups if velero is installed and upgrade is progressing
* block upgrades until all of the backups are completed
* new indexer for backups with autoupgrades
* new RBAC permission for apps/deployments
* update signature of func adding kcm component labels
* put mgmtbackups into backups
* reconcile mgmtbackups statuses after restoration

Closes #864 