### PR TITLE
change aws controlplane lb to network

### DIFF
--- a/templates/cluster/aws-standalone-cp/templates/awscluster.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/awscluster.yaml
@@ -13,6 +13,7 @@ spec:
     name: {{ .Values.clusterIdentity.name }}
   controlPlaneLoadBalancer:
     healthCheckProtocol: TCP
+    loadBalancerType: nlb
   network:
     additionalControlPlaneIngressRules:
       - description: "k0s controller join API"


### PR DESCRIPTION
AWS classic load balancers are [deprecated](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/introduction.html), it is recommended to use nlb/alb 