### PR TITLE
Add custom ratelimiter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMG ?= localhost/kcm/controller:latest
 IMG_REPO = $(shell echo $(IMG) | cut -d: -f1)
 IMG_TAG = $(shell echo $(IMG) | cut -d: -f2)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.29.0
+ENVTEST_K8S_VERSION = 1.32.0
 
 HOSTOS := $(shell go env GOHOSTOS)
 HOSTARCH := $(shell go env GOHOSTARCH)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -258,7 +258,6 @@ func main() {
 	}
 	if err = (&controller.AccessManagementReconciler{
 		Client:          mgr.GetClient(),
-		Config:          mgr.GetConfig(),
 		SystemNamespace: currentNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AccessManagement")

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/stretchr/testify v1.10.0
 	github.com/vmware-tanzu/velero v1.15.2
+	golang.org/x/time v0.9.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.17.1
 	k8s.io/api v0.32.1
@@ -175,7 +176,6 @@ require (
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/term v0.28.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
-	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.28.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241219192143-6b3ec007d9bb // indirect

--- a/internal/controller/accessmanagement_controller.go
+++ b/internal/controller/accessmanagement_controller.go
@@ -23,18 +23,18 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
 	"github.com/K0rdent/kcm/internal/utils"
+	"github.com/K0rdent/kcm/internal/utils/ratelimit"
 )
 
 // AccessManagementReconciler reconciles an AccessManagement object
 type AccessManagementReconciler struct {
 	client.Client
-	Config          *rest.Config
 	SystemNamespace string
 }
 
@@ -352,6 +352,9 @@ func (r *AccessManagementReconciler) updateStatus(ctx context.Context, accessMgm
 // SetupWithManager sets up the controller with the Manager.
 func (r *AccessManagementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.TypedOptions[ctrl.Request]{
+			RateLimiter: ratelimit.DefaultFastSlow(),
+		}).
 		For(&kcm.AccessManagement{}).
 		Complete(r)
 }

--- a/internal/controller/credential_controller.go
+++ b/internal/controller/credential_controller.go
@@ -26,9 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
 	"github.com/K0rdent/kcm/internal/utils"
+	"github.com/K0rdent/kcm/internal/utils/ratelimit"
 )
 
 // CredentialReconciler reconciles a Credential object
@@ -125,6 +127,9 @@ func (r *CredentialReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.syncPeriod = 15 * time.Minute
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.TypedOptions[ctrl.Request]{
+			RateLimiter: ratelimit.DefaultFastSlow(),
+		}).
 		For(&kcm.Credential{}).
 		Complete(r)
 }

--- a/internal/controller/management_backup_controller.go
+++ b/internal/controller/management_backup_controller.go
@@ -21,11 +21,13 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	kcmv1alpha1 "github.com/K0rdent/kcm/api/v1alpha1"
 	"github.com/K0rdent/kcm/internal/controller/backup"
+	"github.com/K0rdent/kcm/internal/utils/ratelimit"
 )
 
 // ManagementBackupReconciler reconciles a ManagementBackup object
@@ -77,6 +79,9 @@ func (r *ManagementBackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.internal = backup.NewReconciler(r.Client, r.SystemNamespace)
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.TypedOptions[ctrl.Request]{
+			RateLimiter: ratelimit.DefaultFastSlow(),
+		}).
 		Named("mgmtbackup_controller").
 		For(&kcmv1alpha1.ManagementBackup{}).
 		WatchesRawSource(source.Channel(runner.GetEventChannel(), &handler.EnqueueRequestForObject{})).

