### PR TITLE
Add support for additionalBlockDevices in openstack-standalone-cp

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-0-1-0
+  template: openstack-standalone-cp-0-1-1
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
@@ -27,6 +27,10 @@ spec:
       rootVolume:
         {{ .Values.controlPlane.rootVolume | toYaml | nindent 8 }}
       {{- end }}
+      {{- if gt (len .Values.controlPlane.additionalBlockDevices) 0 }}
+      additionalBlockDevices:
+        {{ .Values.controlPlane.additionalBlockDevices | toYaml | nindent 8 }}
+      {{- end }}
       {{- if gt (len .Values.controlPlane.securityGroups) 0 }}
       securityGroups:
         {{ .Values.controlPlane.securityGroups | toYaml | nindent 8 }}

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
@@ -27,6 +27,10 @@ spec:
       rootVolume:
         {{ .Values.worker.rootVolume | toYaml | nindent 8 }}
       {{- end }}
+      {{- if gt (len .Values.worker.additionalBlockDevices) 0 }}
+      additionalBlockDevices:
+        {{ .Values.worker.additionalBlockDevices | toYaml | nindent 8 }}
+      {{- end }}
       {{- if gt (len .Values.worker.securityGroups) 0 }}
       securityGroups:
         {{ .Values.worker.securityGroups | toYaml | nindent 8 }}

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -111,7 +111,7 @@
         }
       },
       "required": ["allowAllInClusterTraffic"]
