### PR TITLE
Validate CAPI contracts in-used by deployments on management update

### DIFF
--- a/internal/controller/backup/reconcile_test.go
+++ b/internal/controller/backup/reconcile_test.go
@@ -80,7 +80,7 @@ func Test_getMostRecentProducedBackup(t *testing.T) {
 
 func futureName() createOpt {
 	return func(b *velerov1.Backup) {
-		rn := time.Duration(rand.Intn(100) * int(time.Minute))
+		rn := time.Duration((rand.Intn(100) + 1) * int(time.Minute))
 		future := time.Now().Add(rn)
 		b.Name = b.Name[:strings.LastIndexByte(b.Name, '-')] + "-" + future.Format(tsFormat)
 	}

--- a/test/objects/template/template.go
+++ b/test/objects/template/template.go
@@ -213,3 +213,16 @@ func WithClusterStatusK8sVersion(v string) Opt {
 		ct.Status.KubernetesVersion = v
 	}
 }
+
+func WithClusterStatusProviderContracts(providerContracts map[string]string) Opt {
+	return func(template Template) {
+		if len(providerContracts) == 0 {
+			return
+		}
+		ct, ok := template.(*v1alpha1.ClusterTemplate)
+		if !ok {
+			panic(fmt.Sprintf("unexpected type %T, expected ClusterTemplate", template))
+		}
+		ct.Status.ProviderContracts = providerContracts
+	}
+}


### PR DESCRIPTION
This PR adds validation for CAPI provider contracts during `Management` updates. It prevents updates to provider templates currently in use if the updated provider contract version is incompatible with one or more existing cluster deployments.

Closes #684