### PR TITLE
Disallow cross-namespace references in ClusterDeployment

### DIFF
--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -52,6 +52,7 @@ import (
 	"github.com/K0rdent/kcm/internal/telemetry"
 	"github.com/K0rdent/kcm/internal/utils"
 	"github.com/K0rdent/kcm/internal/utils/status"
+	"github.com/K0rdent/kcm/internal/webhook"
 )
 
 const (
@@ -501,6 +502,10 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, mc *kc
 
 		err = errors.Join(err, servicesErr)
 	}()
+
+	if err := webhook.ValidateCrossNamespaceRefs(ctx, mc.Namespace, &mc.Spec.ServiceSpec); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	opts, err := sveltos.GetHelmChartOpts(ctx, r.Client, mc.Namespace, mc.Spec.ServiceSpec.Services)
 	if err != nil {

--- a/internal/webhook/clusterdeployment_webhook.go
+++ b/internal/webhook/clusterdeployment_webhook.go
@@ -80,6 +80,10 @@ func (v *ClusterDeploymentValidator) ValidateCreate(ctx context.Context, obj run
 		return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)
 	}
 
+	if err := ValidateCrossNamespaceRefs(ctx, clusterDeployment.Namespace, &clusterDeployment.Spec.ServiceSpec); err != nil {
+		return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)
+	}
+
 	if err := validateServices(ctx, v.Client, clusterDeployment.Namespace, clusterDeployment.Spec.ServiceSpec.Services); err != nil {
 		return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)
 	}
@@ -121,6 +125,10 @@ func (v *ClusterDeploymentValidator) ValidateUpdate(ctx context.Context, oldObj,
 	}
 
 	if err := v.validateCredential(ctx, newClusterDeployment, template); err != nil {
+		return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)
+	}
+
+	if err := ValidateCrossNamespaceRefs(ctx, newClusterDeployment.Namespace, &newClusterDeployment.Spec.ServiceSpec); err != nil {
 		return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)
 	}
 
@@ -295,4 +303,30 @@ func isCredMatchTemplate(cred *kcmv1.Credential, template *kcmv1.ClusterTemplate
 	}
 
 	return nil
+}
+
+func ValidateCrossNamespaceRefs(ctx context.Context, namespace string, serviceSpec *kcmv1.ServiceSpec) (errs error) {
+	l := ctrl.LoggerFrom(ctx)
+
+	l.Info(fmt.Sprintf("Validating that the references in .spec.serviceSpec.TemplateRefs do not refer to any resource outside the %s namespace", namespace))
+	for _, ref := range serviceSpec.TemplateResourceRefs {
+		if ref.Resource.Namespace != namespace {
+			errs = errors.Join(errs, fmt.Errorf("%s %q is in namespace %s, cannot refer to a resource in a namespace other than %s in .spec.serviceSpec.templateResourceRefs", ref.Resource.Kind, ref.Resource.Name, ref.Resource.Namespace, namespace))
+		}
+	}
+
+	if errs != nil {
+		return errs
+	}
+
+	l.Info(fmt.Sprintf("Validating that the references in .spec.serviceSpec.services[].ValueFrom do not refer to any resource outside the %s namespace", namespace))
+	for _, svc := range serviceSpec.Services {
+		for _, v := range svc.ValuesFrom {
+			if v.Namespace != namespace {
+				errs = errors.Join(errs, fmt.Errorf("%s %q is in namespace %s, cannot refer to a resource in a namespace other than %s in .spec.serviceSpec.services[].valuesFrom", v.Kind, v.Name, v.Namespace, namespace))
+			}
+		}
+	}
+
+	return errs
 }

