### PR TITLE
Fix issue with installation with create management flag set to false

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -221,8 +221,9 @@ func main() {
 	currentNamespace := utils.CurrentNamespace()
 
 	templateReconciler := controller.TemplateReconciler{
-		Client:          mgr.GetClient(),
-		SystemNamespace: currentNamespace,
+		Client:           mgr.GetClient(),
+		CreateManagement: createManagement,
+		SystemNamespace:  currentNamespace,
 		DefaultRegistryConfig: helm.DefaultRegistryConfig{
 			URL:               defaultRegistryURL,
 			RepoType:          determinedRepositoryType,

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -394,7 +394,10 @@ func (r *ReleaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
-
+	//
+	if !r.CreateManagement && !r.CreateRelease {
+		return nil
+	}
 	// There's no Release objects created yet and we need to trigger reconcile
 	initChannel := make(chan event.GenericEvent, 1)
 	initChannel <- event.GenericEvent{Object: &kcm.Release{}}

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -394,10 +394,7 @@ func (r *ReleaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
-	//
-	if !r.CreateManagement {
-		return nil
-	}
+
 	// There's no Release objects created yet and we need to trigger reconcile
 	initChannel := make(chan event.GenericEvent, 1)
 	initChannel <- event.GenericEvent{Object: &kcm.Release{}}

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -52,6 +52,7 @@ type TemplateReconciler struct {
 
 	SystemNamespace       string
 	DefaultRegistryConfig helm.DefaultRegistryConfig
+	CreateManagement      bool
 
 	defaultRequeueTime time.Duration
 }
@@ -176,14 +177,13 @@ func (r *ProviderTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	management, err := r.getManagement(ctx, providerTemplate)
-	if err != nil {
+	if r.CreateManagement && err != nil {
 		if apierrors.IsNotFound(err) {
 			l.Info("Management is not created yet, retrying")
 			return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
 		}
-		return ctrl.Result{}, err
 	}
-	if !management.DeletionTimestamp.IsZero() {
+	if management != nil && !management.DeletionTimestamp.IsZero() {
 		l.Info("Management is being deleted, skipping ProviderTemplate reconciliation")
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
Fixed an issue where the provider templates depend on the management object and the management object depends on the provider templates making it impossible to deploy kcm with the create management flag set to false.

Resolves issue https://github.com/k0rdent/kcm/issues/940