### PR TITLE
Template webhook verbose warning

### DIFF
--- a/internal/webhook/template_webhook.go
+++ b/internal/webhook/template_webhook.go
@@ -174,7 +174,11 @@ func (v *ServiceTemplateValidator) ValidateDelete(ctx context.Context, obj runti
 		}
 
 		if len(multiSvcClusters.Items) > 0 {
-			return admission.Warnings{"The ServiceTemplate object can't be removed if MultiClusterService objects referencing it still exist"}, errTemplateDeletionForbidden
+			mscNames := make([]string, len(multiSvcClusters.Items))
+			for i, msc := range multiSvcClusters.Items {
+				mscNames[i] = msc.Name
+			}
+			return admission.Warnings{fmt.Sprintf("The %s ServiceTemplate object can't be removed if MultiClusterService objects [%s] referencing it still exist", tmpl.Name, strings.Join(mscNames, ","))}, errTemplateDeletionForbidden
 		}
 	}
 


### PR DESCRIPTION
Improve warning message to make it more verbose
```
W0327 16:24:07.538608    5186 warnings.go:70] The kof-storage-0-2-0-rc2 ServiceTemplate object can't be removed if MultiClusterService objects [kof-regional-cluster] referencing it still exist
Error: UPGRADE FAILED: pre-upgrade hooks failed: admission webhook "validation.servicetemplate.k0rdent.mirantis.com" denied the request: template deletion is forbidden
```
instead of just
```
W0327 15:45:04.626916   91612 warnings.go:70] The ServiceTemplate object can't be removed if MultiClusterService objects referencing it still exist
Error: UPGRADE FAILED: pre-upgrade hooks failed: admission webhook "validation.servicetemplate.k0rdent.mirantis.com" denied the request: template deletion is forbidden
```