### PR TITLE
Handle `Release` object delete request

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -17,6 +17,10 @@ resources:
   kind: ClusterDeployment
   path: github.com/K0rdent/kcm/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
   controller: true
@@ -25,6 +29,10 @@ resources:
   kind: Management
   path: github.com/K0rdent/kcm/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
   domain: k0rdent.mirantis.com
@@ -44,6 +52,10 @@ resources:
   kind: ClusterTemplate
   path: github.com/K0rdent/kcm/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
   controller: true
@@ -52,6 +64,10 @@ resources:
   kind: ProviderTemplate
   path: github.com/K0rdent/kcm/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true
@@ -61,6 +77,10 @@ resources:
   kind: ServiceTemplate
   path: github.com/K0rdent/kcm/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
   controller: true
@@ -69,6 +89,9 @@ resources:
   kind: AccessManagement
   path: github.com/K0rdent/kcm/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true
@@ -77,13 +100,20 @@ resources:
   kind: ClusterTemplateChain
   path: github.com/K0rdent/kcm/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
+    namespaced: true
   domain: k0rdent.mirantis.com
   group: k0rdent.mirantis.com
   kind: ServiceTemplateChain
   path: github.com/K0rdent/kcm/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true
@@ -101,6 +131,9 @@ resources:
   kind: MultiClusterService
   path: github.com/K0rdent/kcm/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
   controller: true

