### PR TITLE
Improve cluster deployment status for nested infra (#1044)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist
 
 # Output of the go coverage tool
 *.out
+cover.html
 
 # Go workspace file
 go.work

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,6 +33,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -72,6 +73,7 @@ func init() {
 	utilruntime.Must(hcv2.AddToScheme(scheme))
 	utilruntime.Must(sveltosv1beta1.AddToScheme(scheme))
 	utilruntime.Must(libsveltosv1beta1.AddToScheme(scheme))
+	utilruntime.Must(capiv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -123,7 +124,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	return r.reconcileUpdate(ctx, clusterDeployment)
 }
 
-func (r *ClusterDeploymentReconciler) setStatusFromChildObjects(ctx context.Context, clusterDeployment *kcm.ClusterDeployment, gvr schema.GroupVersionResource, conditions []string) (requeue bool, _ error) {
+func (r *ClusterDeploymentReconciler) setStatusFromChildObjects(ctx context.Context, clusterDeployment *kcm.ClusterDeployment, gvr schema.GroupVersionResource, conditions, excludeConditions []string) (requeue bool, _ error) {
 	l := ctrl.LoggerFrom(ctx)
 
 	resourceConditions, err := status.GetResourceConditions(ctx, clusterDeployment.Namespace, r.DynamicClient, gvr,
@@ -139,7 +140,7 @@ func (r *ClusterDeploymentReconciler) setStatusFromChildObjects(ctx context.Cont
 
 	allConditionsComplete := true
 	for _, metaCondition := range resourceConditions.Conditions {
-		if slices.Contains(conditions, metaCondition.Type) {
+		if slices.Contains(conditions, metaCondition.Type) || !slices.Contains(excludeConditions, metaCondition.Type) {
 			if metaCondition.Status != metav1.ConditionTrue {
 				allConditionsComplete = false
 			}
@@ -369,7 +370,12 @@ func (r *ClusterDeploymentReconciler) updateCluster(ctx context.Context, mc *kcm
 		})
 	}
 
-	requeue, err := r.aggregateCapoConditions(ctx, mc)
+	cluster := &capiv1.Cluster{}
+	if err = r.Client.Get(ctx, client.ObjectKey{Name: mc.Name, Namespace: mc.Namespace}, cluster); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	requeue, err := r.aggregateCapoConditions(ctx, mc, cluster)
 	if err != nil {
 		if requeue {
 			return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, err
@@ -421,10 +427,11 @@ func (r *ClusterDeploymentReconciler) updateSveltosClusterCondition(ctx context.
 	return false, nil
 }
 
-func (r *ClusterDeploymentReconciler) aggregateCapoConditions(ctx context.Context, clusterDeployment *kcm.ClusterDeployment) (requeue bool, _ error) {
+func (r *ClusterDeploymentReconciler) aggregateCapoConditions(ctx context.Context, clusterDeployment *kcm.ClusterDeployment, cluster *capiv1.Cluster) (requeue bool, _ error) {
 	type objectToCheck struct {
-		gvr        schema.GroupVersionResource
-		conditions []string
+		gvr               schema.GroupVersionResource
+		conditions        []string
+		excludeConditions []string
 	}
 
 	var errs error
@@ -434,14 +441,15 @@ func (r *ClusterDeploymentReconciler) aggregateCapoConditions(ctx context.Contex
 	}
 	errs = errors.Join(errs, err)
 
-	for _, obj := range []objectToCheck{
+	objectToChecks := []objectToCheck{
 		{
 			gvr: schema.GroupVersionResource{
 				Group:    "cluster.x-k8s.io",
 				Version:  "v1beta1",
 				Resource: "clusters",
 			},
-			conditions: []string{"ControlPlaneInitialized", "ControlPlaneReady", "InfrastructureReady"},
+			conditions:        []string{"ControlPlaneInitialized", "ControlPlaneReady", "InfrastructureReady"},
+			excludeConditions: []string{},
 		},
 		{
 			gvr: schema.GroupVersionResource{
@@ -449,10 +457,36 @@ func (r *ClusterDeploymentReconciler) aggregateCapoConditions(ctx context.Contex
 				Version:  "v1beta1",
 				Resource: "machinedeployments",
 			},
-			conditions: []string{"Available"},
+			conditions:        []string{"Available"},
+			excludeConditions: []string{},
 		},
-	} {
-		needRequeue, err = r.setStatusFromChildObjects(ctx, clusterDeployment, obj.gvr, obj.conditions)
+	}
+
+	// Check nested cluster if infrastructure reference is exists on cluster
+	// If cluster phase is not Provisioning, nothing because status is none on Cluster
+	if cluster != nil && cluster.Status.Phase == "Provisioning" && cluster.Spec.InfrastructureRef != nil {
+		// Split cluster.spec.infrastructureRef.apiVersion of Cluster
+		apiVersionParts := strings.Split(cluster.Spec.InfrastructureRef.APIVersion, "/")
+		if len(apiVersionParts) == 2 {
+			// Convert from Kind to Resource
+			objKind := schema.GroupKind(metav1.GroupKind{Group: apiVersionParts[0], Kind: cluster.Spec.InfrastructureRef.Kind})
+			mapping, err := r.Client.RESTMapper().RESTMapping(objKind, apiVersionParts[1])
+			if err == nil {
+				objectToChecks = append(objectToChecks, objectToCheck{
+					gvr: schema.GroupVersionResource{
+						Group:    apiVersionParts[0],
+						Version:  apiVersionParts[1],
+						Resource: mapping.Resource.Resource,
+					},
+					conditions:        []string{},
+					excludeConditions: []string{"Ready"},
+				})
+			}
+		}
+	}
+
+	for _, obj := range objectToChecks {
+		needRequeue, err = r.setStatusFromChildObjects(ctx, clusterDeployment, obj.gvr, obj.conditions, obj.excludeConditions)
 		errs = errors.Join(errs, err)
 		if needRequeue {
 			requeue = true


### PR DESCRIPTION
* fixed #1044
* ref #1027

It was inconvenient that we couldn't see the status of AwsCluster (VPC threshold, Credential invalid, etc.). An issue has already been filed. So I have tried to add the cluster information of Cluster's InfraRef to ClusterDeployment's Conditions.
If you already have other designs or ideas, I want to try to rework that.

This is sample flow on my testing.

Add message example: `my-aws-clusterdeployment1: failed to create new managed VPC: failed to create vpc: AuthFailure: AWS was not able to validate the provided access credentials...`

```
$ kubectl -n kcm-system get clusterdeployments.k0rdent.mirantis.com -w
NAME                        READY   STATUS
my-aws-clusterdeployment1   False   my-aws-clusterdeployment1: Waiting for control plane provider to indicate the control plane has been initialized. my-aws-clusterdeployment1. my-aws-clusterdeployment1: 0 of 8 completed. my-aws-clusterdeployment1-md: Minimum availability requires 2 replicas, current 0 available. my-aws-clusterdeployment1: failed to create new managed VPC: failed to create vpc: AuthFailure: AWS was not able to validate the provided access credentials...
..
..
my-aws-clusterdeployment1   False   my-aws-clusterdeployment1: Waiting for control plane provider to indicate the control plane has been initialized. my-aws-clusterdeployment1. my-aws-clusterdeployment1-md: Minimum availability requires 2 replicas, current 0 available.
my-aws-clusterdeployment1   False   failed to reconcile Profile: Operation cannot be fulfilled on profiles.config.projectsveltos.io "my-aws-clusterdeployment1": the object has been modified; please apply your changes to the latest version and try again. my-aws-clusterdeployment1-md: Minimum availability requires 2 replicas, current 0 available.
my-aws-clusterdeployment1   False   my-aws-clusterdeployment1-md: Minimum availability requires 2 replicas, current 0 available.
my-aws-clusterdeployment1   True    ClusterDeployment is ready
```