### PR TITLE
Adjust `cld` and `mcs` statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [Install KCM for development purposes](docs/dev.md#kcm-installation-for-deve
 
 ### Software Prerequisites
 
-Mirantis kcm requires the following:
+KCM requires the following:
 
 1. Existing management cluster (minimum required kubernetes version 1.28.0).
 2. `kubectl` CLI installed locally.

--- a/api/v1alpha1/clusterdeployment_types.go
+++ b/api/v1alpha1/clusterdeployment_types.go
@@ -95,9 +95,12 @@ type ClusterDeploymentStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=clusterd;cld
-// +kubebuilder:printcolumn:name="ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description="Ready",priority=0
-// +kubebuilder:printcolumn:name="status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",description="Status",priority=0
-// +kubebuilder:printcolumn:name="dryRun",type="string",JSONPath=".spec.dryRun",description="Dry Run",priority=1
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Shows readiness of the ClusterDeployment",priority=0
+// +kubebuilder:printcolumn:name="Services",type="string",JSONPath=`.status.conditions[?(@.type=="ServicesInReadyState")].message`,description="Number of ready out of total services",priority=0
+// +kubebuilder:printcolumn:name="Template",type="string",JSONPath=`.spec.template`,description="ClusterTemplate used for the ClusterDeployment",priority=0
+// +kubebuilder:printcolumn:name="Messages",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].message`,description="Shows either readiness or error messages from child objects",priority=0
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time elapsed since object creation",priority=0
+// +kubebuilder:printcolumn:name="DryRun",type="string",JSONPath=`.spec.dryRun`,description="Dry Run",priority=1
 
 // ClusterDeployment is the Schema for the ClusterDeployments API
 type ClusterDeployment struct {

--- a/api/v1alpha1/multiclusterservice_types.go
+++ b/api/v1alpha1/multiclusterservice_types.go
@@ -37,6 +37,16 @@ const (
 	// FetchServicesStatusSuccessCondition indicates if status
 	// for the deployed services have been fetched successfully.
 	FetchServicesStatusSuccessCondition = "FetchServicesStatusSuccess"
+
+	// ServicesInReadyStateCondition shows the number of multiclusterservices or clusterdeployments
+	// services that are ready. A service is marked as ready if all its conditions are ready.
+	// The format is "<ready-num>/<total-num>", e.g. "2/3" where 2 services of total 3 are ready.
+	ServicesInReadyStateCondition = "ServicesInReadyState"
+
+	// ClusterInReadyStateCondition shows the number of clusters that are ready.
+	// A Cluster is ready if corresponding ClusterDeployment is ready.
+	// The format is "<ready-num>/<total-num>", e.g. "2/3" where 2 clusters of total 3 are ready.
+	ClusterInReadyStateCondition = "ClusterInReadyState"
 )
 
 // Service represents a Service to be deployed.
@@ -140,7 +150,10 @@ type MultiClusterServiceStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=mcs
+// +kubebuilder:printcolumn:name="Services",type="string",JSONPath=`.status.conditions[?(@.type=="ServicesInReadyState")].message`,description="Number of ready out of total services",priority=0
+// +kubebuilder:printcolumn:name="Clusters",type="string",JSONPath=`.status.conditions[?(@.type=="ClusterInReadyState")].message`,description="Number of ready out of total selected clusters",priority=0
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time elapsed since object creation",priority=0
 
 // MultiClusterService is the Schema for the multiclusterservices API
 type MultiClusterService struct {

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -615,8 +615,10 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, mc *kc
 
 // updateStatus updates the status for the ClusterDeployment object.
 func (r *ClusterDeploymentReconciler) updateStatus(ctx context.Context, clusterDeployment *kcm.ClusterDeployment, template *kcm.ClusterTemplate) error {
+	apimeta.SetStatusCondition(clusterDeployment.GetConditions(), getServicesReadinessCondition(clusterDeployment.Status.Services, len(clusterDeployment.Spec.ServiceSpec.Services)))
+
 	clusterDeployment.Status.ObservedGeneration = clusterDeployment.Generation
-	clusterDeployment.Status.Conditions = updateStatusConditions(clusterDeployment.Status.Conditions, "ClusterDeployment is ready")
+	clusterDeployment.Status.Conditions = updateStatusConditions(clusterDeployment.Status.Conditions)
 
 	if err := r.setAvailableUpgrades(ctx, clusterDeployment, template); err != nil {
 		return errors.New("failed to set available upgrades")

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
@@ -18,17 +18,29 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Ready
+    - description: Shows readiness of the ClusterDeployment
       jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: ready
+      name: Ready
       type: string
-    - description: Status
+    - description: Number of ready out of total services
+      jsonPath: .status.conditions[?(@.type=="ServicesInReadyState")].message
+      name: Services
+      type: string
+    - description: ClusterTemplate used for the ClusterDeployment
+      jsonPath: .spec.template
+      name: Template
+      type: string
+    - description: Shows either readiness or error messages from child objects
       jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: status
+      name: Messages
       type: string
+    - description: Time elapsed since object creation
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: Dry Run
       jsonPath: .spec.dryRun
-      name: dryRun
+      name: DryRun
       priority: 1
       type: string
     name: v1alpha1

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -11,10 +11,25 @@ spec:
     kind: MultiClusterService
     listKind: MultiClusterServiceList
     plural: multiclusterservices
+    shortNames:
+    - mcs
     singular: multiclusterservice
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Number of ready out of total services
+      jsonPath: .status.conditions[?(@.type=="ServicesInReadyState")].message
+      name: Services
+      type: string
+    - description: Number of ready out of total selected clusters
+      jsonPath: .status.conditions[?(@.type=="ClusterInReadyState")].message
+      name: Clusters
+      type: string
+    - description: Time elapsed since object creation
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: MultiClusterService is the Schema for the multiclusterservices


### PR DESCRIPTION
* add number of ready services condition to `cld`/`mcs` statuses
* add number of ready clusters condition to `mcs` status
* print the new conditions in custom columns
* adjust `cld` print columns
* calculate `cld`/`mcs` readiness based on services readiness
* calculate `mcs` readiness based on selected clusters readiness
* add short name to `mcs` resource

Closes #1028 
Closes #1027
Closes #813 