### PR TITLE
Merge v0.2.0-release into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Detailed documentation is available in [k0rdent Docs](https://docs.k0rdent.io)
 ### TL;DR
 
 ```bash
-helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 0.1.0 -n kcm-system --create-namespace
+helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 0.2.0 -n kcm-system --create-namespace
 ```
 
 Then follow the [Deploy a cluster deployment](#create-a-clusterdeployment) guide to
@@ -80,7 +80,7 @@ spec:
   - name: cluster-api-provider-openstack
   - name: cluster-api-provider-k0sproject-k0smotron
   - name: projectsveltos
-  release: kcm-0-1-0
+  release: kcm-0-2-0
 ```
 
 There are two options to override the default management configuration of KCM:
@@ -206,7 +206,7 @@ spec:
       instanceType: ""
     controlPlaneNumber: 3
     k0s:
-      version: v1.27.2+k0s.0
+      version: v1.31.5+k0s.0
     publicIP: false
     region: ""
     sshKeyName: ""
@@ -214,7 +214,7 @@ spec:
       iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
       instanceType: ""
     workersNumber: 2
-  template: aws-standalone-cp-0-1-0
+  template: aws-standalone-cp-0-2-0
   credential: aws-credential
   dryRun: true
 ```
@@ -232,7 +232,7 @@ metadata:
   name: aws-standalone
   namespace: kcm-system
 spec:
-  template: aws-standalone-cp-0-1-0
+  template: aws-standalone-cp-0-2-0
   credential: aws-credential
   config:
     region: us-east-2

--- a/config/dev/adopted-clusterdeployment.yaml
+++ b/config/dev/adopted-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: adopted-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: adopted-cluster-0-1-1
+  template: adopted-cluster-0-2-0
   credential: adopted-cluster-cred
   config:
     clusterLabels: {}

--- a/config/dev/aks-clusterdeployment.yaml
+++ b/config/dev/aks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-aks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-aks-0-1-1
+  template: azure-aks-0-2-0
   credential: azure-aks-credential
   propagateCredentials: false
   config:

--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-0-1-6
+  template: aws-standalone-cp-0-2-0
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-0-1-5
+  template: azure-standalone-cp-0-2-0
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/docker-clusterdeployment.yaml
+++ b/config/dev/docker-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: docker-hosted-cp-0-1-4
+  template: docker-hosted-cp-0-2-0
   credential: docker-stub-credential
   config:
     clusterLabels: {}

--- a/config/dev/eks-clusterdeployment.yaml
+++ b/config/dev/eks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-eks-0-1-2
+  template: aws-eks-0-2-0
   credential: "aws-cluster-identity-cred"
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-0-1-3
+  template: gcp-standalone-cp-0-2-0
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/gke-clusterdeployment.yaml
+++ b/config/dev/gke-clusterdeployment.yaml
@@ -4,11 +4,14 @@ metadata:
   name: gke-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-gke-0-1-0
+  template: gcp-gke-0-2-0
   credential: gcp-credential
+  propagateCredentials: false
   config:
     clusterLabels: {}
-    workersNumber: 3 # For regional GKE clusters, the workersNumber must be divisible by 3
+    # workersNumber should be divisible by the number of zones in machines.nodeLocations.
+    # If nodeLocations is not specified, must be divisible by the number of zones in this region (default: 3)
+    workersNumber: 3
     clusterAnnotations: {}
     project: k0rdent-dev
     region: us-east4

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-0-1-8
+  template: openstack-standalone-cp-0-2-0
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-0-1-3
+  template: remote-cluster-0-2-0
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-0-1-5
+  template: vsphere-standalone-cp-0-2-0
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -484,11 +484,17 @@ func isProviderReady(gp capioperatorv1.GenericProvider) bool {
 }
 
 func getFalseConditions(gp capioperatorv1.GenericProvider) []string {
-	var messages []string
-	for _, cond := range gp.GetStatus().Conditions {
-		if cond.Status != corev1.ConditionTrue && cond.Message != "" {
-			messages = append(messages, cond.Message)
+	conditions := gp.GetStatus().Conditions
+	messages := make([]string, 0, len(conditions))
+	for _, cond := range conditions {
+		if cond.Status == corev1.ConditionTrue {
+			continue
 		}
+		msg := fmt.Sprintf("condition %s is in status %s", cond.Type, cond.Status)
+		if cond.Message != "" {
+			msg += ": " + cond.Message
+		}
+		messages = append(messages, msg)
 	}
 	return messages
 }

--- a/internal/webhook/template_webhook.go
+++ b/internal/webhook/template_webhook.go
@@ -174,7 +174,11 @@ func (v *ServiceTemplateValidator) ValidateDelete(ctx context.Context, obj runti
 		}
 
 		if len(multiSvcClusters.Items) > 0 {
-			return admission.Warnings{"The ServiceTemplate object can't be removed if MultiClusterService objects referencing it still exist"}, errTemplateDeletionForbidden
+			mscNames := make([]string, len(multiSvcClusters.Items))
+			for i, msc := range multiSvcClusters.Items {
+				mscNames[i] = msc.Name
+			}
+			return admission.Warnings{fmt.Sprintf("The %s ServiceTemplate object can't be removed if MultiClusterService objects [%s] referencing it still exist", tmpl.Name, strings.Join(mscNames, ","))}, errTemplateDeletionForbidden
 		}
 	}
 

--- a/internal/webhook/template_webhook_test.go
+++ b/internal/webhook/template_webhook_test.go
@@ -356,7 +356,7 @@ func TestServiceTemplateValidateDelete(t *testing.T) {
 					multiclusterservice.WithServiceTemplate(templateName),
 				),
 			},
-			warnings: admission.Warnings{"The ServiceTemplate object can't be removed if MultiClusterService objects referencing it still exist"},
+			warnings: admission.Warnings{"The mytemplate ServiceTemplate object can't be removed if MultiClusterService objects [mymulticlusterservice] referencing it still exist"},
 			err:      errTemplateDeletionForbidden.Error(),
 		},
 	}

