### PR TITLE
Implement IPAM provider and include it in vsphere cluster templates.

### DIFF
--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -28,7 +28,8 @@ spec:
       cpus: 4
       memory: 4096
       vmTemplate: ${VSPHERE_VM_TEMPLATE}
-      network: ${VSPHERE_NETWORK}
+      network:
+        name: ${VSPHERE_NETWORK}
     worker:
       ssh:
         user: ubuntu
@@ -37,4 +38,5 @@ spec:
       cpus: 4
       memory: 4096
       vmTemplate: ${VSPHERE_VM_TEMPLATE}
-      network: ${VSPHERE_NETWORK}
+      network:
+       name: ${VSPHERE_NETWORK}

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -394,6 +394,7 @@ func (r *ManagementReconciler) checkProviderStatus(ctx context.Context, componen
 		"infrastructureproviders",
 		"controlplaneproviders",
 		"bootstrapproviders",
+		"ipamproviders",
 	} {
 		gvr := schema.GroupVersionResource{
 			Group:    "operator.cluster.x-k8s.io",

--- a/providers/ipam.yml
+++ b/providers/ipam.yml
@@ -1,0 +1,15 @@
+# Copyright 2024
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: ipam

--- a/templates/cluster/vsphere-hosted-cp/templates/ipam.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/ipam.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.network.ipam }}
-apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
 kind: InClusterIPPool
 metadata:
   name: ip-pool

--- a/templates/cluster/vsphere-hosted-cp/templates/ipam.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/ipam.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.network.ipam }}
+apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+kind: InClusterIPPool
+metadata:
+  name: ip-pool
+spec:
+  {{- .Values.network.ipam | toYaml | nindent 4 }}
+  {{- end }}

--- a/templates/cluster/vsphere-hosted-cp/templates/vspheremachinetemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/vspheremachinetemplate.yaml
@@ -1,3 +1,4 @@
+{{- $ipamEnabled := .Values.network.ipam }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
@@ -13,8 +14,17 @@ spec:
       memoryMiB: {{ .Values.memory }}
       network:
         devices:
-        - dhcp4: true
-          networkName: {{ .Values.network }}
+          - dhcp4: {{ not $ipamEnabled }}
+            networkName: {{ .Values.network.name }}
+          {{- if .Values.network.nameservers }}
+            nameservers: {{ .Values.network.nameservers | toYaml | nindent 14 }}
+          {{- end }}
+          {{- if $ipamEnabled }}
+            addressesFromPools:
+              - apiGroup: ipam.cluster.x-k8s.io
+                kind: InClusterIPPool
+                name: ip-pool
+            {{- end }}
       numCPUs: {{ .Values.cpus }}
       os: Linux
       powerOffMode: hard

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -140,7 +140,7 @@
       "type": "string"
     },
     "network": {
-      "type": "string"
+      "type": "object"
     },
     "k0s": {
       "description": "K0s parameters",

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -140,7 +140,35 @@
       "type": "string"
     },
     "network": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "ipam": {
+          "type": "object",
+          "properties": {
+            "addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "subnet": {
+              "type": "string"
+            },
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "prefix": {
+              "type": "string"
+            },
+            "gateway": {
+              "type": "string"
+            }
+          }
+        }
+      }
     },
     "k0s": {
       "description": "K0s parameters",

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -32,7 +32,8 @@ rootVolumeSize: 30
 cpus: 2
 memory: 4096
 vmTemplate: ""
-network: ""
+network:
+  name: ""
 
 # K0smotron parameters
 k0smotron:

--- a/templates/cluster/vsphere-standalone-cp/templates/controlplaneipam.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/controlplaneipam.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.controlPlane.network.ipam }}
-apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
 kind: InClusterIPPool
 metadata:
   name: control-plane-ip-pool

--- a/templates/cluster/vsphere-standalone-cp/templates/controlplaneipam.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/controlplaneipam.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.controlPlane.network.ipam }}
+apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+kind: InClusterIPPool
+metadata:
+  name: control-plane-ip-pool
+spec:
+  {{- .Values.controlPlane.network.ipam | toYaml | nindent 4 }}
+  {{- end }}

