### PR TITLE
feat: emit events for Management and ClusterDeployment operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ kcm-deploy: helm
 	$(HELM) upgrade --values $(KCM_VALUES) --reuse-values --install --create-namespace kcm $(PROVIDER_TEMPLATES_DIR)/kcm -n $(NAMESPACE)
 
 .PHONY: dev-deploy
-dev-deploy: ## Deploy KCM helm chart to the K8s cluster specified in ~/.kube/config.
+dev-deploy: yq ## Deploy KCM helm chart to the K8s cluster specified in ~/.kube/config.
 	@$(YQ) eval -i '.image.repository = "$(IMG_REPO)"' config/dev/kcm_values.yaml
 	@$(YQ) eval -i '.image.tag = "$(IMG_TAG)"' config/dev/kcm_values.yaml
 	@if [ "$(REGISTRY_REPO)" = "oci://127.0.0.1:$(REGISTRY_PORT)/charts" ]; then \
@@ -377,7 +377,7 @@ stable-templates: yq
 	done
 
 .PHONY: dev-release
-dev-release:
+dev-release: yq
 	@$(YQ) e ".spec.version = \"${VERSION}\"" $(PROVIDER_TEMPLATES_DIR)/kcm-templates/files/release.yaml | $(KUBECTL) -n $(NAMESPACE) apply -f -
 
 .PHONY: dev-adopted-creds

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -28,8 +28,13 @@ const (
 	ProgressingReason string = "Progressing"
 )
 
