### PR TITLE
Revert "chore(bump): k0smotron v1.5.1"

### DIFF
--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.5.1"
+appVersion: "1.4.2"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron, control-plane-k0sproject-k0smotron
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/providers.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/providers.yaml
@@ -3,7 +3,7 @@ kind: InfrastructureProvider
 metadata:
   name: k0sproject-k0smotron
 spec:
-  version: v1.5.1
+  version: v1.4.2
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
@@ -15,7 +15,7 @@ kind: BootstrapProvider
 metadata:
   name: k0sproject-k0smotron
 spec:
-  version: v1.5.1
+  version: v1.4.2
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
@@ -27,7 +27,7 @@ kind: ControlPlaneProvider
 metadata:
   name: k0sproject-k0smotron
 spec:
-  version: v1.5.1
+  version: v1.4.2
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -12,7 +12,7 @@ spec:
     template: cluster-api-0-2-1
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
-      template: cluster-api-provider-k0sproject-k0smotron-0-2-1
+      template: cluster-api-provider-k0sproject-k0smotron-0-2-2
     - name: cluster-api-provider-azure
       template: cluster-api-provider-azure-0-2-1
     - name: cluster-api-provider-vsphere

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-k0sproject-k0smotron-0-2-1
+  name: cluster-api-provider-k0sproject-k0smotron-0-2-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-k0sproject-k0smotron
-      version: 0.2.1
+      version: 0.2.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Reverts k0rdent/kcm#1397

In k0smotron v1.5.1, a webhook was introduced using the certificate secret name `webhook-server-cert`, which conflicts with the secret name used by CAPZ.