### PR TITLE
capo: Fix missing region in providerID on cluster nodes

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-0-1-3
+  template: openstack-standalone-cp-0-1-4
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -47,6 +47,9 @@ spec:
                       effect: NoSchedule
                     - key: node-role.kubernetes.io/master
                       effect: NoSchedule
+                  extraEnv:
+                    - name: OS_CCM_REGIONAL
+                      value: {{ .Values.ccmRegional | quote }}
               - name: openstack-csi
                 chartname: openstack/openstack-cinder-csi
                 version: 2.31.2

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -61,6 +61,10 @@
       "required": [],
       "additionalProperties": true
     },
+    "ccmRegional": {
+      "type": "boolean",
+      "description": "Allow OpenStack CCM to set ProviderID with region name"
+    },
     "identityRef": {
       "type": "object",
       "description": "OpenStack cluster identity object reference",

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -12,6 +12,8 @@ clusterNetwork:
 
 clusterLabels: {}
 
+ccmRegional: true
+
 identityRef:
   name: ""
   cloudName: ""

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-1-4.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-1-4.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-0-1-3
+  name: openstack-standalone-cp-0-1-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-standalone-cp
-      version: 0.1.3
+      version: 0.1.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Sometimes node deployment could be slow therefore openstack ccm sets providerID without region in format `openstack:///<instanceID>` instead of `openstack://<region>/<instanceID>`. Enable OS_CCM_REGIONAL to openstack ccm always set region to providerID.

-----

Fixes https://github.com/k0rdent/kcm/issues/1077