### PR TITLE
feat: Emit events for services

### DIFF
--- a/api/v1alpha1/multiclusterservice_types.go
+++ b/api/v1alpha1/multiclusterservice_types.go
@@ -25,7 +25,9 @@ const (
 	MultiClusterServiceFinalizer = "k0rdent.mirantis.com/multicluster-service"
 	// MultiClusterServiceKind is the string representation of a MultiClusterServiceKind.
 	MultiClusterServiceKind = "MultiClusterService"
+)
 
+const (
 	// SveltosProfileReadyCondition indicates if the Sveltos Profile is ready.
 	SveltosProfileReadyCondition = "SveltosProfileReady"
 	// SveltosClusterProfileReadyCondition indicates if the Sveltos ClusterProfile is ready.
@@ -50,6 +52,26 @@ const (
 
 	// ServicesReferencesValidationCondition defines the condition of services' references validation.
 	ServicesReferencesValidationCondition = "ServicesReferencesValidation"
+)
+
+// Reasons are provided as utility, and not part of the declarative API.
+const (
+	// ServicesReferencesValidationFailedReason signals that the validation for references related to services (KSM) failed.
+	ServicesReferencesValidationFailedReason = "ServicesReferencesValidationFailed"
+	// ServicesReferencesValidationSucceededReason signals that the validation for references related to services (KSM) succeeded.
+	ServicesReferencesValidationSucceededReason = "ServicesReferencesValidationSucceeded"
+	// SveltosProfileNotReadyReason signals that the Sveltos Profile object is not yet ready.
+	SveltosProfileNotReadyReason = "SveltosProfileNotReady"
+	// SveltosClusterProfileNotReadyReason signals that the Sveltos ClusterProfile object is not yet ready.
+	SveltosClusterProfileNotReadyReason = "SveltosClusterProfileNotReady"
+	// FetchServicesStatusFailedReason signals that fetching the status of services from Sveltos objects failed.
+	FetchServicesStatusFailedReason = "FetchServicesStatusFailed"
+	// SveltosHelmReleaseNotReadyReason signals that the helm release managed by Sveltos on target cluster is not yet ready.
+	SveltosHelmReleaseNotReadyReason = "SveltosHelmReleaseNotReady"
+	// SveltosFeatureReadyReason signals that the feature managed by Sveltos on target cluster is ready.
+	SveltosFeatureReadyReason = "SveltosFeatureReady"
+	// SveltosFeatureNotReadyReason signals that the feature managed by Sveltos on target cluster is not yet ready.
+	SveltosFeatureNotReadyReason = "SveltosFeatureNotReady"
 )
 
 // Service represents a Service to be deployed.

--- a/internal/sveltos/status.go
+++ b/internal/sveltos/status.go
@@ -17,21 +17,23 @@ package sveltos
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
+	"github.com/K0rdent/kcm/internal/record"
 )
 
 // GetStatusConditions returns a list of conditions from provided ClusterSummary.
