### PR TITLE
Add mgmt watcher to clustertemplates

### DIFF
--- a/config/dev/kcm_values.yaml
+++ b/config/dev/kcm_values.yaml
@@ -6,3 +6,5 @@ controller:
   insecureRegistry: true
   createRelease: false
   createTemplates: false
+  logger:
+    devel: true


### PR DESCRIPTION
* add mgmt watcher to clustertemplates to queue templates if providers have been removed or added
* turn on dev logger in dev config
* unrelated micro fix trying to address periodic runner tests sporadic panic

Closes #954 