### PR TITLE
feat: ClusterDeployment reconciles validations

### DIFF
--- a/api/v1alpha1/credential_types.go
+++ b/api/v1alpha1/credential_types.go
@@ -24,8 +24,6 @@ const (
 
 	// CredentialReadyCondition indicates if referenced Credential exists and has Ready state
 	CredentialReadyCondition = "CredentialReady"
-	// CredentialPropagatedCondition indicates that CCM credentials were delivered to managed cluster
-	CredentialsPropagatedCondition = "CredentialsApplied"
 )
 
 // CredentialSpec defines the desired state of Credential

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -262,7 +262,7 @@ func main() {
 	if err = (&controller.ManagementReconciler{
 		SystemNamespace:        currentNamespace,
 		CreateAccessManagement: createAccessManagement,
-		IsDisabledValidation:   !enableWebhook,
+		IsDisabledValidationWH: !enableWebhook,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Management")
 		os.Exit(1)

--- a/config/dev/kcm_values.yaml
+++ b/config/dev/kcm_values.yaml
@@ -6,6 +6,7 @@ controller:
   insecureRegistry: true
   createRelease: false
   createTemplates: false
+  enableTelemetry: false
   validateClusterUpgradePath: true
   logger:
     devel: true

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -40,12 +40,14 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
 	"github.com/K0rdent/kcm/internal/helm"
@@ -76,6 +78,8 @@ type ClusterDeploymentReconciler struct {
 	SystemNamespace string
 
 	defaultRequeueTime time.Duration
+
+	IsDisabledValidationWH bool // is webhook disabled set via the controller flags
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -178,23 +182,14 @@ func (r *ClusterDeploymentReconciler) reconcileUpdate(ctx context.Context, cd *k
 	}
 
 	clusterTpl := &kcm.ClusterTemplate{}
-
 	defer func() {
 		err = errors.Join(err, r.updateStatus(ctx, cd, clusterTpl))
 	}()
 
 	if err = r.Client.Get(ctx, client.ObjectKey{Name: cd.Spec.Template, Namespace: cd.Namespace}, clusterTpl); err != nil {
-		l.Error(err, "Failed to get Template")
-		errMsg := fmt.Sprintf("failed to get provided template: %s", err)
-		if apierrors.IsNotFound(err) {
-			errMsg = "provided template is not found"
-		}
-		apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{
-			Type:    kcm.TemplateReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  kcm.FailedReason,
-			Message: errMsg,
-		})
+		l.Error(err, "failed to get ClusterTemplate")
+		err = fmt.Errorf("failed to get ClusterTemplate %s/%s: %w", cd.Namespace, cd.Spec.Template, err)
+		r.setCondition(cd, kcm.TemplateReadyCondition, err)
 		return ctrl.Result{}, err
 	}
 
@@ -215,108 +210,93 @@ func (r *ClusterDeploymentReconciler) reconcileUpdate(ctx context.Context, cd *k
 }
 
 func (r *ClusterDeploymentReconciler) updateCluster(ctx context.Context, cd *kcm.ClusterDeployment, clusterTpl *kcm.ClusterTemplate) (ctrl.Result, error) {
-	l := ctrl.LoggerFrom(ctx)
-
 	if clusterTpl == nil {
 		return ctrl.Result{}, errors.New("cluster template cannot be nil")
 	}
 
+	l := ctrl.LoggerFrom(ctx)
+
+	r.initClusterConditions(cd)
+
 	if !clusterTpl.Status.Valid {
-		errMsg := "provided template is not marked as valid"
-		apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{
-			Type:    kcm.TemplateReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  kcm.FailedReason,
-			Message: errMsg,
-		})
-		return ctrl.Result{}, errors.New(errMsg)
+		err := fmt.Errorf("ClusterTemplate %s is not marked as valid", client.ObjectKeyFromObject(clusterTpl))
+		r.setCondition(cd, kcm.TemplateReadyCondition, err)
+		if r.IsDisabledValidationWH {
+			l.Error(err, "template is not valid, will not retrigger this error")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
 	}
+	r.setCondition(cd, kcm.TemplateReadyCondition, nil)
 	// template is ok, propagate data from it
 	cd.Status.KubernetesVersion = clusterTpl.Status.KubernetesVersion
 
-	apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{
-		Type:    kcm.TemplateReadyCondition,
-		Status:  metav1.ConditionTrue,
-		Reason:  kcm.SucceededReason,
-		Message: "Template is valid",
-	})
+	var cred *kcm.Credential
+	if r.IsDisabledValidationWH {
+		l.Info("Validating ClusterTemplate K8s compatibility")
+		compErr := validation.ClusterTemplateK8sCompatibility(ctx, r.Client, clusterTpl, cd)
+		if compErr != nil {
+			compErr = fmt.Errorf("failed to validate ClusterTemplate K8s compatibility: %w", compErr)
+		}
+		r.setCondition(cd, kcm.TemplateReadyCondition, compErr)
 
-	source, err := r.getSource(ctx, clusterTpl.Status.ChartRef)
+		l.Info("Validating Credential")
+		var credErr error
+		if cred, credErr = validation.ClusterDeployCredential(ctx, r.Client, cd, clusterTpl); credErr != nil {
+			credErr = fmt.Errorf("failed to validate Credential: %w", credErr)
+		}
+		r.setCondition(cd, kcm.CredentialReadyCondition, credErr)
+
+		if merr := errors.Join(compErr, credErr); merr != nil {
+			l.Error(merr, "failed to validate ClusterDeployment, will not retrigger this error")
+			return ctrl.Result{}, nil
+		}
+	}
+
+	helmChartArtifact, err := r.getSourceArtifact(ctx, clusterTpl.Status.ChartRef)
 	if err != nil {
-		apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{
-			Type:    kcm.HelmChartReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  kcm.FailedReason,
-			Message: fmt.Sprintf("failed to get helm chart source: %s", err),
-		})
+		err = fmt.Errorf("failed to get HelmChart Artifact: %w", err)
+		r.setCondition(cd, kcm.HelmChartReadyCondition, err)
 		return ctrl.Result{}, err
 	}
+
 	l.Info("Downloading Helm chart")
-	hcChart, err := r.DownloadChartFromArtifact(ctx, source.GetArtifact())
+	hcChart, err := r.DownloadChartFromArtifact(ctx, helmChartArtifact)
 	if err != nil {
-		apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{
-			Type:    kcm.HelmChartReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  kcm.FailedReason,
-			Message: fmt.Sprintf("failed to download helm chart: %s", err),
-		})
+		err = fmt.Errorf("failed to download HelmChart from Artifact %s: %w", helmChartArtifact.URL, err)
+		r.setCondition(cd, kcm.HelmChartReadyCondition, err)
 		return ctrl.Result{}, err
 	}
 
 	l.Info("Initializing Helm client")
-	actionConfig, err := r.InitializeConfiguration(cd, l.Info)
+	actionConfig, err := r.InitializeConfiguration(cd, l.WithName("helm-actor").V(1).Info)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	l.Info("Validating Helm chart with provided values")
-	if err = r.EnsureReleaseWithValues(ctx, actionConfig, hcChart, cd); err != nil {
-		apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{
-			Type:    kcm.HelmChartReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  kcm.FailedReason,
-			Message: fmt.Sprintf("failed to validate template with provided configuration: %s", err),
-		})
+	if err := r.EnsureReleaseWithValues(ctx, actionConfig, hcChart, cd); err != nil {
+		err = fmt.Errorf("failed to validate template with provided configuration: %w", err)
+		r.setCondition(cd, kcm.HelmChartReadyCondition, err)
 		return ctrl.Result{}, err
 	}
 
-	apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{
-		Type:    kcm.HelmChartReadyCondition,
-		Status:  metav1.ConditionTrue,
-		Reason:  kcm.SucceededReason,
-		Message: "Helm chart is valid",
-	})
+	r.setCondition(cd, kcm.HelmChartReadyCondition, nil)
 
