### PR TITLE
chore: change Make default cluster suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAMESPACE ?= kcm-system
-CLUSTER_NAME_SUFFIX ?= dev
+CLUSTER_NAME_SUFFIX ?= $(shell echo -n '$$(whoami)-$$(date +"%d%m%Y")')
 VERSION ?= $(shell git describe --tags --always)
 VERSION := $(patsubst v%,%,$(VERSION))
 FQDN_VERSION = $(subst .,-,$(VERSION))


### PR DESCRIPTION
This PR changes the default value for the `CLUSTER_NAME_SUFFIX` to better understand the names of clusters in the case of default values.

The previous version allowed the value to be `<provider>-dev`, and the updatedversion  sets the default value to the `<provider>-<current-logged-user>-<date>`, where `<date>` is in format `dd-mm-yyyy`