### PR TITLE
Golangci-lint@v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,36 +1,11 @@
+version: "2"
 run:
   timeout: 5m
+  modules-download-mode: readonly
   allow-parallel-runners: true
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: (cmd\/main\.go)|(.*_test\.go)
-      linters:
-        - maintidx
-    - path: test/
-      linters:
-        - perfsprint
-        - errorlint
-        - exhaustive
-    - text: 'shadow: declaration of "err" shadows declaration'
-      linters:
-        - govet
-    - text: "fieldalignment: "
-      path: (.*_test\.go|test\/|api\/?.*\/.*_types\.go) # ignore tests, and k8s API-specific files
-      linters:
-        - govet
-    - text: "max-public-structs: you have exceeded the maximum number.*of public struct declarations"
-      linters:
-        - revive
-      path: api/ # the api/ pkgs have lots of structs
-
+  go: '1.24'
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -53,18 +28,13 @@ linters:
     - exhaustive
     - forbidigo
     - forcetypeassert
-    - gci
     - ginkgolinter
     - gocheckcompilerdirectives
     - gochecksumtype
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - gofumpt
-    - goimports
     - goprintffuncname
-    - gosimple
     - govet
     - ineffassign
     - interfacebloat
@@ -86,7 +56,6 @@ linters:
     - promlinter
     - revive
     - staticcheck
-    - stylecheck
     - testifylint
     - thelper
     - tparallel
@@ -97,234 +66,305 @@ linters:
     - usetesting
     - wastedassign
     - whitespace