-// ReadyCondition indicates a resource is ready and fully reconciled.
-const ReadyCondition string = "Ready"
+const (
+	// ReadyCondition indicates a resource is ready and fully reconciled.
+	ReadyCondition string = "Ready"
+
+	// DeletingCondition indicates a resource is deleting.
+	DeletingCondition string = "Deleting"
+)
 
 type (
 	// Holds different types of CAPI providers.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/K0rdent/kcm/internal/controller"
 	"github.com/K0rdent/kcm/internal/helm"
 	"github.com/K0rdent/kcm/internal/providers"
+	"github.com/K0rdent/kcm/internal/record"
 	"github.com/K0rdent/kcm/internal/telemetry"
 	"github.com/K0rdent/kcm/internal/utils"
 	kcmwebhook "github.com/K0rdent/kcm/internal/webhook"
@@ -228,6 +229,8 @@ func main() {
 		setupLog.Error(err, "unable to setup indexers")
 		os.Exit(1)
 	}
+
+	record.InitFromRecorder(mgr.GetEventRecorderFor("kcm-controller-manager"))
 
 	currentNamespace := utils.CurrentNamespace()
 

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/vmware-tanzu/velero v1.16.0
 	golang.org/x/crypto v0.37.0
+	golang.org/x/text v0.24.0
 	golang.org/x/time v0.11.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.17.3
@@ -181,7 +182,6 @@ require (
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/term v0.31.0 // indirect
-	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/tools v0.31.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect

--- a/internal/controller/accessmanagement_controller.go
+++ b/internal/controller/accessmanagement_controller.go
@@ -65,11 +65,13 @@ func (r *AccessManagementReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
+	errMsg := ""
 	err := r.reconcileObj(ctx, accessMgmt)
 	if err != nil {
-		accessMgmt.Status.Error = err.Error()
+		errMsg = err.Error()
 	}
 	accessMgmt.Status.ObservedGeneration = accessMgmt.Generation
+	accessMgmt.Status.Error = errMsg
 
 	return ctrl.Result{}, errors.Join(err, r.updateStatus(ctx, accessMgmt))
 }

--- a/internal/controller/accessmanagement_controller.go
+++ b/internal/controller/accessmanagement_controller.go
@@ -113,12 +113,12 @@ func (r *AccessManagementReconciler) reconcileObj(ctx context.Context, accessMgm
 
 				created, err := r.createTemplateChain(ctx, systemCtChains[ctChain], namespace)
 				if err != nil {
-					record.Warnf(accessMgmt, nil, "ClusterTemplateChainCreationFailed", "Failed to create ClusterTemplateChain %s/%s: %v", namespace, ctChain, err)
+					r.warnf(accessMgmt, "ClusterTemplateChainCreationFailed", "Failed to create ClusterTemplateChain %s/%s: %v", namespace, ctChain, err)
 					errs = errors.Join(errs, err)
 					continue
 				}
 				if created {
-					record.Eventf(accessMgmt, nil, "ClusterTemplateChainCreated", "Successfully created ClusterTemplateChain %s/%s", namespace, ctChain)
+					r.eventf(accessMgmt, "ClusterTemplateChainCreated", "Successfully created ClusterTemplateChain %s/%s", namespace, ctChain)
 				}
 			}
 			for _, stChain := range rule.ServiceTemplateChains {
@@ -130,12 +130,12 @@ func (r *AccessManagementReconciler) reconcileObj(ctx context.Context, accessMgm
 
 				created, err := r.createTemplateChain(ctx, systemStChains[stChain], namespace)
 				if err != nil {
-					record.Warnf(accessMgmt, nil, "ServiceTemplateChainCreationFailed", "Failed to create ServiceTemplateChain %s/%s: %v", namespace, stChain, err)
+					r.warnf(accessMgmt, "ServiceTemplateChainCreationFailed", "Failed to create ServiceTemplateChain %s/%s: %v", namespace, stChain, err)
 					errs = errors.Join(errs, err)
 					continue
 				}
 				if created {
-					record.Eventf(accessMgmt, nil, "ServiceTemplateChainCreated", "Successfully created ServiceTemplateChain %s/%s", namespace, stChain)
+					r.eventf(accessMgmt, "ServiceTemplateChainCreated", "Successfully created ServiceTemplateChain %s/%s", namespace, stChain)
 				}
 			}
 			for _, credentialName := range rule.Credentials {
@@ -147,12 +147,12 @@ func (r *AccessManagementReconciler) reconcileObj(ctx context.Context, accessMgm
 
 				created, err := r.createCredential(ctx, namespace, credentialName, systemCredentials[credentialName])
 				if err != nil {
-					record.Warnf(accessMgmt, nil, "CredentialCreationFailed", "Failed to create Credential %s/%s: %v", namespace, credentialName, err)
+					r.warnf(accessMgmt, "CredentialCreationFailed", "Failed to create Credential %s/%s: %v", namespace, credentialName, err)
 					errs = errors.Join(errs, err)
 					continue
 				}
 				if created {
-					record.Eventf(accessMgmt, nil, "CredentialCreated", "Successfully created Credential %s/%s", namespace, credentialName)
+					r.eventf(accessMgmt, "CredentialCreated", "Successfully created Credential %s/%s", namespace, credentialName)
 				}
 			}
 		}
@@ -177,12 +177,12 @@ func (r *AccessManagementReconciler) reconcileObj(ctx context.Context, accessMgm
 		if !keep {
 			deleted, err := r.deleteManagedObject(ctx, managedObject)
 			if err != nil {
-				record.Warnf(accessMgmt, nil, kind+"DeletionFailed", "Failed to delete %s %s: %v", kind, namespacedName, err)
+				r.warnf(accessMgmt, kind+"DeletionFailed", "Failed to delete %s %s: %v", kind, namespacedName, err)
 				errs = errors.Join(errs, err)
 				continue
 			}
 			if deleted {
-				record.Eventf(accessMgmt, nil, kind+"Deleted", "Successfully deleted %s %s", kind, namespacedName)
+				r.eventf(accessMgmt, kind+"Deleted", "Successfully deleted %s %s", kind, namespacedName)
 			}
 		}
 	}
@@ -383,4 +383,12 @@ func (r *AccessManagementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}).
 		For(&kcm.AccessManagement{}).
 		Complete(r)
+}
+
+func (*AccessManagementReconciler) eventf(am *kcm.AccessManagement, reason, message string, args ...any) {
+	record.Eventf(am, am.Generation, reason, message, args...)
+}
+
+func (*AccessManagementReconciler) warnf(am *kcm.AccessManagement, reason, message string, args ...any) {
+	record.Warnf(am, am.Generation, reason, message, args...)
 }

--- a/internal/controller/accessmanagement_controller.go
+++ b/internal/controller/accessmanagement_controller.go
@@ -75,10 +75,6 @@ func (r *AccessManagementReconciler) Reconcile(ctx context.Context, req ctrl.Req
 }
 
 func (r *AccessManagementReconciler) reconcileObj(ctx context.Context, accessMgmt *kcm.AccessManagement) error {
-	if len(accessMgmt.Spec.AccessRules) == 0 {
-		return nil // nothing to do
-	}
-
 	systemCtChains, managedCtChains, err := r.getCurrentTemplateChains(ctx, kcm.ClusterTemplateChainKind)
 	if err != nil {
 		return err

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -766,6 +766,7 @@ func (r *ClusterDeploymentReconciler) reconcileDelete(ctx context.Context, cd *k
 		return ctrl.Result{}, err
 	}
 
+	r.setCondition(cd, kcm.DeletingCondition, nil)
 	if controllerutil.RemoveFinalizer(cd, kcm.ClusterDeploymentFinalizer) {
 		l.Info("Removing Finalizer", "finalizer", kcm.ClusterDeploymentFinalizer)
 		if err := r.Client.Update(ctx, cd); err != nil {

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -769,9 +769,6 @@ func (r *ClusterDeploymentReconciler) reconcileDelete(ctx context.Context, cd *k
 	r.setCondition(cd, kcm.DeletingCondition, nil)
 	if controllerutil.RemoveFinalizer(cd, kcm.ClusterDeploymentFinalizer) {
 		l.Info("Removing Finalizer", "finalizer", kcm.ClusterDeploymentFinalizer)
-		if err := r.Client.Update(ctx, cd); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to update clusterDeployment %s/%s: %w", cd.Namespace, cd.Name, err)
-		}
 	}
 	r.eventf(cd, "ClusterDeleted", "Cluster %s has been deleted", client.ObjectKeyFromObject(cd))
 

--- a/internal/controller/clusterdeployment_controller_test.go
+++ b/internal/controller/clusterdeployment_controller_test.go
@@ -470,7 +470,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 								HaveField("Type", kcm.CAPIClusterSummaryCondition),
 								HaveField("Status", metav1.ConditionUnknown),
 								HaveField("Reason", "UnknownReported"),
-								HaveField("Message", "* InfrastructureReady: Condition not yet reported\n* ControlPlaneInitialized: Condition not yet reported\n* ControlPlaneAvailable: Condition not yet reported\n* WorkersAvailable: Condition not yet reported\n* WorkerMachinesReady: Condition not yet reported\n* RemoteConnectionProbe: Condition not yet reported"),
+								HaveField("Message", "* InfrastructureReady: Condition not yet reported\n* ControlPlaneInitialized: Condition not yet reported\n* ControlPlaneAvailable: Condition not yet reported\n* ControlPlaneMachinesReady: Condition not yet reported\n* WorkersAvailable: Condition not yet reported\n* WorkerMachinesReady: Condition not yet reported\n* RemoteConnectionProbe: Condition not yet reported"),
 							),
 						))))
 				}).Should(Succeed())
