### PR TITLE
feat: Management reconciles validations

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -30,7 +30,6 @@ resources:
   path: github.com/K0rdent/kcm/api/v1alpha1
   version: v1alpha1
   webhooks:
-    defaulting: true
     validation: true
     webhookVersion: v1
 - api:

--- a/api/v1alpha1/compatibility_contract.go
+++ b/api/v1alpha1/compatibility_contract.go
@@ -22,7 +22,7 @@ import (
 // isCAPIContractVersion determines whether a given string
 // represents a version in the CAPI contract version format (e.g. v1_v1beta1_v1alpha1, etc.).
 func isCAPIContractVersion(version string) bool {
-	for _, v := range strings.Split(version, "_") {
+	for v := range strings.SplitSeq(version, "_") {
 		if !isCAPIContractSingleVersion(v) {
 			return false
 		}

--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -55,6 +55,10 @@ const (
 	NotAllComponentsHealthyReason = "NotAllComponentsHealthy"
 	// ReleaseIsNotFoundReason declares that the referenced in the [Management] [Release] object does not (yet) exist.
 	ReleaseIsNotFoundReason = "ReleaseIsNotFound"
+	// ReleaseIsNotReadyReason declares that the referenced in the [Management] [Release] object is not (yet) ready.
+	ReleaseIsNotReadyReason = "ReleaseIsNotReady"
+	// HasIncompatibleContractsReason declares that the [Management] object has incompatible CAPI contracts in providers.
+	HasIncompatibleContractsReason = "HasIncompatibleContracts"
 )
 
 // Core represents a structure describing core Management components.

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -57,6 +57,7 @@ import (
 	"github.com/K0rdent/kcm/internal/helm"
 	"github.com/K0rdent/kcm/internal/utils"
 	"github.com/K0rdent/kcm/internal/utils/ratelimit"
+	"github.com/K0rdent/kcm/internal/utils/validation"
 )
 
 // ManagementReconciler reconciles a Management object
@@ -92,13 +93,13 @@ func (r *ManagementReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if !management.DeletionTimestamp.IsZero() {
 		l.Info("Deleting Management")
-		return r.Delete(ctx, management)
+		return r.delete(ctx, management)
 	}
 
-	return r.Update(ctx, management)
+	return r.update(ctx, management)
 }
 
-func (r *ManagementReconciler) Update(ctx context.Context, management *kcm.Management) (ctrl.Result, error) {
+func (r *ManagementReconciler) update(ctx context.Context, management *kcm.Management) (ctrl.Result, error) {
 	l := ctrl.LoggerFrom(ctx)
 
 	if controllerutil.AddFinalizer(management, kcm.ManagementFinalizer) {
@@ -117,24 +118,16 @@ func (r *ManagementReconciler) Update(ctx context.Context, management *kcm.Manag
 	}
 
 	release, err := r.getRelease(ctx, management)
-	if err != nil {
-		if !r.IsDisabledValidationWH {
-			l.Error(err, "failed to get Release")
+	if err != nil && !r.IsDisabledValidationWH {
+		l.Error(err, "failed to get Release")
+		return ctrl.Result{}, err
+	}
+
+	if r.IsDisabledValidationWH {
+		valid, err := r.validateManagement(ctx, management, release)
+		if !valid {
 			return ctrl.Result{}, err
 		}
-
-		l.Error(err, "failed to get Release, will not retrigger until it exists")
-		meta.SetStatusCondition(&management.Status.Conditions, metav1.Condition{
-			Type:               kcm.ReadyCondition,
-			ObservedGeneration: management.Generation,
-			Status:             metav1.ConditionFalse,
-			Reason:             kcm.ReleaseIsNotFoundReason,
-			Message:            management.Spec.Release + " is not found",
-		})
-		if err := r.Client.Status().Update(ctx, management); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to update status for Management %s: %w", management.Name, err)
-		}
-		return ctrl.Result{}, nil
 	}
 
 	if err := r.cleanupRemovedComponents(ctx, management); err != nil {
@@ -256,12 +249,9 @@ func (r *ManagementReconciler) Update(ctx context.Context, management *kcm.Manag
 		requeue = true
 	}
 
-	setReadyCondition(management)
+	r.setReadyCondition(management)
 
-	if err := r.Client.Status().Update(ctx, management); err != nil {
-		errs = errors.Join(errs, fmt.Errorf("failed to update status for Management %s: %w", management.Name, err))
-	}
-
+	errs = errors.Join(errs, r.updateStatus(ctx, management))
 	if errs != nil {
 		l.Error(errs, "Multiple errors during Management reconciliation")
 		return ctrl.Result{}, errs
@@ -271,6 +261,62 @@ func (r *ManagementReconciler) Update(ctx context.Context, management *kcm.Manag
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *ManagementReconciler) validateManagement(ctx context.Context, management *kcm.Management, release *kcm.Release) (valid bool, _ error) {
+	if release == nil {
+		return false, errors.New("unexpected nil Release reference")
+	}
+
+	l := ctrl.LoggerFrom(ctx)
+
+	l.V(1).Info("Validating Release readiness")
+	releaseFound := !release.CreationTimestamp.IsZero()
+	if !releaseFound || !release.Status.Ready {
+		reason, relErrMsg := kcm.ReleaseIsNotReadyReason, fmt.Sprintf("Release %s is not ready", management.Spec.Release)
+		if !releaseFound {
+			reason, relErrMsg = kcm.ReleaseIsNotFoundReason, fmt.Sprintf("Release %s is not found", management.Spec.Release)
+		}
+
+		l.Error(errors.New(relErrMsg), "Will not retrigger until Release exists and valid")
+		meta.SetStatusCondition(&management.Status.Conditions, metav1.Condition{
+			Type:               kcm.ReadyCondition,
+			ObservedGeneration: management.Generation,
+			Status:             metav1.ConditionFalse,
+			Reason:             reason,
+			Message:            relErrMsg,
+		})
+
+		return false, r.updateStatus(ctx, management)
+	}
+
+	l.V(1).Info("Validating providers CAPI contracts compatibility")
+	incompContracts, err := validation.GetIncompatibleContracts(ctx, r.Client, release, management)
+	isProviderTplReady := !errors.Is(err, validation.ErrProviderIsNotReady)
+	if err != nil && isProviderTplReady {
+		l.Error(err, "failed to get incompatible contracts")
+		return false, fmt.Errorf("failed to get incompatible contracts: %w", err)
+	}
+
+	if len(incompContracts) == 0 && isProviderTplReady {
+		return true, nil
+	}
+
+	errMsg := incompContracts
+	if !isProviderTplReady {
+		errMsg = err.Error()
+	}
+
+	l.Error(errors.New(errMsg), "Will not retrigger this error")
+	meta.SetStatusCondition(&management.Status.Conditions, metav1.Condition{
+		Type:               kcm.ReadyCondition,
+		ObservedGeneration: management.Generation,
+		Status:             metav1.ConditionFalse,
+		Reason:             kcm.HasIncompatibleContractsReason,
+		Message:            errMsg,
+	})
+
+	return false, r.updateStatus(ctx, management)
 }
 
 // startDependentControllers starts controllers that cannot be started
@@ -527,8 +573,19 @@ func getFalseConditions(gp capioperatorv1.GenericProvider) []string {
 	return messages
 }
 
-func (r *ManagementReconciler) Delete(ctx context.Context, management *kcm.Management) (ctrl.Result, error) {
+func (r *ManagementReconciler) delete(ctx context.Context, management *kcm.Management) (ctrl.Result, error) {
 	l := ctrl.LoggerFrom(ctx)
+	if r.IsDisabledValidationWH {
+		clusterDeployments := new(kcm.ClusterDeploymentList)
+		if err := r.Client.List(ctx, clusterDeployments, client.Limit(1)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to list ClusterDeployments: %w", err)
+		}
+
+		if len(clusterDeployments.Items) > 0 {
+			return ctrl.Result{}, errors.New("the Management object can't be removed if ClusterDeployment objects still exist")
+		}
+	}
+
 	listOpts := &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{kcm.KCMManagedLabelKey: kcm.KCMManagedLabelValue}),
 	}
@@ -901,6 +958,13 @@ func (r *ManagementReconciler) ensureUpgradeBackup(ctx context.Context, mgmt *kc
 	return requeue, nil
 }
 
+func (r *ManagementReconciler) updateStatus(ctx context.Context, mgmt *kcm.Management) error {
+	if err := r.Client.Status().Update(ctx, mgmt); err != nil {
+		return fmt.Errorf("failed to update status for Management %s: %w", mgmt.Name, err)
+	}
+	return nil
+}
+
 type mgmtStatusAccumulator struct {
 	components             map[string]kcm.ComponentStatus
 	compatibilityContracts map[string]kcm.CompatibilityContracts
@@ -936,7 +1000,7 @@ func updateComponentsStatus(
 
 // setReadyCondition updates the Management resource's "Ready" condition based on whether
 // all components are healthy.
-func setReadyCondition(management *kcm.Management) {
+func (*ManagementReconciler) setReadyCondition(management *kcm.Management) {
 	var failing []string
 	for name, comp := range management.Status.Components {
 		if !comp.Success {
@@ -987,14 +1051,48 @@ func (r *ManagementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&kcm.Management{})
 
 	if r.IsDisabledValidationWH {
+		setupLog := mgr.GetLogger().WithName("management_ctrl_setup")
+
 		managedController.Watches(&kcm.Release{}, handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []ctrl.Request {
-			return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: kcm.ManagementName}}} // always trigger, so if fetching Management fails its status would be still updated then
+			return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: kcm.ManagementName}}}
 		}), builder.WithPredicates(predicate.Funcs{
 			GenericFunc: func(event.TypedGenericEvent[client.Object]) bool { return false },
-			UpdateFunc:  func(event.TypedUpdateEvent[client.Object]) bool { return false },
-		}))
+			UpdateFunc: func(tue event.TypedUpdateEvent[client.Object]) bool {
+				ro, ok := tue.ObjectOld.(*kcm.Release)
+				if !ok {
+					return false
+				}
 
-		mgr.GetLogger().WithName("management_ctrl_setup").Info("Validations are disabled, watcher for Release objects is set")
+				rn, ok := tue.ObjectNew.(*kcm.Release)
+				if !ok {
+					return false
+				}
+
+				return ro.Status.Ready != rn.Status.Ready // any change in readiness must trigger event
+			},
+		}))
+		setupLog.Info("Validations are disabled, watcher for Release objects is set")
+
+		managedController.Watches(&kcm.ProviderTemplate{}, handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []ctrl.Request {
+			return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: kcm.ManagementName}}}
+		}), builder.WithPredicates(predicate.Funcs{
+			GenericFunc: func(event.TypedGenericEvent[client.Object]) bool { return false },
+			DeleteFunc:  func(event.TypedDeleteEvent[client.Object]) bool { return false },
+			UpdateFunc: func(tue event.TypedUpdateEvent[client.Object]) bool {
+				pto, ok := tue.ObjectOld.(*kcm.ProviderTemplate)
+				if !ok {
+					return false
+				}
+
+				ptn, ok := tue.ObjectNew.(*kcm.ProviderTemplate)
+				if !ok {
+					return false
+				}
+
+				return ptn.Status.Valid && !pto.Status.Valid
+			},
+		}))
+		setupLog.Info("Validations are disabled, watcher for ProviderTemplate objects is set")
 	}
 
 	return managedController.Complete(r)

--- a/internal/utils/validation/mgmt.go
+++ b/internal/utils/validation/mgmt.go
@@ -1,0 +1,107 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1alpha1"
+)
+
+// ErrProviderIsNotReady signals if the corresponding [github.com/K0rdent/kcm/api/v1alpha1.ProviderTemplate] is not yet ready.
+var ErrProviderIsNotReady = errors.New("provider is not yet ready")
+
+// GetIncompatibleContracts validates if all of the providers specified in the given [github.com/K0rdent/kcm/api/v1alpha1.Management]
+// have compatible CAPI [contract versions]. Returns [ErrProviderIsNotReady] is the corresponding [github.com/K0rdent/kcm/api/v1alpha1.ProviderTemplate]
+// is not yet ready and the validation cannot proceed further.
+//
+// [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
+func GetIncompatibleContracts(ctx context.Context, cl client.Client, release *kcmv1.Release, mgmt *kcmv1.Management) (string, error) {
+	capiTplName := release.Spec.CAPI.Template
+	if mgmt.Spec.Core != nil && mgmt.Spec.Core.CAPI.Template != "" {
+		capiTplName = mgmt.Spec.Core.CAPI.Template
+	}
+
+	capiTpl := new(kcmv1.ProviderTemplate)
+	if err := cl.Get(ctx, client.ObjectKey{Name: capiTplName}, capiTpl); err != nil {
+		return "", fmt.Errorf("failed to get ProviderTemplate %s: %w", capiTplName, err)
+	}
+
+	if len(capiTpl.Status.CAPIContracts) > 0 && !capiTpl.Status.Valid {
+		return "", fmt.Errorf("not valid ProviderTemplate %s: %w", capiTpl.Name, ErrProviderIsNotReady)
+	}
+
+	incompatibleContracts := strings.Builder{}
+	for _, p := range mgmt.Spec.Providers {
+		tplName := p.Template
+		if tplName == "" {
+			tplName = release.ProviderTemplate(p.Name)
+		}
+
+		if tplName == capiTpl.Name || tplName == "" {
+			continue
+		}
+
+		pTpl := new(kcmv1.ProviderTemplate)
+		if err := cl.Get(ctx, client.ObjectKey{Name: tplName}, pTpl); err != nil {
+			return "", fmt.Errorf("failed to get ProviderTemplate %s: %w", tplName, err)
+		}
+
+		if len(pTpl.Status.CAPIContracts) == 0 {
+			continue
+		}
+
+		if !pTpl.Status.Valid {
+			return "", fmt.Errorf("not valid ProviderTemplate %s: %w", tplName, ErrProviderIsNotReady)
+		}
+
+		inUseProviders, err := GetInUseProvidersWithContracts(ctx, cl, pTpl)
+		if err != nil {
+			return "", fmt.Errorf("failed to get in-use providers for the template %s: %w", pTpl.Name, err)
+		}
+
+		exposedContracts := make(map[string]struct{})
+		for capiVersion, providerContracts := range pTpl.Status.CAPIContracts {
+			for contract := range strings.SplitSeq(providerContracts, "_") {
+				exposedContracts[contract] = struct{}{}
+			}
+
+			if len(capiTpl.Status.CAPIContracts) > 0 {
+				if _, ok := capiTpl.Status.CAPIContracts[capiVersion]; !ok {
+					_, _ = incompatibleContracts.WriteString(fmt.Sprintf("core CAPI contract versions does not support %s version in the ProviderTemplate %s, ", capiVersion, pTpl.Name))
+				}
+			}
+		}
+
+		if len(inUseProviders) == 0 {
+			continue
+		}
+
+		for provider, contracts := range inUseProviders {
+			for _, contract := range contracts {
+				if _, ok := exposedContracts[contract]; !ok {
+					_, _ = incompatibleContracts.WriteString(fmt.Sprintf("missing contract version %s for %s provider that is required by one or more ClusterDeployment, ", contract, provider))
+				}
+			}
+		}
+	}
+
+	return strings.TrimSuffix(incompatibleContracts.String(), ", "), nil
+}

--- a/internal/utils/validation/provider_template.go
+++ b/internal/utils/validation/provider_template.go
@@ -1,0 +1,59 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1alpha1"
+)
+
+// GetInUseProvidersWithContracts constructs a map based on the given [github.com/K0rdent/kcm/api/v1alpha1.ProviderTemplate]
+// where keys are a provider name in the format (bootstrap|control-plane|infrastructure)-<name> and values are the
+// corresponding CAPI [contract versions], e.g. infrastructure-aws: []{v1alpha3, v1alpha4, v1beta1}
+//
+// [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
+func GetInUseProvidersWithContracts(ctx context.Context, cl client.Client, pTpl *kcmv1.ProviderTemplate) (map[string][]string, error) {
+	inUseProviders := make(map[string][]string)
+	for _, providerName := range pTpl.Status.Providers {
+		clusterTemplates := new(kcmv1.ClusterTemplateList)
+		if err := cl.List(ctx, clusterTemplates, client.MatchingFields{kcmv1.ClusterTemplateProvidersIndexKey: providerName}); err != nil {
+			return nil, fmt.Errorf("failed to list ClusterTemplates: %w", err)
+		}
+
+		if len(clusterTemplates.Items) == 0 {
+			continue
+		}
+
+		for _, cltpl := range clusterTemplates.Items {
+			clds := new(kcmv1.ClusterDeploymentList)
+			if err := cl.List(ctx, clds,
+				client.MatchingFields{kcmv1.ClusterDeploymentTemplateIndexKey: cltpl.Name},
+				client.Limit(1)); err != nil {
+				return nil, fmt.Errorf("failed to list ClusterDeployments: %w", err)
+			}
+
+			if len(clds.Items) == 0 {
+				continue
+			}
+
+			inUseProviders[providerName] = append(inUseProviders[providerName], cltpl.Status.ProviderContracts[providerName])
+		}
+	}
+	return inUseProviders, nil
+}

