### PR TITLE
Add sveltos cluster status to the clusterdeployment conditions

### DIFF
--- a/api/v1alpha1/clusterdeployment_types.go
+++ b/api/v1alpha1/clusterdeployment_types.go
@@ -46,6 +46,8 @@ const (
 	HelmChartReadyCondition = "HelmChartReady"
 	// HelmReleaseReadyCondition indicates the corresponding HelmRelease is ready and fully reconciled.
 	HelmReleaseReadyCondition = "HelmReleaseReady"
+	// SveltosClusterReadyCondition indicates the sveltos cluster is valid and ready.
+	SveltosClusterReadyCondition = "SveltosClusterReady"
 )
 
 // ClusterDeploymentSpec defines the desired state of ClusterDeployment

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ import (
 	hcv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	velerov2alpha1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v2alpha1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -70,6 +71,7 @@ func init() {
 	utilruntime.Must(sourcev1.AddToScheme(scheme))
 	utilruntime.Must(hcv2.AddToScheme(scheme))
 	utilruntime.Must(sveltosv1beta1.AddToScheme(scheme))
+	utilruntime.Must(libsveltosv1beta1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -27,12 +27,14 @@ import (
 	fluxconditions "github.com/fluxcd/pkg/runtime/conditions"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -388,6 +390,58 @@ func (r *ClusterDeploymentReconciler) updateCluster(ctx context.Context, mc *kcm
 	return ctrl.Result{}, nil
 }
 
+func (r *ClusterDeploymentReconciler) updateSveltosClusterCondition(ctx context.Context, clusterDeployment *kcm.ClusterDeployment) (bool, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    libsveltosv1beta1.GroupVersion.Group,
+		Version:  libsveltosv1beta1.GroupVersion.Version,
+		Resource: "sveltosclusters",
+	}
+
+	sveltosClusters, err := r.DynamicClient.Resource(gvr).Namespace(clusterDeployment.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{kcm.FluxHelmChartNameKey: clusterDeployment.Name}).String(),
+	})
+	if err != nil {
+		if !errors.As(err, &status.ResourceNotFoundError{}) {
+			return false, fmt.Errorf("failed to get sveltos cluster status: %w", err)
+		}
+	}
+
+	for _, sveltosCluster := range sveltosClusters.Items {
+		sveltosCondition := metav1.Condition{
+			Status: metav1.ConditionUnknown,
+			Type:   kcm.SveltosClusterReadyCondition,
+		}
+		connectionStatus, found, err := unstructured.NestedString(sveltosCluster.Object, "status", "connectionStatus")
+		if err != nil {
+			return true, fmt.Errorf("failed to get connections status for %s: %w", sveltosCluster.GetName(), err)
+		}
+		if !found {
+			return true, fmt.Errorf("no connections status found for: %s", sveltosCluster.GetName())
+		}
+
+		if connectionStatus == string(libsveltosv1beta1.ConnectionHealthy) {
+			sveltosCondition.Status = metav1.ConditionTrue
+			sveltosCondition.Message = "sveltos cluster is healthy"
+			sveltosCondition.Reason = kcm.SucceededReason
+		} else {
+			sveltosCondition.Status = metav1.ConditionFalse
+			sveltosCondition.Reason = kcm.FailedReason
+			failureMessage, found, err := unstructured.NestedString(sveltosCluster.Object, "status", "failureMessage")
+			if err != nil {
+				return true, fmt.Errorf("failed to get failure message for %s: %w", sveltosCluster.GetName(), err)
+			}
+
+			if !found {
+				return false, fmt.Errorf("no failure message for: %s", sveltosCluster.GetName())
+			}
+			sveltosCondition.Message = failureMessage
+		}
+		apimeta.SetStatusCondition(clusterDeployment.GetConditions(), sveltosCondition)
+	}
+
+	return false, nil
+}
+
 func (r *ClusterDeploymentReconciler) aggregateCapoConditions(ctx context.Context, clusterDeployment *kcm.ClusterDeployment) (requeue bool, _ error) {
 	type objectToCheck struct {
 		gvr        schema.GroupVersionResource
@@ -395,6 +449,12 @@ func (r *ClusterDeploymentReconciler) aggregateCapoConditions(ctx context.Contex
 	}
 
 	var errs error
+	needRequeue, err := r.updateSveltosClusterCondition(ctx, clusterDeployment)
+	if needRequeue {
+		requeue = true
+	}
+	errs = errors.Join(errs, err)
+
 	for _, obj := range []objectToCheck{
 		{
 			gvr: schema.GroupVersionResource{
@@ -413,7 +473,7 @@ func (r *ClusterDeploymentReconciler) aggregateCapoConditions(ctx context.Contex
 			conditions: []string{"Available"},
 		},
 	} {
-		needRequeue, err := r.setStatusFromChildObjects(ctx, clusterDeployment, obj.gvr, obj.conditions)
+		needRequeue, err = r.setStatusFromChildObjects(ctx, clusterDeployment, obj.gvr, obj.conditions)
 		errs = errors.Join(errs, err)
 		if needRequeue {
 			requeue = true

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -392,13 +392,10 @@ func (r *ClusterDeploymentReconciler) updateCluster(ctx context.Context, mc *kcm
 func (r *ClusterDeploymentReconciler) updateSveltosClusterCondition(ctx context.Context, clusterDeployment *kcm.ClusterDeployment) (bool, error) {
 	sveltosClusters := &libsveltosv1beta1.SveltosClusterList{}
 
-	err := r.Client.List(ctx, sveltosClusters, &client.ListOptions{
+	if err := r.Client.List(ctx, sveltosClusters, &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{kcm.FluxHelmChartNameKey: clusterDeployment.Name}),
-	})
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return true, fmt.Errorf("failed to get sveltos cluster status: %w", err)
-		}
+	}); err != nil {
+		return true, fmt.Errorf("failed to get sveltos cluster status: %w", err)
 	}
 
 	for _, sveltosCluster := range sveltosClusters.Items {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -120,20 +121,14 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = kcmv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = sourcev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = helmcontrollerv2.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = sveltosv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = capioperator.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = clusterapiv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(kcmv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(sourcev1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(helmcontrollerv2.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(sveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(capioperator.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(clusterapiv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(velerov1.AddToScheme(scheme.Scheme)).To(Succeed())
-
+	Expect(libsveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})

--- a/templates/cluster/adopted-cluster/templates/sveltoscluster.yaml
+++ b/templates/cluster/adopted-cluster/templates/sveltoscluster.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "cluster.name" . }}
   {{- if .Values.clusterLabels }}
   labels: {{- toYaml .Values.clusterLabels | nindent 4}}
+    helm.toolkit.fluxcd.io/name: {{ .Release.Name }}
+    helm.toolkit.fluxcd.io/namespace: {{ .Release.Namespace }}
   {{- end }}  
 spec:
   consecutiveFailureThreshold: {{ .Values.consecutiveFailureThreshold }}

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -189,6 +189,11 @@ rules:
   - vsphereclusteridentities
   verbs: {{ include "rbac.viewerVerbs" . | nindent 2 }}
 - apiGroups:
+    - lib.projectsveltos.io
+  resources:
+    - sveltosclusters
+  verbs: {{ include "rbac.viewerVerbs" . | nindent 4 }}
+- apiGroups:
   - config.projectsveltos.io
   resources:
   - profiles


### PR DESCRIPTION
Simple change to add the sveltos cluster status to the clusterdeployment conditions for adopted clusters. This fixes issue #953.