### PR TITLE
Add GCP hosted cluster template

### DIFF
--- a/templates/cluster/gcp-hosted-cp/.helmignore
+++ b/templates/cluster/gcp-hosted-cp/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: gcp-hosted-cp
+description: |
+  A KCM template to deploy a k8s cluster on GCP with control plane components
+  within the management cluster.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v1.31.5+k0s.0"
+annotations:
+  cluster.x-k8s.io/provider: infrastructure-gcp, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-hosted-cp/templates/_helpers.tpl
+++ b/templates/cluster/gcp-hosted-cp/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{- define "cluster.name" -}}
+    {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "gcpmachinetemplate.worker.name" -}}
+    {{- include "cluster.name" . }}-worker-mt
+{{- end }}
+
+{{- define "k0smotroncontrolplane.name" -}}
+    {{- include "cluster.name" . }}-cp
+{{- end }}
+
+{{- define "k0sworkerconfigtemplate.name" -}}
+    {{- include "cluster.name" . }}-machine-config
+{{- end }}
+
+{{- define "machinedeployment.name" -}}
+    {{- include "cluster.name" . }}-md
+{{- end }}

--- a/templates/cluster/gcp-hosted-cp/templates/cluster.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/cluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: {{ include "cluster.name" . }}
+  {{- if .Values.clusterLabels }}
+  labels: {{- toYaml .Values.clusterLabels | nindent 4 }}
+  {{- end }}
+  {{- if .Values.clusterAnnotations }}
+  annotations: {{- toYaml .Values.clusterAnnotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.clusterNetwork }}
+  clusterNetwork:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: K0smotronControlPlane
+    name: {{ include "k0smotroncontrolplane.name" . }}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: GCPCluster
+    name: {{ include "cluster.name" . }}

--- a/templates/cluster/gcp-hosted-cp/templates/gcpcluster.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/gcpcluster.yaml
@@ -1,0 +1,18 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPCluster
+metadata:
+  name: {{ include "cluster.name" . }}
+  finalizers:
+    - k0rdent.mirantis.com/cleanup
+spec:
+  project: {{ .Values.project }}
+  region: {{ .Values.region }}
+  network:
+    name: {{ .Values.network.name }}
+    mtu: {{ .Values.network.mtu }}
+  {{- if .Values.additionalLabels }}
+  additionalLabels: {{- toYaml .Values.additionalLabels | nindent 4 }}
+  {{- end }}
+  credentialsRef:
+    name: {{ .Values.clusterIdentity.name }}
+    namespace: {{ .Values.clusterIdentity.namespace }}

