### PR TITLE
Add Remote Server cluster template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,6 +392,10 @@ dev-openstack-creds: envsubst
 dev-docker-creds: envsubst
 	@NAMESPACE=$(NAMESPACE) $(ENVSUBST) -no-unset -i config/dev/docker-credentials.yaml | $(KUBECTL) apply -f -
 
+.PHONY: dev-remote-creds
+dev-remote-creds: envsubst
+	@NAMESPACE=$(NAMESPACE) $(ENVSUBST) -no-unset -i config/dev/remote-credentials.yaml | $(KUBECTL) apply -f -
+
 .PHONY: dev-apply
 dev-apply: kind-deploy registry-deploy dev-push dev-deploy dev-templates dev-release ## Apply the development environment by deploying the kind cluster, local registry and the KCM helm chart.
 

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ClusterDeployment
+metadata:
+  name: remote-${CLUSTER_NAME_SUFFIX}
+  namespace: ${NAMESPACE}
+spec:
+  template: remote-cluster-0-1-0
+  credential: remote-cred
+  propagateCredentials: false
+  config:
+    machines:
+      - address: ${MACHINE_0_ADDRESS}
+        user: root
+        port: 22
+      - address: ${MACHINE_1_ADDRESS}
+        user: root
+        port: 22

--- a/config/dev/remote-credentials.yaml
+++ b/config/dev/remote-credentials.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+data:
+  value: ${PRIVATE_SSH_KEY_B64}
+kind: Secret
+metadata:
+  name: remote-ssh-key
+  namespace: ${NAMESPACE}
+  labels:
+    k0rdent.mirantis.com/component: "kcm"
+type: Opaque
+---
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: Credential
+metadata:
+  name: remote-cred
+  namespace: ${NAMESPACE}
+spec:
+  description: Credentials for accessing remote machines
+  identityRef:
+    apiVersion: v1
+    kind: Secret
+    name: remote-ssh-key
+    namespace: ${NAMESPACE}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: remote-ssh-key-resource-template
+  namespace: ${NAMESPACE}
+  labels:
+    k0rdent.mirantis.com/component: "kcm"
+  annotations:
+    projectsveltos.io/template: "true"

--- a/templates/cluster/remote-cluster/.helmignore
+++ b/templates/cluster/remote-cluster/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: remote-cluster
+description: |
+  A KCM template to deploy and manage remote machine-based clusters on Linux hosts
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+annotations:
+  cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/infrastructure-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/templates/_helpers.tpl
+++ b/templates/cluster/remote-cluster/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "cluster.name" -}}
+    {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "k0smotroncontrolplane.name" -}}
+    {{- include "cluster.name" . }}-cp
+{{- end }}

--- a/templates/cluster/remote-cluster/templates/cluster.yaml
+++ b/templates/cluster/remote-cluster/templates/cluster.yaml
@@ -1,0 +1,20 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: {{ include "cluster.name" . }}
+  {{- if .Values.clusterLabels }}
+  labels: {{- toYaml .Values.clusterLabels | nindent 4}}
+  {{- end }}
+spec:
+  {{- with .Values.clusterNetwork }}
+  clusterNetwork:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: K0sControlPlane
+    name: {{ include "k0smotroncontrolplane.name" .  }}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: RemoteCluster
+    name: {{ include "cluster.name" . }}

