### PR TITLE
Support for providing a testing configuration to the workflow

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,8 +28,26 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.repository) &&
       'external' || 'internal' }}
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    outputs:
+      config: ${{ steps.get_config.outputs.config }}
     steps:
-      - run: echo ✓
+      - name: Get Testing Configuration
+        id: get_config
+        run: |
+          config=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/approvals" --jq '.[0] | .comment')
+          if [ -z "$config" ]; then
+            exit 0
+          fi
+
+          echo "Provided testing configuration:"
+          echo "$config"
+          if ! echo "$config" | yq e > /dev/null; then
+            echo "Invalid testing configuration provided"
+            exit 1
+          fi
+          echo "config=$(echo -n "$config" | base64)" >> $GITHUB_OUTPUT
   build:
     concurrency:
       group: build-${{ github.head_ref || github.run_id }}
@@ -171,6 +189,12 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup kubectl
         uses: azure/setup-kubectl@v4
+      - name: Load testing configuration
+        if: ${{ needs.authorize.outputs.config != '' }}
+        run: |
+          echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
+          echo "Testing configuration was overwritten:"
+          cat test/e2e/config/config.yaml
       - name: Run E2E tests
         env:
           GINKGO_LABEL_FILTER: 'provider:cloud'
@@ -226,6 +250,12 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: Setup kubectl
         uses: azure/setup-kubectl@v4
+      - name: Load testing configuration
+        if: ${{ needs.authorize.outputs.config != '' }}
+        run: |
+          echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
+          echo "Testing configuration was overwritten:"
+          cat test/e2e/config/config.yaml
       - name: Run E2E tests
         env:
           GINKGO_LABEL_FILTER: 'provider:onprem'


### PR DESCRIPTION
This PR updates the `authorize` job to retrieve the testing configuration from the approval comment. The comment should be provided during the approval process for deployment in the `external` environment.

* The comment must contain valid YAML content representing the testing configuration.
* If the comment is empty, the default testing configuration will be used, which deploys a single AWS standalone cluster.
* If the comment contains invalid YAML, an error will occur and the job will fail.

Below is an example that demonstrates how this process should work:

https://github.com/user-attachments/assets/84971961-4dcc-4912-aa22-12ad030d5254



Closes #642