--- a/templates/cluster/gcp-hosted-cp/templates/gcpmachinetemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/gcpmachinetemplate.yaml
@@ -1,0 +1,27 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: GCPMachineTemplate
+metadata:
+  name: {{ include "gcpmachinetemplate.worker.name" . }}
+spec:
+  template:
+    spec:
+      {{- with .Values.worker }}
+      instanceType: {{ .instanceType }}
+      subnet: {{ .subnet }}
+      providerID: {{ .providerID }}
+      imageFamily: {{ .imageFamily }}
+      image: {{ .image }}
+      {{- if .additionalLabels }}
+      additionalLabels: {{- toYaml .additionalLabels | nindent 8 }}
+      {{- end }}
+      publicIP: {{ .publicIP }}
+      {{- if .additionalNetworkTags }}
+      additionalNetworkTags: {{- toYaml .additionalNetworkTags | nindent 8 }}
+      {{- end }}
+      rootDeviceSize: {{ .rootDeviceSize }}
+      rootDeviceType: {{ .rootDeviceType }}
+      serviceAccount:
+        email: {{ .serviceAccount.email }}
+        scopes: {{- toYaml .serviceAccount.scopes | nindent 10 }}
+      ipForwarding: {{ .ipForwarding }}
+      {{- end }}

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,0 +1,97 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: K0smotronControlPlane
+metadata:
+  name: {{ include "k0smotroncontrolplane.name" . }}
+spec:
+  replicas: {{ .Values.controlPlaneNumber }}
+  version: {{ .Values.k0s.version | replace "+" "-" }}
+  {{- with .Values.k0smotron.service }}
+  service:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  controllerPlaneFlags:
+  - "--enable-cloud-provider=true"
+  - "--debug=true"
+  k0sConfig:
+    apiVersion: k0s.k0sproject.io/v1beta1
+    kind: ClusterConfig
+    metadata:
+      name: k0s
+    spec:
+      {{- with .Values.k0s.api.extraArgs }}
+      api:
+        extraArgs:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+      network:
+        provider: calico
+        calico:
+          mode: vxlan
+      extensions:
+        helm:
+          repositories:
+            - name: mirantis
+              {{- if .Values.extensions.chartRepository }}
+              url: {{ .Values.extensions.chartRepository }}
+              {{- else }}
+              url: https://charts.mirantis.com
+              {{- end }}
+          charts:
+            - name: gcp-cloud-controller-manager
+              namespace: kube-system
+              chartname: mirantis/gcp-cloud-controller-manager
+              version: "0.0.1"
+              values: |
+                cloudConfig:
+                  enabled: true
+                  data: W0dsb2JhbF0KbXVsdGl6b25lPXRydWUK
+                cloudCredentials:
+                  secretName: gcp-cloud-sa
+                  secretKey: cloud-sa.json
+                clusterCIDR: {{ first .Values.clusterNetwork.pods.cidrBlocks }}
+                image:
+                  {{- if .Values.extensions.imageRepository }}
+                  repository: {{ .Values.extensions.imageRepository }}/cloud-controller-manager
+                  {{- end }}
+                  tag: v32.2.3
+#  TODO: uncomment once https://github.com/Mirantis/helm-charts/pull/4 lands
+#           - name: gcp-compute-persistent-disk-csi-driver
+#             namespace: kube-system
+#             chartname: mirantis/gcp-compute-persistent-disk-csi-driver
+#             version: "0.0.1"
+#             values: |
+#               cloudCredentials:
+#                 secretName: gcp-cloud-sa
+#                 secretKey: cloud-sa.json
+#               node:
+#                 linux:
+#                   enabled: true
+#                   kubeletPath: /var/lib/k0s/kubelet
+#                 windows:
+#                   enabled: false
+#               defaultStorageClass:
+#                 enabled: true
+#               {{- if .Values.extensions.imageRepository }}
+#               controller:
+#                 provisioner:
+#                   image:
+#                     repository: {{ .Values.extensions.imageRepository }}/csi-provisioner
+#                 attacher:
+#                   image:
+#                     repository: {{ .Values.extensions.imageRepository }}/csi-attacher
+#                 resizer:
+#                   image:
+#                     repository: {{ .Values.extensions.imageRepository }}/csi-resizer
+#                 snapshotter:
+#                   image:
+#                     repository: {{ .Values.extensions.imageRepository }}/csi-snapshotter
+#                 driver:
+#                   image:
+#                     repository: {{ .Values.extensions.imageRepository }}/csi-gcp-compute-persistent-disk-csi-driver
+#               node:
+#                 registrar:
+#                   repository: {{ .Values.extensions.imageRepository }}/csi-node-driver-registrar
+#                 driver:
+#                   image:
+#                     repository: {{ .Values.extensions.imageRepository }}/csi-gcp-compute-persistent-disk-csi-driver
+#               {{- end }}

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,0 +1,11 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: K0sWorkerConfigTemplate
+metadata:
+  name: {{ include "k0sworkerconfigtemplate.name" . }}
+spec:
+  template:
+    spec:
+      version: {{ .Values.k0s.version }}
+      args:
+      - --enable-cloud-provider
+      - --kubelet-extra-args="--cloud-provider=external"

--- a/templates/cluster/gcp-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/machinedeployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: {{ include "machinedeployment.name" . }}
+  annotations:
+    # Temporary fix to address https://github.com/k0sproject/k0smotron/issues/911
+    machineset.cluster.x-k8s.io/skip-preflight-checks: "ControlPlaneIsStable"
+spec:
+  clusterName: {{ include "cluster.name" . }}
+  replicas: {{ .Values.workersNumber }}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
+    spec:
+      version: {{ (split "+" .Values.k0s.version)._0 }}
+      clusterName: {{ include "cluster.name" . }}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: K0sWorkerConfigTemplate
+          name: {{ include "k0sworkerconfigtemplate.name" . }}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: GCPMachineTemplate
+        name: {{ include "gcpmachinetemplate.worker.name" . }}