--- a/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-controlplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-controlplane.yaml
@@ -1,3 +1,4 @@
+{{- $ipamEnabled := .Values.controlPlane.network.ipam }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
@@ -13,8 +14,17 @@ spec:
       memoryMiB: {{ .Values.controlPlane.memory }}
       network:
         devices:
-        - dhcp4: true
-          networkName: {{ .Values.controlPlane.network }}
+        - dhcp4: {{ not $ipamEnabled }}
+          networkName: {{ .Values.controlPlane.network.name }}
+          {{- if .Values.controlPlane.network.nameservers }}
+          nameservers: {{ .Values.controlPlane.network.nameservers | toYaml | nindent 10 }}
+          {{- end }}
+          {{- if $ipamEnabled }}
+          addressesFromPools:
+            - apiGroup: ipam.cluster.x-k8s.io
+              kind: InClusterIPPool
+              name: control-plane-ip-pool
+            {{- end }}
       numCPUs: {{ .Values.controlPlane.cpus }}
       os: Linux
       powerOffMode: hard

--- a/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-worker.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-worker.yaml
@@ -1,3 +1,4 @@
+{{- $ipamEnabled := .Values.worker.network.ipam }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
@@ -13,8 +14,17 @@ spec:
       memoryMiB: {{ .Values.worker.memory }}
       network:
         devices:
-        - dhcp4: true
-          networkName: {{ .Values.worker.network }}
+          - dhcp4: {{ not $ipamEnabled }}
+            networkName: {{ .Values.worker.network.name }}
+          {{- if .Values.worker.network.nameservers }}
+            nameservers: {{ .Values.worker.network.nameservers | toYaml | nindent 14 }}
+          {{- end }}
+          {{- if $ipamEnabled }}
+            addressesFromPools:
+              - apiGroup: ipam.cluster.x-k8s.io
+                kind: InClusterIPPool
+                name: worker-ip-pool
+            {{- end }}
       numCPUs: {{ .Values.worker.cpus }}
       os: Linux
       powerOffMode: hard

--- a/templates/cluster/vsphere-standalone-cp/templates/workeripam.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/workeripam.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.worker.network.ipam }}
-apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
 kind: InClusterIPPool
 metadata:
   name: worker-ip-pool

--- a/templates/cluster/vsphere-standalone-cp/templates/workeripam.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/workeripam.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.worker.network.ipam }}
+apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+kind: InClusterIPPool
+metadata:
+  name: worker-ip-pool
+spec:
+  {{- .Values.worker.network.ipam | toYaml | nindent 4 }}
+  {{- end }}

--- a/templates/cluster/vsphere-standalone-cp/values.schema.json
+++ b/templates/cluster/vsphere-standalone-cp/values.schema.json
@@ -146,7 +146,7 @@
           "type": "string"
         },
         "network": {
-          "type": "string"
+          "type": "object"
         }
       }
     },
@@ -190,7 +190,7 @@
           "type": "string"
         },
         "network": {
-          "type": "string"
+          "type": "object"
         }
       }
     },