-
-linters-settings:
-  depguard:
+  settings:
+    depguard:
+      rules:
+        # Name of a rule.
+        aliases:
+          # List of file globs that will match this list of settings to compare against.
+          # Default: $all
+          files:
+            - '!test/**'
+            - '!**/*_test.go'
+          deny:
+            - pkg: sigs.k8s.io/controller-runtime/pkg/reconcile
+              desc: Use aliases from the 'ctrl "sigs.k8s.io/controller-runtime"' package
+        main:
+          # Packages that are not allowed where the value is a suggestion.
+          deny:
+            - pkg: github.com/pkg/errors
+              desc: Should be replaced by standard lib 'errors' package
+            - pkg: github.com/hashicorp/go-multierror
+              desc: Should be replaced by standard lib 'errors' package
+            - pkg: go.uber.org/multierr
+              desc: Should be replaced by standard lib 'errors' package
+    dupl:
+      # Tokens count to trigger issue.
+      # Default: 150
+      threshold: 200
+    errcheck:
+      disable-default-exclusions: true
+      check-type-assertions: true
+      check-blank: false
+    govet:
+      disable-all: true
+      enable:
+        - appends
+        - asmdecl
+        - assign
+        - atomic
+        - atomicalign
+        - bools
+        - buildtag
+        - cgocall
+        - composites
+        - copylocks
+        - deepequalerrors
+        - defers
+        - directive
+        - errorsas
+        - fieldalignment
+        - findcall
+        - framepointer
+        - httpresponse
+        - ifaceassert
+        - loopclosure
+        - lostcancel
+        - nilfunc
+        - nilness
+        - printf
+        - reflectvaluecompare
+        - shadow
+        - shift
+        - sigchanyzer
+        - slog
+        - sortslice
+        - stdmethods
+        - stringintconv
+        - structtag
+        - testinggoroutine
+        - tests
+        - unmarshal
+        - unreachable
+        - unsafeptr
+        - unusedresult
+        - unusedwrite
+    loggercheck:
+      kitlog: false
+      klog: false
+      require-string-key: true
+      no-printf-like: true
+    paralleltest:
+      ignore-missing: true
+    prealloc:
+      for-loops: true
+    revive:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
+      rules:
+        - name: add-constant
+          disabled: true
+        - name: argument-limit
+          disabled: true
+        - name: atomic
+        - name: banned-characters
+          arguments: [Ω,Σ,σ,"7"]
+        - name: bare-return
+        - name: blank-imports
+        - name: bool-literal-in-expr
+        - name: call-to-gc
+        - name: cognitive-complexity
+          disabled: true
+        - name: comment-spacings
+        - name: comments-density
+          disabled: true
+        - name: confusing-naming
+        - name: confusing-results
+        - name: constant-logical-expr
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: '*testing.T'
+        - name: context-keys-type
+        - name: cyclomatic
+          disabled: true
+        - name: datarace
+        - name: deep-exit
+        - name: defer
+          arguments:
+            - ["call-chain", "loop", "method-call", "recover", "immediate-recover", "return"]
+        - name: dot-imports
+          arguments:
+            - allowedPackages:
+                - github.com/onsi/ginkgo/v2
+                - github.com/onsi/gomega
+                - sigs.k8s.io/controller-runtime/pkg/envtest/komega
+        - name: duplicated-imports
+        - name: early-return
+        - name: empty-block
+        - name: empty-lines
+        - name: enforce-map-style
+          arguments: ["make"]
+          exclude: ["TEST"]
+        - name: enforce-repeated-arg-type-style
+          arguments:
+            - { funcArgStyle = "any", funcRetValStyle = "short" }
+        - name: enforce-slice-style
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: exported
+          arguments:
+            - "checkPrivateReceivers"
+            - "sayRepetitiveInsteadOfStutters"
+          disabled: true
+        - name: file-header
+          disabled: true
+        - name: flag-parameter
+        - name: function-length
+          disabled: true
+        - name: function-result-limit
+          disabled: true
+        - name: get-return
+        - name: identical-branches
+        - name: if-return
+        - name: import-alias-naming
+          arguments:
+            - "^[a-z][a-z0-9]{0,}$"
+        - name: import-shadowing
+        - name: imports-blocklist
+          disabled: true
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: line-length-limit
+          disabled: true
+        - name: max-control-nesting
+        - name: max-public-structs
+          arguments: [5]
+          exclude: ["TEST"]
+        - name: modifies-parameter
+        - name: modifies-value-receiver
+        - name: nested-structs
+        - name: optimize-operands-order
+        - name: package-comments
+          disabled: true
+        - name: range
+        - name: range-val-address
+        - name: range-val-in-closure
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: redundant-import-alias
+        - name: string-format
+          arguments:
+            # TODO: enable commented when existing warnings are fixed
+            # - - 'fmt.Errorf[0]'
+            #   - '/^([^A-Z]|$)/'
+            #   - 'Error string must not start with a capital letter.'
+            - - 'fmt.Errorf[0]'
+              - '/(^|[^\.!?])$/'
+              - 'Error string must not end in punctuation.'
+            # - - 'errors.New[0]'
+            #   - '/^([^A-Z]|$)/'
+            #   - 'Error string must not start with a capital letter.'
+            - - 'errors.New[0]'
+              - '/(^|[^\.!?])$/'
+              - 'Error string must not end in punctuation.'
+            - - 'panic'
+              - '/^[^\n]*$/'
+              - 'Must not contain line breaks.'
+        - name: string-of-int
+        - name: struct-tag
+          arguments:
+            - "json,inline"
+        - name: superfluous-else
+        - name: time-equal
+        - name: time-naming
+        - name: unchecked-type-assertion
+        - name: unconditional-recursion
+        - name: unexported-naming
+        - name: unexported-return
+        - name: unhandled-error
+        - name: unnecessary-stmt
+        - name: unreachable-code
+        - name: unused-parameter
+        - name: unused-receiver
+        - name: use-any
+        - name: useless-break
+        - name: var-declaration
+        - name: var-naming
+        - name: waitgroup-by-value
+    staticcheck:
+      checks:
+        - all
+        - -ST1000
+        - -ST1001
+        - -ST1021
+    testifylint:
+      disable-all: true
+      enable:
+        - blank-import
+        - bool-compare
+        - compares
+        - contains
+        - empty
+        - encoded-compare
+        - equal-values
+        - error-is-as
+        - error-nil
+        - expected-actual
+        - float-compare
+        - formatter
+        - go-require
+        - len
+        - negative-positive
+        - nil-compare
+        - regexp
+        - require-error
+        - suite-broken-parallel
+        - suite-dont-use-pkg
+        - suite-extra-assert-call
+        - suite-method-signature
+        - suite-subtest-run
+        - suite-thelper
+        - useless-assert
+  exclusions:
+    generated: lax
+    warn-unused: true
     rules:
-      # Name of a rule.
-      main:
-        # Packages that are not allowed where the value is a suggestion.
-        deny:
-          - pkg: "github.com/pkg/errors"
-            desc: Should be replaced by standard lib 'errors' package
-          - pkg: "github.com/hashicorp/go-multierror"
-            desc: Should be replaced by standard lib 'errors' package
-          - pkg: "go.uber.org/multierr"
-            desc: Should be replaced by standard lib 'errors' package
-      aliases:
-        # List of file globs that will match this list of settings to compare against.
-        # Default: $all
-        files:
-          - "!test/**"
-          - "!**/*_test.go"
-        deny:
-          - pkg: "sigs.k8s.io/controller-runtime/pkg/reconcile"
-            desc: Use aliases from the 'ctrl "sigs.k8s.io/controller-runtime"' package
-  dupl:
-    # Tokens count to trigger issue.
-    # Default: 150
-    threshold: 200
-  errcheck:
-    check-type-assertions: true
-    check-blank: false
-    disable-default-exclusions: true
-  gci:
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(github.com/K0rdent/kcm) # Custom section: groups all imports with the specified Prefix.
-    skip-generated: false
-  gofmt:
-    # Apply the rewrite rules to the source before reformatting.
-    # https://pkg.go.dev/cmd/gofmt
-    # Default: []
-    rewrite-rules:
-      - pattern: "interface{}"
-        replacement: "any"
-  gofumpt:
-    extra-rules: true
-  govet:
-    disable-all: true
-    enable:
-      - appends
-      - asmdecl
-      - assign
-      - atomic
-      - atomicalign
-      - bools
-      - buildtag
-      - cgocall
-      - composites
-      - copylocks
-      - deepequalerrors
-      - defers
-      - directive
-      - errorsas
-      - fieldalignment
-      - findcall
-      - framepointer
-      - httpresponse
-      - ifaceassert
-      - loopclosure
-      - lostcancel
-      - nilfunc
-      - nilness
-      - printf
-      - reflectvaluecompare
-      - shadow
-      - shift
-      - sigchanyzer
-      - slog
-      - sortslice
-      - stdmethods
-      - stringintconv
-      - structtag
-      - testinggoroutine
-      - tests
-      - unmarshal
-      - unreachable
-      - unsafeptr
-      - unusedresult
-      - unusedwrite
-  loggercheck:
-    kitlog: false
-    klog: false
-    require-string-key: true
-    no-printf-like: true
-  paralleltest:
-    ignore-missing: true
-  prealloc:
-    for-loops: true
-  revive:
-    # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
-    rules:
-      - name: add-constant
-        disabled: true
-      - name: argument-limit
-        disabled: true
-      - name: atomic
-      - name: banned-characters
-        arguments: ["Ω", "Σ", "σ", "7"]
-      - name: bare-return
-      - name: blank-imports
-      - name: bool-literal-in-expr
-      - name: call-to-gc
-      - name: cognitive-complexity
-        disabled: true
-      - name: comment-spacings
-      - name: comments-density
-        disabled: true
-      - name: confusing-naming
-      - name: confusing-results
-      - name: constant-logical-expr
-      - name: context-as-argument
-        arguments:
-          - allowTypesBefore: "*testing.T"
-      - name: context-keys-type
-      - name: cyclomatic
-        disabled: true
-      - name: datarace
-      - name: deep-exit
-      - name: defer
-        arguments:
-          - ["call-chain", "loop", "method-call", "recover", "immediate-recover", "return"]
-      - name: dot-imports
-        arguments:
-          - { allowedPackages: ["github.com/onsi/ginkgo/v2","github.com/onsi/gomega","sigs.k8s.io/controller-runtime/pkg/envtest/komega"] }
-      - name: duplicated-imports
-      - name: early-return
-      - name: empty-block
-      - name: empty-lines
-      - name: enforce-map-style
-        arguments: ["make"]
-        exclude: ["TEST"]
-      - name: enforce-repeated-arg-type-style
-        arguments:
-          - { funcArgStyle = "any", funcRetValStyle = "short" }
-      - name: enforce-slice-style
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: errorf
-      - name: exported
-        disabled: true
-        arguments:
-          - "checkPrivateReceivers"
-          - "sayRepetitiveInsteadOfStutters"
-      - name: file-header
-        disabled: true
-      - name: flag-parameter
-      - name: function-length
-        disabled: true
-      - name: function-result-limit
-        disabled: true
-      - name: get-return
-      - name: identical-branches
-      - name: if-return
-      - name: import-alias-naming
-        arguments:
-          - "^[a-z][a-z0-9]{0,}$"
-      - name: import-shadowing
-      - name: imports-blocklist
-        disabled: true
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: line-length-limit
-        disabled: true
-      - name: max-control-nesting
-      - name: max-public-structs
-        exclude: ["TEST"]
-        arguments: [5]
-      - name: modifies-parameter
-      - name: modifies-value-receiver
-      - name: nested-structs
-      - name: optimize-operands-order
-      - name: package-comments
-        disabled: true
-      - name: range
-      - name: range-val-address
-      - name: range-val-in-closure
-      - name: receiver-naming
-      - name: redefines-builtin-id
-      - name: redundant-import-alias
-      - name: string-format
-        arguments:
-          # TODO: enable commented when existing warnings are fixed
-          # - - 'fmt.Errorf[0]'
-          #   - '/^([^A-Z]|$)/'
-          #   - 'Error string must not start with a capital letter.'
-          - - 'fmt.Errorf[0]'
-            - '/(^|[^\.!?])$/'
-            - 'Error string must not end in punctuation.'
-          # - - 'errors.New[0]'
-          #   - '/^([^A-Z]|$)/'
-          #   - 'Error string must not start with a capital letter.'
-          - - 'errors.New[0]'
-            - '/(^|[^\.!?])$/'
-            - 'Error string must not end in punctuation.'
-          - - 'panic'
-            - '/^[^\n]*$/'
-            - 'Must not contain line breaks.'
-      - name: string-of-int
-      - name: struct-tag
-        arguments:
-          - "json,inline"
-      - name: superfluous-else
-      - name: time-equal
-      - name: time-naming
-      - name: unchecked-type-assertion
-      - name: unconditional-recursion
-      - name: unexported-naming
-      - name: unexported-return
-      - name: unhandled-error
-      - name: unnecessary-stmt
-      - name: unreachable-code
-      - name: unused-parameter
-      - name: unused-receiver
-      - name: use-any
-      - name: useless-break
-      - name: var-declaration
-      - name: var-naming
-      - name: waitgroup-by-value
-  stylecheck:
-    checks: ["all", "-ST1000", "-ST1001", "-ST1021"]
+      - linters:
+          - maintidx
+        path: (cmd\/main\.go)|(.*_test\.go)
+      - linters:
+          - errorlint
+          - exhaustive
+          - perfsprint
+        path: test/
+      - linters:
+          - govet
+        text: 'shadow: declaration of "err" shadows declaration'
+      - linters:
+          - govet
+        path: (.*_test\.go|test\/|api\/?.*\/.*_types\.go)
+        text: 'fieldalignment: '
+      - linters:
+          - revive
+        path: api/
+        text: 'max-public-structs: you have exceeded the maximum number.*of public struct declarations'
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/K0rdent/kcm) # Custom section: groups all imports with the specified Prefix.
+    gofmt:
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: strict
+output:
+  sort-order:
+    - linter
+    - severity
+    - file # filepath, line, and column.
+severity:
+  default: "@linter"
+issues:
+  max-same-issues: 10

