### PR TITLE
Adjust admission validation for the k0smotron infrastructure provider

### DIFF
--- a/internal/webhook/clusterdeployment_webhook.go
+++ b/internal/webhook/clusterdeployment_webhook.go
@@ -280,25 +280,23 @@ func isCredMatchTemplate(cred *kcmv1.Credential, template *kcmv1.ClusterTemplate
 	const secretKind = "Secret"
 
 	for _, provider := range template.Status.Providers {
-		if provider == providersloader.InfraPrefix+"internal" {
-			if idtyKind != secretKind {
-				return errMsg(provider)
-			}
-
+		if !strings.HasPrefix(provider, providersloader.InfraPrefix) {
 			continue
 		}
-
-		idtys, found := providersloader.GetClusterIdentityKinds(provider)
-		if !found {
-			if strings.HasPrefix(provider, providersloader.InfraPrefix) {
-				return fmt.Errorf("unsupported infrastructure provider %s", provider)
+		infraProviderName := strings.TrimPrefix(provider, providersloader.InfraPrefix)
+		if infraProviderName == "internal" || infraProviderName == "k0sproject-k0smotron" {
+			if idtyKind != secretKind {
+				return errMsg(infraProviderName)
 			}
+		}
 
-			continue
+		idtys, found := providersloader.GetClusterIdentityKinds(infraProviderName)
+		if !found {
+			return fmt.Errorf("unsupported infrastructure provider %s", infraProviderName)
 		}
 
 		if !slices.Contains(idtys, idtyKind) {
-			return errMsg(provider)
+			return errMsg(infraProviderName)
 		}
 	}
 

--- a/internal/webhook/clusterdeployment_webhook_test.go
+++ b/internal/webhook/clusterdeployment_webhook_test.go
@@ -390,7 +390,7 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
 				),
 			},
-			err: "the ClusterDeployment is invalid: wrong kind of the ClusterIdentity \"SomeOtherDummyClusterStaticIdentity\" for provider \"infrastructure-aws\"",
+			err: "the ClusterDeployment is invalid: wrong kind of the ClusterIdentity \"SomeOtherDummyClusterStaticIdentity\" for provider \"aws\"",
 		},
 	}
 	for _, tt := range tests {

--- a/templates/cluster/remote-cluster/templates/cluster.yaml
+++ b/templates/cluster/remote-cluster/templates/cluster.yaml
@@ -12,7 +12,7 @@ spec:
   {{- end }}
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-    kind: K0sControlPlane
+    kind: K0smotronControlPlane
     name: {{ include "k0smotroncontrolplane.name" .  }}
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
1. Adjust admission validation for the k0smotron infrastructure provider
2. Fix incorrect control plane ref in the `remote-server` template

Closes #1113