--- a/internal/webhook/management_webhook_test.go
+++ b/internal/webhook/management_webhook_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/K0rdent/kcm/api/v1alpha1"
+	"github.com/K0rdent/kcm/internal/utils/validation"
 	"github.com/K0rdent/kcm/test/objects/clusterdeployment"
 	"github.com/K0rdent/kcm/test/objects/management"
 	"github.com/K0rdent/kcm/test/objects/release"
@@ -265,7 +266,7 @@ func TestManagementValidateUpdate(t *testing.T) {
 					template.WithProviderStatusCAPIContracts(capiVersion, ""),
 				),
 			},
-			err: "the Management is invalid: not valid ProviderTemplate " + release.DefaultCAPITemplateName,
+			err: fmt.Sprintf("the Management is invalid: not valid ProviderTemplate %s: %s", release.DefaultCAPITemplateName, validation.ErrProviderIsNotReady),
 		},
 		{
 			name:    "no providertemplates that declared in mgmt spec.providers, should fail",
@@ -320,7 +321,7 @@ func TestManagementValidateUpdate(t *testing.T) {
 					template.WithProviderStatusCAPIContracts(capiVersionOther, someContractVersion),
 				),
 			},
-			err: "the Management is invalid: not valid ProviderTemplate " + awsProviderTemplateName,
+			err: fmt.Sprintf("the Management is invalid: not valid ProviderTemplate %s: %s", awsProviderTemplateName, validation.ErrProviderIsNotReady),
 		},
 		{
 			name:    "providertemplates do not match capi contracts, should fail",

--- a/templates/provider/kcm/templates/webhooks.yaml
+++ b/templates/provider/kcm/templates/webhooks.yaml
@@ -35,28 +35,6 @@ webhooks:
       service:
         name: {{ include "kcm.webhook.serviceName" . }}
         namespace: {{ include "kcm.webhook.serviceNamespace" . }}
-        path: /mutate-k0rdent-mirantis-com-v1alpha1-management
-    failurePolicy: Fail
-    matchPolicy: Equivalent
-    name: mutation.management.k0rdent.mirantis.com
-    rules:
-      - apiGroups:
-          - k0rdent.mirantis.com
-        apiVersions:
-          - v1alpha1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - managements
-    sideEffects: None
-  - admissionReviewVersions:
-      - v1
-      - v1beta1
-    clientConfig:
-      service:
-        name: {{ include "kcm.webhook.serviceName" . }}
-        namespace: {{ include "kcm.webhook.serviceNamespace" . }}
         path: /mutate-k0rdent-mirantis-com-v1alpha1-clustertemplate
     failurePolicy: Fail
     matchPolicy: Equivalent


### PR DESCRIPTION
* if validations wh is disabled, mgmt ctrl watches `releases`
  updates and `providertemplates` valid updates
* if validations wh is disabled, mgmt ctrl reconciles release
  readiness validation and providers' capi contracts compatibility
* removed unused management mutations
* if validations wh is disabled, mgmt ctrl
  blocks deletion if clusterdeployment objects
  exist

NOTE: validating component removal is not possible hence there is
no such validation within the management ctrl

Fixes #1235 

