### PR TITLE
Add arm64 platform to post-merge push job

### DIFF
--- a/.github/workflows/post-merge-push.yaml
+++ b/.github/workflows/post-merge-push.yaml
@@ -36,7 +36,7 @@ jobs:
           build-args: |
             LD_FLAGS=-s -w -X github.com/K0rdent/kcm/internal/build.Version=${{ steps.version.outputs.version }}
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/k0rdent/kcm/controller-ci:${{ steps.version.outputs.version }}
           push: true


### PR DESCRIPTION
This PR adds the `arm64` platform to the post-merge job to build a CI controller image for arm64 as well.

Related task: https://github.com/k0rdent/kcm/pull/1381