-	cred := &kcm.Credential{}
-	err = r.Client.Get(ctx, client.ObjectKey{
-		Name:      cd.Spec.Credential,
-		Namespace: cd.Namespace,
-	}, cred)
-	if err != nil {
-		apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{
-			Type:    kcm.CredentialReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  kcm.FailedReason,
-			Message: fmt.Sprintf("Failed to get Credential: %s", err),
-		})
-		return ctrl.Result{}, err
+	if !r.IsDisabledValidationWH {
+		cred = new(kcm.Credential)
+		if err := r.Client.Get(ctx, client.ObjectKey{Name: cd.Spec.Credential, Namespace: cd.Namespace}, cred); err != nil {
+			err = fmt.Errorf("failed to get Credential %s/%s: %w", cd.Namespace, cd.Spec.Credential, err)
+			r.setCondition(cd, kcm.CredentialReadyCondition, err)
+			return ctrl.Result{}, err
+		}
+
+		if !cred.Status.Ready {
+			r.setCondition(cd, kcm.CredentialReadyCondition, fmt.Errorf("the Credential %s is not ready", client.ObjectKeyFromObject(cred)))
+		} else {
+			r.setCondition(cd, kcm.CredentialReadyCondition, nil)
+		}
 	}
-
-	if !cred.Status.Ready {
-		apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{
-			Type:    kcm.CredentialReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  kcm.FailedReason,
-			Message: "Credential is not in Ready state",
-		})
-	}
-
-	apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{
-		Type:    kcm.CredentialReadyCondition,
-		Status:  metav1.ConditionTrue,
-		Reason:  kcm.SucceededReason,
-		Message: "Credential is Ready",
-	})
 
 	if cd.Spec.DryRun {
 		return ctrl.Result{}, nil
@@ -351,12 +331,8 @@ func (r *ClusterDeploymentReconciler) updateCluster(ctx context.Context, cd *kcm
 
 	hr, _, err := helm.ReconcileHelmRelease(ctx, r.Client, cd.Name, cd.Namespace, hrReconcileOpts)
 	if err != nil {
-		apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{
-			Type:    kcm.HelmReleaseReadyCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  kcm.FailedReason,
-			Message: err.Error(),
-		})
+		err = fmt.Errorf("failed to reconcile HelmRelease: %w", err)
+		r.setCondition(cd, kcm.HelmReleaseReadyCondition, err)
 		return ctrl.Result{}, err
 	}
 
@@ -388,6 +364,21 @@ func (r *ClusterDeploymentReconciler) updateCluster(ctx context.Context, cd *kcm
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (*ClusterDeploymentReconciler) initClusterConditions(cd *kcm.ClusterDeployment) (changed bool) {
+	for _, typ := range [4]string{kcm.CredentialReadyCondition, kcm.HelmReleaseReadyCondition, kcm.HelmChartReadyCondition, kcm.TemplateReadyCondition} {
+		if apimeta.SetStatusCondition(&cd.Status.Conditions, metav1.Condition{
+			Type:               typ,
+			Status:             metav1.ConditionUnknown,
+			Reason:             kcm.ProgressingReason,
+			ObservedGeneration: cd.Generation,
+		}) {
+			changed = true
+		}
+	}
+
+	return changed
 }
 
 func (r *ClusterDeploymentReconciler) updateSveltosClusterCondition(ctx context.Context, clusterDeployment *kcm.ClusterDeployment) (bool, error) {
@@ -527,10 +518,11 @@ func (*ClusterDeploymentReconciler) setCondition(cd *kcm.ClusterDeployment, typ 
 	}
 
 	return apimeta.SetStatusCondition(&cd.Status.Conditions, metav1.Condition{
-		Type:    typ,
-		Status:  cstatus,
-		Reason:  reason,
-		Message: msg,
+		Type:               typ,
+		Status:             cstatus,
+		Reason:             reason,
+		Message:            msg,
+		ObservedGeneration: cd.Generation,
 	})
 }
 
@@ -542,11 +534,13 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, cd *kc
 	r.initServicesConditions(cd)
 
 	{
-		nsErr := validation.ClusterDeployCrossNamespaceServicesRefs(ctx, cd)
-		tplErr := validation.ServicesHaveValidTemplates(ctx, r.Client, cd.Spec.ServiceSpec.Services, cd.Namespace)
-		merr := errors.Join(nsErr, tplErr)
+		merr := validation.ClusterDeployCrossNamespaceServicesRefs(ctx, cd) // changes must be done in the spec, which is a new event
+		if r.IsDisabledValidationWH {
+			merr = errors.Join(merr, validation.ServicesHaveValidTemplates(ctx, r.Client, cd.Spec.ServiceSpec.Services, cd.Namespace))
+		}
 		r.setCondition(cd, kcm.ServicesReferencesValidationCondition, merr)
 		if merr != nil {
+			// at this point 2/3 conditions will have unknown status, 1/3 (services validation) cond will have failed cond
 			l.Error(merr, "failed to validate services, will not retrigger this error")
 			return ctrl.Result{}, nil // no reason to reconcile further
 		}
@@ -664,16 +658,18 @@ func (r *ClusterDeploymentReconciler) updateStatus(ctx context.Context, cd *kcm.
 	return nil
 }
 
-func (r *ClusterDeploymentReconciler) getSource(ctx context.Context, ref *hcv2.CrossNamespaceSourceReference) (sourcev1.Source, error) {
+func (r *ClusterDeploymentReconciler) getSourceArtifact(ctx context.Context, ref *hcv2.CrossNamespaceSourceReference) (*sourcev1.Artifact, error) {
 	if ref == nil {
 		return nil, errors.New("helm chart source is not provided")
 	}
-	chartRef := client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
-	hc := sourcev1.HelmChart{}
-	if err := r.Client.Get(ctx, chartRef, &hc); err != nil {
-		return nil, err
+
+	key := client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
+	hc := new(sourcev1.HelmChart)
+	if err := r.Client.Get(ctx, key, hc); err != nil {
+		return nil, fmt.Errorf("failed to get HelmChart %s: %w", key, err)
 	}
-	return &hc, nil
+
+	return hc.GetArtifact(), nil
 }
 
 func (r *ClusterDeploymentReconciler) Delete(ctx context.Context, cd *kcm.ClusterDeployment) (result ctrl.Result, err error) {
@@ -842,29 +838,30 @@ func (r *ClusterDeploymentReconciler) objectsAvailable(ctx context.Context, name
 	return len(itemsList.Items) != 0, nil
 }
 
-func (r *ClusterDeploymentReconciler) setAvailableUpgrades(ctx context.Context, clusterDeployment *kcm.ClusterDeployment, template *kcm.ClusterTemplate) error {
-	if template == nil {
+func (r *ClusterDeploymentReconciler) setAvailableUpgrades(ctx context.Context, clusterDeployment *kcm.ClusterDeployment, clusterTpl *kcm.ClusterTemplate) error {
+	if clusterTpl == nil {
 		return nil
 	}
-	chains := &kcm.ClusterTemplateChainList{}
-	err := r.Client.List(ctx, chains,
-		client.InNamespace(template.Namespace),
-		client.MatchingFields{kcm.TemplateChainSupportedTemplatesIndexKey: template.GetName()},
-	)
-	if err != nil {
-		return err
+
+	chains := new(kcm.ClusterTemplateChainList)
+	if err := r.Client.List(ctx, chains,
+		client.InNamespace(clusterTpl.Namespace),
+		client.MatchingFields{kcm.TemplateChainSupportedTemplatesIndexKey: clusterTpl.Name},
+	); err != nil {
+		return fmt.Errorf("failed to list ClusterTemplateChains: %w", err)
 	}
 
 	availableUpgradesMap := make(map[string]kcm.AvailableUpgrade)
 	for _, chain := range chains.Items {
 		for _, supportedTemplate := range chain.Spec.SupportedTemplates {
-			if supportedTemplate.Name == template.Name {
+			if supportedTemplate.Name == clusterTpl.Name {
 				for _, availableUpgrade := range supportedTemplate.AvailableUpgrades {
 					availableUpgradesMap[availableUpgrade.Name] = availableUpgrade
 				}
 			}
 		}
 	}
+
 	availableUpgrades := make([]string, 0, len(availableUpgradesMap))
 	for _, availableUpgrade := range availableUpgradesMap {
 		availableUpgrades = append(availableUpgrades, availableUpgrade.Name)
@@ -872,6 +869,64 @@ func (r *ClusterDeploymentReconciler) setAvailableUpgrades(ctx context.Context, 
 
 	clusterDeployment.Status.AvailableUpgrades = availableUpgrades
 	return nil
+}
+
+// templatesValidUpdateSource is a source of exclusively update events which enqueues ClusterDeployment objects if the referenced ServiceTemplate or ClusterTemplate object gets the valid status.
+func templatesValidUpdateSource(cl client.Client, cache crcache.Cache, obj client.Object) source.TypedSource[ctrl.Request] {
+	var isServiceTemplateKind bool // quick kludge to avoid complicated switches
+	var indexKey string
+
+	switch obj.(type) {
+	case *kcm.ServiceTemplate:
+		isServiceTemplateKind = true
+		indexKey = kcm.ClusterDeploymentServiceTemplatesIndexKey
+	case *kcm.ClusterTemplate:
+		indexKey = kcm.ClusterDeploymentTemplateIndexKey
+	default:
+		panic(fmt.Sprintf("unexpected type %T, expected one of [%T, %T]", obj, new(kcm.ServiceTemplate), new(kcm.ClusterTemplate)))
+	}
+
+	return source.TypedKind(cache, obj, handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
+		clds := new(kcm.ClusterDeploymentList)
+		if err := cl.List(ctx, clds, client.InNamespace(o.GetNamespace()), client.MatchingFields{indexKey: o.GetName()}); err != nil {
+			return nil
+		}
+
+		resp := make([]ctrl.Request, 0, len(clds.Items))
+		for _, v := range clds.Items {
+			resp = append(resp, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&v)})
+		}
+
+		return resp
+	}), predicate.TypedFuncs[client.Object]{
+		GenericFunc: func(event.TypedGenericEvent[client.Object]) bool { return false },
+		CreateFunc:  func(event.TypedCreateEvent[client.Object]) bool { return false },
+		DeleteFunc:  func(event.TypedDeleteEvent[client.Object]) bool { return false },
+		UpdateFunc: func(tue event.TypedUpdateEvent[client.Object]) bool {
+			// NOTE: might be optimized, probably with go's core types gone (>=go1.25)
+			if isServiceTemplateKind {
+				sto, ok := tue.ObjectOld.(*kcm.ServiceTemplate)
+				if !ok {
+					return false
+				}
+				stn, ok := tue.ObjectNew.(*kcm.ServiceTemplate)
+				if !ok {
+					return false
+				}
+				return stn.Status.Valid && !sto.Status.Valid
+			}
+
+			cto, ok := tue.ObjectOld.(*kcm.ClusterTemplate)
+			if !ok {
+				return false
+			}
+			ctn, ok := tue.ObjectNew.(*kcm.ClusterTemplate)
+			if !ok {
+				return false
+			}
+			return ctn.Status.Valid && !cto.Status.Valid
+		},
+	})
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -883,7 +938,7 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	r.defaultRequeueTime = 10 * time.Second
 
-	return ctrl.NewControllerManagedBy(mgr).
+	managedController := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.TypedOptions[ctrl.Request]{
 			RateLimiter: ratelimit.DefaultFastSlow(),
 		}).
@@ -959,6 +1014,15 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 				return req
 			}),
-		).
-		Complete(r)
+		)
+
+	if r.IsDisabledValidationWH {
+		setupLog := mgr.GetLogger().WithName("clusterdeployment_ctrl_setup")
+		managedController.WatchesRawSource(templatesValidUpdateSource(mgr.GetClient(), mgr.GetCache(), &kcm.ServiceTemplate{}))
+		setupLog.Info("Validations are disabled, watcher for ServiceTemplate objects is set")
+		managedController.WatchesRawSource(templatesValidUpdateSource(mgr.GetClient(), mgr.GetCache(), &kcm.ClusterTemplate{}))
+		setupLog.Info("Validations are disabled, watcher for ClusterTemplate objects is set")
+	}
+
+	return managedController.Complete(r)
 }

--- a/internal/controller/clusterdeployment_controller_test.go
+++ b/internal/controller/clusterdeployment_controller_test.go
@@ -299,7 +299,6 @@ var _ = Describe("ClusterDeployment Controller", func() {
 							HaveField("Type", kcm.TemplateReadyCondition),
 							HaveField("Status", metav1.ConditionTrue),
 							HaveField("Reason", kcm.SucceededReason),
-							HaveField("Message", "Template is valid"),
 						))),
 					))
 				}).Should(Succeed())