--- a/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
@@ -1,0 +1,42 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: K0smotronControlPlane
+metadata:
+  name: {{ include "k0smotroncontrolplane.name" . }}
+spec:
+  replicas: {{ .Values.controlPlaneNumber }}
+  version: {{ .Values.k0s.version | replace "+" "-" }}
+  {{- with .Values.k0smotron.controllerPlaneFlags }}
+  controllerPlaneFlags:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.k0smotron.service }}
+  service:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  k0sConfig:
+    apiVersion: k0s.k0sproject.io/v1beta1
+    kind: ClusterConfig
+    metadata:
+      name: k0s
+    spec:
+      {{- with .Values.k0s.api.extraArgs }}
+      api:
+        extraArgs:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.k0s.network }}
+      network:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      extensions:
+        helm:
+          {{- with .Values.k0s.extensions.helm.repositories }}
+          repositories:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.k0s.extensions.helm.charts }}
+          charts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+  persistence:
+    type: emptyDir

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -1,0 +1,51 @@
+{{- range $index, $machine := .Values.machines }}
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Machine
+metadata:
+  name: {{ include "cluster.name" $ }}-{{ $index }}
+spec:
+  clusterName: {{ include "cluster.name" $ }}
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+      kind: K0sWorkerConfig
+      name: {{ include "cluster.name" $ }}-{{ $index }}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: RemoteMachine
+    name: {{ include "cluster.name" $ }}-{{ $index }}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: K0sWorkerConfig
+metadata:
+  name: {{ include "cluster.name" $ }}-{{ $index }}
+spec:
+  version: {{ $.Values.k0s.version }}
+  {{- if and $machine.k0s $machine.k0s.args }}
+  args:
+    {{- toYaml $machine.k0s.args | nindent 4 }}
+  {{- end }}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: RemoteMachine
+metadata:
+  name: {{ include "cluster.name" $ }}-{{ $index }}
+spec:
+  address: {{ $machine.address }}
+  {{- if $machine.port }}
+  port: {{ $machine.port }}
+  {{- end }}
+  {{- if $machine.user }}
+  user: {{ $machine.user }}
+  {{- end }}
+  {{- if $machine.useSudo }}
+  useSudo: {{ $machine.useSudo }}
+  {{- end }}
+  {{- with $machine.provisionJob }}
+  provisionJob:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  sshKeyRef:
+    name: {{ $.Values.clusterIdentity.name }}
+---
+{{- end }}

--- a/templates/cluster/remote-cluster/templates/remotecluster.yaml
+++ b/templates/cluster/remote-cluster/templates/remotecluster.yaml
@@ -1,0 +1,5 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: RemoteCluster
+metadata:
+  name: {{ include "cluster.name" . }}
+spec:

