### PR TITLE
Add template invalidity metric

### DIFF
--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -591,10 +591,10 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, cd *kc
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile Profile: %w", err)
 	}
 
-	metrics.TrackMetricTemplateUsageSet(ctx, kcm.ClusterTemplateKind, cd.Spec.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta)
+	metrics.TrackMetricTemplateUsageSet(ctx, kcm.ClusterTemplateKind, cd.Spec.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, 1)
 
 	for _, svc := range cd.Spec.ServiceSpec.Services {
-		metrics.TrackMetricTemplateUsageSet(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta)
+		metrics.TrackMetricTemplateUsageSet(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, 1)
 	}
 
 	// NOTE:
@@ -659,10 +659,10 @@ func (r *ClusterDeploymentReconciler) Delete(ctx context.Context, cd *kcm.Cluste
 
 	defer func() {
 		if err == nil {
-			metrics.TrackMetricTemplateUsageDelete(ctx, kcm.ClusterTemplateKind, cd.Spec.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta)
+			metrics.TrackMetricTemplateUsageSet(ctx, kcm.ClusterTemplateKind, cd.Spec.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, 0)
 
 			for _, svc := range cd.Spec.ServiceSpec.Services {
-				metrics.TrackMetricTemplateUsageDelete(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta)
+				metrics.TrackMetricTemplateUsageSet(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, 0)
 			}
 		}
 	}()

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -591,10 +591,10 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, cd *kc
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile Profile: %w", err)
 	}
 
-	metrics.TrackMetricTemplateUsageSet(ctx, kcm.ClusterTemplateKind, cd.Spec.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, 1)
+	metrics.TrackMetricTemplateUsage(ctx, kcm.ClusterTemplateKind, cd.Spec.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, true)
 
 	for _, svc := range cd.Spec.ServiceSpec.Services {
-		metrics.TrackMetricTemplateUsageSet(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, 1)
+		metrics.TrackMetricTemplateUsage(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, true)
 	}
 
 	// NOTE:
@@ -659,10 +659,10 @@ func (r *ClusterDeploymentReconciler) Delete(ctx context.Context, cd *kcm.Cluste
 
 	defer func() {
 		if err == nil {
-			metrics.TrackMetricTemplateUsageSet(ctx, kcm.ClusterTemplateKind, cd.Spec.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, 0)
+			metrics.TrackMetricTemplateUsage(ctx, kcm.ClusterTemplateKind, cd.Spec.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, false)
 
 			for _, svc := range cd.Spec.ServiceSpec.Services {
-				metrics.TrackMetricTemplateUsageSet(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, 0)
+				metrics.TrackMetricTemplateUsage(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.ClusterDeploymentKind, cd.ObjectMeta, false)
 			}
 		}
 	}()

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -161,7 +161,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 
 	for _, svc := range mcs.Spec.ServiceSpec.Services {
-		metrics.TrackMetricTemplateUsageSet(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.MultiClusterServiceKind, mcs.ObjectMeta, 1)
+		metrics.TrackMetricTemplateUsage(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.MultiClusterServiceKind, mcs.ObjectMeta, true)
 	}
 
 	// NOTE:
@@ -383,7 +383,7 @@ func (r *MultiClusterServiceReconciler) reconcileDelete(ctx context.Context, mcs
 	defer func() {
 		if err == nil {
 			for _, svc := range mcs.Spec.ServiceSpec.Services {
-				metrics.TrackMetricTemplateUsageSet(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.MultiClusterServiceKind, mcs.ObjectMeta, 0)
+				metrics.TrackMetricTemplateUsage(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.MultiClusterServiceKind, mcs.ObjectMeta, false)
 			}
 		}
 	}()

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -161,7 +161,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 
 	for _, svc := range mcs.Spec.ServiceSpec.Services {
-		metrics.TrackMetricTemplateUsageSet(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.MultiClusterServiceKind, mcs.ObjectMeta)
+		metrics.TrackMetricTemplateUsageSet(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.MultiClusterServiceKind, mcs.ObjectMeta, 1)
 	}
 
 	// NOTE:
@@ -383,7 +383,7 @@ func (r *MultiClusterServiceReconciler) reconcileDelete(ctx context.Context, mcs
 	defer func() {
 		if err == nil {
 			for _, svc := range mcs.Spec.ServiceSpec.Services {
-				metrics.TrackMetricTemplateUsageDelete(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.MultiClusterServiceKind, mcs.ObjectMeta)
+				metrics.TrackMetricTemplateUsageSet(ctx, kcm.ServiceTemplateKind, svc.Template, kcm.MultiClusterServiceKind, mcs.ObjectMeta, 0)
 			}
 		}
 	}()

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -357,11 +357,7 @@ func (r *TemplateReconciler) updateStatus(ctx context.Context, template template
 		return fmt.Errorf("failed to update status for template %s/%s: %w", template.GetNamespace(), template.GetName(), err)
 	}
 
-	if status.Valid {
-		metrics.TrackMetricTemplateInvaliditySet(ctx, template.GetObjectKind().GroupVersionKind().Kind, template.GetNamespace(), template.GetName(), 0)
-	} else {
-		metrics.TrackMetricTemplateInvaliditySet(ctx, template.GetObjectKind().GroupVersionKind().Kind, template.GetNamespace(), template.GetName(), 1)
-	}
+	metrics.TrackMetricTemplateInvalidity(ctx, template.GetObjectKind().GroupVersionKind().Kind, template.GetNamespace(), template.GetName(), status.Valid)
 
 	return nil
 }

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -40,6 +40,7 @@ import (
 
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
 	"github.com/K0rdent/kcm/internal/helm"
+	"github.com/K0rdent/kcm/internal/metrics"
 	"github.com/K0rdent/kcm/internal/utils"
 	"github.com/K0rdent/kcm/internal/utils/ratelimit"
 )
@@ -355,6 +356,13 @@ func (r *TemplateReconciler) updateStatus(ctx context.Context, template template
 	if err != nil {
 		return fmt.Errorf("failed to update status for template %s/%s: %w", template.GetNamespace(), template.GetName(), err)
 	}
+
+	if status.Valid {
+		metrics.TrackMetricTemplateInvalidityDelete(ctx, template.GetObjectKind().GroupVersionKind().Kind, template.GetNamespace(), template.GetName())
+	} else {
+		metrics.TrackMetricTemplateInvaliditySet(ctx, template.GetObjectKind().GroupVersionKind().Kind, template.GetNamespace(), template.GetName())
+	}
+
 	return nil
 }
 

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -358,9 +358,9 @@ func (r *TemplateReconciler) updateStatus(ctx context.Context, template template
 	}
 
 	if status.Valid {
-		metrics.TrackMetricTemplateInvalidityDelete(ctx, template.GetObjectKind().GroupVersionKind().Kind, template.GetNamespace(), template.GetName())
+		metrics.TrackMetricTemplateInvaliditySet(ctx, template.GetObjectKind().GroupVersionKind().Kind, template.GetNamespace(), template.GetName(), 0)
 	} else {
-		metrics.TrackMetricTemplateInvaliditySet(ctx, template.GetObjectKind().GroupVersionKind().Kind, template.GetNamespace(), template.GetName())
+		metrics.TrackMetricTemplateInvaliditySet(ctx, template.GetObjectKind().GroupVersionKind().Kind, template.GetNamespace(), template.GetName(), 1)
 	}
 
 	return nil

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -59,7 +59,13 @@ func init() {
 	)
 }
 
-func TrackMetricTemplateUsageSet(ctx context.Context, templateKind, templateName, parentKind string, parent metav1.ObjectMeta, value float64) {
+//nolint:revive // false-positive
+func TrackMetricTemplateUsage(ctx context.Context, templateKind, templateName, parentKind string, parent metav1.ObjectMeta, inUse bool) {
+	var value float64
+	if inUse {
+		value = 1
+	}
+
 	metricTemplateUsage.With(prometheus.Labels{
 		metricLabelTemplateKind:    templateKind,
 		metricLabelTemplateName:    templateName,
@@ -78,7 +84,13 @@ func TrackMetricTemplateUsageSet(ctx context.Context, templateKind, templateName
 	)
 }
 
-func TrackMetricTemplateInvaliditySet(ctx context.Context, templateKind, templateNamespace, templateName string, value float64) {
+//nolint:revive // false-positive
+func TrackMetricTemplateInvalidity(ctx context.Context, templateKind, templateNamespace, templateName string, valid bool) {
+	var value float64
+	if !valid {
+		value = 1
+	}
+
 	metricTemplateInvalidity.With(prometheus.Labels{
 		metricLabelTemplateKind:      templateKind,
 		metricLabelTemplateNamespace: templateNamespace,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -59,66 +59,36 @@ func init() {
 	)
 }
 
-func TrackMetricTemplateUsageSet(ctx context.Context, templateKind, templateName, parentKind string, parent metav1.ObjectMeta) {
+func TrackMetricTemplateUsageSet(ctx context.Context, templateKind, templateName, parentKind string, parent metav1.ObjectMeta, value float64) {
 	metricTemplateUsage.With(prometheus.Labels{
 		metricLabelTemplateKind:    templateKind,
 		metricLabelTemplateName:    templateName,
 		metricLabelParentKind:      parentKind,
 		metricLabelParentNamespace: parent.Namespace,
 		metricLabelParentName:      parent.Name,
-	}).Set(1)
+	}).Set(value)
 
-	ctrl.LoggerFrom(ctx).V(1).Info("Tracking template usage metric (set to 1)",
+	ctrl.LoggerFrom(ctx).V(1).Info("Tracking template usage metric",
 		metricLabelTemplateKind, templateKind,
 		metricLabelTemplateName, templateName,
 		metricLabelParentKind, parentKind,
 		metricLabelParentNamespace, parent.Namespace,
 		metricLabelParentName, parent.Name,
+		"value", value,
 	)
 }
 
-func TrackMetricTemplateUsageDelete(ctx context.Context, templateKind, templateName, parentKind string, parent metav1.ObjectMeta) {
-	metricTemplateUsage.Delete(prometheus.Labels{
-		metricLabelTemplateKind:    templateKind,
-		metricLabelTemplateName:    templateName,
-		metricLabelParentKind:      parentKind,
-		metricLabelParentNamespace: parent.Namespace,
-		metricLabelParentName:      parent.Name,
-	})
-
-	ctrl.LoggerFrom(ctx).V(1).Info("Tracking template usage metric (delete)",
-		metricLabelTemplateKind, templateKind,
-		metricLabelTemplateName, templateName,
-		metricLabelParentKind, parentKind,
-		metricLabelParentNamespace, parent.Namespace,
-		metricLabelParentName, parent.Name,
-	)
-}
-
-func TrackMetricTemplateInvaliditySet(ctx context.Context, templateKind, templateNamespace, templateName string) {
+func TrackMetricTemplateInvaliditySet(ctx context.Context, templateKind, templateNamespace, templateName string, value float64) {
 	metricTemplateInvalidity.With(prometheus.Labels{
 		metricLabelTemplateKind:      templateKind,
 		metricLabelTemplateNamespace: templateNamespace,
 		metricLabelTemplateName:      templateName,
-	}).Set(1)
+	}).Set(value)
 
-	ctrl.LoggerFrom(ctx).V(1).Info("Tracking template invalidity metric (set to 1)",
+	ctrl.LoggerFrom(ctx).V(1).Info("Tracking template invalidity metric",
 		metricLabelTemplateKind, templateKind,
 		metricLabelTemplateNamespace, templateNamespace,
 		metricLabelTemplateName, templateName,
-	)
-}
-
-func TrackMetricTemplateInvalidityDelete(ctx context.Context, templateKind, templateNamespace, templateName string) {
-	metricTemplateInvalidity.Delete(prometheus.Labels{
-		metricLabelTemplateKind:      templateKind,
-		metricLabelTemplateNamespace: templateNamespace,
-		metricLabelTemplateName:      templateName,
-	})
-
-	ctrl.LoggerFrom(ctx).V(1).Info("Tracking template invalidity metric (delete)",
-		metricLabelTemplateKind, templateKind,
-		metricLabelTemplateNamespace, templateNamespace,
-		metricLabelTemplateName, templateName,
+		"value", value,
 	)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -26,11 +26,12 @@ import (
 )
 
 const (
-	metricLabelTemplateKind    = "template_kind"
-	metricLabelTemplateName    = "template_name"
-	metricLabelParentKind      = "parent_kind"
-	metricLabelParentNamespace = "parent_namespace"
-	metricLabelParentName      = "parent_name"
+	metricLabelTemplateKind      = "template_kind"
+	metricLabelTemplateNamespace = "template_namespace"
+	metricLabelTemplateName      = "template_name"
+	metricLabelParentKind        = "parent_kind"
+	metricLabelParentNamespace   = "parent_namespace"
+	metricLabelParentName        = "parent_name"
 )
 
 var metricTemplateUsage = prometheus.NewGaugeVec(
@@ -42,9 +43,19 @@ var metricTemplateUsage = prometheus.NewGaugeVec(
 	[]string{metricLabelTemplateKind, metricLabelTemplateName, metricLabelParentKind, metricLabelParentNamespace, metricLabelParentName},
 )
 
+var metricTemplateInvalidity = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: kcm.CoreKCMName,
+		Name:      "template_invalidity",
+		Help:      "Number of invalid templates",
+	},
+	[]string{metricLabelTemplateKind, metricLabelTemplateNamespace, metricLabelTemplateName},
+)
+
 func init() {
 	metrics.Registry.MustRegister(
 		metricTemplateUsage,
+		metricTemplateInvalidity,
 	)
 }
 
@@ -81,5 +92,33 @@ func TrackMetricTemplateUsageDelete(ctx context.Context, templateKind, templateN
 		metricLabelParentKind, parentKind,
 		metricLabelParentNamespace, parent.Namespace,
 		metricLabelParentName, parent.Name,
+	)
+}
+
+func TrackMetricTemplateInvaliditySet(ctx context.Context, templateKind, templateNamespace, templateName string) {
+	metricTemplateInvalidity.With(prometheus.Labels{
+		metricLabelTemplateKind:      templateKind,
+		metricLabelTemplateNamespace: templateNamespace,
+		metricLabelTemplateName:      templateName,
+	}).Set(1)
+
+	ctrl.LoggerFrom(ctx).V(1).Info("Tracking template invalidity metric (set to 1)",
+		metricLabelTemplateKind, templateKind,
+		metricLabelTemplateNamespace, templateNamespace,
+		metricLabelTemplateName, templateName,
+	)
+}
+
+func TrackMetricTemplateInvalidityDelete(ctx context.Context, templateKind, templateNamespace, templateName string) {
+	metricTemplateInvalidity.Delete(prometheus.Labels{
+		metricLabelTemplateKind:      templateKind,
+		metricLabelTemplateNamespace: templateNamespace,
+		metricLabelTemplateName:      templateName,
+	})
+
+	ctrl.LoggerFrom(ctx).V(1).Info("Tracking template invalidity metric (delete)",
+		metricLabelTemplateKind, templateKind,
+		metricLabelTemplateNamespace, templateNamespace,
+		metricLabelTemplateName, templateName,
 	)
 }


### PR DESCRIPTION
# Description

Add a metric to track currently invalid templates. Example:
```
# HELP kcm_template_invalidity Number of invalid templates
# TYPE kcm_template_invalidity gauge
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="aws-hosted-cp-0-1-5",template_namespace="kcm-system"} 1
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="aws-standalone-cp-0-1-5",template_namespace="kcm-system"} 1
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="azure-aks-0-1-1",template_namespace="kcm-system"} 1
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="azure-hosted-cp-0-1-5",template_namespace="kcm-system"} 1
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="azure-standalone-cp-0-1-5",template_namespace="kcm-system"} 1
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="docker-hosted-cp-0-1-3",template_namespace="kcm-system"} 1
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="gcp-hosted-cp-0-1-3",template_namespace="kcm-system"} 1
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="gcp-standalone-cp-0-1-3",template_namespace="kcm-system"} 1
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="openstack-standalone-cp-0-1-8",template_namespace="kcm-system"} 1
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="remote-cluster-0-1-3",template_namespace="kcm-system"} 1
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="vsphere-hosted-cp-0-1-5",template_namespace="kcm-system"} 1
kcm_template_invalidity{template_kind="ClusterTemplate",template_name="vsphere-standalone-cp-0-1-5",template_namespace="kcm-system"} 1
```