--- a/templates/cluster/vsphere-standalone-cp/values.schema.json
+++ b/templates/cluster/vsphere-standalone-cp/values.schema.json
@@ -146,7 +146,35 @@
           "type": "string"
         },
         "network": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "ipam": {
+              "type": "object",
+              "properties": {
+                "addresses": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "subnet": {
+                  "type": "string"
+                },
+                "first": {
+                  "type": "string"
+                },
+                "last": {
+                  "type": "string"
+                },
+                "prefix": {
+                  "type": "string"
+                },
+                "gateway": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -190,7 +218,35 @@
           "type": "string"
         },
         "network": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "ipam" : {
+              "type": "object",
+              "properties" : {
+                "addresses": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "subnet": {
+                  "type": "string"
+                },
+                "first": {
+                  "type": "string"
+                },
+                "last": {
+                  "type": "string"
+                },
+                "prefix": {
+                  "type": "string"
+                },
+                "gateway": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/templates/cluster/vsphere-standalone-cp/values.yaml
+++ b/templates/cluster/vsphere-standalone-cp/values.yaml
@@ -33,7 +33,8 @@ controlPlane:
   cpus: 2
   memory: 4096
   vmTemplate: ""
-  network: ""
+  network:
+    name: ""
 
 worker:
   ssh:
@@ -43,7 +44,8 @@ worker:
   cpus: 2
   memory: 4096
   vmTemplate: ""
-  network: ""
+  network:
+    name: ""
 
 # K0s parameters
 k0s:

--- a/templates/provider/cluster-api-provider-ipam/Chart.yaml
+++ b/templates/provider/cluster-api-provider-ipam/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: cluster-api-provider-ipam
+description: A Helm chart for Cluster API provider IPAM
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v1.0.0"
+annotations:
+  cluster.x-k8s.io/provider: cluster-api-provider-ipam
+  cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/cluster-api-provider-ipam/Chart.yaml
+++ b/templates/provider/cluster-api-provider-ipam/Chart.yaml
@@ -20,5 +20,5 @@ version: 0.1.0
 # It is recommended to use it with quotes.
 appVersion: "v1.0.0"
 annotations:
-  cluster.x-k8s.io/provider: cluster-api-provider-ipam
+  cluster.x-k8s.io/provider: in-cluster
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/cluster-api-provider-ipam/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-ipam/templates/provider.yaml
@@ -1,8 +1,6 @@
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: IPAMProvider
 metadata:
-  name: ipam
+  name: in-cluster
 spec:
   version: v1.0.0
-  fetchConfig:
-    url: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/download/v1.0.0/ipam-components.yaml

--- a/templates/provider/cluster-api-provider-ipam/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-ipam/templates/provider.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: IPAMProvider
+metadata:
+  name: ipam
+spec:
+  version: v1.0.0
+  fetchConfig:
+    url: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/download/v1.0.0/ipam-components.yaml

--- a/templates/provider/cluster-api-provider-ipam/values.schema.json
+++ b/templates/provider/cluster-api-provider-ipam/values.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "properties": {
+    "configSecret": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/templates/provider/cluster-api-provider-ipam/values.yaml
+++ b/templates/provider/cluster-api-provider-ipam/values.yaml
@@ -1,0 +1,6 @@
+configSecret:
+  create: true
+  name: "capi-ipam-in-cluster-webhook-service-cert"
+  namespace: ""
+
+config: {}

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -23,5 +23,8 @@ spec:
       template: cluster-api-provider-openstack-0-1-2
     - name: cluster-api-provider-docker
       template: cluster-api-provider-docker-0-1-0
+    - name: cluster-api-provider-ipam
+      template: cluster-api-provider-ipam-0-1-0
     - name: projectsveltos
       template: projectsveltos-0-47-0
+

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-ipam.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-ipam.yaml
@@ -1,0 +1,15 @@
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ProviderTemplate
+metadata:
+  name: cluster-api-provider-ipam-0-1-0
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  helm:
+    chartSpec:
+      chart: cluster-api-provider-ipam
+      version: 0.1.0
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: kcm-templates

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -6,12 +6,18 @@ metadata:
   {{- include "kcm.labels" . | nindent 4 }}
 rules:
 - apiGroups:
+    - ipam.cluster.x-k8s.io/v1alpha1
+  resources:
+    - inclusterippools
+  verbs: {{ include "rbac.editorVerbs" . | nindent 4 }}
+- apiGroups:
   - operator.cluster.x-k8s.io
   resources:
   - coreproviders
   - infrastructureproviders
   - bootstrapproviders
   - controlplaneproviders
+  - ipamproviders
   verbs:
   - get
   - list

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kcm.labels" . | nindent 4 }}
 rules:
 - apiGroups:
-    - ipam.cluster.x-k8s.io/v1alpha1
+    - ipam.cluster.x-k8s.io/v1alpha2
   resources:
     - inclusterippools
   verbs: {{ include "rbac.editorVerbs" . | nindent 4 }}


### PR DESCRIPTION
This change resolves issue https://github.com/k0rdent/2a-internal/issues/7 by creating a new provider template for the CNCF cluster API IPAM provider (https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster) and incorporating it into the vsphere standalone and hosted cluster templates.