### PR TITLE
fix: update templatechain validity printcolumn

### DIFF
--- a/api/v1alpha1/clustertemplatechain_types.go
+++ b/api/v1alpha1/clustertemplatechain_types.go
@@ -38,7 +38,7 @@ func (t *ClusterTemplateChain) GetStatus() *TemplateChainStatus {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Valid",type=boolean,JSONPath=`.status.isValid`,description="Is the chain valid",priority=0
+// +kubebuilder:printcolumn:name="Valid",type=boolean,JSONPath=`.status.valid`,description="Is the chain valid",priority=0
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time elapsed since object creation",priority=0
 
 // ClusterTemplateChain is the Schema for the clustertemplatechains API

--- a/api/v1alpha1/servicetemplatechain_types.go
+++ b/api/v1alpha1/servicetemplatechain_types.go
@@ -38,7 +38,7 @@ func (t *ServiceTemplateChain) GetStatus() *TemplateChainStatus {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Valid",type=boolean,JSONPath=`.status.isValid`,description="Is the chain valid",priority=0
+// +kubebuilder:printcolumn:name="Valid",type=boolean,JSONPath=`.status.valid`,description="Is the chain valid",priority=0
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time elapsed since object creation",priority=0
 
 // ServiceTemplateChain is the Schema for the servicetemplatechains API

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplatechains.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplatechains.yaml
@@ -16,7 +16,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: Is the chain valid
-      jsonPath: .status.isValid
+      jsonPath: .status.valid
       name: Valid
       type: boolean
     - description: Time elapsed since object creation

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplatechains.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplatechains.yaml
@@ -16,7 +16,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: Is the chain valid
-      jsonPath: .status.isValid
+      jsonPath: .status.valid
       name: Valid
       type: boolean
     - description: Time elapsed since object creation


### PR DESCRIPTION
This PR is a follow-up for #1405. It updates printcolumns for `ClusterTemplateChain` and `ServiceTemplateChain` CRs after `.status.isValid` field was changed to `.status.valid`