-    },      
+    },
     "network": {
       "type": "object",
       "description": "Networking resources reference for nodes",
@@ -261,34 +261,86 @@
         "rootVolume": {
           "type": "object",
           "description": "The volume metadata to boot from",
-	  "items": {
-	    "type": "object",
+          "items": {
+            "type": "object",
             "required": ["sizeGiB"],
-	    "properties": {
-	      "availabilityZone": {
-	        "type": "object",
+            "properties": {
+              "availabilityZone": {
+                "type": "object",
                 "description": "AvailabilityZone is the volume availability zone to create the volume in. If not specified, the volume will be created without an explicit availability zone.",
                 "properties": {
-		  "from": {
-		    "type": "string",
+                  "from": {
+                    "type": "string",
                     "description": "From specifies where we will obtain the availability zone for the volume. The options are Name and Machine. If Name is specified then the Name field must also be specified. If Machine is specified the volume will use the value of FailureDomain, if any, from the associated Machine."
-		  },
-		  "name": {
-		    "type": "string",
+                  },
+                  "name": {
+                    "type": "string",
                     "description": "Name is the name of a volume availability zone to use. It is required if From is Name. The volume availability zone name may not contain spaces."
-		  }
-		}
-	      },
-	      "sizeGiB": {
+                  }
+                }
+              },
+              "sizeGiB": {
                 "type": "integer",
                 "description": "SizeGiB is the size of the block device in gibibytes (GiB)."
               },
-	      "type": {
-	        "type": "string",
+              "type": {
+                "type": "string",
                 "description": "Type is the Cinder volume type of the volume. If omitted, the default Cinder volume type that is configured in the OpenStack cloud will be used."
-	      }
-	    }
-	  }
+              }
+            }
+          }
+        },
+        "additionalBlockDevices": {
+          "type": "array",
+          "description": "AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance",
+          "items": {
+            "type": "object",
+            "required": ["name","sizeGiB"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the block device in the context of a machine. If the block device is a volume, the Cinder volume will be named as a combination of the machine name and this name. Also, this name will be used for tagging the block device. Information about the block device tag can be obtained from the OpenStack metadata API or the config drive. Name cannot be ‘root’, which is reserved for the root volume."
+              },
+              "sizeGiB": {
+                "type": "integer",
+                "description": "SizeGiB is the size of the block device in gibibytes (GiB)."
+              },
+              "storage": {
+                "type": "object",
+                "description": "Storage specifies the storage type of the block device and additional storage options.",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "Type is the type of block device to create. This can be either 'Volume' or 'Local'."
+                  },
+                  "volume": {
+                    "type": "object",
+                    "description": "Volume contains additional storage options for a volume block device.",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "Type is the Cinder volume type of the volume. If omitted, the default Cinder volume type that is configured in the OpenStack cloud will be used."
+                      },
+                      "availabilityZone": {
+                        "type": "object",
+                        "description": "AvailabilityZone is the volume availability zone to create the volume in. If not specified, the volume will be created without an explicit availability zone.",
+                        "properties": {
+                          "from": {
+                            "type": "string",
+                            "description": "From specifies where we will obtain the availability zone for the volume. The options are Name and Machine. If Name is specified then the Name field must also be specified. If Machine is specified the volume will use the value of FailureDomain, if any, from the associated Machine."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Name is the name of a volume availability zone to use. It is required if From is Name. The volume availability zone name may not contain spaces."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "securityGroups": {
           "type": "array",
@@ -296,26 +348,26 @@
           "items": {
             "type": "object",
             "properties": {
-            "filter": {
-              "type": "object",
-              "properties": {
-              "name": {
-                "type": "string",
-                "description": "Name of the security group to filter by"
-              },
-              "description": {
-                "type": "string",
-                "description": "Optional: description for filtering"
-              },
-              "projectID": {
-                "type": "string",
-                "description": "Optional: project ID for filtering"
-              }
+              "filter": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the security group to filter by"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Optional: description for filtering"
+                  },
+                  "projectID": {
+                    "type": "string",
+                    "description": "Optional: project ID for filtering"
+                  }
+                }
               }
             }
-            }
           }
-          }
+        }
       }
     },
     "worker": {
@@ -367,34 +419,86 @@
         "rootVolume": {
           "type": "object",
           "description": "The volume metadata to boot from",
-	  "items": {
-	    "type": "object",
+          "items": {
+            "type": "object",
             "required": ["sizeGiB"],
-	    "properties": {
-	      "availabilityZone": {
-	        "type": "object",
+            "properties": {
+              "availabilityZone": {
+                "type": "object",
                 "description": "AvailabilityZone is the volume availability zone to create the volume in. If not specified, the volume will be created without an explicit availability zone.",
                 "properties": {
-		  "from": {
-		    "type": "string",
+                  "from": {
+                    "type": "string",
                     "description": "From specifies where we will obtain the availability zone for the volume. The options are Name and Machine. If Name is specified then the Name field must also be specified. If Machine is specified the volume will use the value of FailureDomain, if any, from the associated Machine."
-		  },
-		  "name": {
-		    "type": "string",
+                  },
+                  "name": {
+                    "type": "string",
                     "description": "Name is the name of a volume availability zone to use. It is required if From is Name. The volume availability zone name may not contain spaces."
-		  }
-		}
-	      },
-	      "sizeGiB": {
+                  }
+                }
+              },
+              "sizeGiB": {
                 "type": "integer",
                 "description": "SizeGiB is the size of the block device in gibibytes (GiB)."
               },
-	      "type": {
-	        "type": "string",
+              "type": {
+                "type": "string",
                 "description": "Type is the Cinder volume type of the volume. If omitted, the default Cinder volume type that is configured in the OpenStack cloud will be used."
-	      }
-	    }
-	  }
+              }
+            }
+          }
+        },
+        "additionalBlockDevices": {
+          "type": "array",
+          "description": "AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance",
+          "items": {
+            "type": "object",
+            "required": ["name","sizeGiB"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the block device in the context of a machine. If the block device is a volume, the Cinder volume will be named as a combination of the machine name and this name. Also, this name will be used for tagging the block device. Information about the block device tag can be obtained from the OpenStack metadata API or the config drive. Name cannot be ‘root’, which is reserved for the root volume."
+              },
+              "sizeGiB": {
+                "type": "integer",
+                "description": "SizeGiB is the size of the block device in gibibytes (GiB)."
+              },
+              "storage": {
+                "type": "object",
+                "description": "Storage specifies the storage type of the block device and additional storage options.",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "Type is the type of block device to create. This can be either 'Volume' or 'Local'."
+                  },
+                  "volume": {
+                    "type": "object",
+                    "description": "Volume contains additional storage options for a volume block device.",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "Type is the Cinder volume type of the volume. If omitted, the default Cinder volume type that is configured in the OpenStack cloud will be used."
+                      },
+                      "availabilityZone": {
+                        "type": "object",
+                        "description": "AvailabilityZone is the volume availability zone to create the volume in. If not specified, the volume will be created without an explicit availability zone.",
+                        "properties": {
+                          "from": {
+                            "type": "string",
+                            "description": "From specifies where we will obtain the availability zone for the volume. The options are Name and Machine. If Name is specified then the Name field must also be specified. If Machine is specified the volume will use the value of FailureDomain, if any, from the associated Machine."
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Name is the name of a volume availability zone to use. It is required if From is Name. The volume availability zone name may not contain spaces."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "securityGroups": {
           "type": "array",
@@ -402,26 +506,26 @@
           "items": {
             "type": "object",
             "properties": {
-            "filter": {
-              "type": "object",
-              "properties": {
-              "name": {
-                "type": "string",
-                "description": "Name of the security group to filter by"
-              },
-              "description": {
-                "type": "string",
-                "description": "Optional: description for filtering"
-              },
-              "projectID": {
-                "type": "string",
-                "description": "Optional: project ID for filtering"
-              }
+              "filter": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the security group to filter by"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Optional: description for filtering"
+                  },
+                  "projectID": {
+                    "type": "string",
+                    "description": "Optional: project ID for filtering"
+                  }
+                }
               }
             }
-            }
           }
-          }
+        }
       }
     },
     "k0smotron": {

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -48,6 +48,7 @@ controlPlane:
       name: ""
   portOpts: []
   rootVolume: {}
+  additionalBlockDevices: []
   securityGroups:
     - filter:
         name: "default"
@@ -63,6 +64,7 @@ worker:
       name: ""
   portOpts: []
   rootVolume: {}
+  additionalBlockDevices: []
   securityGroups:
     - filter:
         name: "default"

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-1-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-1-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-0-1-0
+  name: openstack-standalone-cp-0-1-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-standalone-cp
-      version: 0.1.0
+      version: 0.1.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Add support for additional block devices for openstack cluster machines. It is required for storage solutions.

Implements https://github.com/k0rdent/kcm/issues/1054