### PR TITLE
feat: Allow self management of mothership cluster via Sveltos

### DIFF
--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -29,8 +29,8 @@ const (
 	ManagementName      = "kcm"
 	ManagementFinalizer = "k0rdent.mirantis.com/management"
 
-	K0rdentManagementClusterLabelKey    = "k0rdent.mirantis.com/management-cluster"
-	K0rdentMManagementClusterLabelValue = "true"
+	K0rdentManagementClusterLabelKey   = "k0rdent.mirantis.com/management-cluster"
+	K0rdentManagementClusterLabelValue = "true"
 )
 
 // ManagementSpec defines the desired state of Management

--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -28,6 +28,9 @@ const (
 	ManagementKind      = "Management"
 	ManagementName      = "kcm"
 	ManagementFinalizer = "k0rdent.mirantis.com/management"
+
+	K0rdentManagementClusterLabelKey    = "k0rdent.mirantis.com/management-cluster"
+	K0rdentMManagementClusterLabelValue = "true"
 )
 
 // ManagementSpec defines the desired state of Management

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -624,7 +624,7 @@ func applySveltosDefaults(config *apiextensionsv1.JSON) (*apiextensionsv1.JSON, 
 				"registerMgmtCluster": map[string]any{
 					"args": []string{
 						// expected to be in format: --labels=labelA=A,labelB=B,labelC=C
-						"--labels=" + kcm.K0rdentManagementClusterLabelKey + "=" + kcm.K0rdentMManagementClusterLabelValue,
+						"--labels=" + kcm.K0rdentManagementClusterLabelKey + "=" + kcm.K0rdentManagementClusterLabelValue,
 					},
 				},
 			},


### PR DESCRIPTION
# Description

This PR adds labels to the "mgmt" `sveltoscluster`, which is used to self-manage the management/mothership cluster. Once the labels are added, we can then use a `MultiClusterService` object to deploy services on the management cluster.

Documentation for users to be added in https://github.com/k0rdent/kcm/issues/1305.

# Verification