@@ -343,13 +342,11 @@ var _ = Describe("ClusterDeployment Controller", func() {
 								HaveField("Type", kcm.HelmChartReadyCondition),
 								HaveField("Status", metav1.ConditionTrue),
 								HaveField("Reason", kcm.SucceededReason),
-								HaveField("Message", "Helm chart is valid"),
 							),
 							SatisfyAll(
 								HaveField("Type", kcm.CredentialReadyCondition),
 								HaveField("Status", metav1.ConditionTrue),
 								HaveField("Reason", kcm.SucceededReason),
-								HaveField("Message", "Credential is Ready"),
 							),
 						))))
 				}).Should(Succeed())
@@ -458,19 +455,16 @@ var _ = Describe("ClusterDeployment Controller", func() {
 								HaveField("Type", kcm.TemplateReadyCondition),
 								HaveField("Status", metav1.ConditionTrue),
 								HaveField("Reason", kcm.SucceededReason),
-								HaveField("Message", "Template is valid"),
 							),
 							SatisfyAll(
 								HaveField("Type", kcm.HelmChartReadyCondition),
 								HaveField("Status", metav1.ConditionTrue),
 								HaveField("Reason", kcm.SucceededReason),
-								HaveField("Message", "Helm chart is valid"),
 							),
 							SatisfyAll(
 								HaveField("Type", kcm.CredentialReadyCondition),
 								HaveField("Status", metav1.ConditionTrue),
 								HaveField("Reason", kcm.SucceededReason),
-								HaveField("Message", "Credential is Ready"),
 							),
 						))))
 				}).Should(Succeed())

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -70,7 +70,7 @@ type ManagementReconciler struct {
 	defaultRequeueTime time.Duration
 
 	CreateAccessManagement bool
-	IsDisabledValidation   bool // is webhook disabled set via the controller flags
+	IsDisabledValidationWH bool // is webhook disabled set via the controller flags
 
 	sveltosDependentControllersStarted bool
 }