@@ -545,7 +545,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 								HaveField("Type", kcm.CAPIClusterSummaryCondition),
 								HaveField("Status", metav1.ConditionUnknown),
 								HaveField("Reason", "UnknownReported"),
-								HaveField("Message", "* InfrastructureReady: Condition not yet reported\n* ControlPlaneInitialized: Condition not yet reported\n* ControlPlaneAvailable: Condition not yet reported\n* WorkersAvailable: Condition not yet reported\n* WorkerMachinesReady: Condition not yet reported\n* RemoteConnectionProbe: Condition not yet reported"),
+								HaveField("Message", "* InfrastructureReady: Condition not yet reported\n* ControlPlaneInitialized: Condition not yet reported\n* ControlPlaneAvailable: Condition not yet reported\n* ControlPlaneMachinesReady: Condition not yet reported\n* WorkersAvailable: Condition not yet reported\n* WorkerMachinesReady: Condition not yet reported\n* RemoteConnectionProbe: Condition not yet reported"),
 							),
 							// TODO (#852 brongineer): add corresponding resources with expected state for successful reconciliation
 							// SatisfyAll(

--- a/internal/controller/credential_controller.go
+++ b/internal/controller/credential_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
+	"github.com/K0rdent/kcm/internal/record"
 	"github.com/K0rdent/kcm/internal/utils"
 	"github.com/K0rdent/kcm/internal/utils/ratelimit"
 )
