### PR TITLE
capo: Add orc v1.0.0 file with all required objects

### DIFF
--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/templates/orc-1-0-0.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/orc-1-0-0.yaml
@@ -1,0 +1,856 @@
+{{ if (eq .Values.orcVersion "1.0.0") }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+    control-plane: controller-manager
+  name: orc-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: images.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    kind: Image
+    listKind: ImageList
+    plural: images
+    singular: image
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Resource ID
+          jsonPath: .status.id
+          name: ID
+          type: string
+        - description: Availability status of resource
+          jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: Available
+          type: string
+        - description: Message describing current availability status
+          jsonPath: .status.conditions[?(@.type=='Available')].message
+          name: Message
+          type: string
+        - description: Time duration since creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Image is the Schema for an ORC resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ImageSpec defines the desired state of an ORC object.
+              properties:
+                cloudCredentialsRef:
+                  description: CloudCredentialsRef points to a secret containing OpenStack credentials
+                  properties:
+                    cloudName:
+                      description: CloudName specifies the name of the entry in the clouds.yaml file to use.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    secretName:
+                      description: |-
+                        SecretName is the name of a secret in the same namespace as the resource being provisioned.
+                        The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                        The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                    - cloudName
+                    - secretName
+                  type: object
+                import:
+                  description: |-
+                    Import refers to an existing OpenStack resource which will be imported instead of
+                    creating a new one.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: |-
+                        Filter contains a resource query which is expected to return a single
+                        result. The controller will continue to retry if filter returns no
+                        results. If filter returns multiple results the controller will set an
+                        error state and will not continue to retry.
+                      minProperties: 1
+                      properties:
+                        name:
+                          description: Name specifies the name of a Glance image
+                          maxLength: 1000
+                          minLength: 1
+                          type: string
+                      type: object
+                    id:
+                      description: |-
+                        ID contains the unique identifier of an existing OpenStack resource. Note
+                        that when specifying an import by ID, the resource MUST already exist.
+                        The ORC object will enter an error state if the resource does not exist.
+                      format: uuid
+                      type: string
+                  type: object
+                managedOptions:
+                  description: ManagedOptions specifies options which may be applied to managed objects.
+                  properties:
+                    onDelete:
+                      default: delete
+                      description: |-
+                        OnDelete specifies the behaviour of the controller when the ORC
+                        object is deleted. Options are `delete` - delete the OpenStack resource;
+                        `detach` - do not delete the OpenStack resource. If not specified, the
+                        default is `delete`.
+                      enum:
+                        - delete
+                        - detach
+                      type: string
+                  type: object
+                managementPolicy:
+                  default: managed
+                  description: |-
+                    ManagementPolicy defines how ORC will treat the object. Valid values are
+                    `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                    ORC will import an existing resource, and will not apply updates to it or
+                    delete it.
+                  enum:
+                    - managed
+                    - unmanaged
+                  type: string
+                  x-kubernetes-validations:
+                    - message: managementPolicy is immutable
+                      rule: self == oldSelf
+                resource:
+                  description: |-
+                    Resource specifies the desired state of the resource.
+
+                    Resource may not be specified if the management policy is `unmanaged`.
+
+                    Resource must be specified if the management policy is `managed`.
+                  properties:
+                    content:
+                      description: Content specifies how to obtain the image content.
+                      properties:
+                        containerFormat:
+                          default: bare
+                          description: |-
+                            ContainerFormat is the format of the image container.
+                            qcow2 and raw images do not usually have a container. This is specified as "bare", which is also the default.
+                            Permitted values are ami, ari, aki, bare, ovf, ova, and docker.
+                          enum:
+                            - ami
+                            - ari
+                            - aki
+                            - bare
+                            - ovf
+                            - ova
+                            - docker
+                          type: string
+                        diskFormat:
+                          description: |-
+                            DiskFormat is the format of the disk image.
+                            Normal values are "qcow2", or "raw". Glance may be configured to support others.
+                          enum:
+                            - ami
+                            - ari
+                            - aki
+                            - vhd
+                            - vhdx
+                            - vmdk
+                            - raw
+                            - qcow2
+                            - vdi
+                            - ploop
+                            - iso
+                          type: string
+                        download:
+                          description: |-
+                            Download describes how to obtain image data by downloading it from a URL.
+                            Must be set when creating a managed image.
+                          properties:
+                            decompress:
+                              description: |-
+                                Decompress specifies that the source data must be decompressed with the
+                                given compression algorithm before being stored. Specifying Decompress
+                                will disable the use of Glance's web-download, as web-download cannot
+                                currently deterministically decompress downloaded content.
+                              enum:
+                                - xz
+                                - gz
+                                - bz2
+                              type: string
+                            hash:
+                              description: |-
+                                Hash is a hash which will be used to verify downloaded data, i.e.
+                                before any decompression. If not specified, no hash verification will be
+                                performed. Specifying a Hash will disable the use of Glance's
+                                web-download, as web-download cannot currently deterministically verify
+                                the hash of downloaded content.
+                              properties:
+                                algorithm:
+                                  description: Algorithm is the hash algorithm used to generate value.
+                                  enum:
+                                    - md5
+                                    - sha1
+                                    - sha256
+                                    - sha512
+                                  type: string
+                                value:
+                                  description: Value is the hash of the image data using Algorithm. It must be hex encoded using lowercase letters.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  pattern: ^[0-9a-f]+$
+                                  type: string
+                              required:
+                                - algorithm
+                                - value
+                              type: object
+                              x-kubernetes-validations:
+                                - message: hash is immutable
+                                  rule: self == oldSelf
+                            url:
+                              description: URL containing image data
+                              format: uri
+                              type: string
+                          required:
+                            - url
+                          type: object
+                      required:
+                        - diskFormat
+                        - download
+                      type: object
+                      x-kubernetes-validations:
+                        - message: content is immutable
+                          rule: self == oldSelf
+                    name:
+                      description: |-
+                        Name will be the name of the created Glance image. If not specified, the
+                        name of the Image object will be used.
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                    properties:
+                      description: Properties is metadata available to consumers of the image
+                      properties:
+                        hardware:
+                          description: |-
+                            Hardware is a set of properties which control the virtual hardware
+                            created by Nova.
+                          properties:
+                            cdromBus:
+                              description: CDROMBus specifies the type of disk controller to attach CD-ROM devices to.
+                              enum:
+                                - scsi
+                                - virtio
+                                - uml
+                                - xen
+                                - ide
+                                - usb
+                                - lxc
+                              type: string
+                            cpuCores:
+                              description: CPUCores is the preferred number of cores to expose to the guest
+                              type: integer
+                            cpuPolicy:
+                              description: |-
+                                CPUPolicy is used to pin the virtual CPUs (vCPUs) of instances to the
+                                host's physical CPU cores (pCPUs). Host aggregates should be used to
+                                separate these pinned instances from unpinned instances as the latter
+                                will not respect the resourcing requirements of the former.
+
+                                Permitted values are shared (the default), and dedicated.
+
+                                shared: The guest vCPUs will be allowed to freely float across host
+                                pCPUs, albeit potentially constrained by NUMA policy.
+
+                                dedicated: The guest vCPUs will be strictly pinned to a set of host
+                                pCPUs. In the absence of an explicit vCPU topology request, the
+                                drivers typically expose all vCPUs as sockets with one core and one
+                                thread. When strict CPU pinning is in effect the guest CPU topology
+                                will be setup to match the topology of the CPUs to which it is
+                                pinned. This option implies an overcommit ratio of 1.0. For example,
+                                if a two vCPU guest is pinned to a single host core with two threads,
+                                then the guest will get a topology of one socket, one core, two
+                                threads.
+                              enum:
+                                - shared
+                                - dedicated
+                              type: string
+                            cpuSockets:
+                              description: CPUSockets is the preferred number of sockets to expose to the guest
+                              type: integer
+                            cpuThreadPolicy:
+                              description: |-
+                                CPUThreadPolicy further refines a CPUPolicy of 'dedicated' by stating
+                                how hardware CPU threads in a simultaneous multithreading-based (SMT)
+                                architecture be used. SMT-based architectures include Intel
+                                processors with Hyper-Threading technology. In these architectures,
+                                processor cores share a number of components with one or more other
+                                cores. Cores in such architectures are commonly referred to as
+                                hardware threads, while the cores that a given core share components
+                                with are known as thread siblings.
+
+                                Permitted values are prefer (the default), isolate, and require.
+
+                                prefer: The host may or may not have an SMT architecture. Where an
+                                SMT architecture is present, thread siblings are preferred.
+
+                                isolate: The host must not have an SMT architecture or must emulate a
+                                non-SMT architecture. If the host does not have an SMT architecture,
+                                each vCPU is placed on a different core as expected. If the host does
+                                have an SMT architecture - that is, one or more cores have thread
+                                siblings - then each vCPU is placed on a different physical core. No
+                                vCPUs from other guests are placed on the same core. All but one
+                                thread sibling on each utilized core is therefore guaranteed to be
+                                unusable.
+
+                                require: The host must have an SMT architecture. Each vCPU is
+                                allocated on thread siblings. If the host does not have an SMT
+                                architecture, then it is not used. If the host has an SMT
+                                architecture, but not enough cores with free thread siblings are
+                                available, then scheduling fails.
+                              enum:
+                                - prefer
+                                - isolate
+                                - require
+                              type: string
+                            cpuThreads:
+                              description: CPUThreads is the preferred number of threads to expose to the guest
+                              type: integer
+                            diskBus:
+                              description: DiskBus specifies the type of disk controller to attach disk devices to.
+                              enum:
+                                - scsi
+                                - virtio
+                                - uml
+                                - xen
+                                - ide
+                                - usb
+                                - lxc
+                              type: string
+                            scsiModel:
+                              description: |-
+                                SCSIModel enables the use of VirtIO SCSI (virtio-scsi) to provide
+                                block device access for compute instances; by default, instances use
+                                VirtIO Block (virtio-blk). VirtIO SCSI is a para-virtualized SCSI
+                                controller device that provides improved scalability and performance,
+                                and supports advanced SCSI hardware.
+
+                                The only permitted value is virtio-scsi.
+                              enum:
+                                - virtio-scsi
+                              type: string
+                            vifModel:
+                              description: |-
+                                VIFModel specifies the model of virtual network interface device to use.
+
+                                Permitted values are e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio,
+                                and vmxnet3.
+                              enum:
+                                - e1000
+                                - e1000e
+                                - ne2k_pci
+                                - pcnet
+                                - rtl8139
+                                - virtio
+                                - vmxnet3
+                              type: string
+                          type: object
+                        minDiskGB:
+                          description: MinDisk is the minimum amount of disk space in GB that is required to boot the image
+                          minimum: 1
+                          type: integer
+                        minMemoryMB:
+                          description: MinMemoryMB is the minimum amount of RAM in MB that is required to boot the image.
+                          minimum: 1
+                          type: integer
+                      type: object
+                    protected:
+                      description: |-
+                        Protected specifies that the image is protected from deletion.
+                        If not specified, the default is false.
+                      type: boolean
+                    tags:
+                      description: Tags is a list of tags which will be applied to the image. A tag has a maximum length of 255 characters.
+                      items:
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    visibility:
+                      description: Visibility of the image
+                      enum:
+                        - public
+                        - private
+                        - shared
+                        - community
+                      type: string
+                      x-kubernetes-validations:
+                        - message: visibility is immutable
+                          rule: self == oldSelf
+                  type: object
+                  x-kubernetes-validations:
+                    - message: name is immutable
+                      rule: 'has(self.name) ? self.name == oldSelf.name : !has(oldSelf.name)'
+                    - message: name is immutable
+                      rule: 'has(self.protected) ? self.protected == oldSelf.protected : !has(oldSelf.protected)'
+                    - message: tags is immutable
+                      rule: 'has(self.tags) ? self.tags == oldSelf.tags : !has(oldSelf.tags)'
+                    - message: visibility is immutable
+                      rule: 'has(self.visibility) ? self.visibility == oldSelf.visibility : !has(oldSelf.visibility)'
+                    - message: properties is immutable
+                      rule: 'has(self.properties) ? self.properties == oldSelf.properties : !has(oldSelf.properties)'
+              required:
+                - cloudCredentialsRef
+              type: object
+              x-kubernetes-validations:
+                - message: resource must be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+                - message: import may not be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__) : true'
+                - message: resource may not be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource) : true'
+                - message: import must be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__) : true'
+                - message: managedOptions may only be provided when policy is managed
+                  rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed'' : true'
+                - message: resource content must be specified when not importing
+                  rule: '!has(self.__import__) ? has(self.resource.content) : true'
+            status:
+              description: ImageStatus defines the observed state of an ORC resource.
+              properties:
+                conditions:
+                  description: |-
+                    Conditions represents the observed status of the object.
+                    Known .status.conditions.type are: "Available", "Progressing"
+
+                    Available represents the availability of the OpenStack resource. If it is
+                    true then the resource is ready for use.
+
+                    Progressing indicates whether the controller is still attempting to
+                    reconcile the current state of the OpenStack resource to the desired
+                    state. Progressing will be False either because the desired state has
+                    been achieved, or because some terminal error prevents it from ever being
+                    achieved and the controller is no longer attempting to reconcile. If
+                    Progressing is True, an observer waiting on the resource should continue
+                    to wait.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                downloadAttempts:
+                  description: DownloadAttempts is the number of times the controller has attempted to download the image contents
+                  type: integer
+                id:
+                  description: ID is the unique identifier of the OpenStack resource.
+                  type: string
+                resource:
+                  description: Resource contains the observed state of the OpenStack resource.
+                  properties:
+                    hash:
+                      description: |-
+                        Hash is the hash of the image data published by Glance. Note that this is
+                        a hash of the data stored internally by Glance, which will have been
+                        decompressed and potentially format converted depending on server-side
+                        configuration which is not visible to clients. It is expected that this
+                        hash will usually differ from the download hash.
+                      properties:
+                        algorithm:
+                          description: Algorithm is the hash algorithm used to generate value.
+                          enum:
+                            - md5
+                            - sha1
+                            - sha256
+                            - sha512
+                          type: string
+                        value:
+                          description: Value is the hash of the image data using Algorithm. It must be hex encoded using lowercase letters.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[0-9a-f]+$
+                          type: string
+                      required:
+                        - algorithm
+                        - value
+                      type: object
+                    sizeB:
+                      description: SizeB is the size of the image data, in bytes
+                      format: int64
+                      type: integer
+                    status:
+                      description: Status is the image status as reported by Glance
+                      type: string
+                    virtualSizeB:
+                      description: VirtualSizeB is the size of the disk the image data represents, in bytes
+                      format: int64
+                      type: integer
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-controller-manager
+  namespace: orc-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-leader-election-role
+  namespace: orc-system
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-image-editor-role
+rules:
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - images
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - images/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-image-viewer-role
+rules:
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - images
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - images/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orc-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - images
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - images/status
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orc-metrics-auth-role
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orc-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-leader-election-rolebinding
+  namespace: orc-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: orc-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: orc-controller-manager
+    namespace: orc-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: orc-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: orc-controller-manager
+    namespace: orc-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orc-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: orc-metrics-auth-role
+subjects:
+  - kind: ServiceAccount
+    name: orc-controller-manager
+    namespace: orc-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+    control-plane: controller-manager
+  name: orc-controller-manager-metrics-service
+  namespace: orc-system
+spec:
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+    control-plane: controller-manager
+  name: orc-controller-manager
+  namespace: orc-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+        - args:
+            - --metrics-bind-address=:8443
+            - --leader-elect
+            - --health-probe-bind-address=:8081
+          command:
+            - /manager
+          image: quay.io/orc/openstack-resource-controller:v{{ .Values.orcVersion }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: orc-controller-manager
+      terminationGracePeriodSeconds: 10
+{{- end }}

--- a/templates/provider/cluster-api-provider-openstack/values.yaml
+++ b/templates/provider/cluster-api-provider-openstack/values.yaml
@@ -4,3 +4,5 @@ configSecret:
   namespace: ""
 
 config: {}
+
+orcVersion: "1.0.0"

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -20,6 +20,6 @@ spec:
     - name: cluster-api-provider-aws
       template: cluster-api-provider-aws-0-1-0
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-0-1-1
+      template: cluster-api-provider-openstack-0-1-2
     - name: projectsveltos
       template: projectsveltos-0-47-0

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-0-1-1
+  name: cluster-api-provider-openstack-0-1-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 0.1.1
+      version: 0.1.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Fixes https://github.com/k0rdent/kcm/issues/1090

-----

CAPO v0.12.0 misses openstack-resource-controller with all required objects and CRDs. Add orc v1.0.0 `install.yaml` as a template to capo chart.