--- a/internal/webhook/clusterdeployment_webhook.go
+++ b/internal/webhook/clusterdeployment_webhook.go
@@ -310,7 +310,9 @@ func ValidateCrossNamespaceRefs(ctx context.Context, namespace string, serviceSp
 
 	l.Info(fmt.Sprintf("Validating that the references in .spec.serviceSpec.TemplateRefs do not refer to any resource outside the %s namespace", namespace))
 	for _, ref := range serviceSpec.TemplateResourceRefs {
-		if ref.Resource.Namespace != namespace {
+		// Sveltos will use same namespace as cluster if namespace is empty:
+		// https://projectsveltos.github.io/sveltos/template/intro_template/#templateresourcerefs-namespace-and-name
+		if ref.Resource.Namespace != "" && ref.Resource.Namespace != namespace {
 			errs = errors.Join(errs, fmt.Errorf("%s %q is in namespace %s, cannot refer to a resource in a namespace other than %s in .spec.serviceSpec.templateResourceRefs", ref.Resource.Kind, ref.Resource.Name, ref.Resource.Namespace, namespace))
 		}
 	}
@@ -322,7 +324,8 @@ func ValidateCrossNamespaceRefs(ctx context.Context, namespace string, serviceSp
 	l.Info(fmt.Sprintf("Validating that the references in .spec.serviceSpec.services[].ValueFrom do not refer to any resource outside the %s namespace", namespace))
 	for _, svc := range serviceSpec.Services {
 		for _, v := range svc.ValuesFrom {
-			if v.Namespace != namespace {
+			// Sveltos will use same namespace as cluster if namespace is empty.
+			if v.Namespace != "" && v.Namespace != namespace {
 				errs = errors.Join(errs, fmt.Errorf("%s %q is in namespace %s, cannot refer to a resource in a namespace other than %s in .spec.serviceSpec.services[].valuesFrom", v.Kind, v.Name, v.Namespace, namespace))
 			}
 		}

--- a/internal/webhook/clusterdeployment_webhook_test.go
+++ b/internal/webhook/clusterdeployment_webhook_test.go
@@ -248,7 +248,23 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 			ClusterDeployment: clusterdeployment.NewClusterDeployment(
 				clusterdeployment.WithClusterTemplate(testTemplateName),
 				clusterdeployment.WithCredential(testCredentialName),
-				clusterdeployment.WithServiceTemplate(testSvcTemplate1Name),
+				clusterdeployment.WithServiceSpec(v1alpha1.ServiceSpec{
+					TemplateResourceRefs: []sveltosv1beta1.TemplateResourceRef{
+						// Should not fail if namespace is empty
+						{Resource: corev1.ObjectReference{APIVersion: "v1", Kind: "ConfigMap", Name: "test-configmap"}},
+						{Resource: corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Name: "test-secret"}},
+					},
+					Services: []v1alpha1.Service{
+						{
+							Template: testSvcTemplate1Name,
+							ValuesFrom: []sveltosv1beta1.ValueFrom{
+								// Should not fail if namespace is empty
+								{Kind: "ConfigMap", Name: "test-configmap"},
+								{Kind: "Secret", Name: "test-secret"},
+							},
+						},
+					},
+				}),
 			),
 			existingObjects: []runtime.Object{
 				mgmt,

--- a/internal/webhook/clusterdeployment_webhook_test.go
+++ b/internal/webhook/clusterdeployment_webhook_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -170,6 +171,77 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 				),
 			},
 			err: "the ClusterDeployment is invalid: the template is not valid: validation error example",
+		},
+		{
+			name: "should fail if TemplateResourceRefs are referring to resource in another namespace",
+			ClusterDeployment: clusterdeployment.NewClusterDeployment(
+				clusterdeployment.WithClusterTemplate(testTemplateName),
+				clusterdeployment.WithCredential(testCredentialName),
+				clusterdeployment.WithServiceTemplate(testSvcTemplate1Name),
+				clusterdeployment.WithServiceSpec(v1alpha1.ServiceSpec{
+					Services: []v1alpha1.Service{
+						{Template: testSvcTemplate1Name},
+					},
+					TemplateResourceRefs: []sveltosv1beta1.TemplateResourceRef{
+						{Resource: corev1.ObjectReference{APIVersion: "v1", Kind: "ConfigMap", Name: "test-configmap", Namespace: "othernamespace"}},
+						{Resource: corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Name: "test-secret", Namespace: "othernamespace"}},
+					},
+				}),
+			),
+			existingObjects: []runtime.Object{
+				mgmt,
+				cred,
+				template.NewClusterTemplate(
+					template.WithName(testTemplateName),
+					template.WithProvidersStatus(
+						"infrastructure-aws",
+						"control-plane-k0smotron",
+						"bootstrap-k0smotron",
+					),
+					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
+				),
+				template.NewServiceTemplate(
+					template.WithName(testSvcTemplate1Name),
+					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
+				),
+			},
+			err: "the ClusterDeployment is invalid: ConfigMap \"test-configmap\" is in namespace othernamespace, cannot refer to a resource in a namespace other than default in .spec.serviceSpec.templateResourceRefs\nSecret \"test-secret\" is in namespace othernamespace, cannot refer to a resource in a namespace other than default in .spec.serviceSpec.templateResourceRefs",
+		},
+		{
+			name: "should fail if ValuesFrom are referring to resource in another namespace",
+			ClusterDeployment: clusterdeployment.NewClusterDeployment(
+				clusterdeployment.WithClusterTemplate(testTemplateName),
+				clusterdeployment.WithCredential(testCredentialName),
+				clusterdeployment.WithServiceSpec(v1alpha1.ServiceSpec{
+					Services: []v1alpha1.Service{
+						{
+							Template: testSvcTemplate1Name,
+							ValuesFrom: []sveltosv1beta1.ValueFrom{
+								{Kind: "ConfigMap", Name: "test-configmap", Namespace: "othernamespace"},
+								{Kind: "Secret", Name: "test-secret", Namespace: "othernamespace"},
+							},
+						},
+					},
+				}),
+			),
+			existingObjects: []runtime.Object{
+				mgmt,
+				cred,
+				template.NewClusterTemplate(
+					template.WithName(testTemplateName),
+					template.WithProvidersStatus(
+						"infrastructure-aws",
+						"control-plane-k0smotron",
+						"bootstrap-k0smotron",
+					),
+					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
+				),
+				template.NewServiceTemplate(
+					template.WithName(testSvcTemplate1Name),
+					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
+				),
+			},
+			err: "the ClusterDeployment is invalid: ConfigMap \"test-configmap\" is in namespace othernamespace, cannot refer to a resource in a namespace other than default in .spec.serviceSpec.services[].valuesFrom\nSecret \"test-secret\" is in namespace othernamespace, cannot refer to a resource in a namespace other than default in .spec.serviceSpec.services[].valuesFrom",
 		},
 		{
 			name: "should succeed",

--- a/test/objects/clusterdeployment/clusterdeployment.go
+++ b/test/objects/clusterdeployment/clusterdeployment.go
@@ -15,6 +15,7 @@
 package clusterdeployment
 
 import (
+	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -79,6 +80,18 @@ func WithServiceTemplate(templateName string) Opt {
 		p.Spec.ServiceSpec.Services = append(p.Spec.ServiceSpec.Services, v1alpha1.Service{
 			Template: templateName,
 		})
+	}
+}
+
+func WithServiceSpec(serviceSpec v1alpha1.ServiceSpec) Opt {
+	return func(p *v1alpha1.ClusterDeployment) {
+		p.Spec.ServiceSpec = serviceSpec
+	}
+}
+
+func WithTemplateResourceRefs(templRefs []sveltosv1beta1.TemplateResourceRef) Opt {
+	return func(p *v1alpha1.ClusterDeployment) {
+		p.Spec.ServiceSpec.TemplateResourceRefs = append(p.Spec.ServiceSpec.TemplateResourceRefs, templRefs...)
 	}
 }
 


### PR DESCRIPTION
# Description

Disallow cross-namespace references in ClusterDeployment because it is namespace scoped. If there is a reference to another namespace and the validation webhooks are disabled, the kcm-controller will return an error and it will show up in the status for example:
```yaml
apiVersion: k0rdent.mirantis.com/v1alpha1
kind: ClusterDeployment
metadata:
  . . .
  name: wali-dev-1
  namespace: kcm-system
  . . .
spec:
  . . .
  serviceSpec:
    priority: 100
    services:
    - name: kyverno
      namespace: kyverno
      template: kyverno-3-2-6
      valuesFrom:
      - kind: Secret
        name: my-creds
        namespace: testns1
    stopOnConflict: false
    syncMode: Continuous
  template: aws-standalone-cp-0-0-7
status:
  conditions:
  - lastTransitionTime: "2025-01-30T17:45:12Z"
    message: Template is valid
    reason: Succeeded
    status: "True"
    type: TemplateReady
  - lastTransitionTime: "2025-01-30T17:45:12Z"
    message: Helm chart is valid
    reason: Succeeded
    status: "True"
    type: HelmChartReady
  - lastTransitionTime: "2025-01-30T17:45:13Z"
    message: Helm install succeeded for release kcm-system/wali-dev-1.v1 with chart
      aws-standalone-cp@0.0.7
    reason: InstallSucceeded
    status: "True"
    type: HelmReleaseReady
  - lastTransitionTime: "2025-01-30T17:45:12Z"
    message: 'Secret "my-creds" is in namespace testns1, cannot refer to a resource
      in a namespace other than kcm-system in .spec.serviceSpec.services[].valuesFrom.
      wali-dev-1-md: Minimum availability requires 1 replicas, current 0 available.
      wali-dev-1: Waiting for control plane provider to indicate the control plane
      has been initialized. wali-dev-1. '
    reason: Failed
    status: "False"
    type: Ready
  - lastTransitionTime: "2025-01-30T17:45:12Z"
    message: Credential is Ready
    reason: Succeeded
    status: "True"
    type: CredentialReady
  - lastTransitionTime: "2025-01-30T17:45:12Z"
    message: Secret "my-creds" is in namespace testns1, cannot refer to a resource
      in a namespace other than kcm-system in .spec.serviceSpec.services[].valuesFrom
    reason: Failed
    status: "False"
    type: SveltosProfileReady
  - lastTransitionTime: "2025-01-30T17:45:12Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: FetchServicesStatusSuccess
  - lastTransitionTime: "2025-01-30T17:45:13Z"
    message: 'wali-dev-1-md: Minimum availability requires 1 replicas, current 0 available'
    reason: WaitingForAvailableMachines
    status: "False"
    type: Available
  - lastTransitionTime: "2025-01-30T17:45:13Z"
    message: 'wali-dev-1: Waiting for control plane provider to indicate the control
      plane has been initialized'
    reason: WaitingForControlPlaneProviderInitialized
    status: "False"
    type: ControlPlaneInitialized
  - lastTransitionTime: "2025-01-30T17:45:13Z"
    message: wali-dev-1
    reason: WaitingForControlPlane
    status: "False"
    type: ControlPlaneReady
  - lastTransitionTime: "2025-01-30T17:47:37Z"
    message: wali-dev-1 is Ready
    reason: Succeeded
    status: "True"
    type: InfrastructureReady
  observedGeneration: 1
```