--- a/templates/cluster/adopted-cluster/Chart.yaml
+++ b/templates/cluster/adopted-cluster/Chart.yaml
@@ -6,6 +6,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 annotations:
   cluster.x-k8s.io/provider: infrastructure-internal

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-aks/Chart.yaml
+++ b/templates/cluster/azure-aks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure
   cluster.x-k8s.io/infrastructure-azure: v1beta1

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-gke/Chart.yaml
+++ b/templates/cluster/gcp-gke/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-gke/values.schema.json
+++ b/templates/cluster/gcp-gke/values.schema.json
@@ -285,7 +285,7 @@
                     ]
                 },
                 "name": {
-                    "description": "The GCP network name",
+                    "description": "The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP",
                     "type": [
                         "string"
                     ]
@@ -322,9 +322,8 @@
             ]
         },
         "workersNumber": {
-            "description": "The number of the worker nodes",
-            "minimum": 3,
-            "multipleOf": 3,
+            "description": "The number of the worker nodes. Should be divisible by the number of zones in machines.nodeLocations. If nodeLocations is not specified, must be divisible by the number of zones in this region (default: 3)",
+            "minimum": 1,
             "type": [
                 "number"
             ]

--- a/templates/cluster/gcp-gke/values.yaml
+++ b/templates/cluster/gcp-gke/values.yaml
@@ -1,5 +1,5 @@
 # Cluster parameters
-workersNumber: 3 # @schema description: The number of the worker nodes; type: number; minimum: 3; multipleOf: 3
+workersNumber: 3 # @schema description: The number of the worker nodes. Should be divisible by the number of zones in machines.nodeLocations. If nodeLocations is not specified, must be divisible by the number of zones in this region (default: 3); type: number; minimum: 1;
 
 clusterIdentity: # @schema description: The GCP Service Account credentials secret reference, auto-populated; type: object
   name: "" # @schema description: The GCP Service Account credentials secret name, auto-populated; type: string
@@ -25,7 +25,7 @@ masterAuthorizedNetworksConfig: {} # @schema description: Represents configurati
 region: "" # @schema description: The GCP Region the cluster lives in; type: string; required: true
 location: "" # @schema description: The location where the GKE cluster will be created. If unspecified, a region will be used, making the cluster regional. Otherwise, specifying a location will create a zonal cluster; type: string
 network: # @schema description: The GCP network configuration; type: object
-  name: "default" # @schema description: The GCP network name; type: string; required: true
+  name: "default" # @schema description: The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP; type: string; required: true
   mtu: 1460 # @schema description: Maximum Transmission Unit in bytes; type: number; minimum: 1300; maximum: 8896
 additionalLabels: {} # @schema description: Additional set of labels to add to all the GCP resources; type: object; additionalProperties: false; patternProperties: {"^[a-zA-Z0-9._-]+$": {"type": "string"}}
 

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/values.schema.json
+++ b/templates/cluster/gcp-hosted-cp/values.schema.json
@@ -95,7 +95,7 @@
             ]
         },
         "controlPlaneNumber": {
-            "description": "The number of the control plane nodes",
+            "description": "The number of the control plane pods",
             "minimum": 1,
             "type": [
                 "number"
@@ -206,7 +206,7 @@
                     ]
                 },
                 "name": {
-                    "description": "The GCP network name",
+                    "description": "The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP",
                     "type": [
                         "string"
                     ]

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -1,5 +1,5 @@
 # Cluster parameters
-controlPlaneNumber: 3 # @schema description: The number of the control plane nodes; type: number; minimum: 1
+controlPlaneNumber: 3 # @schema description: The number of the control plane pods; type: number; minimum: 1
 workersNumber: 2 # @schema description: The number of the worker nodes; type: number; minimum: 1
 
 clusterIdentity: # @schema description: The GCP Service Account credentials secret reference, auto-populated; type: object
@@ -21,7 +21,7 @@ clusterAnnotations: {} # @schema description: Annotations to apply to the cluste
 project: "" # @schema description: The name of the project to deploy the cluster to; type: string; required: true
 region: "" # @schema description: The GCP Region the cluster lives in; type: string; required: true
 network: # @schema description: The GCP network configuration; type: object
-  name: "default" # @schema description: The GCP network name; type: string; required: true
+  name: "default" # @schema description: The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP; type: string; required: true
   mtu: 1460 # @schema description: Maximum Transmission Unit in bytes; type: number; minimum: 1300; maximum: 8896
 additionalLabels: {} # @schema description: Additional set of labels to add to all the GCP resources; type: object; additionalProperties: false; patternProperties: {"^[a-zA-Z0-9._-]+$": {"type": "string"}}
 

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/values.schema.json
+++ b/templates/cluster/gcp-standalone-cp/values.schema.json
@@ -284,7 +284,7 @@
                     ]
                 },
                 "name": {
-                    "description": "The GCP network name",
+                    "description": "The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP",
                     "type": [
                         "string"
                     ]

--- a/templates/cluster/gcp-standalone-cp/values.yaml
+++ b/templates/cluster/gcp-standalone-cp/values.yaml
@@ -21,7 +21,7 @@ clusterAnnotations: {} # @schema description: Annotations to apply to the cluste
 project: "" # @schema description: The name of the project to deploy the cluster to; type: string; required: true
 region: "" # @schema description: The GCP Region the cluster lives in; type: string; required: true
 network: # @schema description: The GCP network configuration; type: object
-  name: "default" # @schema description: The GCP network name; type: string; required: true
+  name: "default" # @schema description: The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP; type: string; required: true
   mtu: 1460 # @schema description: Maximum Transmission Unit in bytes; type: number; minimum: 1300; maximum: 8896
 additionalLabels: {} # @schema description: Additional set of labels to add to all the GCP resources; type: object; additionalProperties: false; patternProperties: {"^[a-zA-Z0-9._-]+$": {"type": "string"}}
 

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.2.0
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-aws/Chart.yaml
+++ b/templates/provider/cluster-api-provider-aws/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-docker/Chart.yaml
+++ b/templates/provider/cluster-api-provider-docker/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-gcp/Chart.yaml
+++ b/templates/provider/cluster-api-provider-gcp/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-vsphere/Chart.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api/Chart.yaml
+++ b/templates/provider/cluster-api/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/kcm-templates/Chart.yaml
+++ b/templates/provider/kcm-templates/Chart.yaml
@@ -13,4 +13,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -1,29 +1,29 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: Release
 metadata:
-  name: kcm-0-1-0
+  name: kcm-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  version: 0.1.0
+  version: 0.2.0
   kcm:
-    template: kcm-0-1-0
+    template: kcm-0-2-0
   capi:
-    template: cluster-api-0-1-2
+    template: cluster-api-0-2-0
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
-      template: cluster-api-provider-k0sproject-k0smotron-0-1-1
+      template: cluster-api-provider-k0sproject-k0smotron-0-2-0
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-0-1-1
+      template: cluster-api-provider-azure-0-2-0
     - name: cluster-api-provider-vsphere
-      template: cluster-api-provider-vsphere-0-1-0
+      template: cluster-api-provider-vsphere-0-2-0
     - name: cluster-api-provider-aws
-      template: cluster-api-provider-aws-0-1-0
+      template: cluster-api-provider-aws-0-2-0
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-0-1-4
+      template: cluster-api-provider-openstack-0-2-0
     - name: cluster-api-provider-docker
-      template: cluster-api-provider-docker-0-1-3
+      template: cluster-api-provider-docker-0-2-0
     - name: cluster-api-provider-gcp
-      template: cluster-api-provider-gcp-0-1-0
+      template: cluster-api-provider-gcp-0-2-0
     - name: projectsveltos
       template: projectsveltos-0-51-2

--- a/templates/provider/kcm-templates/files/templates/adopted-cluster-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/adopted-cluster-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: adopted-cluster-0-1-1
+  name: adopted-cluster-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: adopted-cluster
-      version: 0.1.1
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-eks-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-0-1-5
+  name: aws-eks-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 0.1.5
+      chart: aws-eks
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-0-1-5
+  name: aws-hosted-cp-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 0.1.5
+      chart: aws-hosted-cp
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-0-1-5
+  name: aws-standalone-cp-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 0.1.5
+      chart: aws-standalone-cp
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-aks-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-aks-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-0-1-3
+  name: azure-aks-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 0.1.3
+      chart: azure-aks
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: docker-hosted-cp-0-1-4
+  name: azure-hosted-cp-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: docker-hosted-cp
-      version: 0.1.4
+      chart: azure-hosted-cp
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-aks-0-1-1
+  name: azure-standalone-cp-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-aks
-      version: 0.1.1
+      chart: azure-standalone-cp
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-aws-0-1-0
+  name: cluster-api-provider-aws-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-aws
-      version: 0.1.0
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-0-1-1
+  name: cluster-api-provider-azure-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-azure
-      version: 0.1.1
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-docker-0-1-3
+  name: cluster-api-provider-docker-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-docker
-      version: 0.1.3
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-gcp-0-1-0
+  name: cluster-api-provider-gcp-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-gcp
-      version: 0.1.0
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-k0sproject-k0smotron-0-1-1
+  name: cluster-api-provider-k0sproject-k0smotron-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-k0sproject-k0smotron
-      version: 0.1.1
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-0-1-4
+  name: cluster-api-provider-openstack-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 0.1.4
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-vsphere-0-1-0
+  name: cluster-api-provider-vsphere-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-vsphere
-      version: 0.1.0
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-0-1-2
+  name: cluster-api-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api
-      version: 0.1.2
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-eks-0-1-2
+  name: docker-hosted-cp-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-eks
-      version: 0.1.2
+      chart: docker-hosted-cp
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-gke-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-gke-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-gke-0-1-0
+  name: gcp-gke-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-gke
-      version: 0.1.0
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-0-1-3
+  name: gcp-hosted-cp-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-hosted-cp
-      version: 0.1.3
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-0-1-5
+  name: gcp-standalone-cp-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 0.1.5
+      chart: gcp-standalone-cp
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: kcm-0-1-0
+  name: kcm-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 0.1.0
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-0-1-6
+  name: openstack-standalone-cp-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 0.1.6
+      chart: openstack-standalone-cp
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-0-1-5
+  name: remote-cluster-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 0.1.5
+      chart: remote-cluster
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-0-1-3
+  name: vsphere-hosted-cp-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 0.1.3
+      chart: vsphere-hosted-cp
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-0-2-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-0-1-8
+  name: vsphere-standalone-cp-0-2-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 0.1.8
+      chart: vsphere-standalone-cp
+      version: 0.2.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 dependencies:
   - name: flux2

--- a/test/e2e/clusterdeployment/resources/adopted-cluster.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/adopted-cluster.yaml.tpl
@@ -4,6 +4,6 @@ metadata:
   name: ${CLUSTER_DEPLOYMENT_NAME}
   namespace: ${NAMESPACE}
 spec:
-  template: adopted-cluster-0-1-0
+  template: adopted-cluster-0-2-0
   credential: ${ADOPTED_CREDENTIAL}
   config: {}

--- a/test/e2e/config/config.yaml
+++ b/test/e2e/config/config.yaml
@@ -19,17 +19,17 @@
 # Example of the e2e configuration:
 
 #adopted:
-#- template: adopted-cluster-0-1-0
+#- template: adopted-cluster-0-2-0
 #aws:
-#- template: aws-standalone-cp-0-1-0
+#- template: aws-standalone-cp-0-2-0
 #  hosted:
-#    template: aws-hosted-cp-0-1-0
-#- template: aws-eks-0-1-0
+#    template: aws-hosted-cp-0-2-0
+#- template: aws-eks-0-2-0
 #azure:
-#- template: azure-standalone-cp-0-1-0
+#- template: azure-standalone-cp-0-2-0
 #  hosted:
-#    template: azure-hosted-cp-0-1-0
+#    template: azure-hosted-cp-0-2-0
 #vsphere:
-#- template: vsphere-standalone-cp-0-1-0
+#- template: vsphere-standalone-cp-0-2-0
 
 aws: []


### PR DESCRIPTION
commit 3305027e8e891c4e7a4fd6cc5c022dac432b24e0
Author: Ekaterina Kazakova <41469478+eromanova@users.noreply.github.com>
Date:   Mon Mar 31 15:27:57 2025 +0400

    Bump components for 0.2.0 release (#1302)

commit b57a4853a1bb904a23f4488dd285738941d66c21
Author: Michael Morgen <mmorgen@posteo.com>
Date:   Fri Mar 28 12:34:14 2025 +0100

    Fix incorrect svc readiness calculation (#1311)

commit 86a3d7c94ddc67cc65af2a4261ed2a884c057533
Author: Ekaterina Kazakova <41469478+eromanova@users.noreply.github.com>
Date:   Thu Mar 27 22:18:00 2025 +0400

    Several minor fixes (#1289)

    * Fix objects description for GCP templates

    * Collect false condition even if message is empty

    * Do not release ClusterDeployent if Cluster still exists

    HelmRelease is being forcefully deleted after the timeout is reached
    (by default, 5 min). This change will prevent ClusterDeployment
    from removal until the Cluster object is removed (along with HelmRelease).

    * Update false condition message in mgmt status

commit 8a2f92dd9b594b652b8fac0189d8dd589327100b
Author: Aleksei Larkov <gmlexx@gmail.com>
Date:   Thu Mar 27 16:48:54 2025 +0200

    Add template name and multiclusterservices to the warning message (#1292)