### PR TITLE
Change the e2e-tests to a reusable structure

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -71,7 +71,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{fromJSON(steps.pr.outputs.result).merge_commit_sha}}
           fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -211,7 +210,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,26 +1,16 @@
 name: CI
 on:
-  pull_request_target:
-    types:
-      - labeled
-      - opened
-      - synchronize
-      - reopened
-    branches:
-      - main
-      - '*-release'
+  pull_request:
+    types: ["opened", "reopened", "synchronize", "ready_for_review"]
+    branches: ["main"]
     paths-ignore:
-      - 'config/**'
-      - '**.md'
-  push:
-    tags:
-      - '*'
+      - "config/**"
+      - "**.md"
 
 jobs:
   authorize:
     if: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') }}
-    environment:
-      ${{ (github.event_name == 'pull_request_target' &&
+    environment: ${{ (github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository) &&
       'external' || 'internal' }}
     runs-on: ubuntu-latest
@@ -86,7 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           cache: true # default
       - name: Lint
         run: GOLANGCI_LINT_TIMEOUT=10m make lint
@@ -128,189 +118,89 @@ jobs:
           make kcm-chart-release
           make helm-push
 
-  controller-e2etest:
-    name: E2E Controller
+  generate-provider-list:
+    name: Generate Provider List from Config
     runs-on: ubuntu-latest
-    env:
-      PUBLIC_REPO: ${{ contains(needs.authorize.result, 'success') && needs.authorize.outputs.public_repo == 'true' }}
-    if: ${{ !contains( github.event.pull_request.labels.*.name, 'test e2e') }}
-    needs: build
-    concurrency:
-      group: controller-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
+    needs: authorize
+    # Only run if authorize succeeded and provided a config
+    if: ${{ needs.authorize.result == 'success' && needs.authorize.outputs.config != '' }}
     outputs:
-      clusterprefix: ${{ needs.build.outputs.clusterprefix }}
-      version: ${{ needs.build.outputs.version }}
-      pr: ${{ needs.build.outputs.pr }}
+      providers: ${{ steps.get_providers.outputs.providers }}
     steps:
-      - name: Set public registry env variables
-        if: ${{ env.PUBLIC_REPO == 'true' }}
+      - name: Install yq
         run: |
-          echo "REGISTRY_REPO=oci://ghcr.io/k0rdent/kcm/charts-ci" >> $GITHUB_ENV
-          echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.build.outputs.version }}" >> $GITHUB_ENV
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@v4
-      - name: Run E2E tests
-        env:
-          GINKGO_LABEL_FILTER: 'controller'
-          CLUSTER_DEPLOYMENT_PREFIX: ${{ needs.build.outputs.clusterprefix }}
-          VERSION: ${{ needs.build.outputs.version }}
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
+      - name: Extract providers from config
+        id: get_providers
         run: |
-          make test-e2e
-      - name: Archive test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: support-bundles
-          path: |
-            *.tar.gz
+          config_base64="${{ needs.authorize.outputs.config }}"
+          providers_json=$(echo "$config_base64" | base64 -d | yq e 'keys | .[]' -o=json | jq -c 'unique')
+          echo "Detected providers: $providers_json"
+          echo "providers=$providers_json" >> $GITHUB_OUTPUT
 
-  provider-cloud-e2etest:
-    name: E2E Cloud Providers
-    runs-on: ubuntu-latest
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') }}
-    needs:
-       - authorize
-       - build
-    concurrency:
-      group: cloud-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
-    outputs:
-      clusterprefix: ${{ needs.build.outputs.clusterprefix }}
-      version: ${{ needs.build.outputs.version }}
-      pr: ${{ needs.build.outputs.pr }}
-    env:
-      AWS_REGION: us-west-2
-      AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
-      AZURE_REGION: westus2
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.CI_AZURE_SUBSCRIPTION_ID }}
-      AZURE_TENANT_ID: ${{ secrets.CI_AZURE_TENANT_ID }}
-      AZURE_CLIENT_ID: ${{ secrets.CI_AZURE_CLIENT_ID }}
-      AZURE_CLIENT_SECRET: ${{ secrets.CI_AZURE_CLIENT_SECRET }}
-      GCP_B64ENCODED_CREDENTIALS: ${{ secrets.CI_GCP_B64ENCODED_CREDENTIALS }}
-      GCP_PROJECT: k0rdent-ci
-      GCP_REGION: us-east4
-      PUBLIC_REPO: ${{ needs.authorize.outputs.public_repo == 'true' }}
-    steps:
-      - name: Set public registry env variables
-        if: ${{ env.PUBLIC_REPO == 'true' }}
-        run: |
-          echo "REGISTRY_REPO=oci://ghcr.io/k0rdent/kcm/charts-ci" >> $GITHUB_ENV
-          echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.build.outputs.version }}" >> $GITHUB_ENV
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true # default
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@v4
-      - name: Load testing configuration
-        if: ${{ needs.authorize.outputs.config != '' }}
-        run: |
-          echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
-          echo "Testing configuration was overwritten:"
-          cat test/e2e/config/config.yaml
-      - name: Run E2E tests
-        env:
-          GINKGO_LABEL_FILTER: 'provider:cloud'
-          CLUSTER_DEPLOYMENT_PREFIX: ${{ needs.build.outputs.clusterprefix }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          make test-e2e
-      - name: Archive test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: support-bundles
-          path: |
-            *.tar.gz
-
-  provider-onprem-e2etest:
-    name: E2E On-Prem Providers
-    runs-on: self-hosted
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') }}
+  e2e-tests:
+    name: E2E Tests
+    uses: .github/workflows/e2e-test.yml
     needs:
       - authorize
       - build
-    concurrency:
-      group: onprem-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
-    outputs:
+      - generate-provider-list
+    secrets: inherit
+    # Always run the job structure, but matrix entries control actual execution
+    if: ${{ always() }}
+    with:
+      provider: ${{ matrix.provider }}
+      runner: ${{ matrix.runner }}
+      condition: ${{ matrix.condition }}
+      ginkgo_filter: ${{ matrix.ginkgo_filter }}
       clusterprefix: ${{ needs.build.outputs.clusterprefix }}
       version: ${{ needs.build.outputs.version }}
       pr: ${{ needs.build.outputs.pr }}
-    env:
-      VSPHERE_USER: ${{ secrets.CI_VSPHERE_USER }}
-      VSPHERE_PASSWORD: ${{ secrets.CI_VSPHERE_PASSWORD }}
-      VSPHERE_SERVER: ${{ secrets.CI_VSPHERE_SERVER }}
-      VSPHERE_THUMBPRINT: ${{ secrets.CI_VSPHERE_THUMBPRINT }}
-      VSPHERE_DATACENTER: ${{ secrets.CI_VSPHERE_DATACENTER }}
-      VSPHERE_DATASTORE: ${{ secrets.CI_VSPHERE_DATASTORE }}
-      VSPHERE_RESOURCEPOOL: ${{ secrets.CI_VSPHERE_RESOURCEPOOL }}
-      VSPHERE_FOLDER: ${{ secrets.CI_VSPHERE_FOLDER }}
-      VSPHERE_CONTROL_PLANE_ENDPOINT: ${{ secrets.CI_VSPHERE_CONTROL_PLANE_ENDPOINT }}
-      VSPHERE_VM_TEMPLATE: ${{ secrets.CI_VSPHERE_VM_TEMPLATE }}
-      VSPHERE_NETWORK: ${{ secrets.CI_VSPHERE_NETWORK }}
-      VSPHERE_SSH_KEY: ${{ secrets.CI_VSPHERE_SSH_KEY }}
-      PUBLIC_REPO: ${{ needs.authorize.outputs.public_repo == 'true' }}
-    steps:
-      - name: Set public registry env variables
-        if: ${{ env.PUBLIC_REPO == 'true' }}
-        run: |
-          echo "REGISTRY_REPO=oci://ghcr.io/k0rdent/kcm/charts-ci" >> $GITHUB_ENV
-          echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.build.outputs.version }}" >> $GITHUB_ENV
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{fromJSON(needs.build.outputs.pr).merge_commit_sha}}
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: true # default
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@v4
-      - name: Load testing configuration
-        if: ${{ needs.authorize.outputs.config != '' }}
-        run: |
-          echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
-          echo "Testing configuration was overwritten:"
-          cat test/e2e/config/config.yaml
-      - name: Run E2E tests
-        env:
-          GINKGO_LABEL_FILTER: 'provider:onprem'
-          CLUSTER_DEPLOYMENT_PREFIX: ${{ needs.build.outputs.clusterprefix }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          make test-e2e
-      - name: Archive test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: support-bundles
-          path: |
-            *.tar.gz
+    strategy:
+      fail-fast: false # Allow other matrix jobs to continue if one fails
+      matrix:
+        include:
+          # Controller tests run only when 'test e2e' label is NOT present
+          - provider: controller
+            runner: ubuntu-latest
+            # Condition: No 'test e2e' label
+            condition: ${{ !contains( github.event.pull_request.labels.*.name, 'test e2e') }}
+            ginkgo_filter: "controller"
+
+          # Provider tests run only when 'test e2e' label IS present AND the provider is in the generated list
+          - provider: aws
+            runner: ubuntu-latest
+            # Condition: 'test e2e' label IS present AND generate-provider-list succeeded AND 'aws' is in its output
+            condition: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') && needs.generate-provider-list.result == 'success' && contains(fromJson(needs.generate-provider-list.outputs.providers), 'aws') }}
+            ginkgo_filter: "provider:cloud"
+          - provider: azure
+            runner: ubuntu-latest
+            # Condition: 'test e2e' label IS present AND generate-provider-list succeeded AND 'azure' is in its output
+            condition: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') && needs.generate-provider-list.result == 'success' && contains(fromJson(needs.generate-provider-list.outputs.providers), 'azure') }}
+            ginkgo_filter: "provider:cloud"
+          - provider: gcp
+            runner: ubuntu-latest
+            # Condition: 'test e2e' label IS present AND generate-provider-list succeeded AND 'gcp' is in its output
+            condition: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') && needs.generate-provider-list.result == 'success' && contains(fromJson(needs.generate-provider-list.outputs.providers), 'gcp') }}
+            ginkgo_filter: "provider:cloud"
+          - provider: onprem
+            runner: self-hosted
+            # Condition: 'test e2e' label IS present AND generate-provider-list succeeded AND any onprem provider (vsphere, docker, openstack, adopted) is in its output
+            condition: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') && needs.generate-provider-list.result == 'success' && (contains(fromJson(needs.generate-provider-list.outputs.providers), 'vsphere') || contains(fromJson(needs.generate-provider-list.outputs.providers), 'docker') || contains(fromJson(needs.generate-provider-list.outputs.providers), 'openstack') || contains(fromJson(needs.generate-provider-list.outputs.providers), 'adopted')) }}
+            ginkgo_filter: "provider:onprem"
+
 
   cleanup:
     name: Cleanup
     needs:
       - build
-      - provider-cloud-e2etest
+      - e2e-tests
       - authorize
     runs-on: ubuntu-latest
-    if: ${{ always() && !contains(needs.provider-cloud-e2etest.result, 'skipped') && contains(needs.build.result, 'success') }}
+    # Run cleanup if build succeeded, authorize succeeded (meaning e2e was requested),
+    # and the e2e-tests job didn't fail or get cancelled.
+    if: ${{ always() && needs.build.result == 'success' && needs.authorize.result == 'success' && needs.e2e-tests.result != 'failure' && needs.e2e-tests.result != 'cancelled' }}
     timeout-minutes: 15
     outputs:
       clusterprefix: ${{ needs.build.outputs.clusterprefix }}
@@ -325,7 +215,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           cache: true # default
       - name: AWS Test Resources
         env:
@@ -337,7 +227,7 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.CI_AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.CI_AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.CI_AZURE_CLIENT_SECRET }}
-          CLUSTER_NAME: '${{ needs.build.outputs.clusterprefix }}'
+          CLUSTER_NAME: "${{ needs.build.outputs.clusterprefix }}"
         run: |
           make dev-aws-nuke
           make dev-azure-nuke

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,6 +8,11 @@ on:
       - "**.md"
 
 jobs:
