### PR TITLE
Revert k0s version to 1.32.1 for docker cluster template

### DIFF
--- a/config/dev/docker-clusterdeployment.yaml
+++ b/config/dev/docker-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: docker-hosted-cp-0-1-3
+  template: docker-hosted-cp-0-1-4
   credential: docker-stub-credential
   config:
     clusterLabels: {}

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.31.5+k0s.0"
+appVersion: "v1.32.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-docker, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/docker-hosted-cp/values.yaml
+++ b/templates/cluster/docker-hosted-cp/values.yaml
@@ -18,4 +18,5 @@ k0smotron:
     type: NodePort
 
 k0s:
-  version: v1.31.5+k0s.0
+  # NOTE: Update with caution – see: PR https://github.com/k0rdent/kcm/pull/1057#issuecomment-2668629616
+  version: v1.32.1+k0s.0

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-0-1-4.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-0-1-4.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: docker-hosted-cp-0-1-3
+  name: docker-hosted-cp-0-1-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: docker-hosted-cp
-      version: 0.1.3
+      version: 0.1.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Cherry Pick #1282 

Reason: https://github.com/k0rdent/kcm/pull/1057#issuecomment-2668629616