@@ -118,7 +118,7 @@ func (r *ManagementReconciler) Update(ctx context.Context, management *kcm.Manag
 
 	release, err := r.getRelease(ctx, management)
 	if err != nil {
-		if !r.IsDisabledValidation {
+		if !r.IsDisabledValidationWH {
 			l.Error(err, "failed to get Release")
 			return ctrl.Result{}, err
 		}
@@ -291,8 +291,9 @@ func (r *ManagementReconciler) startDependentControllers(ctx context.Context, ma
 
 	l.Info("Provider has been successfully installed, so setting up controller for ClusterDeployment")
 	if err = (&ClusterDeploymentReconciler{
-		DynamicClient:   r.DynamicClient,
-		SystemNamespace: currentNamespace,
+		DynamicClient:          r.DynamicClient,
+		SystemNamespace:        currentNamespace,
+		IsDisabledValidationWH: r.IsDisabledValidationWH,
 	}).SetupWithManager(r.Manager); err != nil {
 		return false, fmt.Errorf("failed to setup controller for ClusterDeployment: %w", err)
 	}
@@ -300,7 +301,8 @@ func (r *ManagementReconciler) startDependentControllers(ctx context.Context, ma
 
 	l.Info("Provider has been successfully installed, so setting up controller for MultiClusterService")
 	if err = (&MultiClusterServiceReconciler{
-		SystemNamespace: currentNamespace,
+		SystemNamespace:        currentNamespace,
+		IsDisabledValidationWH: r.IsDisabledValidationWH,
 	}).SetupWithManager(r.Manager); err != nil {
 		return false, fmt.Errorf("failed to setup controller for MultiClusterService: %w", err)
 	}
@@ -948,7 +950,7 @@ func (r *ManagementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}).
 		For(&kcm.Management{})
 
-	if r.IsDisabledValidation {
+	if r.IsDisabledValidationWH {
 		managedController.Watches(&kcm.Release{}, handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []ctrl.Request {
 			return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: kcm.ManagementName}}} // always trigger, so if fetching Management fails its status would be still updated then
 		}), builder.WithPredicates(predicate.Funcs{

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -48,8 +48,9 @@ import (
 
 // MultiClusterServiceReconciler reconciles a MultiClusterService object
 type MultiClusterServiceReconciler struct {
-	Client          client.Client
-	SystemNamespace string
+	Client                 client.Client
+	SystemNamespace        string
+	IsDisabledValidationWH bool // is webhook disabled set via the controller flags
 }
 
 // Reconcile reconciles a MultiClusterService object.
@@ -135,12 +136,14 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 
 	r.initServicesConditions(mcs)
 
-	if err := validation.ServicesHaveValidTemplates(ctx, r.Client, mcs.Spec.ServiceSpec.Services, r.SystemNamespace); err != nil {
-		r.setCondition(mcs, kcm.ServicesReferencesValidationCondition, err)
-		l.Error(err, "failed to validate services reference valid ServiceTemplates, will not retrigger this error")
-		return ctrl.Result{}, r.updateStatus(ctx, mcs) // no reason to reconcile further
+	if r.IsDisabledValidationWH {
+		if err := validation.ServicesHaveValidTemplates(ctx, r.Client, mcs.Spec.ServiceSpec.Services, r.SystemNamespace); err != nil {
+			r.setCondition(mcs, kcm.ServicesReferencesValidationCondition, err)
+			l.Error(err, "failed to validate services reference valid ServiceTemplates, will not retrigger this error")
+			return ctrl.Result{}, r.updateStatus(ctx, mcs) // no reason to reconcile further
+		}
 	}
-	r.setCondition(mcs, kcm.ServicesReferencesValidationCondition, nil)
+	r.setCondition(mcs, kcm.ServicesReferencesValidationCondition, nil) // if wh is enabled just set it ok, otherwise it succeeded
 
 	// servicesErr is handled separately from err because we do not want
 	// to set the condition of SveltosClusterProfileReady type to "False"
@@ -471,7 +474,7 @@ func requeueSveltosProfileForClusterSummary(ctx context.Context, obj client.Obje
 func (r *MultiClusterServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Client = mgr.GetClient()
 
-	return ctrl.NewControllerManagedBy(mgr).
+	managedController := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.TypedOptions[ctrl.Request]{
 			RateLimiter: ratelimit.DefaultFastSlow(),
 		}).
@@ -482,6 +485,12 @@ func (r *MultiClusterServiceReconciler) SetupWithManager(mgr ctrl.Manager) error
 				DeleteFunc:  func(event.DeleteEvent) bool { return false },
 				GenericFunc: func(event.GenericEvent) bool { return false },
 			}),
-		).
-		Complete(r)
+		)
+
+	if r.IsDisabledValidationWH {
+		managedController.WatchesRawSource(templatesValidUpdateSource(mgr.GetClient(), mgr.GetCache(), &kcm.ServiceTemplate{}))
+		mgr.GetLogger().WithName("multiclusterservice_ctrl_setup").Info("Validations are disabled, watcher for ServiceTemplate objects is set")
+	}
+
+	return managedController.Complete(r)
 }

--- a/internal/utils/validation/cluster_template.go
+++ b/internal/utils/validation/cluster_template.go
@@ -1,0 +1,68 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1alpha1"
+)
+
+// ClusterTemplateK8sCompatibility validates the K8s version of the given [github.com/K0rdent/kcm/api/v1alpha1.ClusterTemplate]
+// satisfies the K8s constraints (if any) of the [github.com/K0rdent/kcm/api/v1alpha1.ServiceTemplate] objects
+// referenced by the given [github.com/K0rdent/kcm/api/v1alpha1.ClusterDeployment].
+func ClusterTemplateK8sCompatibility(ctx context.Context, cl client.Client, clusterTemplate *kcmv1.ClusterTemplate, cd *kcmv1.ClusterDeployment) error {
+	if len(cd.Spec.ServiceSpec.Services) == 0 || clusterTemplate.Status.KubernetesVersion == "" {
+		return nil // nothing to do
+	}
+
+	clTplKubeVersion, err := semver.NewVersion(clusterTemplate.Status.KubernetesVersion)
+	if err != nil { // should never happen
+		return fmt.Errorf("failed to parse k8s version %s of the ClusterTemplate %s: %w", clusterTemplate.Status.KubernetesVersion, client.ObjectKeyFromObject(clusterTemplate), err)
+	}
+
+	for _, svc := range cd.Spec.ServiceSpec.Services {
+		if svc.Disable {
+			continue
+		}
+
+		var svcTpl kcmv1.ServiceTemplate
+		if err := cl.Get(ctx, client.ObjectKey{Namespace: cd.Namespace, Name: svc.Template}, &svcTpl); err != nil {
+			return fmt.Errorf("failed to get ServiceTemplate %s/%s: %w", cd.Namespace, svc.Template, err)
+		}
+
+		constraint := svcTpl.Status.KubernetesConstraint
+		if constraint == "" {
+			continue
+		}
+
+		tplConstraint, err := semver.NewConstraint(constraint)
+		if err != nil { // should never happen
+			return fmt.Errorf("failed to parse k8s constrained version %s of the ServiceTemplate %s: %w", constraint, client.ObjectKeyFromObject(&svcTpl), err)
+		}
+
+		if !tplConstraint.Check(clTplKubeVersion) {
+			return fmt.Errorf("k8s version %s of the ClusterTemplate %s does not satisfy k8s constraint %s from the ServiceTemplate %s referred in the ClusterDeployment %s",
+				clusterTemplate.Status.KubernetesVersion, client.ObjectKeyFromObject(clusterTemplate), constraint,
+				client.ObjectKeyFromObject(&svcTpl), client.ObjectKeyFromObject(cd))
+		}
+	}
+
+	return nil
+}

--- a/internal/webhook/clusterdeployment_webhook.go
+++ b/internal/webhook/clusterdeployment_webhook.go
@@ -19,9 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
-	"github.com/Masterminds/semver/v3"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1alpha1"
-	providersloader "github.com/K0rdent/kcm/internal/providers"
 	"github.com/K0rdent/kcm/internal/utils/validation"
 )
 
@@ -71,15 +68,15 @@ func (v *ClusterDeploymentValidator) ValidateCreate(ctx context.Context, obj run
 		return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)
 	}
 