+  hello:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hello world
+        run: echo "Hello world!"
   authorize:
     if: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') }}
     environment: ${{ (github.event_name == 'pull_request' &&

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -138,6 +138,82 @@ jobs:
           echo "Detected providers: $providers_json"
           echo "providers=$providers_json" >> $GITHUB_OUTPUT
 
+  generate-e2e-matrix:
+    name: Generate E2E Test Matrix
+    runs-on: ubuntu-latest
+    needs: generate-provider-list
+    # Only run if generate-provider-list succeeded (which implies authorize succeeded and provided a config)
+    if: ${{ needs.generate-provider-list.result == 'success' }}
+    outputs:
+      matrix: ${{ steps.generate_matrix.outputs.matrix }}
+    steps:
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Generate matrix
+        id: generate_matrix
+        env:
+          PROVIDERS_JSON: ${{ needs.generate-provider-list.outputs.providers }}
+        run: |
+          # Base matrix with controller test (runs when 'test e2e' label is NOT present)
+          matrix='[
+            {
+              "provider": "controller",
+              "runner": "ubuntu-latest",
+              "condition": "${{ !contains( github.event.pull_request.labels.*.name, ''test e2e'') }}",
+              "ginkgo_filter": "controller"
+            }
+          ]'
+
+          # Condition prefix for provider tests (run when 'test e2e' label IS present AND generate-provider-list succeeded)
+          condition_prefix="${{ contains( github.event.pull_request.labels.*.name, ''test e2e'') && needs.generate-provider-list.result == ''success'' && "
+
+          # Add cloud providers if present
+          if echo "$PROVIDERS_JSON" | jq -e 'contains(["aws"])' > /dev/null; then
+            matrix=$(echo "$matrix" | jq '. + [{
+              "provider": "aws",
+              "runner": "ubuntu-latest",
+              "condition": env.condition_prefix + "contains(fromJson(needs.generate-provider-list.outputs.providers), ''aws'') }}",
+              "ginkgo_filter": "provider:cloud"
+            }]')
+          fi
+          if echo "$PROVIDERS_JSON" | jq -e 'contains(["azure"])' > /dev/null; then
+            matrix=$(echo "$matrix" | jq '. + [{
+              "provider": "azure",
+              "runner": "ubuntu-latest",
+              "condition": env.condition_prefix + "contains(fromJson(needs.generate-provider-list.outputs.providers), ''azure'') }}",
+              "ginkgo_filter": "provider:cloud"
+            }]')
+          fi
+          if echo "$PROVIDERS_JSON" | jq -e 'contains(["gcp"])' > /dev/null; then
+            matrix=$(echo "$matrix" | jq '. + [{
+              "provider": "gcp",
+              "runner": "ubuntu-latest",
+              "condition": env.condition_prefix + "contains(fromJson(needs.generate-provider-list.outputs.providers), ''gcp'') }}",
+              "ginkgo_filter": "provider:cloud"
+            }]')
+          fi
+
+          # Add onprem provider if any onprem provider is present
+          if echo "$PROVIDERS_JSON" | jq -e 'any(. == "vsphere" or . == "docker" or . == "openstack" or . == "adopted")' > /dev/null; then
+            onprem_condition="env.condition_prefix + \"(\" + \
+              \"contains(fromJson(needs.generate-provider-list.outputs.providers), ''vsphere'') || \" + \
+              \"contains(fromJson(needs.generate-provider-list.outputs.providers), ''docker'') || \" + \
+              \"contains(fromJson(needs.generate-provider-list.outputs.providers), ''openstack'') || \" + \
+              \"contains(fromJson(needs.generate-provider-list.outputs.providers), ''adopted'')\" + \
+              \") }}\""
+            matrix=$(echo "$matrix" | jq --argjson cond "$onprem_condition" '. + [{
+              "provider": "onprem",
+              "runner": "self-hosted",
+              "condition": $cond,
+              "ginkgo_filter": "provider:onprem"
+            }]')
+          fi
+
+          # Output the final matrix as a compact JSON string
+          echo "matrix=$(echo "$matrix" | jq -c .)" >> $GITHUB_OUTPUT
+          echo "Generated Matrix:"
+          echo "$matrix" | jq .
+
   e2e-tests:
     name: E2E Tests
     uses: .github/workflows/e2e-test.yml