--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -50,6 +50,8 @@ const (
 	AllComponentsHealthyReason = "AllComponentsHealthy"
 	// NotAllComponentsHealthyReason documents a condition not in Status=True because one or more components are failing.
 	NotAllComponentsHealthyReason = "NotAllComponentsHealthy"
+	// ReleaseIsNotFoundReason declares that the referenced in the [Management] [Release] object does not (yet) exist.
+	ReleaseIsNotFoundReason = "ReleaseIsNotFound"
 )
 
 // Core represents a structure describing core Management components.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -262,6 +262,7 @@ func main() {
 	if err = (&controller.ManagementReconciler{
 		SystemNamespace:        currentNamespace,
 		CreateAccessManagement: createAccessManagement,
+		IsDisabledValidation:   !enableWebhook,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Management")
 		os.Exit(1)

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -43,10 +43,14 @@ import (
 	capioperatorv1 "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
 	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
 	"github.com/K0rdent/kcm/internal/certmanager"
@@ -66,6 +70,7 @@ type ManagementReconciler struct {
 	defaultRequeueTime time.Duration
 
 	CreateAccessManagement bool
+	IsDisabledValidation   bool // is webhook disabled set via the controller flags
 
 	sveltosDependentControllersStarted bool
 }
@@ -111,6 +116,27 @@ func (r *ManagementReconciler) Update(ctx context.Context, management *kcm.Manag
 		return ctrl.Result{}, err
 	}
 
+	release, err := r.getRelease(ctx, management)
+	if err != nil {
+		if !r.IsDisabledValidation {
+			l.Error(err, "failed to get Release")
+			return ctrl.Result{}, err
+		}
+
+		l.Error(err, "failed to get Release, will not retrigger until it exists")
+		meta.SetStatusCondition(&management.Status.Conditions, metav1.Condition{
+			Type:               kcm.ReadyCondition,
+			ObservedGeneration: management.Generation,
+			Status:             metav1.ConditionFalse,
+			Reason:             kcm.ReleaseIsNotFoundReason,
+			Message:            management.Spec.Release + " is not found",
+		})
+		if err := r.Client.Status().Update(ctx, management); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to update status for Management %s: %w", management.Name, err)
+		}
+		return ctrl.Result{}, nil
+	}
+
 	if err := r.cleanupRemovedComponents(ctx, management); err != nil {
 		l.Error(err, "failed to cleanup removed components")
 		return ctrl.Result{}, err
@@ -137,7 +163,7 @@ func (r *ManagementReconciler) Update(ctx context.Context, management *kcm.Manag
 		return ctrl.Result{}, err
 	}
 
-	components, err := getWrappedComponents(ctx, r.Client, management)
+	components, err := getWrappedComponents(management, release)
 	if err != nil {
 		l.Error(err, "failed to wrap KCM components")
 		return ctrl.Result{}, err
@@ -607,12 +633,7 @@ func applyKCMDefaults(config *apiextensionsv1.JSON) (*apiextensionsv1.JSON, erro
 	return &apiextensionsv1.JSON{Raw: raw}, nil
 }
 
-func getWrappedComponents(ctx context.Context, cl client.Client, mgmt *kcm.Management) ([]component, error) {
-	release := &kcm.Release{}
-	if err := cl.Get(ctx, client.ObjectKey{Name: mgmt.Spec.Release}, release); err != nil {
-		return nil, fmt.Errorf("failed to get Release %s: %w", mgmt.Spec.Release, err)
-	}
-
+func getWrappedComponents(mgmt *kcm.Management, release *kcm.Release) ([]component, error) {
 	components := make([]component, 0, len(mgmt.Spec.Providers)+2)
 
 	kcmComponent := kcm.Component{}
@@ -734,6 +755,8 @@ func (r *ManagementReconciler) enableAdditionalComponents(ctx context.Context, m
 			if !found || !castedOk || enabledValue {
 				l.Info("Cert manager is installed, enabling the KCM admission webhook")
 				admissionWebhookValues["enabled"] = true
+			} else {
+				l.Info("KCM admission webhook is disabled")
 			}
 		}
 	}
@@ -888,7 +911,7 @@ func setReadyCondition(management *kcm.Management) {
 		ObservedGeneration: management.Generation,
 		Status:             metav1.ConditionTrue,
 		Reason:             kcm.AllComponentsHealthyReason,
-		Message:            "All components are successfully installed.",
+		Message:            "All components are successfully installed",
 	}
 	sort.Strings(failing)
 	if len(failing) > 0 {
@@ -898,6 +921,11 @@ func setReadyCondition(management *kcm.Management) {
 	}
 
 	meta.SetStatusCondition(&management.Status.Conditions, readyCond)
+}
+
+func (r *ManagementReconciler) getRelease(ctx context.Context, mgmt *kcm.Management) (release *kcm.Release, _ error) {
+	release = new(kcm.Release)
+	return release, r.Client.Get(ctx, client.ObjectKey{Name: mgmt.Spec.Release}, release)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -914,10 +942,22 @@ func (r *ManagementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	r.defaultRequeueTime = 10 * time.Second
 
-	return ctrl.NewControllerManagedBy(mgr).
+	managedController := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.TypedOptions[ctrl.Request]{
 			RateLimiter: ratelimit.DefaultFastSlow(),
 		}).
-		For(&kcm.Management{}).
-		Complete(r)
+		For(&kcm.Management{})
+
+	if r.IsDisabledValidation {
+		managedController.Watches(&kcm.Release{}, handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []ctrl.Request {
+			return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: kcm.ManagementName}}} // always trigger, so if fetching Management fails its status would be still updated then
+		}), builder.WithPredicates(predicate.Funcs{
+			GenericFunc: func(event.TypedGenericEvent[client.Object]) bool { return false },
+			UpdateFunc:  func(event.TypedUpdateEvent[client.Object]) bool { return false },
+		}))
+
+		mgr.GetLogger().WithName("management_ctrl_setup").Info("Validations are disabled, watcher for Release objects is set")
+	}
+
+	return managedController.Complete(r)
 }

--- a/internal/webhook/accessmanagement_webhook.go
+++ b/internal/webhook/accessmanagement_webhook.go
@@ -41,14 +41,10 @@ func (v *AccessManagementValidator) SetupWebhookWithManager(mgr ctrl.Manager) er
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&v1alpha1.AccessManagement{}).
 		WithValidator(v).
-		WithDefaulter(v).
 		Complete()
 }
 
-var (
-	_ webhook.CustomValidator = &AccessManagementValidator{}
-	_ webhook.CustomDefaulter = &AccessManagementValidator{}
-)
+var _ webhook.CustomValidator = &AccessManagementValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (v *AccessManagementValidator) ValidateCreate(ctx context.Context, _ runtime.Object) (admission.Warnings, error) {
@@ -88,9 +84,4 @@ func (v *AccessManagementValidator) ValidateDelete(ctx context.Context, _ runtim
 	}
 
 	return nil, nil
-}
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (*AccessManagementValidator) Default(context.Context, runtime.Object) error {
-	return nil
 }

--- a/internal/webhook/multiclusterservice_webhook.go
+++ b/internal/webhook/multiclusterservice_webhook.go
@@ -42,19 +42,10 @@ func (v *MultiClusterServiceValidator) SetupWebhookWithManager(mgr ctrl.Manager)
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&v1alpha1.MultiClusterService{}).
 		WithValidator(v).
-		WithDefaulter(v).
 		Complete()
 }
 
