### PR TITLE
Fix dev AKS credentials configmap name

### DIFF
--- a/config/dev/aks-credentials.yaml
+++ b/config/dev/aks-credentials.yaml
@@ -29,7 +29,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: azure-cluster-identity-resource-template
+  name: azure-aks-credential-resource-template
   namespace: ${NAMESPACE}
   labels:
     k0rdent.mirantis.com/component: "kcm"


### PR DESCRIPTION
Currently, its name matches the ConfigMap from `config/dev/azure-credentials.yaml`. If I run `make dev-azure-creds` followed by make `dev-aks-creds`, the Azure credentials ConfigMap gets overwritten with the AKS credentials (which is empty since no creds propagation is required).