### PR TITLE
feat: support to override manager settings for CAPI providers

### DIFF
--- a/templates/provider/cluster-api-provider-aws/Chart.yaml
+++ b/templates/provider/cluster-api-provider-aws/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-aws/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-aws/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{- define "featureGates.default" -}}
+ExternalResourceGC: true
+{{- end }}
+
+{{/*
+Merge .Values.manager.featureGates with the default
+*/}}
+{{- define "featureGates" -}}
+{{ toYaml (merge (.Values.manager.featureGates | default dict) (include "featureGates.default" . | fromYaml)) }}
+{{- end }}
+
+{{/*
+Manager settings with the default feature gates
+*/}}
+{{- define "spec.manager" -}}
+{{- $manager := deepCopy .Values.manager }}
+{{- $_ := set $manager "featureGates" (include "featureGates" . | fromYaml) }}
+{{- toYaml $manager }}
+{{- end }}

--- a/templates/provider/cluster-api-provider-aws/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-aws/templates/provider.yaml
@@ -9,6 +9,4 @@ spec:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
-  manager:
-    featureGates:
-      ExternalResourceGC: true
+  manager: {{ include "spec.manager" . | nindent 4 }}

--- a/templates/provider/cluster-api-provider-aws/values.yaml
+++ b/templates/provider/cluster-api-provider-aws/values.yaml
@@ -5,3 +5,5 @@ configSecret:
 
 config:
   AWS_B64ENCODED_CREDENTIALS: Cg==
+
+manager: {}

--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-azure/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-azure/templates/provider.yaml
@@ -9,6 +9,7 @@ spec:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
+  manager: {{- toYaml .Values.manager | nindent 4 }}
   manifestPatches:
     - |
       apiVersion: v1

--- a/templates/provider/cluster-api-provider-azure/values.yaml
+++ b/templates/provider/cluster-api-provider-azure/values.yaml
@@ -4,3 +4,5 @@ configSecret:
   namespace: ""
 
 config: {}
+
+manager: {}

--- a/templates/provider/cluster-api-provider-docker/Chart.yaml
+++ b/templates/provider/cluster-api-provider-docker/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-docker/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-docker/templates/provider.yaml
@@ -9,3 +9,4 @@ spec:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
+  manager: {{- toYaml .Values.manager | nindent 4 }}

--- a/templates/provider/cluster-api-provider-docker/values.yaml
+++ b/templates/provider/cluster-api-provider-docker/values.yaml
@@ -4,3 +4,5 @@ configSecret:
   namespace: ""
 
 config: {}
+
+manager: {}

--- a/templates/provider/cluster-api-provider-gcp/Chart.yaml
+++ b/templates/provider/cluster-api-provider-gcp/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-gcp/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-gcp/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{- define "featureGates.default" -}}
+GKE: true
+{{- end }}
+
+{{/*
+Merge .Values.manager.featureGates with the default
+*/}}
+{{- define "featureGates" -}}
+{{ toYaml (merge (.Values.manager.featureGates | default dict) (include "featureGates.default" . | fromYaml)) }}
+{{- end }}
+
+{{/*
+Manager settings with the default feature gates
+*/}}
+{{- define "spec.manager" -}}
+{{- $manager := deepCopy .Values.manager }}
+{{- $_ := set $manager "featureGates" (include "featureGates" . | fromYaml) }}
+{{- toYaml $manager }}
+{{- end }}

--- a/templates/provider/cluster-api-provider-gcp/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-gcp/templates/provider.yaml
@@ -9,6 +9,5 @@ spec:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
-  manager:
-    featureGates:
-      GKE: true
+  manager: {{ include "spec.manager" . | nindent 4 }}
+

--- a/templates/provider/cluster-api-provider-gcp/values.yaml
+++ b/templates/provider/cluster-api-provider-gcp/values.yaml
@@ -5,3 +5,5 @@ configSecret:
 
 config:
   GCP_B64ENCODED_CREDENTIALS: ""
+
+manager: {}

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
@@ -9,3 +9,4 @@ spec:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
+  manager: {{- toYaml .Values.manager | nindent 4 }}