-func GetStatusConditions(summary *sveltosv1beta1.ClusterSummary) ([]metav1.Condition, error) {
+func GetStatusConditions(summary *sveltosv1beta1.ClusterSummary) (conditions []metav1.Condition, err error) {
 	if summary == nil {
 		return nil, errors.New("error getting status from ClusterSummary: nil summary provided")
 	}
-
-	conditions := make([]metav1.Condition, 0, len(summary.Status.FeatureSummaries)+len(summary.Status.HelmReleaseSummaries))
 
 	for _, x := range summary.Status.FeatureSummaries {
 		msg := ""
@@ -66,6 +68,30 @@ func GetStatusConditions(summary *sveltosv1beta1.ClusterSummary) ([]metav1.Condi
 	return conditions, nil
 }
 
+// CreateEventFromCondition creates sveltos related kubernetes event from the provided condition.
+func CreateEventFromCondition(object runtime.Object, generation int64, targetCluster client.ObjectKey, condition *metav1.Condition) {
+	if isHelmReleaseReadyConditionType(condition) {
+		if condition.Status == metav1.ConditionTrue {
+			record.Eventf(object, generation, kcm.SveltosHelmReleaseReadyCondition, condition.Message)
+		} else {
+			record.Warnf(object, generation, kcm.SveltosHelmReleaseNotReadyReason, condition.Message)
+		}
+		return
+	}
+
+	// If here then the condition is related to one of the Sveltos Features (Resources, Helm, Kustomize).
+
+	// This msg will render as:
+	// 1. Sveltos feature Resources Provisioned on target cluster cluster-namespace/cluster-name
+	// 2. Sveltos feature Helm FailedNonRetriable on target cluster cluster-namespace/cluster-name
+	msg := fmt.Sprintf("Sveltos feature %s %s on target cluster %s", condition.Type, condition.Reason, targetCluster.String())
+	if condition.Status == metav1.ConditionTrue {
+		record.Eventf(object, generation, kcm.SveltosFeatureReadyReason, msg)
+	} else {
+		record.Eventf(object, generation, kcm.SveltosFeatureNotReadyReason, msg)
+	}
+}
+
 // helmReleaseReadyConditionType returns a SveltosHelmReleaseReady
 // type per service to be used in status conditions.
 func helmReleaseReadyConditionType(releaseNamespace, releaseName string) string {
@@ -75,6 +101,10 @@ func helmReleaseReadyConditionType(releaseNamespace, releaseName string) string 
 		releaseName,
 		kcm.SveltosHelmReleaseReadyCondition,
 	)
+}
+
+func isHelmReleaseReadyConditionType(condition *metav1.Condition) bool {
+	return strings.HasSuffix(condition.Type, kcm.SveltosHelmReleaseReadyCondition)
 }
 
 func helmReleaseConditionMessage(releaseNamespace, releaseName, conflictMsg string) string {


### PR DESCRIPTION
# Description

This PR introduces the following events:
```
1. ServicesReferencesValidationSucceeded
2. ServicesReferencesValidationFailed
3. SveltosProfileReady
4. SveltosProfileNotReady
5. SveltosClusterProfileReady
6. SveltosClusterProfileNotReady
7. FetchServicesStatusSuccess
8. FetchServicesStatusFailed
9. SveltosHelmReleaseReady
10. SveltosHelmReleaseNotReady
11. SveltosFeatureReady
12. SveltosFeatureNotReady
```

# Testing

The following output shows that the status `ClusterDeployment` is being reported correctly:
```sh
➜  ~ kubectl -n kcm-system get clusterdeployment wali-dev-1 -o yaml    
apiVersion: k0rdent.mirantis.com/v1alpha1
kind: ClusterDeployment
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"k0rdent.mirantis.com/v1alpha1","kind":"ClusterDeployment","metadata":{"annotations":{},"name":"wali-dev-1","namespace":"kcm-system"},"spec":{"config":{"clusterIdentity":{"name":"aws-cluster-identity","namespace":"kcm-system"},"controlPlane":{"amiID":"ami-0eb9fdcf0d07bd5ef","instanceProfile":"control-plane.cluster-api-provider-aws.sigs.k8s.io","instanceType":"t3.small"},"controlPlaneNumber":1,"publicIP":true,"region":"ca-central-1","worker":{"amiID":"ami-0eb9fdcf0d07bd5ef","instanceProfile":"nodes.cluster-api-provider-aws.sigs.k8s.io","instanceType":"t3.small"},"workersNumber":1},"credential":"aws-cluster-identity-cred","serviceSpec":{"services":[{"name":"ingress-nginx","namespace":"ingress-nginx-4-11-3","template":"ingress-nginx-4-11-3"},{"name":"kyverno","namespace":"kyverno","template":"kyverno-3-2-6"}],"stopOnConflict":false,"syncMode":"Continuous"},"template":"aws-standalone-cp-0-2-0"}}
  creationTimestamp: "2025-04-23T01:20:06Z"
  finalizers:
  - k0rdent.mirantis.com/cluster-deployment
  generation: 2
  labels:
    k0rdent.mirantis.com/component: kcm
  name: wali-dev-1
  namespace: kcm-system
  resourceVersion: "34110"
  uid: 60941995-5bdb-4d47-b099-1ec6799cbf6a
spec:
  config:
    clusterIdentity:
      name: aws-cluster-identity
      namespace: kcm-system
    controlPlane:
      amiID: ami-0eb9fdcf0d07bd5ef
      instanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
      instanceType: t3.small
    controlPlaneNumber: 1
    publicIP: true
    region: ca-central-1
    worker:
      amiID: ami-0eb9fdcf0d07bd5ef
      instanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io
      instanceType: t3.small
    workersNumber: 1
  credential: aws-cluster-identity-cred
  propagateCredentials: true
  serviceSpec:
    continueOnError: false
    priority: 100
    services:
    - name: ingress-nginx
      namespace: ingress-nginx-4-11-3
      template: ingress-nginx-4-11-3
    - name: kyverno
      namespace: kyverno
      template: kyverno-3-2-6
    stopOnConflict: false
    syncMode: Continuous
  template: aws-standalone-cp-0-2-0
status:
  conditions:
  - lastTransitionTime: "2025-04-23T02:09:54Z"
    message: ""
    observedGeneration: 2
    reason: Succeeded
    status: "True"
    type: TemplateReady
  - lastTransitionTime: "2025-04-23T02:09:54Z"
    message: ""
    observedGeneration: 2
    reason: Succeeded
    status: "True"
    type: HelmChartReady
  - lastTransitionTime: "2025-04-23T02:09:54Z"
    message: Helm install succeeded for release kcm-system/wali-dev-1.v1 with chart
      aws-standalone-cp@0.2.0
    reason: InstallSucceeded
    status: "True"
    type: HelmReleaseReady
  - lastTransitionTime: "2025-04-23T01:42:13Z"
    message: Object is ready
    reason: Succeeded
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-04-23T02:09:54Z"
    message: ""
    observedGeneration: 2
    reason: Succeeded
    status: "True"
    type: CredentialReady
  - lastTransitionTime: "2025-04-23T02:09:54Z"
    message: ""
    observedGeneration: 2
    reason: Succeeded
    status: "True"
    type: SveltosProfileReady
  - lastTransitionTime: "2025-04-23T02:09:54Z"
    message: ""
    observedGeneration: 2
    reason: Succeeded
    status: "True"
    type: FetchServicesStatusSuccess
  - lastTransitionTime: "2025-04-23T02:09:54Z"
    message: ""
    observedGeneration: 2
    reason: Succeeded
    status: "True"
    type: ServicesReferencesValidation
  - lastTransitionTime: "2025-04-23T01:42:13Z"
    message: 2/2
    reason: Succeeded
    status: "True"
    type: ServicesInReadyState
  - lastTransitionTime: "2025-04-23T01:26:42Z"
    message: ""
    observedGeneration: 2
    reason: InfoReported
    status: "True"
    type: CAPIClusterSummary
  observedGeneration: 2
  services:
  - clusterName: wali-dev-1
    clusterNamespace: kcm-system
    conditions:
    - lastTransitionTime: "2025-04-23T02:09:54Z"
      message: ""
      reason: Provisioned
      status: "True"
      type: Resources
    - lastTransitionTime: "2025-04-23T02:09:54Z"
      message: ""
      reason: Provisioned
      status: "True"
      type: Helm
    - lastTransitionTime: "2025-04-23T02:09:54Z"
      message: Release ingress-nginx-4-11-3/ingress-nginx
      reason: Managing
      status: "True"
      type: ingress-nginx-4-11-3.ingress-nginx/SveltosHelmReleaseReady
    - lastTransitionTime: "2025-04-23T02:09:54Z"
      message: Release kyverno/kyverno
      reason: Managing
      status: "True"
      type: kyverno.kyverno/SveltosHelmReleaseReady
```

✅ The following successful events can be seen via kubectl:
```sh
➜  ~ kubectl -n kcm-system get event --field-selector reason=ServicesReferencesValidationSucceeded
LAST SEEN   TYPE     REASON                                  OBJECT                         MESSAGE
57m         Normal   ServicesReferencesValidationSucceeded   clusterdeployment/wali-dev-1   Successfully validated services references
➜  ~ kubectl -n kcm-system get event --field-selector reason=SveltosProfileReady                  
LAST SEEN   TYPE     REASON                OBJECT                         MESSAGE
57m         Normal   SveltosProfileReady   clusterdeployment/wali-dev-1   Successfully reconciled kcm-system/wali-dev-1 Profile
➜  ~ kubectl -n kcm-system get event --field-selector reason=FetchServicesStatusSuccess
LAST SEEN   TYPE     REASON                       OBJECT                         MESSAGE
58m         Normal   FetchServicesStatusSuccess   clusterdeployment/wali-dev-1   Successfully fetched status of services from Sveltos ClusterSummary
```

:no_entry_sign: Whereas, the following events should have been created but are not:
```sh
➜  ~ kubectl -n kcm-system get event --field-selector reason=SveltosHelmReleaseReady   
No resources found in kcm-system namespace.
➜  ~ kubectl -n kcm-system get event --field-selector reason=SveltosHelmReleaseNotReady
No resources found in kcm-system namespace.
➜  ~ kubectl -n kcm-system get event --field-selector reason=SveltosFeatureReady       
No resources found in kcm-system namespace.
```

Even though the controller logs show that these events were created:
```sh
2025-04-23T01:42:34Z	DEBUG	events	Sveltos feature Resources Provisioned on target cluster kcm-system/wali-dev-1	{"type": "Normal", "object": {"kind":"ClusterDeployment","namespace":"kcm-system","name":"wali-dev-1","uid":"60941995-5bdb-4d47-b099-1ec6799cbf6a","apiVersion":"k0rdent.mirantis.com/v1alpha1","resourceVersion":"19535"}, "reason": "SveltosFeatureReady"}
2025-04-23T01:42:34Z	DEBUG	events	Sveltos feature Helm Provisioned on target cluster kcm-system/wali-dev-1	{"type": "Normal", "object": {"kind":"ClusterDeployment","namespace":"kcm-system","name":"wali-dev-1","uid":"60941995-5bdb-4d47-b099-1ec6799cbf6a","apiVersion":"k0rdent.mirantis.com/v1alpha1","resourceVersion":"19535"}, "reason": "SveltosFeatureReady"}
2025-04-23T01:42:34Z	DEBUG	events	Release ingress-nginx-4-11-3/ingress-nginx	{"type": "Normal", "object": {"kind":"ClusterDeployment","namespace":"kcm-system","name":"wali-dev-1","uid":"60941995-5bdb-4d47-b099-1ec6799cbf6a","apiVersion":"k0rdent.mirantis.com/v1alpha1","resourceVersion":"19535"}, "reason": "SveltosHelmReleaseReady"}
2025-04-23T01:42:34Z	DEBUG	events	Release kyverno/kyverno	{"type": "Normal", "object": {"kind":"ClusterDeployment","namespace":"kcm-system","name":"wali-dev-1","uid":"60941995-5bdb-4d47-b099-1ec6799cbf6a","apiVersion":"k0rdent.mirantis.com/v1alpha1","resourceVersion":"19535"}, "reason": "SveltosHelmReleaseReady"}
```
