### PR TITLE
Add ability to setup `pprof` and enhance `Release` name generation checks

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -90,6 +90,7 @@ func main() {
 		enableWebhook             bool
 		webhookPort               int
 		webhookCertDir            string
+		pprofBindAddress          string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -115,6 +116,8 @@ func main() {
 	flag.IntVar(&webhookPort, "webhook-port", 9443, "Admission webhook port.")
 	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
 		"Webhook cert dir, only used when webhook-port is specified.")
+	flag.StringVar(&pprofBindAddress, "pprof-bind-address", "", "The TCP address that the controller should bind to for serving pprof, \"0\" or empty value disables pprof")
+
 	opts := zap.Options{
 		Development: true,
 	}
@@ -184,6 +187,8 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+
+		PprofBindAddress: pprofBindAddress,
 	}
 
 	if enableWebhook {

--- a/config/dev/kcm_values.yaml
+++ b/config/dev/kcm_values.yaml
@@ -8,3 +8,5 @@ controller:
   createTemplates: false
   logger:
     devel: true
+  debug:
+    pprofBindAddress: ":8082"

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -275,7 +275,11 @@ func (r *ReleaseReconciler) reconcileKCMTemplates(ctx context.Context, releaseNa
 	initialInstall := releaseName == ""
 	var ownerRefs []metav1.OwnerReference
 	if releaseName == "" {
-		releaseName = utils.ReleaseNameFromVersion(build.Version)
+		releaseName, err = utils.ReleaseNameFromVersion(build.Version)
+		if err != nil {
+			return false, fmt.Errorf("failed to get Release name from version %q: %w", build.Version, err)
+		}
+
 		releaseVersion = build.Version
 		err := helm.ReconcileHelmRepository(ctx, r.Client, kcm.DefaultRepoName, r.SystemNamespace, r.DefaultRegistryConfig.HelmRepositorySpec())
 		if err != nil {

--- a/internal/utils/release.go
+++ b/internal/utils/release.go
@@ -14,10 +14,28 @@
 
 package utils
 
-import "strings"
+import (
+	"fmt"
+	"strings"
 
-func ReleaseNameFromVersion(version string) string {
-	return "kcm-" + strings.ReplaceAll(strings.TrimPrefix(version, "v"), ".", "-")
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func ReleaseNameFromVersion(version string) (string, error) {
+	n := "kcm-" +
+		strings.ToLower(
+			strings.ReplaceAll(
+				strings.ReplaceAll(
+					strings.TrimPrefix(version, "v"),
+					".", "-"),
+				"+", "-"),
+		)
+
+	if vv := validation.IsDNS1123Subdomain(n); len(vv) > 0 {
+		return "", fmt.Errorf("invalid name: %v", vv)
+	}
+
+	return n, nil
 }
 
 func TemplatesChartFromReleaseName(releaseName string) string {

--- a/internal/utils/release_test.go
+++ b/internal/utils/release_test.go
@@ -26,9 +26,26 @@ func TestReleaseNameFromVersion(t *testing.T) {
 		{version: "v0.0.1", expectedName: "kcm-0-0-1"},
 		{version: "v0.0.1-rc", expectedName: "kcm-0-0-1-rc"},
 		{version: "0.0.1", expectedName: "kcm-0-0-1"},
+		{version: "1.2.3-alpha.4", expectedName: "kcm-1-2-3-alpha-4"},
+		{version: "1.2.3+meta", expectedName: "kcm-1-2-3-meta"},
+		{version: "1.2.3-rc.4+build.5", expectedName: "kcm-1-2-3-rc-4-build-5"},
+		{version: "v00.01.02", expectedName: "kcm-00-01-02"},
+		{version: "v1", expectedName: "kcm-1"},
+		{version: "v2.3", expectedName: "kcm-2-3"},
+		{version: "v4.5.6", expectedName: "kcm-4-5-6"},
+		{version: "v1.2.3-rc.4", expectedName: "kcm-1-2-3-rc-4"},
+		{version: "v1.2.3.4.5", expectedName: "kcm-1-2-3-4-5"},
+		{version: "v123", expectedName: "kcm-123"},
+		{version: "0.0.0", expectedName: "kcm-0-0-0"},
+		{version: "9999.9999.9999", expectedName: "kcm-9999-9999-9999"},
+		{version: "1.2.3-RC.4", expectedName: "kcm-1-2-3-rc-4"},
+		{version: "v0.1.0-26-g6d786ca", expectedName: "kcm-0-1-0-26-g6d786ca"},
 	} {
 		t.Run(tc.version, func(t *testing.T) {
-			actual := ReleaseNameFromVersion(tc.version)
+			actual, err := ReleaseNameFromVersion(tc.version)
+			if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
 			if actual != tc.expectedName {
 				t.Errorf("expected name %s, got %s", tc.expectedName, actual)
 			}

--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - --zap-{{ $key }}={{ $value }}
         {{- end }}
         {{- end }}
+        - --pprof-bind-address={{ .Values.controller.debug.pprofBindAddress }}
         command:
         - /manager
         env:

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -107,6 +107,19 @@
         "createTemplates": {
           "type": "boolean"
         },
+        "debug": {
+          "properties": {
+            "pprofBindAddress": {
+              "description": "The TCP address that the controller should bind to for serving pprof, '0' or empty value disables pprof",
+              "pattern": "(?:^0?$)|(?:^(?:[\\w.-]+(?:\\.?[\\w\\.-]+)+)?:(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$)",
+              "title": "Set pprof binding address",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "type": "object"
+        },
         "defaultRegistryURL": {
           "type": "string"
         },

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -21,6 +21,8 @@ controller:
     log-level: "" # @schema enum:[info, debug, error, ""] ; type: string
     stacktrace-level: "" # @schema enum:[info, error, panic, ""] ; type: string
     time-encoding: rfc3339 # @schema enum:[epoch, millis, nano, iso8601, rfc3339, rfc3339nano, ""] ; type: string
+  debug:
+    pprofBindAddress: "" # @schema type: string; title: Set pprof binding address; description: The TCP address that the controller should bind to for serving pprof, '0' or empty value disables pprof; pattern: (?:^0?$)|(?:^(?:[\w.-]+(?:\.?[\w\.-]+)+)?:(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$)
 
 containerSecurityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION
* setup pprof handler
* turn off by default
* enable pprof in dev config
* add rfc1123 name validation
* added some unit tests to cover semver

Since `pprof` is disabled by default there is no reason to provide extra `ports` entry along with the `Service` resource for the port.

Closes #773
Closes #775