@@ -145,8 +221,10 @@ jobs:
       - authorize
       - build
       - generate-provider-list
+      - generate-e2e-matrix # Added dependency
     secrets: inherit
     # Always run the job structure, but matrix entries control actual execution
+    # The condition within each matrix entry determines if it *actually* runs
     if: ${{ always() }}
     with:
       provider: ${{ matrix.provider }}
@@ -158,37 +236,8 @@ jobs:
       pr: ${{ needs.build.outputs.pr }}
     strategy:
       fail-fast: false # Allow other matrix jobs to continue if one fails
-      matrix:
-        include:
-          # Controller tests run only when 'test e2e' label is NOT present
-          - provider: controller
-            runner: ubuntu-latest
-            # Condition: No 'test e2e' label
-            condition: ${{ !contains( github.event.pull_request.labels.*.name, 'test e2e') }}
-            ginkgo_filter: "controller"
-
-          # Provider tests run only when 'test e2e' label IS present AND the provider is in the generated list
-          - provider: aws
-            runner: ubuntu-latest
-            # Condition: 'test e2e' label IS present AND generate-provider-list succeeded AND 'aws' is in its output
-            condition: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') && needs.generate-provider-list.result == 'success' && contains(fromJson(needs.generate-provider-list.outputs.providers), 'aws') }}
-            ginkgo_filter: "provider:cloud"
-          - provider: azure
-            runner: ubuntu-latest
-            # Condition: 'test e2e' label IS present AND generate-provider-list succeeded AND 'azure' is in its output
-            condition: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') && needs.generate-provider-list.result == 'success' && contains(fromJson(needs.generate-provider-list.outputs.providers), 'azure') }}
-            ginkgo_filter: "provider:cloud"
-          - provider: gcp
-            runner: ubuntu-latest
-            # Condition: 'test e2e' label IS present AND generate-provider-list succeeded AND 'gcp' is in its output
-            condition: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') && needs.generate-provider-list.result == 'success' && contains(fromJson(needs.generate-provider-list.outputs.providers), 'gcp') }}
-            ginkgo_filter: "provider:cloud"
-          - provider: onprem
-            runner: self-hosted
-            # Condition: 'test e2e' label IS present AND generate-provider-list succeeded AND any onprem provider (vsphere, docker, openstack, adopted) is in its output
-            condition: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') && needs.generate-provider-list.result == 'success' && (contains(fromJson(needs.generate-provider-list.outputs.providers), 'vsphere') || contains(fromJson(needs.generate-provider-list.outputs.providers), 'docker') || contains(fromJson(needs.generate-provider-list.outputs.providers), 'openstack') || contains(fromJson(needs.generate-provider-list.outputs.providers), 'adopted')) }}
-            ginkgo_filter: "provider:onprem"
-
+      # Dynamically generate the matrix from the previous job's output
+      matrix: ${{ fromJson(needs.generate-e2e-matrix.outputs.matrix) }}
 
   cleanup:
     name: Cleanup

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -117,17 +117,19 @@ jobs:
           make kcm-chart-release
           make helm-push
 
