### PR TITLE
update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @k0rdent/k0rdent-kcm @k0rdent/k0rdent-ksm
+* @Kshatrix @eromanova @a13x5 @zerospiel @kylewuolle @wahabmk @BROngineer

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Kshatrix @eromanova @a13x5 @zerospiel
+* @k0rdent/k0rdent-kcm @k0rdent/k0rdent-ksm


### PR DESCRIPTION
This PR adds @k0rdent/k0rdent-ksm team to CODEOWNERS. Aside from that it replaces list of kcm-team members with reference to @k0rdent/k0rdent-kcm team.