### PR TITLE
fix: add missing RBAC for clustertemplatechain/status

### DIFF
--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -85,6 +85,7 @@ rules:
   resources:
   - managements/status
   - accessmanagements/status
+  - clustertemplatechains/status
   - servicetemplatechains/status
   verbs:
   - get


### PR DESCRIPTION
Fixes #1374 