### PR TITLE
Fix- When removing all services from a cluster deployment the services remain deployed

### DIFF
--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -560,37 +560,36 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, mc *kc
 		return ctrl.Result{}, err
 	}
 
-	if len(mc.Spec.ServiceSpec.Services) > 0 {
-		if _, err = sveltos.ReconcileProfile(ctx, r.Client, mc.Namespace, mc.Name,
-			sveltos.ReconcileProfileOpts{
-				OwnerReference: &metav1.OwnerReference{
-					APIVersion: kcm.GroupVersion.String(),
-					Kind:       kcm.ClusterDeploymentKind,
-					Name:       mc.Name,
-					UID:        mc.UID,
+	if _, err = sveltos.ReconcileProfile(ctx, r.Client, mc.Namespace, mc.Name,
+		sveltos.ReconcileProfileOpts{
+			OwnerReference: &metav1.OwnerReference{
+				APIVersion: kcm.GroupVersion.String(),
+				Kind:       kcm.ClusterDeploymentKind,
+				Name:       mc.Name,
+				UID:        mc.UID,
+			},
+			LabelSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					kcm.FluxHelmChartNamespaceKey: mc.Namespace,
+					kcm.FluxHelmChartNameKey:      mc.Name,
 				},
-				LabelSelector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						kcm.FluxHelmChartNamespaceKey: mc.Namespace,
-						kcm.FluxHelmChartNameKey:      mc.Name,
-					},
-				},
-				HelmChartOpts:  opts,
-				Priority:       mc.Spec.ServiceSpec.Priority,
-				StopOnConflict: mc.Spec.ServiceSpec.StopOnConflict,
-				Reload:         mc.Spec.ServiceSpec.Reload,
-				TemplateResourceRefs: append(
-					getProjectTemplateResourceRefs(mc, cred), mc.Spec.ServiceSpec.TemplateResourceRefs...,
-				),
-				PolicyRefs:      getProjectPolicyRefs(mc, cred),
-				SyncMode:        mc.Spec.ServiceSpec.SyncMode,
-				DriftIgnore:     mc.Spec.ServiceSpec.DriftIgnore,
-				DriftExclusions: mc.Spec.ServiceSpec.DriftExclusions,
-				ContinueOnError: mc.Spec.ServiceSpec.ContinueOnError,
-			}); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile Profile: %w", err)
-		}
+			},
+			HelmChartOpts:  opts,
+			Priority:       mc.Spec.ServiceSpec.Priority,
+			StopOnConflict: mc.Spec.ServiceSpec.StopOnConflict,
+			Reload:         mc.Spec.ServiceSpec.Reload,
+			TemplateResourceRefs: append(
+				getProjectTemplateResourceRefs(mc, cred), mc.Spec.ServiceSpec.TemplateResourceRefs...,
+			),
+			PolicyRefs:      getProjectPolicyRefs(mc, cred),
+			SyncMode:        mc.Spec.ServiceSpec.SyncMode,
+			DriftIgnore:     mc.Spec.ServiceSpec.DriftIgnore,
+			DriftExclusions: mc.Spec.ServiceSpec.DriftExclusions,
+			ContinueOnError: mc.Spec.ServiceSpec.ContinueOnError,
+		}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile Profile: %w", err)
 	}
+
 	// NOTE:
 	// We are returning nil in the return statements whenever servicesErr != nil
 	// because we don't want the error content in servicesErr to be assigned to err.
@@ -604,9 +603,6 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, mc *kc
 	}
 
 	if len(mc.Spec.ServiceSpec.Services) == 0 {
-		if err = r.Client.Delete(ctx, &profile); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to delete Profile %s: %w", profileRef.String(), err)
-		}
 		mc.Status.Services = nil
 	} else {
 		var servicesStatus []kcm.ServiceStatus

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -602,6 +602,12 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, mc *kc
 		return ctrl.Result{}, nil
 	}
 