-  generate-provider-list:
-    name: Generate Provider List from Config
+  generate-e2e-matrix:
+    name: Generate E2E Matrix
     runs-on: ubuntu-latest
     needs: authorize
     # Only run if authorize succeeded and provided a config
     if: ${{ needs.authorize.result == 'success' && needs.authorize.outputs.config != '' }}
     outputs:
       providers: ${{ steps.get_providers.outputs.providers }}
+      matrix: ${{ steps.generate_matrix.outputs.matrix }}
     steps:
-      - name: Install yq
+      - name: Install yq and jq
         run: |
+          sudo apt-get update && sudo apt-get install -y jq
           sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
           sudo chmod +x /usr/bin/yq
       - name: Extract providers from config
@@ -137,22 +139,13 @@ jobs:
           providers_json=$(echo "$config_base64" | base64 -d | yq e 'keys | .[]' -o=json | jq -c 'unique')
           echo "Detected providers: $providers_json"
           echo "providers=$providers_json" >> $GITHUB_OUTPUT
-
-  generate-e2e-matrix:
-    name: Generate E2E Test Matrix
-    runs-on: ubuntu-latest
-    needs: generate-provider-list
-    # Only run if generate-provider-list succeeded (which implies authorize succeeded and provided a config)
-    if: ${{ needs.generate-provider-list.result == 'success' }}
-    outputs:
-      matrix: ${{ steps.generate_matrix.outputs.matrix }}
-    steps:
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
       - name: Generate matrix
         id: generate_matrix
         env:
-          PROVIDERS_JSON: ${{ needs.generate-provider-list.outputs.providers }}
+          # Use output from the previous step in *this* job
+          PROVIDERS_JSON: ${{ steps.get_providers.outputs.providers }}
+          # Define the condition prefix referencing *this* job's needs and outputs
+          CONDITION_PREFIX: "${{ contains( github.event.pull_request.labels.*.name, 'test e2e') && needs.generate-e2e-setup.result == 'success' && "
         run: |
           # Base matrix with controller test (runs when 'test e2e' label is NOT present)
           matrix='[
@@ -164,15 +157,12 @@ jobs:
             }
           ]'
 
-          # Condition prefix for provider tests (run when 'test e2e' label IS present AND generate-provider-list succeeded)
-          condition_prefix="${{ contains( github.event.pull_request.labels.*.name, ''test e2e'') && needs.generate-provider-list.result == ''success'' && "
-
           # Add cloud providers if present
           if echo "$PROVIDERS_JSON" | jq -e 'contains(["aws"])' > /dev/null; then
             matrix=$(echo "$matrix" | jq '. + [{
               "provider": "aws",
               "runner": "ubuntu-latest",
-              "condition": env.condition_prefix + "contains(fromJson(needs.generate-provider-list.outputs.providers), ''aws'') }}",
+              "condition": env.CONDITION_PREFIX + "contains(fromJson(needs.generate-e2e-setup.outputs.providers), ''aws'') }}",
               "ginkgo_filter": "provider:cloud"
             }]')
           fi