--- a/templates/provider/cluster-api-provider-openstack/values.yaml
+++ b/templates/provider/cluster-api-provider-openstack/values.yaml
@@ -5,4 +5,6 @@ configSecret:
 
 config: {}
 
+manager: {}
+
 orcVersion: "1.0.0"

--- a/templates/provider/cluster-api-provider-vsphere/Chart.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-vsphere/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/templates/provider.yaml
@@ -9,3 +9,4 @@ spec:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
+  manager: {{- toYaml .Values.manager | nindent 4 }}

--- a/templates/provider/cluster-api-provider-vsphere/values.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/values.yaml
@@ -20,3 +20,5 @@ config:
   VSPHERE_SSH_AUTHORIZED_KEY: ""
   VSPHERE_STORAGE_POLICY: ""
   CPI_IMAGE_K8S_VERSION: ""
+
+manager: {}

--- a/templates/provider/cluster-api/Chart.yaml
+++ b/templates/provider/cluster-api/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api/templates/provider.yaml
+++ b/templates/provider/cluster-api/templates/provider.yaml
@@ -9,3 +9,4 @@ spec:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
+  manager: {{- toYaml .Values.manager | nindent 4 }}

--- a/templates/provider/cluster-api/values.yaml
+++ b/templates/provider/cluster-api/values.yaml
@@ -4,3 +4,5 @@ configSecret:
   namespace: ""
 
 config: {}
+
+manager: {}

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -9,21 +9,21 @@ spec:
   kcm:
     template: kcm-0-2-0
   capi:
-    template: cluster-api-0-2-0
+    template: cluster-api-0-2-1
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
       template: cluster-api-provider-k0sproject-k0smotron-0-2-0
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-0-2-0
+      template: cluster-api-provider-azure-0-2-1
     - name: cluster-api-provider-vsphere
-      template: cluster-api-provider-vsphere-0-2-0
+      template: cluster-api-provider-vsphere-0-2-1
     - name: cluster-api-provider-aws
-      template: cluster-api-provider-aws-0-2-1
+      template: cluster-api-provider-aws-0-2-2
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-0-2-0
+      template: cluster-api-provider-openstack-0-2-1
     - name: cluster-api-provider-docker
-      template: cluster-api-provider-docker-0-2-0
+      template: cluster-api-provider-docker-0-2-1
     - name: cluster-api-provider-gcp
-      template: cluster-api-provider-gcp-0-2-0
+      template: cluster-api-provider-gcp-0-2-1
     - name: projectsveltos
       template: projectsveltos-0-51-2

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-aws-0-2-1
+  name: cluster-api-provider-aws-0-2-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-aws
-      version: 0.2.1
+      version: 0.2.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-0-2-0
+  name: cluster-api-provider-azure-0-2-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-azure
-      version: 0.2.0
+      version: 0.2.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-docker-0-2-0
+  name: cluster-api-provider-docker-0-2-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-docker
-      version: 0.2.0
+      version: 0.2.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-gcp-0-2-0
+  name: cluster-api-provider-gcp-0-2-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-gcp
-      version: 0.2.0
+      version: 0.2.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-0-2-0
+  name: cluster-api-provider-openstack-0-2-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 0.2.0
+      version: 0.2.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-vsphere-0-2-0
+  name: cluster-api-provider-vsphere-0-2-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-vsphere
-      version: 0.2.0
+      version: 0.2.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-0-2-0
+  name: cluster-api-0-2-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api
-      version: 0.2.0
+      version: 0.2.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
This PR adds the support of overriding `spec.manager` for CAPI providers (except `k0sproject-k0smotron` due to [the bug in CAPI operator](https://github.com/kubernetes-sigs/cluster-api-operator/issues/787)) to allow specifying custom feature gates and other settings.

For example, to add custom feature gates for the AWS provider, user should configure `spec.providers[].config.manager.featureGates` in the Management object:

```
apiVersion: k0rdent.mirantis.com/v1alpha1
kind: Management
metadata:
  labels:
    k0rdent.mirantis.com/component: kcm
  name: kcm
spec:
  providers:
  - name: cluster-api-provider-aws
    config:
      manager:
        featureGates:
          MachinePool: true 
          EKSEnableIAM: true
          EKSAllowAddRoles: true
```

Updates #1369