--- a/templates/cluster/remote-cluster/values.schema.json
+++ b/templates/cluster/remote-cluster/values.schema.json
@@ -1,0 +1,319 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "clusterIdentity": {
+            "description": "The SSH key secret reference, auto-populated",
+            "properties": {
+                "name": {
+                    "description": "The SSH key secret name, auto-populated",
+                    "type": [
+                        "string"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "clusterLabels": {
+            "additionalProperties": true,
+            "description": "Labels to apply to the cluster",
+            "properties": {},
+            "type": [
+                "object"
+            ]
+        },
+        "clusterNetwork": {
+            "description": "The cluster network configuration",
+            "properties": {
+                "pods": {
+                    "description": "The network ranges from which Pod networks are allocated",
+                    "properties": {
+                        "cidrBlocks": {
+                            "description": "A list of CIDR blocks",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "array"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object"
+                    ]
+                },
+                "services": {
+                    "description": "The network ranges from which service VIPs are allocated",
+                    "properties": {
+                        "cidrBlocks": {
+                            "description": "A list of CIDR blocks",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "array"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "controlPlaneNumber": {
+            "description": "The number of the control plane pods",
+            "minimum": 1,
+            "type": [
+                "number"
+            ]
+        },
+        "k0s": {
+            "description": "K0s parameters",
+            "properties": {
+                "api": {
+                    "description": "Kubernetes API server parameters",
+                    "properties": {
+                        "extraArgs": {
+                            "additionalProperties": true,
+                            "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+                            "patternProperties": {
+                                "^[a-z]$": {
+                                    "type": "string"
+                                }
+                            },
+                            "properties": {},
+                            "type": [
+                                "object"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object"
+                    ]
+                },
+                "extensions": {
+                    "description": "K0s extensions configuration",
+                    "properties": {
+                        "helm": {
+                            "description": "K0s helm repositories and charts configuration",
+                            "properties": {
+                                "charts": {
+                                    "description": "The list of helm charts to deploy during cluster bootstrap",
+                                    "items": {
+                                        "type": "object"
+                                    },
+                                    "type": [
+                                        "array"
+                                    ]
+                                },
+                                "repositories": {
+                                    "description": "The list of Helm repositories for deploying charts during cluster bootstrap",
+                                    "items": {
+                                        "type": "object"
+                                    },
+                                    "type": [
+                                        "array"
+                                    ]
+                                }
+                            },
+                            "type": [
+                                "object"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object"
+                    ]
+                },
+                "network": {
+                    "description": "K0s network configuration",
+                    "properties": {},
+                    "type": [
+                        "object"
+                    ]
+                },
+                "version": {
+                    "description": "K0s version",
+                    "type": [
+                        "string"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "k0smotron": {
+            "description": "K0smotron parameters",
+            "properties": {
+                "controllerPlaneFlags": {
+                    "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+                    "type": [
+                        "array"
+                    ]
+                },
+                "persistence": {
+                    "description": "The persistence configuration",
+                    "properties": {
+                        "type": {
+                            "description": "The persistence type",
+                            "type": [
+                                "string"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object"
+                    ]
+                },
+                "service": {
+                    "description": "The API service configuration",
+                    "properties": {
+                        "apiPort": {
+                            "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
+                            "maximum": 65535,
+                            "minimum": 1,
+                            "type": [
+                                "number"
+                            ]
+                        },
+                        "konnectivityPort": {
+                            "description": "The konnectivity port. If empty k0smotron will pick it automatically",
+                            "maximum": 65535,
+                            "minimum": 1,
+                            "type": [
+                                "number"
+                            ]
+                        },
+                        "type": {
+                            "description": "An ingress methods for a service",
+                            "enum": [
+                                "ClusterIP",
+                                "NodePort",
+                                "LoadBalancer"
+                            ],
+                            "type": [
+                                "string"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "machines": {
+            "description": "The list of remote machines configurations",
+            "items": {
+                "properties": {
+                    "address": {
+                        "description": "The IP address of the remote machine",
+                        "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$",
+                        "type": [
+                            "string"
+                        ]
+                    },
+                    "k0s": {
+                        "description": "k0s worker configuration options",
+                        "properties": {
+                            "args": {
+                                "description": "Extra arguments to be passed to k0s worker, see: https://docs.k0sproject.io/stable/worker-node-config/",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": [
+                                    "array"
+                                ]
+                            }
+                        },
+                        "type": [
+                            "object"
+                        ]
+                    },
+                    "port": {
+                        "default": 22,
+                        "description": "The SSH port of the remote machine",
+                        "maximum": 65535,
+                        "minimum": 1,
+                        "type": [
+                            "number"
+                        ]
+                    },
+                    "provisionJob": {
+                        "description": "The kubernetes Job to use to provision the machine",
+                        "properties": {
+                            "jobSpecTemplate": {
+                                "description": "The job template to use to provision the machine, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplate",
+                                "properties": {
+                                    "metadata": {
+                                        "description": "Standard object's metadata of the jobs created from this template, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatemetadata",
+                                        "properties": {},
+                                        "type": [
+                                            "object"
+                                        ]
+                                    },
+                                    "spec": {
+                                        "description": "Specification of the desired behavior of the job, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatespec",
+                                        "properties": {},
+                                        "type": [
+                                            "object"
+                                        ]
+                                    }
+                                },
+                                "type": [
+                                    "object"
+                                ]
+                            },
+                            "scpCommand": {
+                                "description": "The scp command",
+                                "type": [
+                                    "string"
+                                ]
+                            },
+                            "sshCommand": {
+                                "description": "The ssh command",
+                                "type": [
+                                    "string"
+                                ]
+                            }
+                        },
+                        "type": [
+                            "object"
+                        ]
+                    },
+                    "useSudo": {
+                        "default": false,
+                        "description": "Determines whether to use sudo for k0s cluster bootstrap commands",
+                        "type": [
+                            "boolean"
+                        ]
+                    },
+                    "user": {
+                        "description": "The user to use when connecting to the remote machine",
+                        "type": [
+                            "string"
+                        ]
+                    }
+                },
+                "required": [
+                    "address"
+                ],
+                "type": "object"
+            },
+            "minItems": 1,
+            "type": [
+                "array"
+            ]
+        }
+    },
+    "type": "object"
+}

--- a/templates/cluster/remote-cluster/values.yaml
+++ b/templates/cluster/remote-cluster/values.yaml
@@ -1,0 +1,52 @@
+# Cluster parameters
+controlPlaneNumber: 3 # @schema description: The number of the control plane pods; type: number; minimum: 1
+
+clusterLabels: {} # @schema description: Labels to apply to the cluster; type: object; additionalProperties: true
+
+clusterIdentity: # @schema description: The SSH key secret reference, auto-populated; type: object
+  name: "" # @schema description: The SSH key secret name, auto-populated; type: string
+
+clusterNetwork: # @schema description: The cluster network configuration; type: object
+  pods: # @schema description: The network ranges from which Pod networks are allocated; type: object
+    cidrBlocks: # @schema description: A list of CIDR blocks; type: array; item: string
+      - "10.244.0.0/16"
+  services: # @schema description: The network ranges from which service VIPs are allocated; type: object
+    cidrBlocks: # @schema description: A list of CIDR blocks; type: array; item: string
+      - "10.96.0.0/12"
+
+
+# Machines' parameters
+machines: # @schema description: The list of remote machines configurations; type: array; type.items: object; minItems: 1
+  - address: "0.0.0.0" # @schema description: The IP address of the remote machine; type: string; pattern:^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$; required: true
+    port: 22 # @schema description: The SSH port of the remote machine; type: number; minimum: 1; maximum: 65535; default: 22
+    user: "root" # @schema description: The user to use when connecting to the remote machine; type: string; default: root
+    useSudo: false # @schema description: Determines whether to use sudo for k0s cluster bootstrap commands; type: boolean; default: false
+    provisionJob: # @schema description: The kubernetes Job to use to provision the machine; type: object
+      scpCommand: scp # @schema description: The scp command; type: string; default: scp
+      sshCommand: ssh # @schema description: The ssh command; type: string; default: ssh
+      jobSpecTemplate: # @schema description: The job template to use to provision the machine, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplate; type: object
+        metadata: {} # @schema description: Standard object's metadata of the jobs created from this template, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatemetadata; type: object
+        spec: {} # @schema description: Specification of the desired behavior of the job, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatespec; type: object
+    k0s: # @schema description: k0s worker configuration options; type: object
+      args: [] # @schema description: Extra arguments to be passed to k0s worker, see: https://docs.k0sproject.io/stable/worker-node-config/; type: array; item: string
+
+# K0smotron parameters
+k0smotron: # @schema description: K0smotron parameters; type: object
+  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; items.type: string
+  persistence: # @schema description: The persistence configuration; type: object
+    type: EmptyDir # @schema description: The persistence type; type: string; default: EmptyDir
+  service: # @schema description: The API service configuration; type: object
+    type: ClusterIP # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: ClusterIP
+    apiPort: 30443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
+    konnectivityPort: 30132 # @schema description: The konnectivity port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
+
+# K0s parameters
+k0s: # @schema description: K0s parameters; type: object
+  version: v1.31.5+k0s.0 # @schema description: K0s version; type: string
+  api: # @schema description: Kubernetes API server parameters; type: object; additionalProperties: object
+    extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true; patternProperties: {"^[a-z]$": {"type": "string"}}
+  network: {} # @schema description: K0s network configuration; type: object
+  extensions: # @schema description: K0s extensions configuration; type: object
+    helm: # @schema description: K0s helm repositories and charts configuration; type: object
+      repositories: [] # @schema description: The list of Helm repositories for deploying charts during cluster bootstrap; type: array; item: object
+      charts: [] # @schema description: The list of helm charts to deploy during cluster bootstrap; type: array; item: object

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-0-1-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-0-1-0.yaml
@@ -1,0 +1,15 @@
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: remote-cluster-0-1-0
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  helm:
+    chartSpec:
+      chart: remote-cluster
+      version: 0.1.0
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: kcm-templates


### PR DESCRIPTION
This PR adds a new cluster template for provisioning remote servers, corresponding Makefile targets, and dev config examples.

Closes #1085
Closes #1112 