### PR TITLE
Fix panic in adopted e2e testing

### DIFF
--- a/test/e2e/provider_adopted_test.go
+++ b/test/e2e/provider_adopted_test.go
@@ -53,12 +53,13 @@ var _ = Describe("Adopted Cluster Templates", Label("provider:cloud", "provider:
 			Skip("Adopted ClusterDeployment testing is skipped")
 		}
 
+		kc = kubeclient.NewFromLocal(internalutils.DefaultSystemNamespace)
+
 		var err error
 		clusterTemplates, err = templates.GetSortedClusterTemplates(context.Background(), kc.CrClient, internalutils.DefaultSystemNamespace)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("providing cluster identity")
-		kc = kubeclient.NewFromLocal(internalutils.DefaultSystemNamespace)
 		ci := clusteridentity.New(kc, clusterdeployment.ProviderAWS)
 		Expect(os.Setenv(clusterdeployment.EnvVarAWSClusterIdentity, ci.IdentityName)).Should(Succeed())
 		ci.WaitForValidCredential(kc)


### PR DESCRIPTION
From https://github.com/k0rdent/kcm/actions/runs/14056507665/job/39357435892
```
Adopted Cluster Templates [BeforeAll] should work with an Adopted cluster provider [provider:cloud, provider:adopted]
  [BeforeAll] /home/runner/work/kcm/kcm/test/e2e/provider_adopted_test.go:48
  [It] /home/runner/work/kcm/kcm/test/e2e/provider_adopted_test.go:89

  [PANICKED] Test Panicked
  In [BeforeAll] at: /opt/hostedtoolcache/go/1.23.7/x64/src/runtime/panic.go:262 @ 03/25/25 10:14:43.757
```