### PR TITLE
Do not trigger separate controller test on PRs with `test e2e` label

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -122,6 +122,7 @@ jobs:
   controller-e2etest:
     name: E2E Controller
     runs-on: ubuntu-latest
+    if: ${{ !contains( github.event.pull_request.labels.*.name, 'test e2e') }}
     needs: build
     concurrency:
       group: controller-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
When the `test e2e` label is set, the provider tests are triggered, which already validate the controller. A separate controller test is redundant.