### PR TITLE
Always collect the support dump after e2e

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -149,6 +149,7 @@ jobs:
           make test-e2e
       - name: Archive test results
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: support-bundles
           path: |
@@ -205,6 +206,7 @@ jobs:
           make test-e2e
       - name: Archive test results
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: support-bundles
           path: |
@@ -265,6 +267,7 @@ jobs:
           make test-e2e
       - name: Archive test results
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: support-bundles
           path: |


### PR DESCRIPTION
The previous fix does not work since if any step fails, GitHub Actions will stop executing further steps by default.