We can see the labels added to the "mgmt" cluster:
```sh
➜  ~ kubectl -n mgmt get sveltoscluster mgmt --show-labels
NAME   READY   VERSION   LABELS
mgmt   true    v1.32.2   k0rdent.mirantis.com/management-cluster=true,projectsveltos.io/k8s-version=v1.32.2,sveltos-agent=present
```
Now we can deploy "myapp" service using the following `MultiClusterService`:
```yaml
apiVersion: k0rdent.mirantis.com/v1alpha1
kind: MultiClusterService
metadata:
  name: myapp
spec:
  clusterSelector:
    matchLabels:
      k0rdent.mirantis.com/management-cluster: "true"
      sveltos-agent: present
  serviceSpec:
    priority: 1
    services:
      - template: myapp-0-1-0
        name: myapp
        namespace: myapp
```
We can see the status of this `MultiClusterService` with "Provisioned" status:
```sh
➜  ~ kubectl -n kcm-system get multiclusterservice myapp -o yaml         
apiVersion: k0rdent.mirantis.com/v1alpha1
kind: MultiClusterService
metadata:
 . . .
spec:
  clusterSelector:
    matchLabels:
      k0rdent.mirantis.com/management-cluster: "true"
      sveltos-agent: present
  serviceSpec:
    continueOnError: false
    priority: 1
    services:
    - name: myapp
      namespace: myapp
      template: myapp-0-1-0
    stopOnConflict: false
    syncMode: Continuous
status:
  conditions:
  . . .
  observedGeneration: 1
  services:
  - clusterName: mgmt
    clusterNamespace: mgmt
    conditions:
    - lastTransitionTime: "2025-04-07T14:57:11Z"
      message: ""
      reason: Provisioned
      status: "True"
      type: Helm
    - lastTransitionTime: "2025-04-07T14:57:11Z"
      message: Release myapp/myapp
      reason: Managing
      status: "True"
      type: myapp.myapp/SveltosHelmReleaseReady
```
Finally, we can verify that the "myapp" service has been installed on the management cluster itself:
```sh
➜  ~ kubectl get pod -A
NAMESPACE            NAME                                                           READY   STATUS    RESTARTS   AGE
kcm-system           azureserviceoperator-controller-manager-6b4dd86894-t4nxm       1/1     Running   0          13m
kcm-system           capa-controller-manager-64bbcb9f8-pbf5w                        1/1     Running   0          12m
kcm-system           capd-controller-manager-7586b6577c-d5zpq                       1/1     Running   0          13m
kcm-system           capg-controller-manager-774958b9b9-l45bd                       1/1     Running   0          12m
kcm-system           capi-controller-manager-5b67d4fc7-jjvm5                        1/1     Running   0          14m
kcm-system           capo-controller-manager-6f98bb68cd-dwtzr                       1/1     Running   0          12m
kcm-system           capv-controller-manager-69f7fc65d8-wvpb6                       1/1     Running   0          12m
kcm-system           capz-controller-manager-5b87fdf745-nxlkk                       1/1     Running   0          13m
kcm-system           helm-controller-746d7db585-f585w                               1/1     Running   0          16m
kcm-system           k0smotron-controller-manager-bootstrap-67dd88d848-r2d8h        2/2     Running   0          13m
kcm-system           k0smotron-controller-manager-control-plane-657f5578d4-ggjfq    2/2     Running   0          13m
kcm-system           k0smotron-controller-manager-infrastructure-5867d575f9-vvttc   2/2     Running   0          12m
kcm-system           kcm-cert-manager-6979c67bc4-6gplg                              1/1     Running   0          16m
kcm-system           kcm-cert-manager-cainjector-5b97c84fdb-5k9tc                   1/1     Running   0          16m
kcm-system           kcm-cert-manager-webhook-755796f599-fcnfv                      1/1     Running   0          16m
kcm-system           kcm-cluster-api-operator-65c8f75569-4rnsf                      1/1     Running   0          15m
kcm-system           kcm-controller-manager-785c5964d-6l8sl                         1/1     Running   0          15m
kcm-system           kcm-velero-67bf545995-4d8ns                                    1/1     Running   0          16m
kcm-system           source-controller-74b597b995-wkfj2                             1/1     Running   0          16m
kube-system          coredns-668d6bf9bc-46hqk                                       1/1     Running   0          17m
kube-system          coredns-668d6bf9bc-m4bk8                                       1/1     Running   0          17m
kube-system          etcd-kcm-dev-control-plane                                     1/1     Running   0          17m
kube-system          kindnet-fwh7t                                                  1/1     Running   0          17m
kube-system          kube-apiserver-kcm-dev-control-plane                           1/1     Running   0          17m
kube-system          kube-controller-manager-kcm-dev-control-plane                  1/1     Running   0          17m
kube-system          kube-proxy-bk6tx                                               1/1     Running   0          17m
kube-system          kube-scheduler-kcm-dev-control-plane                           1/1     Running   0          17m
local-path-storage   local-path-provisioner-7dc846544d-qjkwh                        1/1     Running   0          17m
myapp                myapp-85b8d7f879-rcdp9                                         1/1     Running   0          6m52s
orc-system           orc-controller-manager-5f6dbcc58-l8mxn                         1/1     Running   0          13m
projectsveltos       access-manager-6696df779-rdn92                                 1/1     Running   0          13m
projectsveltos       addon-controller-7bb87bc597-9c6c9                              1/1     Running   0          13m
projectsveltos       classifier-manager-5b47b66fc9-bzkt2                            1/1     Running   0          13m
projectsveltos       event-manager-564d6644b4-vdtjz                                 1/1     Running   0          13m
projectsveltos       hc-manager-7c56c59d9c-c7lqb                                    1/1     Running   0          13m
projectsveltos       sc-manager-6798cd9d4d-9q6b6                                    1/1     Running   0          13m
projectsveltos       shard-controller-797965bb58-rp6jl                              1/1     Running   0          13m
projectsveltos       sveltos-agent-manager-5445f6f57c-56mjz                         1/1     Running   0          12m
projectsveltos       techsupport-controller-5b666d6884-dhd6s                        1/1     Running   0          13m
```