@@ -81,6 +82,7 @@ func (r *CredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}, clIdty); err != nil {
 		errMsg := fmt.Sprintf("Failed to get ClusterIdentity object of Kind=%s %s/%s: %s",
 			cred.Spec.IdentityRef.Kind, cred.Spec.IdentityRef.Namespace, cred.Spec.IdentityRef.Name, err)
+		record.Warn(cred, nil, "MissingClusterIdentity", errMsg)
 		if apierrors.IsNotFound(err) {
 			errMsg = fmt.Sprintf("ClusterIdentity object of Kind=%s %s/%s not found",
 				cred.Spec.IdentityRef.Kind, cred.Spec.IdentityRef.Namespace, cred.Spec.IdentityRef.Name)

--- a/internal/controller/credential_controller.go
+++ b/internal/controller/credential_controller.go
@@ -82,11 +82,11 @@ func (r *CredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}, clIdty); err != nil {
 		errMsg := fmt.Sprintf("Failed to get ClusterIdentity object of Kind=%s %s/%s: %s",
 			cred.Spec.IdentityRef.Kind, cred.Spec.IdentityRef.Namespace, cred.Spec.IdentityRef.Name, err)
-		record.Warn(cred, nil, "MissingClusterIdentity", errMsg)
 		if apierrors.IsNotFound(err) {
 			errMsg = fmt.Sprintf("ClusterIdentity object of Kind=%s %s/%s not found",
 				cred.Spec.IdentityRef.Kind, cred.Spec.IdentityRef.Namespace, cred.Spec.IdentityRef.Name)
 		}
+		record.Warn(cred, cred.Generation, "MissingClusterIdentity", errMsg)
 
 		apimeta.SetStatusCondition(cred.GetConditions(), metav1.Condition{
 			Type:    kcm.CredentialReadyCondition,

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -129,13 +129,13 @@ func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	if release.Name == "" {
 		if err := r.ensureManagement(ctx); err != nil {
 			l.Error(err, "failed to create Management object")
-			record.Event(release, nil, "ManagementCreationFailed", err.Error())
+			r.eventf(release, "ManagementCreationFailed", err.Error())
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
 	}
 	err = r.validateProviderTemplates(ctx, release.Name, release.Templates())
-	updateTemplatesValidCondition(release, err)
+	r.updateTemplatesValidCondition(release, err)
 	if err != nil {
 		l.Error(err, "failed to validate provider templates")
 		return ctrl.Result{}, err
@@ -165,7 +165,7 @@ func (r *ReleaseReconciler) validateProviderTemplates(ctx context.Context, relea
 	return nil
 }
 
-func updateTemplatesValidCondition(release *kcm.Release, err error) {
+func (r *ReleaseReconciler) updateTemplatesValidCondition(release *kcm.Release, err error) (changed bool) {
 	condition := metav1.Condition{
 		Type:               kcm.TemplatesValidCondition,
 		Status:             metav1.ConditionTrue,
@@ -174,13 +174,13 @@ func updateTemplatesValidCondition(release *kcm.Release, err error) {
 		Message:            "All templates are valid",
 	}
 	if err != nil {
-		record.Event(release, nil, "InvalidProviderTemplates", err.Error())
+		r.eventf(release, "InvalidProviderTemplates", err.Error())
 		condition.Status = metav1.ConditionFalse
 		condition.Message = err.Error()
 		condition.Reason = kcm.FailedReason
 		release.Status.Ready = false
 	}
-	meta.SetStatusCondition(&release.Status.Conditions, condition)
+	return meta.SetStatusCondition(&release.Status.Conditions, condition)
 }
 
 func (r *ReleaseReconciler) updateTemplatesCreatedCondition(release *kcm.Release, err error) (changed bool) {
@@ -195,7 +195,7 @@ func (r *ReleaseReconciler) updateTemplatesCreatedCondition(release *kcm.Release
 		condition.Message = "Templates creation is disabled"
 	}
 	if err != nil {
-		record.Event(release, nil, "TemplatesCreationFailed", err.Error())
+		r.eventf(release, "TemplatesCreationFailed", err.Error())
 		condition.Status = metav1.ConditionFalse
 		condition.Message = err.Error()
 		condition.Reason = kcm.FailedReason
@@ -407,4 +407,8 @@ func (r *ReleaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	initChannel := make(chan event.GenericEvent, 1)
 	initChannel <- event.GenericEvent{Object: &kcm.Release{}}
 	return c.Watch(source.Channel(initChannel, &handler.EnqueueRequestForObject{}))
+}
+
+func (*ReleaseReconciler) eventf(release *kcm.Release, reason, message string, args ...any) {
+	record.Eventf(release, release.Generation, reason, message, args...)
 }

--- a/internal/controller/templatechain_controller.go
+++ b/internal/controller/templatechain_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
+	"github.com/K0rdent/kcm/internal/record"
 	"github.com/K0rdent/kcm/internal/utils"
 	"github.com/K0rdent/kcm/internal/utils/ratelimit"
 )
@@ -195,11 +196,13 @@ func (r *TemplateChainReconciler) reconcileObj(ctx context.Context, tplChain tem
 			return nil
 		})
 		if err != nil {
+			record.Warnf(tplChain, nil, r.templateKind+"CreationFailed", "Failed to create %s %s: %v", r.templateKind, client.ObjectKeyFromObject(target), err)
 			errs = errors.Join(errs, err)
 			continue
 		}
 
 		if operation == controllerutil.OperationResultCreated {
+			record.Eventf(tplChain, nil, r.templateKind+"Created", "Successfully created %s %s", r.templateKind, client.ObjectKeyFromObject(target))
 			l.Info(r.templateKind+" was successfully created", "template namespace", tplChain.GetNamespace(), "template name", supportedTemplate.Name)
 		}
 		if operation == controllerutil.OperationResultUpdated {

--- a/internal/controller/templatechain_controller.go
+++ b/internal/controller/templatechain_controller.go
@@ -196,13 +196,13 @@ func (r *TemplateChainReconciler) reconcileObj(ctx context.Context, tplChain tem
 			return nil
 		})
 		if err != nil {
-			record.Warnf(tplChain, nil, r.templateKind+"CreationFailed", "Failed to create %s %s: %v", r.templateKind, client.ObjectKeyFromObject(target), err)
+			record.Warnf(tplChain, tplChain.GetGeneration(), r.templateKind+"CreationFailed", "Failed to create %s %s: %v", r.templateKind, client.ObjectKeyFromObject(target), err)
 			errs = errors.Join(errs, err)
 			continue
 		}
 
 		if operation == controllerutil.OperationResultCreated {
-			record.Eventf(tplChain, nil, r.templateKind+"Created", "Successfully created %s %s", r.templateKind, client.ObjectKeyFromObject(target))
+			record.Eventf(tplChain, tplChain.GetGeneration(), r.templateKind+"Created", "Successfully created %s %s", r.templateKind, client.ObjectKeyFromObject(target))
 			l.Info(r.templateKind+" was successfully created", "template namespace", tplChain.GetNamespace(), "template name", supportedTemplate.Name)
 		}
 		if operation == controllerutil.OperationResultUpdated {

--- a/internal/record/recorder.go
+++ b/internal/record/recorder.go
@@ -1,0 +1,68 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package record
+
+import (
+	"sync"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+var (
+	initOnce        sync.Once
+	defaultRecorder record.EventRecorder
+)
+
+func init() {
+	defaultRecorder = new(record.FakeRecorder)
+}
+
+// InitFromRecorder initializes the global default recorder. It can only be called once.
+// Subsequent calls are considered noops.
+func InitFromRecorder(recorder record.EventRecorder) {
+	initOnce.Do(func() {
+		defaultRecorder = recorder
+	})
+}
+
+// Event constructs an event from the given information and puts it in the queue for sending.
+func Event(object runtime.Object, annotations map[string]string, reason, message string) {
+	defaultRecorder.AnnotatedEventf(object, annotations, corev1.EventTypeNormal, title(reason), message)
+}
+
+// Eventf is just like Event, but with Sprintf for the message field.
+func Eventf(object runtime.Object, annotations map[string]string, reason, message string, args ...any) {
+	defaultRecorder.AnnotatedEventf(object, annotations, corev1.EventTypeNormal, title(reason), message, args...)
+}
+
+// Warn constructs a warning event from the given information and puts it in the queue for sending.
+func Warn(object runtime.Object, annotations map[string]string, reason, message string) {
+	defaultRecorder.AnnotatedEventf(object, annotations, corev1.EventTypeWarning, title(reason), message)
+}
+
+// Warnf is just like Warn, but with Sprintf for the message field.
+func Warnf(object runtime.Object, annotations map[string]string, reason, message string, args ...any) {
+	defaultRecorder.AnnotatedEventf(object, annotations, corev1.EventTypeWarning, title(reason), message, args...)
+}
+
+// title returns a copy of the string s with all Unicode letters that begin words
+// mapped to their Unicode title case.
+func title(source string) string {
+	return cases.Title(language.Und, cases.NoLower).String(source)
+}

--- a/internal/record/recorder.go
+++ b/internal/record/recorder.go
@@ -15,6 +15,7 @@
 package record
 
 import (
+	"strconv"
 	"sync"
 
 	"golang.org/x/text/cases"
@@ -42,23 +43,32 @@ func InitFromRecorder(recorder record.EventRecorder) {
 }
 
 // Event constructs an event from the given information and puts it in the queue for sending.
-func Event(object runtime.Object, annotations map[string]string, reason, message string) {
-	defaultRecorder.AnnotatedEventf(object, annotations, corev1.EventTypeNormal, title(reason), message)
+func Event(object runtime.Object, generation int64, reason, message string) {
+	defaultRecorder.AnnotatedEventf(object, getEventsAnnotations(generation), corev1.EventTypeNormal, title(reason), message)
 }
 
 // Eventf is just like Event, but with Sprintf for the message field.
-func Eventf(object runtime.Object, annotations map[string]string, reason, message string, args ...any) {
-	defaultRecorder.AnnotatedEventf(object, annotations, corev1.EventTypeNormal, title(reason), message, args...)
+func Eventf(object runtime.Object, generation int64, reason, message string, args ...any) {
+	defaultRecorder.AnnotatedEventf(object, getEventsAnnotations(generation), corev1.EventTypeNormal, title(reason), message, args...)
 }
 
 // Warn constructs a warning event from the given information and puts it in the queue for sending.
-func Warn(object runtime.Object, annotations map[string]string, reason, message string) {
-	defaultRecorder.AnnotatedEventf(object, annotations, corev1.EventTypeWarning, title(reason), message)
+func Warn(object runtime.Object, generation int64, reason, message string) {
+	defaultRecorder.AnnotatedEventf(object, getEventsAnnotations(generation), corev1.EventTypeWarning, title(reason), message)
 }
 
 // Warnf is just like Warn, but with Sprintf for the message field.
-func Warnf(object runtime.Object, annotations map[string]string, reason, message string, args ...any) {
-	defaultRecorder.AnnotatedEventf(object, annotations, corev1.EventTypeWarning, title(reason), message, args...)
+func Warnf(object runtime.Object, generation int64, reason, message string, args ...any) {
+	defaultRecorder.AnnotatedEventf(object, getEventsAnnotations(generation), corev1.EventTypeWarning, title(reason), message, args...)
+}
+
+func getEventsAnnotations(generation int64) map[string]string {
+	if generation == 0 {
+		return nil
+	}
+	return map[string]string{
+		"generation": strconv.FormatInt(generation, 10),
+	}
 }
 
 // title returns a copy of the string s with all Unicode letters that begin words

--- a/internal/utils/conditions/capi.go
+++ b/internal/utils/conditions/capi.go
@@ -1,0 +1,95 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conditions
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kcm "github.com/K0rdent/kcm/api/v1alpha1"
+)
+
+type clusterConditionCustomMergeStrategy struct {
+	negativePolarityConditionTypes []string
+}
+
+func (c clusterConditionCustomMergeStrategy) Merge(conditions []capiconditions.ConditionWithOwnerInfo, negativePolarityConditionTypes []string) (status metav1.ConditionStatus, reason, message string, err error) {
+	status, reason, message, err = capiconditions.DefaultMergeStrategy(
+		capiconditions.GetPriorityFunc(func(condition metav1.Condition) capiconditions.MergePriority {
+			return capiconditions.GetDefaultMergePriorityFunc(c.negativePolarityConditionTypes...)(condition)
+		}),
+	).Merge(conditions, negativePolarityConditionTypes)
+	for _, cond := range conditions {
+		if cond.Type == clusterapiv1.ClusterDeletingV1Beta2Condition {
+			reason = "Deleting"
+			break
+		}
+	}
+	return status, reason, message, err
+}
+
+func getCAPIConditionsSummaryOptions(conditionTypes capiconditions.ForConditionTypes, negativePolarityConditionTypes capiconditions.NegativePolarityConditionTypes) []capiconditions.SummaryOption {
+	return []capiconditions.SummaryOption{
+		conditionTypes,
+		negativePolarityConditionTypes,
+		capiconditions.CustomMergeStrategy{
+			MergeStrategy: clusterConditionCustomMergeStrategy{
+				negativePolarityConditionTypes: negativePolarityConditionTypes,
+			},
+		},
+	}
+}
+
+func GetCAPIClusterSummaryCondition(cd *kcm.ClusterDeployment, cluster *clusterapiv1.Cluster) (*metav1.Condition, error) {
+	var (
+		capiConditionTypes             capiconditions.ForConditionTypes
+		negativePolarityConditionTypes capiconditions.NegativePolarityConditionTypes
+	)
+
+	if cd.DeletionTimestamp.IsZero() {
+		capiConditionTypes = append(capiConditionTypes,
+			clusterapiv1.ClusterInfrastructureReadyV1Beta2Condition,
+			clusterapiv1.ClusterControlPlaneInitializedV1Beta2Condition,
+			clusterapiv1.ClusterControlPlaneAvailableV1Beta2Condition,
+			clusterapiv1.ClusterControlPlaneMachinesReadyV1Beta2Condition,
+			clusterapiv1.ClusterWorkersAvailableV1Beta2Condition,
+			clusterapiv1.ClusterWorkerMachinesReadyV1Beta2Condition,
+			clusterapiv1.ClusterRemoteConnectionProbeV1Beta2Condition,
+		)
+	} else {
+		capiConditionTypes = capiconditions.ForConditionTypes{
+			clusterapiv1.ClusterDeletingV1Beta2Condition,
+		}
+		// When the Cluster is being deleted, these conditions should have negative polarity to collect them if Status:True
+		negativePolarityConditionTypes = []string{
+			clusterapiv1.ClusterDeletingV1Beta2Condition,
+		}
+	}
+
+	capiCondition, err := capiconditions.NewSummaryCondition(
+		cluster,
+		kcm.CAPIClusterSummaryCondition,
+		getCAPIConditionsSummaryOptions(capiConditionTypes, negativePolarityConditionTypes)...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get condition summary from Cluster %s: %w", client.ObjectKeyFromObject(cluster), err)
+	}
+	capiCondition.ObservedGeneration = cd.Generation
+	return capiCondition, nil
+}

--- a/internal/utils/conditions/capi.go
+++ b/internal/utils/conditions/capi.go
@@ -25,6 +25,8 @@ import (
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
 )
 
+var _ capiconditions.MergeStrategy = (*clusterConditionCustomMergeStrategy)(nil)
+
 type clusterConditionCustomMergeStrategy struct {
 	negativePolarityConditionTypes []string
 }

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -231,6 +231,11 @@ rules:
   resources:
   - secrets
   verbs: {{ include "rbac.viewerVerbs" . | nindent 2 }}
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs: {{ include "rbac.editorVerbs" . | nindent 2 }}
 # managementbackups-ctrl
 - apiGroups:
   - k0rdent.mirantis.com


### PR DESCRIPTION
This PR introduces event generation for key management and ClusterDeployment operations, including:

1. K0rdent installation and uninstallation
2. Provider addition and deletion
3. Provider configuration updates
4. Reconciliation failures
5. ClusterDeployment config validation issues
6. ClusterDeployment-related HelmRelease creation/update
7. ClusterDeployment deletion
etc.

Also, contains:
1. Several functions refactoring to reduce cyclomatic complexity.
2. ClusterDeployment deletion conditions aggregator to report deletion issues in events

Note: To emit proper events that will be helpful during debugging, the cluster deployment reconciler should be refactored, and the CAPI conditions aggregation should be reworked (#1366). This will be done in follow-up PRs. 

Closes #1339 
Closes #1341