--- a/Makefile
+++ b/Makefile
@@ -594,7 +594,7 @@ SUPPORT_BUNDLE_CLI ?= $(LOCALBIN)/support-bundle-$(SUPPORT_BUNDLE_CLI_VERSION)
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= release-0.20
-GOLANGCI_LINT_VERSION ?= v1.64.8
+GOLANGCI_LINT_VERSION ?= v2.0.2
 GOLANGCI_LINT_TIMEOUT ?= 1m
 HELM_VERSION ?= v3.17.2
 KIND_VERSION ?= v0.27.0
@@ -624,7 +624,7 @@ $(ENVTEST): | $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): | $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 .PHONY: helm
 helm: $(HELM) ## Download helm locally if necessary.

--- a/internal/controller/credential_controller.go
+++ b/internal/controller/credential_controller.go
@@ -54,7 +54,7 @@ func (r *CredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	cred := &kcm.Credential{}
-	if err := r.Client.Get(ctx, req.NamespacedName, cred); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, cred); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -75,7 +75,7 @@ func (r *CredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	clIdty.SetName(cred.Spec.IdentityRef.Name)
 	clIdty.SetNamespace(cred.Spec.IdentityRef.Namespace)
 
-	if err := r.Client.Get(ctx, client.ObjectKey{
+	if err := r.Get(ctx, client.ObjectKey{
 		Name:      cred.Spec.IdentityRef.Name,
 		Namespace: cred.Spec.IdentityRef.Namespace,
 	}, clIdty); err != nil {

--- a/internal/controller/management_backup_controller.go
+++ b/internal/controller/management_backup_controller.go
@@ -53,7 +53,7 @@ func (r *ManagementBackupReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	mgmtBackup := new(kcmv1alpha1.ManagementBackup)
-	if err := r.Client.Get(ctx, req.NamespacedName, mgmtBackup); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, mgmtBackup); err != nil {
 		l.Error(err, "unable to fetch ManagementBackup")
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -882,7 +882,7 @@ func updateComponentsStatus(
 	stAcc.components[comp.helmReleaseName] = kcm.ComponentStatus{
 		Error:    err,
 		Success:  err == "",
-		Template: comp.Component.Template,
+		Template: comp.Template,
 	}
 
 	if err == "" && template != nil {

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -87,7 +87,7 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	release := &kcm.Release{}
 	if req.Name != "" {
-		err := r.Client.Get(ctx, req.NamespacedName, release)
+		err := r.Get(ctx, req.NamespacedName, release)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				l.Info("Release not found, ignoring since object must be deleted")
@@ -372,7 +372,7 @@ func (r *ReleaseReconciler) getCurrentReleaseName(ctx context.Context) (string, 
 	listOptions := client.ListOptions{
 		FieldSelector: fields.SelectorFromSet(fields.Set{kcm.ReleaseVersionIndexKey: build.Version}),
 	}
-	if err := r.Client.List(ctx, releases, &listOptions); err != nil {
+	if err := r.List(ctx, releases, &listOptions); err != nil {
 		return "", err
 	}
 	if len(releases.Items) != 1 {

--- a/internal/controller/servicetemplate_controller.go
+++ b/internal/controller/servicetemplate_controller.go
@@ -163,19 +163,19 @@ func (r *ServiceTemplateReconciler) reconcileLocalSource(ctx context.Context, te
 
 	defer func() {
 		if err != nil {
-			status.TemplateValidationStatus.Valid = false
-			status.TemplateValidationStatus.ValidationError = err.Error()
+			status.Valid = false
+			status.ValidationError = err.Error()
 		} else {
 			switch status.SourceStatus.Kind {
 			case sourcev1.GitRepositoryKind, sourcev1.BucketKind, sourcev1beta2.OCIRepositoryKind:
-				status.TemplateValidationStatus.Valid = slices.ContainsFunc(status.SourceStatus.Conditions, func(c metav1.Condition) bool {
+				status.Valid = slices.ContainsFunc(status.SourceStatus.Conditions, func(c metav1.Condition) bool {
 					return c.Type == kcm.ReadyCondition && c.Status == metav1.ConditionTrue
 				})
 			default:
-				status.TemplateValidationStatus.Valid = true
+				status.Valid = true
 			}
-			if !status.TemplateValidationStatus.Valid {
-				status.TemplateValidationStatus.ValidationError = sourceNotReadyMessage
+			if !status.Valid {
+				status.ValidationError = sourceNotReadyMessage
 			}
 		}
 		template.Status = status
@@ -288,7 +288,7 @@ func (r *ServiceTemplateReconciler) reconcileGitRepository(
 			kcm.KCMManagedLabelKey: kcm.KCMManagedLabelValue,
 		})
 		gitRepository.Spec = ref.Git.GitRepositorySpec
-		return controllerutil.SetControllerReference(template, gitRepository, r.Client.Scheme())
+		return controllerutil.SetControllerReference(template, gitRepository, r.Scheme())
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile GitRepository object: %w", err)
@@ -339,7 +339,7 @@ func (r *ServiceTemplateReconciler) reconcileBucket(
 			kcm.KCMManagedLabelKey: kcm.KCMManagedLabelValue,
 		})
 		bucket.Spec = ref.Bucket.BucketSpec
-		return controllerutil.SetControllerReference(template, bucket, r.Client.Scheme())
+		return controllerutil.SetControllerReference(template, bucket, r.Scheme())
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile Bucket object: %w", err)
@@ -390,7 +390,7 @@ func (r *ServiceTemplateReconciler) reconcileOCIRepository(
 			kcm.KCMManagedLabelKey: kcm.KCMManagedLabelValue,
 		})
 		ociRepository.Spec = ref.OCI.OCIRepositorySpec
-		return controllerutil.SetControllerReference(template, ociRepository, r.Client.Scheme())
+		return controllerutil.SetControllerReference(template, ociRepository, r.Scheme())
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile OCIRepository object: %w", err)

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -170,7 +170,7 @@ func (r *ProviderTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 func (r *ProviderTemplateReconciler) setReleaseOwnership(ctx context.Context, providerTemplate *kcm.ProviderTemplate) (changed bool, err error) {
 	releases := &kcm.ReleaseList{}
-	err = r.Client.List(ctx, releases,
+	err = r.List(ctx, releases,
 		client.MatchingFields{kcm.ReleaseTemplatesIndexKey: providerTemplate.Name},
 	)
 	if err != nil {

--- a/internal/webhook/management_webhook.go
+++ b/internal/webhook/management_webhook.go
@@ -95,7 +95,7 @@ func (v *ManagementValidator) ValidateUpdate(ctx context.Context, oldObj, newObj
 	}
 
 	release := &kcmv1.Release{}
-	if err := v.Client.Get(ctx, client.ObjectKey{Name: newMgmt.Spec.Release}, release); err != nil {
+	if err := v.Get(ctx, client.ObjectKey{Name: newMgmt.Spec.Release}, release); err != nil {
 		return nil, fmt.Errorf("failed to get Release %s: %w", newMgmt.Spec.Release, err)
 	}
 
@@ -277,7 +277,7 @@ func getInUseProvidersWithContracts(ctx context.Context, cl client.Client, pTpl 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (v *ManagementValidator) ValidateDelete(ctx context.Context, _ runtime.Object) (admission.Warnings, error) {
 	clusterDeployments := &kcmv1.ClusterDeploymentList{}
-	err := v.Client.List(ctx, clusterDeployments, client.Limit(1))
+	err := v.List(ctx, clusterDeployments, client.Limit(1))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/webhook/template_webhook.go
+++ b/internal/webhook/template_webhook.go
@@ -167,7 +167,7 @@ func (v *ServiceTemplateValidator) ValidateDelete(ctx context.Context, obj runti
 	// MultiClusterServices can only refer to serviceTemplates in system namespace.
 	if tmpl.Namespace == v.SystemNamespace {
 		multiSvcClusters := &v1alpha1.MultiClusterServiceList{}
-		if err := v.Client.List(ctx, multiSvcClusters,
+		if err := v.List(ctx, multiSvcClusters,
 			client.MatchingFields{v1alpha1.MultiClusterServiceTemplatesIndexKey: tmpl.Name},
 			client.Limit(1)); err != nil {
 			return nil, err
@@ -277,7 +277,7 @@ func (v TemplateValidator) templateIsInUseByCluster(ctx context.Context, templat
 	}
 
 	clusterDeployments := &v1alpha1.ClusterDeploymentList{}
-	if err := v.Client.List(ctx, clusterDeployments,
+	if err := v.List(ctx, clusterDeployments,
 		client.InNamespace(template.GetNamespace()),
 		client.MatchingFields{key: template.GetName()},
 		client.Limit(1)); err != nil {


### PR DESCRIPTION
* migrate linter from v1 to v2
* address a new QF from the statickcheck
* amend the config adding rules for the testifylint
* amend the config adding issues, severity, output sections