@@ -180,7 +170,7 @@ jobs:
             matrix=$(echo "$matrix" | jq '. + [{
               "provider": "azure",
               "runner": "ubuntu-latest",
-              "condition": env.condition_prefix + "contains(fromJson(needs.generate-provider-list.outputs.providers), ''azure'') }}",
+              "condition": env.CONDITION_PREFIX + "contains(fromJson(needs.generate-e2e-setup.outputs.providers), ''azure'') }}",
               "ginkgo_filter": "provider:cloud"
             }]')
           fi
@@ -188,20 +178,21 @@ jobs:
             matrix=$(echo "$matrix" | jq '. + [{
               "provider": "gcp",
               "runner": "ubuntu-latest",
-              "condition": env.condition_prefix + "contains(fromJson(needs.generate-provider-list.outputs.providers), ''gcp'') }}",
+              "condition": env.CONDITION_PREFIX + "contains(fromJson(needs.generate-e2e-setup.outputs.providers), ''gcp'') }}",
               "ginkgo_filter": "provider:cloud"
             }]')
           fi
 
           # Add onprem provider if any onprem provider is present
           if echo "$PROVIDERS_JSON" | jq -e 'any(. == "vsphere" or . == "docker" or . == "openstack" or . == "adopted")' > /dev/null; then
-            onprem_condition="env.condition_prefix + \"(\" + \
-              \"contains(fromJson(needs.generate-provider-list.outputs.providers), ''vsphere'') || \" + \
-              \"contains(fromJson(needs.generate-provider-list.outputs.providers), ''docker'') || \" + \
-              \"contains(fromJson(needs.generate-provider-list.outputs.providers), ''openstack'') || \" + \
-              \"contains(fromJson(needs.generate-provider-list.outputs.providers), ''adopted'')\" + \
+            onprem_condition="env.CONDITION_PREFIX + \"(\" + \
+              \"contains(fromJson(needs.generate-e2e-setup.outputs.providers), ''vsphere'') || \" + \
+              \"contains(fromJson(needs.generate-e2e-setup.outputs.providers), ''docker'') || \" + \
+              \"contains(fromJson(needs.generate-e2e-setup.outputs.providers), ''openstack'') || \" + \
+              \"contains(fromJson(needs.generate-e2e-setup.outputs.providers), ''adopted'')\" + \
               \") }}\""
