### PR TITLE
add leaderElectionNamespace flag in main.go - helps with debugging 

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -95,10 +95,12 @@ func main() {
 		webhookPort                int
 		webhookCertDir             string
 		pprofBindAddress           string
+		leaderElectionNamespace   string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&leaderElectionNamespace, "leader-election-namespace", "", "The namespace to use for leader election.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", false,
 		"If set the metrics endpoint is served securely")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
@@ -181,6 +183,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         true,
 		LeaderElectionID:       "31c555b4.k0rdent.mirantis.com",
+		LeaderElectionNamespace: leaderElectionNamespace,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -95,7 +95,7 @@ func main() {
 		webhookPort                int
 		webhookCertDir             string
 		pprofBindAddress           string
-		leaderElectionNamespace   string
+		leaderElectionNamespace    string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -180,9 +180,9 @@ func main() {
 			SecureServing: secureMetrics,
 			TLSOpts:       tlsOpts,
 		},
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         true,
-		LeaderElectionID:       "31c555b4.k0rdent.mirantis.com",
+		HealthProbeBindAddress:  probeAddr,
+		LeaderElection:          true,
+		LeaderElectionID:        "31c555b4.k0rdent.mirantis.com",
 		LeaderElectionNamespace: leaderElectionNamespace,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the


### PR DESCRIPTION
Add leader-election-namespace flag for out-of-cluster debugging

When running the controller outside a cluster (e.g., for debugging), the leader election namespace cannot be automatically determined. This change adds a `--leader-election-namespace` flag to explicitly specify the namespace, making local debugging possible while maintaining the default in-cluster behavior unchanged.

The flag is optional and only needed for out-of-cluster scenarios such as while running debuggers.