### PR TITLE
improvement: process absent *Templates

### DIFF
--- a/api/v1alpha1/clusterdeployment_types.go
+++ b/api/v1alpha1/clusterdeployment_types.go
@@ -33,8 +33,6 @@ const (
 
 	KCMManagedLabelKey   = "k0rdent.mirantis.com/managed"
 	KCMManagedLabelValue = "true"
-
-	ClusterNameLabelKey = "cluster.x-k8s.io/cluster-name"
 )
 
 const (


### PR DESCRIPTION
* fix cld controller deletion logic to avoid dropping the finalizer before the rest of the cleanup
* small refactor in the cld ctrl

If admission validation webhook is turned off:

* mgmt ctrl processes absent ProviderTemplates and does not retrigger
* mcs ctrl processes absent ServiceTemplates and does not retrigger
* cld ctrl processes absent ServiceTemplates and ClusterTemplates and does not retrigger
* fix incorrect requests in the servicetemplates watcher in the mcs ctrl
* cld ctrl now watches creation of Cluster and ServiceTemplates
* cld ctrl does not proceed deletion if ClusterTemplate is missing stopping the finalizer deletion

Fixes #1240 