-	if err := isTemplateValid(template.GetCommonStatus()); err != nil {
+	if err := isClusterTemplateValid(template); err != nil {
 		return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)
 	}
 
-	if err := validateK8sCompatibility(ctx, v.Client, template, clusterDeployment); err != nil {
+	if err := validation.ClusterTemplateK8sCompatibility(ctx, v.Client, template, clusterDeployment); err != nil {
 		return admission.Warnings{"Failed to validate k8s version compatibility with ServiceTemplates"}, fmt.Errorf("failed to validate k8s compatibility: %w", err)
 	}
 
-	if err := v.validateCredential(ctx, clusterDeployment, template); err != nil {
+	if _, err := validation.ClusterDeployCredential(ctx, v.Client, clusterDeployment, template); err != nil {
 		return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)
 	}
 
@@ -118,16 +115,16 @@ func (v *ClusterDeploymentValidator) ValidateUpdate(ctx context.Context, oldObj,
 			return admission.Warnings{msg}, errClusterUpgradeForbidden
 		}
 
-		if err := isTemplateValid(template.GetCommonStatus()); err != nil {
+		if err := isClusterTemplateValid(template); err != nil {
 			return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)
 		}
 
-		if err := validateK8sCompatibility(ctx, v.Client, template, newClusterDeployment); err != nil {
+		if err := validation.ClusterTemplateK8sCompatibility(ctx, v.Client, template, newClusterDeployment); err != nil {
 			return admission.Warnings{"Failed to validate k8s version compatibility with ServiceTemplates"}, fmt.Errorf("failed to validate k8s compatibility: %w", err)
 		}
 	}
 
-	if err := v.validateCredential(ctx, newClusterDeployment, template); err != nil {
+	if _, err := validation.ClusterDeployCredential(ctx, v.Client, newClusterDeployment, template); err != nil {
 		return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)
 	}
 
@@ -140,46 +137,6 @@ func (v *ClusterDeploymentValidator) ValidateUpdate(ctx context.Context, oldObj,
 	}
 
 	return nil, nil
-}
-
-func validateK8sCompatibility(ctx context.Context, cl client.Client, template *kcmv1.ClusterTemplate, mc *kcmv1.ClusterDeployment) error {
-	if len(mc.Spec.ServiceSpec.Services) == 0 || template.Status.KubernetesVersion == "" {
-		return nil // nothing to do
-	}
-
-	mcVersion, err := semver.NewVersion(template.Status.KubernetesVersion)
-	if err != nil { // should never happen
-		return fmt.Errorf("failed to parse k8s version %s of the ClusterDeployment %s/%s: %w", template.Status.KubernetesVersion, mc.Namespace, mc.Name, err)
-	}
-
-	for _, v := range mc.Spec.ServiceSpec.Services {
-		if v.Disable {
-			continue
-		}
-
-		svcTpl := new(kcmv1.ServiceTemplate)
-		if err := cl.Get(ctx, client.ObjectKey{Namespace: mc.Namespace, Name: v.Template}, svcTpl); err != nil {
-			return fmt.Errorf("failed to get ServiceTemplate %s/%s: %w", mc.Namespace, v.Template, err)
-		}
-
-		constraint := svcTpl.Status.KubernetesConstraint
-		if constraint == "" {
-			continue
-		}
-
-		tplConstraint, err := semver.NewConstraint(constraint)
-		if err != nil { // should never happen
-			return fmt.Errorf("failed to parse k8s constrained version %s of the ServiceTemplate %s/%s: %w", constraint, mc.Namespace, v.Template, err)
-		}
-
-		if !tplConstraint.Check(mcVersion) {
-			return fmt.Errorf("k8s version %s of the ClusterDeployment %s/%s does not satisfy constrained version %s from the ServiceTemplate %s/%s",
-				template.Status.KubernetesVersion, mc.Namespace, mc.Name,
-				constraint, mc.Namespace, v.Template)
-		}
-	}
-
-	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
@@ -202,11 +159,11 @@ func (v *ClusterDeploymentValidator) Default(ctx context.Context, obj runtime.Ob
 
 	template, err := v.getClusterDeploymentTemplate(ctx, clusterDeployment.Namespace, clusterDeployment.Spec.Template)
 	if err != nil {
-		return fmt.Errorf("could not get template for the clusterDeployment: %w", err)
+		return fmt.Errorf("failed to get ClusterTemplate for the ClusterDeployment %s: %w", client.ObjectKeyFromObject(clusterDeployment), err)
 	}
 
-	if err := isTemplateValid(template.GetCommonStatus()); err != nil {
-		return fmt.Errorf("template is invalid: %w", err)
+	if err := isClusterTemplateValid(template); err != nil {
+		return err
 	}
 
 	if template.Status.Config == nil {
@@ -224,84 +181,9 @@ func (v *ClusterDeploymentValidator) getClusterDeploymentTemplate(ctx context.Co
 	return tpl, v.Get(ctx, client.ObjectKey{Namespace: templateNamespace, Name: templateName}, tpl)
 }
 
-func (v *ClusterDeploymentValidator) getClusterDeploymentCredential(ctx context.Context, credNamespace, credName string) (*kcmv1.Credential, error) {
-	cred := &kcmv1.Credential{}
-	credRef := client.ObjectKey{
-		Name:      credName,
-		Namespace: credNamespace,
-	}
-	if err := v.Get(ctx, credRef, cred); err != nil {
-		return nil, err
-	}
-	return cred, nil
-}
-
-func isTemplateValid(status *kcmv1.TemplateStatusCommon) error {
-	if !status.Valid {
-		return fmt.Errorf("the template is not valid: %s", status.ValidationError)
-	}
-
-	return nil
-}
-
-func (v *ClusterDeploymentValidator) validateCredential(ctx context.Context, clusterDeployment *kcmv1.ClusterDeployment, template *kcmv1.ClusterTemplate) error {
-	if len(template.Status.Providers) == 0 {
-		return fmt.Errorf("template %q has no providers defined", template.Name)
-	}
-
-	hasInfra := false
-	for _, v := range template.Status.Providers {
-		if strings.HasPrefix(v, providersloader.InfraPrefix) {
-			hasInfra = true
-			break
-		}
-	}
-
-	if !hasInfra {
-		return fmt.Errorf("template %q has no infrastructure providers defined", template.Name)
-	}
-
-	cred, err := v.getClusterDeploymentCredential(ctx, clusterDeployment.Namespace, clusterDeployment.Spec.Credential)
-	if err != nil {
-		return err
-	}
-
-	if !cred.Status.Ready {
-		return errors.New("credential is not Ready")
-	}
-
-	return isCredMatchTemplate(cred, template)
-}
-
-func isCredMatchTemplate(cred *kcmv1.Credential, template *kcmv1.ClusterTemplate) error {
-	idtyKind := cred.Spec.IdentityRef.Kind
-
-	errMsg := func(provider string) error {
-		return fmt.Errorf("wrong kind of the ClusterIdentity %q for provider %q", idtyKind, provider)
-	}
-
-	const secretKind = "Secret"
-
-	for _, provider := range template.Status.Providers {
-		if !strings.HasPrefix(provider, providersloader.InfraPrefix) {
-			continue
-		}
-		infraProviderName := strings.TrimPrefix(provider, providersloader.InfraPrefix)
-		if infraProviderName == "internal" {
-			if idtyKind != secretKind {
-				return errMsg(infraProviderName)
-			}
-			continue
-		}
-
-		idtys, found := providersloader.GetClusterIdentityKinds(infraProviderName)
-		if !found {
-			return fmt.Errorf("unsupported infrastructure provider %s", infraProviderName)
-		}
-
-		if !slices.Contains(idtys, idtyKind) {
-			return errMsg(infraProviderName)
-		}
+func isClusterTemplateValid(ct *kcmv1.ClusterTemplate) error {
+	if !ct.Status.Valid {
+		return fmt.Errorf("the ClusterTemplate %s is invalid with the error: %s", client.ObjectKeyFromObject(ct), ct.Status.ValidationError)
 	}
 
 	return nil

--- a/internal/webhook/clusterdeployment_webhook_test.go
+++ b/internal/webhook/clusterdeployment_webhook_test.go
@@ -147,7 +147,7 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 					}),
 				),
 			},
-			err: "the ClusterDeployment is invalid: the template is not valid: validation error example",
+			err: fmt.Sprintf("the ClusterDeployment is invalid: the ClusterTemplate %s/%s is invalid with the error: validation error example", metav1.NamespaceDefault, testTemplateName),
 		},
 		{
 			name: "should fail if the service templates were found but are invalid (some validation error)",
@@ -318,7 +318,7 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
 				),
 			},
-			err:      fmt.Sprintf(`failed to validate k8s compatibility: k8s version v1.30.0 of the ClusterDeployment default/%s does not satisfy constrained version <1.30 from the ServiceTemplate default/%s`, clusterdeployment.DefaultName, testTemplateName),
+			err:      fmt.Sprintf(`failed to validate k8s compatibility: k8s version v1.30.0 of the ClusterTemplate %s/%s does not satisfy k8s constraint <1.30 from the ServiceTemplate %s/%s referred in the ClusterDeployment %s/%s`, metav1.NamespaceDefault, testTemplateName, metav1.NamespaceDefault, testTemplateName, metav1.NamespaceDefault, clusterdeployment.DefaultName),
 			warnings: admission.Warnings{"Failed to validate k8s version compatibility with ServiceTemplates"},
 		},
 		{
@@ -336,7 +336,7 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
 				),
 			},