--- a/templates/cluster/gcp-hosted-cp/values.schema.json
+++ b/templates/cluster/gcp-hosted-cp/values.schema.json
@@ -1,0 +1,371 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "additionalLabels": {
+            "additionalProperties": false,
+            "description": "Additional set of labels to add to all the GCP resources",
+            "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                    "type": "string"
+                }
+            },
+            "properties": {},
+            "type": [
+                "object"
+            ]
+        },
+        "clusterAnnotations": {
+            "additionalProperties": true,
+            "description": "Annotations to apply to the cluster",
+            "properties": {},
+            "type": [
+                "object"
+            ]
+        },
+        "clusterIdentity": {
+            "description": "The GCP Service Account credentials secret reference, auto-populated",
+            "properties": {
+                "name": {
+                    "description": "The GCP Service Account credentials secret name, auto-populated",
+                    "type": [
+                        "string"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "clusterLabels": {
+            "additionalProperties": true,
+            "description": "Labels to apply to the cluster",
+            "properties": {},
+            "type": [
+                "object"
+            ]
+        },
+        "clusterNetwork": {
+            "description": "The cluster network configuration",
+            "properties": {
+                "apiServerPort": {
+                    "description": "The port the API Server should bind to",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": [
+                        "number"
+                    ]
+                },
+                "pods": {
+                    "description": "The network ranges from which Pod networks are allocated",
+                    "properties": {
+                        "cidrBlocks": {
+                            "description": "A list of CIDR blocks",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "array"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object"
+                    ]
+                },
+                "services": {
+                    "description": "The network ranges from which service VIPs are allocated",
+                    "properties": {
+                        "cidrBlocks": {
+                            "description": "A list of CIDR blocks",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "array"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "controlPlaneNumber": {
+            "description": "The number of the control plane nodes",
+            "minimum": 1,
+            "type": [
+                "number"
+            ]
+        },
+        "extensions": {
+            "description": "Defines custom Helm and image repositories to use for pulling k0s extensions",
+            "properties": {
+                "chartRepository": {
+                    "description": "Custom Helm repository",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "imageRepository": {
+                    "description": "Custom images' repository",
+                    "type": [
+                        "string"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "k0s": {
+            "description": "K0s parameters",
+            "properties": {
+                "api": {
+                    "description": "Kubernetes API server parameters",
+                    "properties": {
+                        "extraArgs": {
+                            "additionalProperties": true,
+                            "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+                            "properties": {},
+                            "type": [
+                                "object"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object"
+                    ]
+                },
+                "version": {
+                    "description": "K0s version",
+                    "type": [
+                        "string"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "k0smotron": {
+            "description": "K0smotron parameters",
+            "properties": {
+                "service": {
+                    "description": "The API service configuration",
+                    "properties": {
+                        "apiPort": {
+                            "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
+                            "maximum": 65535,
+                            "minimum": 1,
+                            "type": [
+                                "number"
+                            ]
+                        },
+                        "konnectivityPort": {
+                            "description": "The konnectivity port. If empty k0smotron will pick it automatically",
+                            "maximum": 65535,
+                            "minimum": 1,
+                            "type": [
+                                "number"
+                            ]
+                        },
+                        "type": {
+                            "description": "An ingress methods for a service",
+                            "enum": [
+                                "ClusterIP",
+                                "NodePort",
+                                "LoadBalancer"
+                            ],
+                            "type": [
+                                "string"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object"
+                    ]
+                }
+            },
+            "type": [
+                "object"
+            ]
+        },
+        "network": {
+            "description": "The GCP network configuration",
+            "properties": {
+                "mtu": {
+                    "description": "Maximum Transmission Unit in bytes",
+                    "maximum": 8896,
+                    "minimum": 1300,
+                    "type": [
+                        "number"
+                    ]
+                },
+                "name": {
+                    "description": "The GCP network name",
+                    "type": [
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": [
+                "object"
+            ]
+        },
+        "project": {
+            "description": "The name of the project to deploy the cluster to",
+            "type": [
+                "string"
+            ]
+        },
+        "region": {
+            "description": "The GCP Region the cluster lives in",
+            "type": [
+                "string"
+            ]
+        },
+        "worker": {
+            "description": "Worker parameters",
+            "properties": {
+                "additionalLabels": {
+                    "additionalProperties": false,
+                    "description": "Additional set of labels to add to an instance, in addition to the ones added by default by the GCP provider. If both the GCPCluster and the GCPMachine specify the same tag name with different values, the GCPMachine's value takes precedence",
+                    "patternProperties": {
+                        "^[a-zA-Z0-9._-]+$": {
+                            "type": "string"
+                        }
+                    },
+                    "properties": {},
+                    "type": [
+                        "object"
+                    ]
+                },
+                "additionalNetworkTags": {
+                    "description": "A list of network tags that should be applied to the instance. These tags are set in addition to any network tags defined at the cluster level or in the actuator",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": [
+                        "array"
+                    ]
+                },
+                "image": {
+                    "description": "The full reference to a valid image to be used for this machine. Takes precedence over imageFamily",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "imageFamily": {
+                    "description": "The full reference to a valid image family to be used for this machine",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "instanceType": {
+                    "description": "The type of instance to create. Example: n1.standard-2",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "ipForwarding": {
+                    "description": "IPForwarding allows this instance to send and receive packets with non-matching destination or source IPs. This is required if you plan to use this instance to forward routes. Defaults to Enabled",
+                    "enum": [
+                        "Enabled",
+                        "Disabled"
+                    ],
+                    "type": [
+                        "string"
+                    ]
+                },
+                "providerID": {
+                    "description": "The unique identifier as specified by the cloud provider",
+                    "type": [
+                        "string"
+                    ]
+                },
+                "publicIP": {
+                    "description": "PublicIP specifies whether the instance should get a public IP. Set this to true if you don't have a NAT instances or Cloud Nat setup",
+                    "type": [
+                        "boolean"
+                    ]
+                },
+                "rootDeviceSize": {
+                    "description": "The size of the root volume in GB",
+                    "minimum": 1,
+                    "type": [
+                        "number"
+                    ]
+                },
+                "rootDeviceType": {
+                    "description": "The type of the root volume",
+                    "enum": [
+                        "pd-standard",
+                        "pd-ssd",
+                        "pd-balanced",
+                        "hyperdisk-balanced"
+                    ],
+                    "type": [
+                        "string"
+                    ]
+                },
+                "rootDiskEncryptionKey": {
+                    "type": "null"
+                },
+                "serviceAccount": {
+                    "description": "The service account email and which scopes to assign to the machine",
+                    "properties": {
+                        "email": {
+                            "description": "Email address of the service account",
+                            "type": [
+                                "string"
+                            ]
+                        },
+                        "scopes": {
+                            "description": "The list of scopes to be made available for this service account",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "array"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object"
+                    ]
+                },
+                "subnet": {
+                    "description": "A reference to the subnetwork to use for this instance. If not specified, the first subnetwork retrieved from the Cluster Region and Network is picked",
+                    "type": [
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "instanceType"
+            ],
+            "type": [
+                "object"
+            ]
+        },
+        "workersNumber": {
+            "description": "The number of the worker nodes",
+            "minimum": 1,
+            "type": [
+                "number"
+            ]
+        }
+    },
+    "required": [
+        "project",
+        "region"
+    ],
+    "type": "object"
+}

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -1,0 +1,64 @@
+# Cluster parameters
+controlPlaneNumber: 3 # @schema description: The number of the control plane nodes; type: number; minimum: 1
+workersNumber: 2 # @schema description: The number of the worker nodes; type: number; minimum: 1
+
+clusterIdentity: # @schema description: The GCP Service Account credentials secret reference, auto-populated; type: object
+  name: "" # @schema description: The GCP Service Account credentials secret name, auto-populated; type: string
+
+clusterNetwork: # @schema description: The cluster network configuration; type: object
+  apiServerPort: 6443 # @schema description: The port the API Server should bind to; type: number; minimum: 1; maximum: 65535
+  pods: # @schema description: The network ranges from which Pod networks are allocated; type: object
+    cidrBlocks: # @schema description: A list of CIDR blocks; type: array; item: string
+      - "10.244.0.0/16"
+  services: # @schema description: The network ranges from which service VIPs are allocated; type: object
+    cidrBlocks: # @schema description: A list of CIDR blocks; type: array; item: string
+      - "10.96.0.0/12"
+
+clusterLabels: {} # @schema description: Labels to apply to the cluster; type: object; additionalProperties: true
+clusterAnnotations: {} # @schema description: Annotations to apply to the cluster; type: object; additionalProperties: true
+
+# GCP cluster parameters
+project: "" # @schema description: The name of the project to deploy the cluster to; type: string; required: true
+region: "" # @schema description: The GCP Region the cluster lives in; type: string; required: true
+network: # @schema description: The GCP network configuration; type: object
+  name: "default" # @schema description: The GCP network name; type: string; required: true
+  mtu: 1460 # @schema description: Maximum Transmission Unit in bytes; type: number; minimum: 1300; maximum: 8896
+additionalLabels: {} # @schema description: Additional set of labels to add to all the GCP resources; type: object; additionalProperties: false; patternProperties: {"^[a-zA-Z0-9._-]+$": {"type": "string"}}
+
+# GCP machines parameters
+worker: # @schema description: Worker parameters; type: object
+  instanceType: "" # @schema description: The type of instance to create. Example: n1.standard-2; type: string; required: true
+  subnet: "" # @schema description: A reference to the subnetwork to use for this instance. If not specified, the first subnetwork retrieved from the Cluster Region and Network is picked; type: string
+  providerID: "" # @schema description: The unique identifier as specified by the cloud provider; type: string
+  imageFamily: "" # @schema description: The full reference to a valid image family to be used for this machine; type: string
+  image: "" # @schema description: The full reference to a valid image to be used for this machine. Takes precedence over imageFamily; type: string
+  additionalLabels: {} # @schema description: Additional set of labels to add to an instance, in addition to the ones added by default by the GCP provider. If both the GCPCluster and the GCPMachine specify the same tag name with different values, the GCPMachine's value takes precedence; type: object; additionalProperties: false; patternProperties: {"^[a-zA-Z0-9._-]+$": {"type": "string"}}
+  publicIP: true # @schema description: PublicIP specifies whether the instance should get a public IP. Set this to true if you don't have a NAT instances or Cloud Nat setup; type: boolean
+  additionalNetworkTags: [] # @schema description: A list of network tags that should be applied to the instance. These tags are set in addition to any network tags defined at the cluster level or in the actuator; type: array; item: string
+  rootDeviceSize: 30 # @schema description: The size of the root volume in GB; type: number; minimum: 1
+  rootDeviceType: pd-standard # @schema description: The type of the root volume; type: string; enum: pd-standard,pd-ssd,pd-balanced,hyperdisk-balanced;
+  rootDiskEncryptionKey:
+  serviceAccount: # @schema description: The service account email and which scopes to assign to the machine; type: object
+    email: "default" # @schema description: Email address of the service account; type: string
+    scopes: # @schema description: The list of scopes to be made available for this service account; type: array; item: string
+      - "compute.CloudPlatformScope"
+  ipForwarding: Enabled # @schema description: IPForwarding allows this instance to send and receive packets with non-matching destination or source IPs. This is required if you plan to use this instance to forward routes. Defaults to Enabled; type: string; enum: Enabled,Disabled
+
+# K0smotron parameters
+k0smotron: # @schema description: K0smotron parameters; type: object
+  service: # @schema description: The API service configuration; type: object
+    type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
+    apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
+    konnectivityPort: 8132 # @schema description: The konnectivity port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
+
+# K0s parameters
+k0s: # @schema description: K0s parameters; type: object
+  version: v1.31.5+k0s.0 # @schema description: K0s version; type: string
+  api: # @schema description: Kubernetes API server parameters; type: object; additionalProperties: object
+    extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+
+# extensions defines custom Helm and image repositories to use for pulling
+# k0s extensions.
+extensions: # @schema description: Defines custom Helm and image repositories to use for pulling k0s extensions; type: object
+  chartRepository: "" # @schema description: Custom Helm repository; type: string
+  imageRepository: "" # @schema description: Custom images' repository; type: string

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-0-1-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-0-1-0.yaml
@@ -1,0 +1,15 @@
+apiVersion: k0rdent.mirantis.com/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: gcp-hosted-cp-0-1-0
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  helm:
+    chartSpec:
+      chart: gcp-hosted-cp
+      version: 0.1.0
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: kcm-templates


### PR DESCRIPTION
This PR contains the cluster template for the hosted GCP cluster.
It does not contain a CSI component yet. It'll be enabled in the follow-up PR once https://github.com/Mirantis/helm-charts/pull/4 is landed and the CSI helm chart is published.

Closes #1149