-var (
-	_ webhook.CustomValidator = &MultiClusterServiceValidator{}
-	_ webhook.CustomDefaulter = &MultiClusterServiceValidator{}
-)
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (*MultiClusterServiceValidator) Default(_ context.Context, _ runtime.Object) error {
-	return nil
-}
+var _ webhook.CustomValidator = &MultiClusterServiceValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (v *MultiClusterServiceValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {

--- a/internal/webhook/templatechain_webhook.go
+++ b/internal/webhook/templatechain_webhook.go
@@ -40,14 +40,10 @@ func (in *ClusterTemplateChainValidator) SetupWebhookWithManager(mgr ctrl.Manage
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&v1alpha1.ClusterTemplateChain{}).
 		WithValidator(in).
-		WithDefaulter(in).
 		Complete()
 }
 
-var (
-	_ webhook.CustomValidator = &ClusterTemplateChainValidator{}
-	_ webhook.CustomDefaulter = &ClusterTemplateChainValidator{}
-)
+var _ webhook.CustomValidator = &ClusterTemplateChainValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (*ClusterTemplateChainValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
@@ -73,11 +69,6 @@ func (*ClusterTemplateChainValidator) ValidateDelete(_ context.Context, _ runtim
 	return nil, nil
 }
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (*ClusterTemplateChainValidator) Default(_ context.Context, _ runtime.Object) error {
-	return nil
-}
-
 type ServiceTemplateChainValidator struct {
 	client.Client
 }
@@ -87,14 +78,10 @@ func (in *ServiceTemplateChainValidator) SetupWebhookWithManager(mgr ctrl.Manage
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&v1alpha1.ServiceTemplateChain{}).
 		WithValidator(in).
-		WithDefaulter(in).
 		Complete()
 }
 
-var (
-	_ webhook.CustomValidator = &ServiceTemplateChainValidator{}
-	_ webhook.CustomDefaulter = &ServiceTemplateChainValidator{}
-)
+var _ webhook.CustomValidator = &ServiceTemplateChainValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (*ServiceTemplateChainValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
@@ -118,9 +105,4 @@ func (*ServiceTemplateChainValidator) ValidateUpdate(_ context.Context, _, _ run
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (*ServiceTemplateChainValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
-}
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (*ServiceTemplateChainValidator) Default(_ context.Context, _ runtime.Object) error {
-	return nil
 }

--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - --create-templates={{ .Values.controller.createTemplates }}
         - --validate-cluster-upgrade-path={{ .Values.controller.validateClusterUpgradePath }}
         - --enable-telemetry={{ .Values.controller.enableTelemetry }}
-        - --enable-webhook={{ .Values.admissionWebhook.enabled }}
+        - --enable-webhook={{ .Values.admissionWebhook.enabled | default false }}
         - --webhook-port={{ .Values.admissionWebhook.port }}
         - --webhook-cert-dir={{ .Values.admissionWebhook.certDir }}
         {{- range $key, $value := .Values.controller.logger }}

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -2,7 +2,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 admissionWebhook:
-  enabled: false
+  # enabled: false # WARN: setting the default value to false actually disables the WH; setting to true does not allow to install the KCM chart due to missing cert-manager CRDs
   port: 9443
   certDir: "/tmp/k8s-webhook-server/serving-certs/"
 


### PR DESCRIPTION
* trigger mgmt on release create/delete
* set not ready to mgmt if release is not found
* do not reconcile mgmt if release is not found
* fix admission wh disabled by default
* release ctrl sets release owner ref to kcm-templates
  helm release in order to create a new one when
  a new release is created; this action does not remove
  other components since the mgmt will not be
  reconciled when the release object is absent
* chore: kubebuilder project and redundant defaulters

There is nothing to do with the webhook validations reconciliation. Here goes the same idea as in the #1288: there are currently no finalizers for the `releases` CR and hence it does not make much sense to fully block the reconciliation of a `Release` object and force a user to delete it.

To properly address (re)creation of a `Release` the `Management` object should not be reconciled to avoid removal of the other components. Deletion of a `Release` object will remove the `kcm-templates` `HelmRelease` if the corresponding value `controller.createTemplates` had been set to `true`. (Re)creation of a `Release` object will create a new `kcm-templates` `HelmRelease` properly (re)installing the `providertemplates` without extra frictions to actually re-trigger already existing `kcm-templates` `HelmRelease`. And because the `Management` will wait until there is a `Release` object, no destructive cleanups would be performed.

**Warning**: the new watcher for the `Release` kind is set only if the webhook controller is disabled, otherwise it isn't required.

These changes in behavior would be described in the docs: turning off the webhook controller might change the behavior of the `kcm` but at the same time there is no forcing in deletion of other objects sticking to some predefined (by the controller) order of objects, hence the requirement of the epic still happening 

Closes #1238 