+	if len(mc.Spec.ServiceSpec.Services) == 0 {
+		if err = r.Client.Delete(ctx, &profile); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to delete Profile %s: %w", profileRef.String(), err)
+		}
+	}
+
 	var servicesStatus []kcm.ServiceStatus
 	servicesStatus, servicesErr = updateServicesStatus(ctx, r.Client, profileRef, profile.Status.MatchingClusterRefs, mc.Status.Services)
 	if servicesErr != nil {

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -175,7 +175,6 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	if len(mcs.Spec.ServiceSpec.Services) == 0 {
 		mcs.Status.Services = nil
 	} else {
-
 		var servicesStatus []kcm.ServiceStatus
 		servicesStatus, servicesErr = updateServicesStatus(ctx, r.Client, profileRef, profile.Status.MatchingClusterRefs, mcs.Status.Services)
 		if servicesErr != nil {

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -138,29 +138,28 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 		return ctrl.Result{}, err
 	}
 
-	if len(mcs.Spec.ServiceSpec.Services) > 0 {
-		if _, err = sveltos.ReconcileClusterProfile(ctx, r.Client, mcs.Name,
-			sveltos.ReconcileProfileOpts{
-				OwnerReference: &metav1.OwnerReference{
-					APIVersion: kcm.GroupVersion.String(),
-					Kind:       kcm.MultiClusterServiceKind,
-					Name:       mcs.Name,
-					UID:        mcs.UID,
-				},
-				LabelSelector:        mcs.Spec.ClusterSelector,
-				HelmChartOpts:        opts,
-				Priority:             mcs.Spec.ServiceSpec.Priority,
-				StopOnConflict:       mcs.Spec.ServiceSpec.StopOnConflict,
-				Reload:               mcs.Spec.ServiceSpec.Reload,
-				TemplateResourceRefs: mcs.Spec.ServiceSpec.TemplateResourceRefs,
-				SyncMode:             mcs.Spec.ServiceSpec.SyncMode,
-				DriftIgnore:          mcs.Spec.ServiceSpec.DriftIgnore,
-				DriftExclusions:      mcs.Spec.ServiceSpec.DriftExclusions,
-				ContinueOnError:      mcs.Spec.ServiceSpec.ContinueOnError,
-			}); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile ClusterProfile: %w", err)
-		}
+	if _, err = sveltos.ReconcileClusterProfile(ctx, r.Client, mcs.Name,
+		sveltos.ReconcileProfileOpts{
+			OwnerReference: &metav1.OwnerReference{
+				APIVersion: kcm.GroupVersion.String(),
+				Kind:       kcm.MultiClusterServiceKind,
+				Name:       mcs.Name,
+				UID:        mcs.UID,
+			},
+			LabelSelector:        mcs.Spec.ClusterSelector,
+			HelmChartOpts:        opts,
+			Priority:             mcs.Spec.ServiceSpec.Priority,
+			StopOnConflict:       mcs.Spec.ServiceSpec.StopOnConflict,
+			Reload:               mcs.Spec.ServiceSpec.Reload,
+			TemplateResourceRefs: mcs.Spec.ServiceSpec.TemplateResourceRefs,
+			SyncMode:             mcs.Spec.ServiceSpec.SyncMode,
+			DriftIgnore:          mcs.Spec.ServiceSpec.DriftIgnore,
+			DriftExclusions:      mcs.Spec.ServiceSpec.DriftExclusions,
+			ContinueOnError:      mcs.Spec.ServiceSpec.ContinueOnError,
+		}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile ClusterProfile: %w", err)
 	}
+
 	// NOTE:
 	// We are returning nil in the return statements whenever servicesErr != nil
 	// because we don't want the error content in servicesErr to be assigned to err.
@@ -174,9 +173,6 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 
 	if len(mcs.Spec.ServiceSpec.Services) == 0 {
-		if err = r.Client.Delete(ctx, &profile); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to delete Profile %s: %w", profileRef.String(), err)
-		}
 		mcs.Status.Services = nil
 	} else {
 


### PR DESCRIPTION
This simple fix resolves an issue where the services aren't removed by sveltos when the services list is empty / missing in the cluster deployment after previously being deployed. The fix is to remove the sveltos profile which triggers the adon controller to un-deploy all the helm charts associated with the profile. 

Testing performed:

1. Create cluster deployment with nginx/kyverno installed
2. Remove nginx and apply the cluster deployment yaml
3. nginx is uninstalled as expected
4. Remove kyverno and apply the yaml file again and now kyverno is uninstalled. Previous to this fix kyverno would have remained.

Closes #1132 