### PR TITLE
Ignore CAPO info conditions in mgmt status

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,6 +33,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	capioperatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -72,6 +73,7 @@ func init() {
 	utilruntime.Must(hcv2.AddToScheme(scheme))
 	utilruntime.Must(sveltosv1beta1.AddToScheme(scheme))
 	utilruntime.Must(libsveltosv1beta1.AddToScheme(scheme))
+	utilruntime.Must(capioperatorv1.AddToScheme(scheme)) // required only for the mgmt status updates
 	// +kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
* during the calculation of mgmt status, ignore INFO severity conditions from cluster-api operator resources
* might be reverted or removed after the upstream issue (https://github.com/kubernetes-sigs/cluster-api-operator/issues/755) is addressed

Closes #1221 