### PR TITLE
fix: constant HelmRelease updates

### DIFF
--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -281,8 +282,14 @@ func (r *ClusterDeploymentReconciler) updateCluster(ctx context.Context, cd *kcm
 		return ctrl.Result{}, err
 	}
 
+	var values map[string]any
+	err = json.Unmarshal(cd.Spec.Config.Raw, &values)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	hrReconcileOpts := helm.ReconcileHelmReleaseOpts{
-		Values: cd.Spec.Config,
+		Values: values,
 		OwnerReference: &metav1.OwnerReference{
 			APIVersion: kcm.GroupVersion.String(),
 			Kind:       kcm.ClusterDeploymentKind,

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -239,8 +239,19 @@ func (r *ManagementReconciler) reconcileManagementComponents(ctx context.Context
 			continue
 		}
 
+		var values map[string]any
+		if component.Config != nil {
+			err = json.Unmarshal(component.Config.Raw, &values)
+			if err != nil {
+				errMsg := fmt.Sprintf("Failed to unmarshal %s values: %s", component.Template, err)
+				updateComponentsStatus(statusAccumulator, component, nil, errMsg)
+				errs = errors.Join(errs, errors.New(errMsg))
+				continue
+			}
+		}
+
 		hrReconcileOpts := helm.ReconcileHelmReleaseOpts{
-			Values:          component.Config,
+			Values:          values,
 			ChartRef:        template.Status.ChartRef,
 			DependsOn:       component.dependsOn,
 			TargetNamespace: component.targetNamespace,

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -345,11 +345,7 @@ func (r *ReleaseReconciler) reconcileKCMTemplates(ctx context.Context, releaseNa
 		createReleaseValues := map[string]any{
 			"createRelease": true,
 		}
-		raw, err := json.Marshal(createReleaseValues)
-		if err != nil {
-			return false, err
-		}
-		opts.Values = &apiextensionsv1.JSON{Raw: raw}
+		opts.Values = createReleaseValues
 	}
 
 	hr, operation, err := helm.ReconcileHelmRelease(ctx, r.Client, kcmTemplatesName, r.SystemNamespace, opts)

--- a/internal/helm/release.go
+++ b/internal/helm/release.go
@@ -16,6 +16,8 @@ package helm
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	hcv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -34,7 +36,7 @@ const (
 )
 
 type ReconcileHelmReleaseOpts struct {
-	Values            *apiextensionsv1.JSON
+	Values            map[string]any
 	OwnerReference    *metav1.OwnerReference
 	ChartRef          *hcv2.CrossNamespaceSourceReference
 	ReconcileInterval *time.Duration
@@ -76,7 +78,11 @@ func ReconcileHelmRelease(ctx context.Context,
 		hr.Spec.ReleaseName = name
 
 		if opts.Values != nil {
-			hr.Spec.Values = opts.Values
+			raw, err := json.Marshal(opts.Values)
+			if err != nil {
+				return fmt.Errorf("failed to marshal values: %w", err)
+			}
+			hr.Spec.Values = &apiextensionsv1.JSON{Raw: raw}
 		}
 		if opts.DependsOn != nil {
 			hr.Spec.DependsOn = opts.DependsOn


### PR DESCRIPTION
This PR reworks the `ReconcileHelmRelease` function and updates the way values are handled. When two values of the apiextensionsv1.JSON type are compared (expected vs actual values), it's considered as not equal even if the internal values are the same.

This leads to constant updates of the HelmRelease object. It does not affect components without a custom config specified.

Fixes #1398