-            matrix=$(echo "$matrix" | jq --argjson cond "$onprem_condition" '. + [{
+            # Use --argjson to pass the constructed condition string correctly into jq
+            matrix=$(echo "$matrix" | jq --arg cond "$onprem_condition" '. + [{
               "provider": "onprem",
               "runner": "self-hosted",
               "condition": $cond,
@@ -220,8 +211,7 @@ jobs:
     needs:
       - authorize
       - build
-      - generate-provider-list
-      - generate-e2e-matrix # Added dependency
+      - generate-e2e-matrix
     secrets: inherit
     # Always run the job structure, but matrix entries control actual execution
     # The condition within each matrix entry determines if it *actually* runs
@@ -236,8 +226,8 @@ jobs:
       pr: ${{ needs.build.outputs.pr }}
     strategy:
       fail-fast: false # Allow other matrix jobs to continue if one fails
-      # Dynamically generate the matrix from the previous job's output
-      matrix: ${{ fromJson(needs.generate-e2e-matrix.outputs.matrix) }}
+      # Dynamically generate the matrix from the combined job's output
+      matrix: ${{ fromJson(needs.generate-e2e-setup.outputs.matrix) }}
 
   cleanup:
     name: Cleanup

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -50,7 +50,6 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-[]}}
             - name: Setup Go
               uses: actions/setup-go@v5
               with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -50,7 +50,6 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-                  ref: ${{fromJSON(needs.build.inputs.pr).]
 []}}
             - name: Setup Go
               uses: actions/setup-go@v5

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,139 @@
+name: E2E Tests
+on:
+  workflow_call:
+    inputs:
+      provider:
+        required: true
+        type: string
+      runner:
+        required: true
+        type: string
+      condition:
+        required: false
+        type: string
+        default: "true" # Default to true if not provided
+      ginkgo_filter:
+        required: false
+        type: string
+        default: "" # Default to empty if not provided
+      clusterprefix:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      pr:
+        required: true
+        type: string
+
+jobs:
+    e2e-test:
+        name: E2E Tests - ${{ inputs.provider }}
+        runs-on: ${{ inputs.runner }}
+        if: ${{ inputs.condition }}
+        concurrency:
+            group: ${{ inputs.provider }}-${{ github.head_ref || github.run_id }}
+            cancel-in-progress: true
+        outputs:
+            clusterprefix: ${{ needs.build.inputs.clusterprefix }}
+            version: ${{ needs.build.inputs.version }}
+            pr: ${{ needs.build.inputs.pr }}
+        env:
+            PUBLIC_REPO: ${{ needs.authorize.outputs.public_repo == 'true' }}
+        steps:
+            - name: Set public registry env variables
+              if: ${{ env.PUBLIC_REPO == 'true' }}
+              run: |
+                  echo "REGISTRY_REPO=oci://ghcr.io/k0rdent/kcm/charts-ci" >> $GITHUB_ENV
+                  echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.build.inputs.version }}" >> $GITHUB_ENV
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  ref: ${{fromJSON(needs.build.inputs.pr).]
+[]}}
+            - name: Setup Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version-file: "go.mod"
+                  cache: true # default
+            - name: Setup kubectl
+              uses: azure/setup-kubectl@v4
+            - name: Load testing configuration
+              if: ${{ needs.authorize.outputs.config != '' }}
+              run: |
+                  echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
+                  echo "Testing configuration was overwritten:"
+                  cat test/e2e/config/config.yaml
+
+            - name: Set aws cloud provider environment variables
+              if: inputs.provider == 'aws'
+              env:
+                AWS_REGION: us-west-2
+                AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
+                AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
+              run: |
+                for var in AWS_REGION AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
+                  echo "${var}=${!var}" >> $GITHUB_ENV
+                done
+
+            - name: Set azure cloud provider environment variables
+              if: inputs.provider == 'azure'
+              env:
+                AZURE_REGION: westus2
+                AZURE_SUBSCRIPTION_ID: ${{ secrets.CI_AZURE_SUBSCRIPTION_ID }}
+                AZURE_TENANT_ID: ${{ secrets.CI_AZURE_TENANT_ID }}
+                AZURE_CLIENT_ID: ${{ secrets.CI_AZURE_CLIENT_ID }}
+                AZURE_CLIENT_SECRET: ${{ secrets.CI_AZURE_CLIENT_SECRET }}
+              run: |
+                for var in AZURE_REGION AZURE_SUBSCRIPTION_ID AZURE_TENANT_ID AZURE_CLIENT_ID AZURE_CLIENT_SECRET; do
+                  echo "${var}=${!var}" >> $GITHUB_ENV
+                done
+
+            - name: Set gcp cloud provider environment variables
+              if: inputs.provider == 'gcp'
+              env:
+                GCP_B64ENCODED_CREDENTIALS: ${{ secrets.CI_GCP_B64ENCODED_CREDENTIALS }}
+                GCP_PROJECT: k0rdent-ci
+                GCP_REGION: us-east4
+              run: |
+                for var in GCP_B64ENCODED_CREDENTIALS GCP_PROJECT GCP_REGION; do
+                  echo "${var}=${!var}" >> $GITHUB_ENV
+                done
+
+            - name: Set on-prem environment variables
+              if: inputs.provider == 'onprem'
+              env:
+                VSPHERE_USER: ${{ secrets.CI_VSPHERE_USER }}
+                VSPHERE_PASSWORD: ${{ secrets.CI_VSPHERE_PASSWORD }}
+                VSPHERE_SERVER: ${{ secrets.CI_VSPHERE_SERVER }}
+                VSPHERE_THUMBPRINT: ${{ secrets.CI_VSPHERE_THUMBPRINT }}
+                VSPHERE_DATACENTER: ${{ secrets.CI_VSPHERE_DATACENTER }}
+                VSPHERE_DATASTORE: ${{ secrets.CI_VSPHERE_DATASTORE }}
+                VSPHERE_RESOURCEPOOL: ${{ secrets.CI_VSPHERE_RESOURCEPOOL }}
+                VSPHERE_FOLDER: ${{ secrets.CI_VSPHERE_FOLDER }}
+                VSPHERE_CONTROL_PLANE_ENDPOINT: ${{ secrets.CI_VSPHERE_CONTROL_PLANE_ENDPOINT }}
+                VSPHERE_VM_TEMPLATE: ${{ secrets.CI_VSPHERE_VM_TEMPLATE }}
+                VSPHERE_NETWORK: ${{ secrets.CI_VSPHERE_NETWORK }}
+                VSPHERE_SSH_KEY: ${{ secrets.CI_VSPHERE_SSH_KEY }}
+              run: |
+                for var in VSPHERE_USER VSPHERE_PASSWORD VSPHERE_SERVER VSPHERE_THUMBPRINT \
+                          VSPHERE_DATACENTER VSPHERE_DATASTORE VSPHERE_RESOURCEPOOL VSPHERE_FOLDER \
+                          VSPHERE_CONTROL_PLANE_ENDPOINT VSPHERE_VM_TEMPLATE VSPHERE_NETWORK VSPHERE_SSH_KEY; do
+                  echo "${var}=${!var}" >> $GITHUB_ENV
+                done
+
+            - name: Run E2E tests
+              env:
+                  GINKGO_LABEL_FILTER: ${{ inputs.ginkgo_filter }}
+                  CLUSTER_DEPLOYMENT_PREFIX: ${{ needs.build.inputs.clusterprefix }}
+                  VERSION: ${{ needs.build.inputs.version }}
+              run: |
+                  make test-e2e
+            - name: Archive test results
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: support-bundles-${{ inputs.provider }}
+                  path: |
+                      *.tar.gz