--- a/internal/controller/management_controller_test.go
+++ b/internal/controller/management_controller_test.go
@@ -79,7 +79,6 @@ var _ = Describe("Management Controller", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &ManagementReconciler{
 				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -278,7 +277,6 @@ var _ = Describe("Management Controller", func() {
 			By("Reconciling the Management object")
 			controllerReconciler := &ManagementReconciler{
 				Client:          k8sClient,
-				Scheme:          k8sClient.Scheme(),
 				DynamicClient:   dynamicClient,
 				SystemNamespace: utils.DefaultSystemNamespace,
 			}

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -30,6 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -38,6 +39,7 @@ import (
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
 	"github.com/K0rdent/kcm/internal/sveltos"
 	"github.com/K0rdent/kcm/internal/utils"
+	"github.com/K0rdent/kcm/internal/utils/ratelimit"
 )
 
 // MultiClusterServiceReconciler reconciles a MultiClusterService object
@@ -324,6 +326,9 @@ func (r *MultiClusterServiceReconciler) SetupWithManager(mgr ctrl.Manager) error
 	r.Client = mgr.GetClient()
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.TypedOptions[ctrl.Request]{
+			RateLimiter: ratelimit.DefaultFastSlow(),
+		}).
 		For(&kcm.MultiClusterService{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&sveltosv1beta1.ClusterSummary{},
 			handler.EnqueueRequestsFromMapFunc(requeueSveltosProfileForClusterSummary),

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -39,6 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -50,6 +51,7 @@ import (
 	"github.com/K0rdent/kcm/internal/helm"
 	"github.com/K0rdent/kcm/internal/providers"
 	"github.com/K0rdent/kcm/internal/utils"
+	"github.com/K0rdent/kcm/internal/utils/ratelimit"
 )
 
 // ReleaseReconciler reconciles a Template object
@@ -381,6 +383,9 @@ func (r *ReleaseReconciler) getCurrentReleaseName(ctx context.Context) (string, 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReleaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	c, err := ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.TypedOptions[ctrl.Request]{
+			RateLimiter: ratelimit.DefaultFastSlow(),
+		}).
 		For(&kcm.Release{}, builder.WithPredicates(predicate.Funcs{
 			DeleteFunc:  func(event.DeleteEvent) bool { return false },
 			GenericFunc: func(event.GenericEvent) bool { return false },

--- a/internal/controller/templatechain_controller.go
+++ b/internal/controller/templatechain_controller.go
@@ -23,10 +23,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
 	"github.com/K0rdent/kcm/internal/utils"
+	"github.com/K0rdent/kcm/internal/utils/ratelimit"
 )
 
 // TemplateChainReconciler reconciles a TemplateChain object
@@ -219,6 +221,9 @@ func (r *ClusterTemplateChainReconciler) SetupWithManager(mgr ctrl.Manager) erro
 	r.templateKind = kcm.ClusterTemplateKind
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.TypedOptions[ctrl.Request]{
+			RateLimiter: ratelimit.DefaultFastSlow(),
+		}).
 		For(&kcm.ClusterTemplateChain{}).
 		Complete(r)
 }
@@ -228,6 +233,9 @@ func (r *ServiceTemplateChainReconciler) SetupWithManager(mgr ctrl.Manager) erro
 	r.templateKind = kcm.ServiceTemplateKind
 
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.TypedOptions[ctrl.Request]{
+			RateLimiter: ratelimit.DefaultFastSlow(),
+		}).
 		For(&kcm.ServiceTemplateChain{}).
 		Complete(r)
 }

--- a/internal/utils/ratelimit/ratelimit.go
+++ b/internal/utils/ratelimit/ratelimit.go
@@ -1,0 +1,51 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ratelimit
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	DefaultFastDelay       = 5 * time.Second
+	DefaultSlowDelay       = 2 * time.Minute
+	DefaultMaxFastAttempts = 300
+)
+
+// DefaultFastSlow is an untyped no-arg constructor for a workqueue's rate limiter that uses [sigs.k8s.io/controller-runtime/pkg/reconcile.Request] as a type argument.
+// It has both overall and per-item rate limiting. The overall is a token bucket and the per-item is fast-slow.
+func DefaultFastSlow() workqueue.TypedRateLimiter[ctrl.Request] {
+	return TypedFastSlow[ctrl.Request](DefaultFastDelay, DefaultSlowDelay, DefaultMaxFastAttempts)
+}
+
+// FastSlow is an untyped constructor for a workqueue's rate limiter that uses [sigs.k8s.io/controller-runtime/pkg/reconcile.Request] as a type argument.
+// It has both overall and per-item rate limiting. The overall is a token bucket and the per-item is fast-slow.
+func FastSlow(fastDelay, slowDelay time.Duration, maxFastAttempts int) workqueue.TypedRateLimiter[ctrl.Request] {
+	return TypedFastSlow[ctrl.Request](fastDelay, slowDelay, maxFastAttempts)
+}
+
+// TypedFastSlow is a typed constructor for a workqueue's rate limiter. It has
+// both overall and per-item rate limiting. The overall is a token bucket and the per-item is fast-slow.
+func TypedFastSlow[T comparable](fastDelay, slowDelay time.Duration, maxFastAttempts int) workqueue.TypedRateLimiter[T] {
+	return workqueue.NewTypedMaxOfRateLimiter(
+		workqueue.NewTypedItemFastSlowRateLimiter[T](fastDelay, slowDelay, maxFastAttempts),
+		// 10 qps, 100 bucket size. This is only for retry speed and its only the overall factor (not per item)
+		&workqueue.TypedBucketRateLimiter[T]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+	)
+}


### PR DESCRIPTION
* custom per-item fast-slow ratelimiter for all of the controllers
* chores: requeue period as a dedicated field in corresponding controllers
* update envtest k8s version to 1.32.0

Closes #1081 