-			err: "the ClusterDeployment is invalid: credentials.k0rdent.mirantis.com \"\" not found",
+			err: fmt.Sprintf("the ClusterDeployment is invalid: failed to get Credential %s/%s referred in the ClusterDeployment %s/%s: credentials.k0rdent.mirantis.com \"\" not found", metav1.NamespaceDefault, "", metav1.NamespaceDefault, clusterdeployment.DefaultName),
 		},
 		{
 			name: "should fail if credential is not Ready",
@@ -365,7 +365,7 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
 				),
 			},
-			err: "the ClusterDeployment is invalid: credential is not Ready",
+			err: fmt.Sprintf("the ClusterDeployment is invalid: the Credential %s/%s is not Ready", metav1.NamespaceDefault, testCredentialName),
 		},
 		{
 			name: "should fail if credential and template providers doesn't match",
@@ -400,7 +400,7 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 					template.WithValidationStatus(v1alpha1.TemplateValidationStatus{Valid: true}),
 				),
 			},
-			err: "the ClusterDeployment is invalid: wrong kind of the ClusterIdentity \"SomeOtherDummyClusterStaticIdentity\" for provider \"aws\"",
+			err: fmt.Sprintf("the ClusterDeployment is invalid: provider %s does not support ClusterIdentity Kind %s from the Credential %s/%s", "infrastructure-aws", "SomeOtherDummyClusterStaticIdentity", metav1.NamespaceDefault, testCredentialName),
 		},
 	}
 	for _, tt := range tests {
@@ -462,7 +462,7 @@ func TestClusterDeploymentValidateUpdate(t *testing.T) {
 					}),
 				),
 			},