### PR DESCRIPTION
Closes #426 

This makes changes to the e2e-test job so that it is a reusable workflow based on a matrix. It also splits the cloud provider tests into separate providers in the matrix so that they run separate of one another.

## Testing

I ran this on my fork of the repo to make sure the correct jobs ran but I don't have cloud credentials setup. This needs the `test-e2e` label to be fully tested on the kcm repo.

I created a PR on my fork of the kcm repo to test these changes.

### Without the `test-e2e` label
**Before**
https://github.com/k0rdent/kcm/actions/runs/14170653814
<img width="1130" alt="Screenshot 2025-04-02 at 8 39 21 AM" src="https://github.com/user-attachments/assets/3896c2e3-f6fc-4a3a-ae9e-76d0671843e7" />


**After**
https://github.com/nwneisen/kcm/actions/runs/14221774505
<img width="1130" alt="Screenshot 2025-04-02 at 8 33 43 AM" src="https://github.com/user-attachments/assets/abcac138-5ac8-4640-ab93-73980d9bab41" />

### With the `test-e2e` label
**Before**
https://github.com/k0rdent/kcm/actions/runs/14081361831
<img width="1130" alt="Screenshot 2025-04-02 at 8 57 48 AM" src="https://github.com/user-attachments/assets/f416fb43-7164-45ab-98e8-a750bd9a9eef" />

With most of the providers being skipped due to having no config values
```
Azure Templates should work with an Azure provider [provider:cloud, provider:azure]
/home/runner/work/kcm/kcm/test/e2e/provider_azure_test.go:98
  STEP: get testing configuration @ 03/26/25 10:57:49.1
  [SKIPPED] in [BeforeAll] - /home/runner/work/kcm/kcm/test/e2e/provider_azure_test.go:55 @ 03/26/25 10:57:49.1
```

Except for AWS
```
AWS Templates should work with an AWS provider [provider:cloud, provider:aws]
/home/runner/work/kcm/kcm/test/e2e/provider_aws_test.go:121
  STEP: get testing configuration @ 03/26/25 10:57:49.1
```

**After**
https://github.com/k0rdent/kcm/actions/runs/14199557079?pr=1326
<img width="1130" alt="Screenshot 2025-04-02 at 8 54 09 AM" src="https://github.com/user-attachments/assets/12c60e16-3b18-4b4a-9c58-cf3e6456f346" />

With most of the providers being skipped due to having no config values
```
GCP Templates should work with GCP provider [provider:cloud, provider:gcp]
/home/runner/work/kcm/kcm/test/e2e/provider_gcp_test.go:88
  STEP: get testing configuration @ 04/01/25 15:50:01.972
  [SKIPPED] in [BeforeAll] - /home/runner/work/kcm/kcm/test/e2e/provider_gcp_test.go:53 @ 04/01/25 15:50:01.972
```
```
Azure Templates should work with an Azure provider [provider:cloud, provider:azure]
/home/runner/work/kcm/kcm/test/e2e/provider_azure_test.go:98
  STEP: get testing configuration @ 04/01/25 15:59:54.977
  [SKIPPED] in [BeforeAll] - /home/runner/work/kcm/kcm/test/e2e/provider_azure_test.go:55 @ 04/01/25 15:59:54.977
```

Except for AWS
```
AWS Templates should work with an AWS provider [provider:cloud, provider:aws]
/home/runner/work/kcm/kcm/test/e2e/provider_aws_test.go:121
  STEP: get testing configuration @ 04/01/25 15:50:01.973
```