### PR TITLE
add Ready condition to Management resources

### DIFF
--- a/api/v1alpha1/clusterdeployment_types.go
+++ b/api/v1alpha1/clusterdeployment_types.go
@@ -46,8 +46,6 @@ const (
 	HelmChartReadyCondition = "HelmChartReady"
 	// HelmReleaseReadyCondition indicates the corresponding HelmRelease is ready and fully reconciled.
 	HelmReleaseReadyCondition = "HelmReleaseReady"
-	// ReadyCondition indicates the ClusterDeployment is ready and fully reconciled.
-	ReadyCondition string = "Ready"
 )
 
 // ClusterDeploymentSpec defines the desired state of ClusterDeployment

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -28,6 +28,9 @@ const (
 	ProgressingReason string = "Progressing"
 )
 
+// ReadyCondition indicates a resource is ready and fully reconciled.
+const ReadyCondition string = "Ready"
+
 type (
 	// Holds different types of CAPI providers.
 	Providers []string

--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -45,6 +45,13 @@ type ManagementSpec struct {
 	Providers []Provider `json:"providers,omitempty"`
 }
 
+const (
+	// AllComponentsHealthyReason surfaces overall readiness of Management's components.
+	AllComponentsHealthyReason = "AllComponentsHealthy"
+	// NotAllComponentsHealthyReason documents a condition not in Status=True because one or more components are failing.
+	NotAllComponentsHealthyReason = "NotAllComponentsHealthy"
+)
+
 // Core represents a structure describing core Management components.
 type Core struct {
 	// KCM represents the core KCM component and references the KCM template.
@@ -111,6 +118,11 @@ type ManagementStatus struct {
 	CAPIContracts map[string]CompatibilityContracts `json:"capiContracts,omitempty"`
 	// Components indicates the status of installed KCM components and CAPI providers.
 	Components map[string]ComponentStatus `json:"components,omitempty"`
+	// Conditions represents the observations of a Management's current state.
+	// +listType=map
+	// +listMapKey=type
+	// +kubebuilder:validation:MaxItems=32
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// BackupName is a name of the management cluster scheduled backup.
 	BackupName string `json:"backupName,omitempty"`
 	// Release indicates the current Release object.
@@ -132,8 +144,11 @@ type ComponentStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=kcm-mgmt;mgmt,scope=Cluster
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status",description="Overall readiness of the Management resource"
+// +kubebuilder:printcolumn:name="Release",type="string",JSONPath=".status.release",description="Current release version"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Management"
 
 // Management is the Schema for the managements API
 type Management struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -896,6 +896,13 @@ func (in *ManagementStatus) DeepCopyInto(out *ManagementStatus) {
 			(*out)[key] = val
 		}
 	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]v1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.AvailableProviders != nil {
 		in, out := &in.AvailableProviders, &out.AvailableProviders
 		*out = make(Providers, len(*in))

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_managements.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_managements.yaml
@@ -17,7 +17,20 @@ spec:
     singular: management
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Overall readiness of the Management resource
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: Current release version
+      jsonPath: .status.release
+      name: Release
+      type: string
+    - description: Time duration since creation of Management
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Management is the Schema for the managements API
@@ -163,6 +176,68 @@ spec:
                 description: Components indicates the status of installed KCM components
                   and CAPI providers.
                 type: object
+              conditions:
+                description: Conditions represents the observations of a Management's
+                  current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: ObservedGeneration is the last observed generation.
                 format: int64


### PR DESCRIPTION
## What

This PR introduces a `Ready` Condition and new printer columns in the Management CRD making it possible to look at the readiness of Management object at a glance along with release version. 

✅  Unit Tests
✅  Fixes #807 

Kubectl gets the following:
```bash
kubeclt get management -w
NAME   READY   RELEASE     AGE
kcm    False       kcm-0-0-7   22s
kcm    False       kcm-0-0-7   3m54s
kcm    False       kcm-0-0-7   4m24s
kcm    True        kcm-0-0-7   4m34s
```
<details>
  <summary>Click to check an example Status generated</summary>

```yaml
status:
  availableProviders:
  - bootstrap-k0sproject-k0smotron
  - control-plane-k0sproject-k0smotron
  - infrastructure-aws
  - infrastructure-azure
  - infrastructure-internal
  - infrastructure-k0sproject-k0smotron
  - infrastructure-openstack
  - infrastructure-vsphere
  capiContracts:
    bootstrap-k0sproject-k0smotron:
      v1beta1: v1beta1
    control-plane-k0sproject-k0smotron:
      v1beta1: v1beta1
    infrastructure-aws:
      v1alpha3: v1alpha3
      v1alpha4: v1alpha4
      v1beta1: v1beta1_v1beta2
    infrastructure-azure:
      v1beta1: v1beta1
    infrastructure-k0sproject-k0smotron:
      v1beta1: v1beta1
    infrastructure-openstack:
      v1beta1: v1beta1
    infrastructure-vsphere:
      v1beta1: v1beta1
  components:
    capi:
      success: true
      template: cluster-api-0-0-6
    cluster-api-provider-aws:
      success: true
      template: cluster-api-provider-aws-0-0-4
    cluster-api-provider-azure:
      success: true
      template: cluster-api-provider-azure-0-0-4
    cluster-api-provider-openstack:
      success: true
      template: cluster-api-provider-openstack-0-0-1
    cluster-api-provider-vsphere:
      success: true
      template: cluster-api-provider-vsphere-0-0-5
    k0smotron:
      success: true
      template: k0smotron-0-0-6
    kcm:
      success: true
      template: kcm-0-0-7
    projectsveltos:
      success: true
      template: projectsveltos-0-45-0
  conditions:
  - lastTransitionTime: "2025-01-26T19:51:47Z"
    message: All components are successfully installed.
    observedGeneration: 1
    reason: AllComponentsHealthy
    status: "True"
    type: Ready
  observedGeneration: 1
  release: kcm-0-0-7
```
</details>