### PR TITLE
Expose configuration options for Openstack volumes in the template

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-dev
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-0-0-5
+  template: openstack-standalone-cp-0-0-6
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.5
+version: 0.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
@@ -23,6 +23,10 @@ spec:
       portOpts:
         {{ .Values.controlPlane.portOpts | toYaml | nindent 8 }}
       {{- end }}
+      {{- if .Values.controlPlane.rootVolume }}
+      rootVolume:
+        {{ .Values.controlPlane.rootVolume | toYaml | nindent 8 }}
+      {{- end }}
       {{- if gt (len .Values.controlPlane.securityGroups) 0 }}
       securityGroups:
         {{ .Values.controlPlane.securityGroups | toYaml | nindent 8 }}

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
@@ -23,6 +23,10 @@ spec:
       portOpts:
         {{ .Values.worker.portOpts | toYaml | nindent 8 }}
       {{- end }}
+      {{- if .Values.worker.rootVolume }}
+      rootVolume:
+        {{ .Values.worker.rootVolume | toYaml | nindent 8 }}
+      {{- end }}
       {{- if gt (len .Values.worker.securityGroups) 0 }}
       securityGroups:
         {{ .Values.worker.securityGroups | toYaml | nindent 8 }}

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -258,7 +258,39 @@
             "type": "string"
           }
         },
-          "securityGroups": {
+        "rootVolume": {
+          "type": "object",
+          "description": "The volume metadata to boot from",
+	  "items": {
+	    "type": "object",
+            "required": ["sizeGiB"],
+	    "properties": {
+	      "availabilityZone": {
+	        "type": "object",
+                "description": "AvailabilityZone is the volume availability zone to create the volume in. If not specified, the volume will be created without an explicit availability zone.",
+                "properties": {
+		  "from": {
+		    "type": "string",
+                    "description": "From specifies where we will obtain the availability zone for the volume. The options are Name and Machine. If Name is specified then the Name field must also be specified. If Machine is specified the volume will use the value of FailureDomain, if any, from the associated Machine."
+		  },
+		  "name": {
+		    "type": "string",
+                    "description": "Name is the name of a volume availability zone to use. It is required if From is Name. The volume availability zone name may not contain spaces."
+		  }
+		}
+	      },
+	      "sizeGiB": {
+                "type": "integer",
+                "description": "SizeGiB is the size of the block device in gibibytes (GiB)."
+              },
+	      "type": {
+	        "type": "string",
+                "description": "Type is the Cinder volume type of the volume. If omitted, the default Cinder volume type that is configured in the OpenStack cloud will be used."
+	      }
+	    }
+	  }
+        },
+        "securityGroups": {
           "type": "array",
           "description": "Security groups to be assigned to the instance",
           "items": {
@@ -331,6 +363,38 @@
           "items": {
             "type": "string"
           }
+        },
+        "rootVolume": {
+          "type": "object",
+          "description": "The volume metadata to boot from",
+	  "items": {
+	    "type": "object",
+            "required": ["sizeGiB"],
+	    "properties": {
+	      "availabilityZone": {
+	        "type": "object",
+                "description": "AvailabilityZone is the volume availability zone to create the volume in. If not specified, the volume will be created without an explicit availability zone.",
+                "properties": {
+		  "from": {
+		    "type": "string",
+                    "description": "From specifies where we will obtain the availability zone for the volume. The options are Name and Machine. If Name is specified then the Name field must also be specified. If Machine is specified the volume will use the value of FailureDomain, if any, from the associated Machine."
+		  },
+		  "name": {
+		    "type": "string",
+                    "description": "Name is the name of a volume availability zone to use. It is required if From is Name. The volume availability zone name may not contain spaces."
+		  }
+		}
+	      },
+	      "sizeGiB": {
+                "type": "integer",
+                "description": "SizeGiB is the size of the block device in gibibytes (GiB)."
+              },
+	      "type": {
+	        "type": "string",
+                "description": "Type is the Cinder volume type of the volume. If omitted, the default Cinder volume type that is configured in the OpenStack cloud will be used."
+	      }
+	    }
+	  }
         },
         "securityGroups": {
           "type": "array",

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -47,6 +47,7 @@ controlPlane:
     filter:
       name: ""
   portOpts: []
+  rootVolume: {}
   securityGroups:
     - filter:
         name: "default"
@@ -61,6 +62,7 @@ worker:
     filter:
       name: ""
   portOpts: []
+  rootVolume: {}
   securityGroups:
     - filter:
         name: "default"

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-0-0-5
+  name: openstack-standalone-cp-0-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-standalone-cp
-      version: 0.0.5
+      version: 0.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Expose rootVolume option in Openstack standalone control plane cluster template.
Resolves #965 