### PR TITLE
Add `StorageClass` to `make dev-azure-creds`

### DIFF
--- a/config/dev/azure-credentials.yaml
+++ b/config/dev/azure-credentials.yaml
@@ -95,3 +95,16 @@ data:
     type: Opaque
     data:
       cloud-config: {{ $$cloudConfig | toJson | b64enc }}
+    ---
+    apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: managed-csi
+      annotations:
+        storageclass.kubernetes.io/is-default-class: "true"
+    provisioner: disk.csi.azure.com
+    parameters:
+      skuName: StandardSSD_LRS
+    reclaimPolicy: Delete
+    volumeBindingMode: WaitForFirstConsumer
+    allowVolumeExpansion: true


### PR DESCRIPTION
* Related to https://github.com/k0rdent/kcm/issues/1118
* We already have a default `StorageClass` added to the docs [here](https://docs.k0rdent.io/v0.2.0/quickstarts/quickstart-2-azure/#create-the-configmap-resource-template-object).
* This PR adds it to `make dev-azure-creds` too - for development purposes only, e.g. https://github.com/k0rdent/kof/issues/36
* It does not change cluster template, so there is no conflict with [this comment](https://github.com/k0rdent/kcm/issues/1118#issuecomment-2682078575).