-			err: "the ClusterDeployment is invalid: the template is not valid: validation error example",
+			err: fmt.Sprintf("the ClusterDeployment is invalid: the ClusterTemplate %s/%s is invalid with the error: validation error example", metav1.NamespaceDefault, newTemplateName),
 		},
 		{
 			name: "update spec.template: should fail if the template is not in the list of available",
@@ -789,7 +789,7 @@ func TestClusterDeploymentDefault(t *testing.T) {
 					}),
 				),
 			},
-			err: "template is invalid: the template is not valid: validation error example",
+			err: fmt.Sprintf("the ClusterTemplate %s/%s is invalid with the error: validation error example", metav1.NamespaceDefault, testTemplateName),
 		},
 		{
 			name:   "should not set defaults: config in template status is unset",


### PR DESCRIPTION
* add servicetemplates watcher to cld controller
  and mcs controller if validations are turned off
* add clustertemplate watcher to cld controller
  if validations are turned off
* mcs controller reconciles validations if they are turned off
* cld controller reconciles validations if they are turned off
  - k8s compatibility failure results in template ready cond
  - credentials validation failure results in creds ready cond
* cld controller: if validation WH is turned off and validation
  has failed it won't be retriggered due to watchers
* cld controller: if validation WH is turned off and cluster template
  is not valid it won't be retriggered due to clustertemplate watcher
* fixed always-ready creds condition in cld

NOTES:

* the mutations are not reconciled
* the upgrade sequence validation is not reconciled