### PR TITLE
fix: explicitly specify azure ccm imageTag

### DIFF
--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-0-2-1
+  template: azure-standalone-cp-0-2-2
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -56,8 +56,10 @@ spec:
                   {{- if .Values.extensions.imageRepository }}
                   imageRepository: {{ .Values.extensions.imageRepository }}
                   {{- end }}
-                {{- if .Values.extensions.imageRepository }}
+                  imageTag: v1.32.4
                 cloudNodeManager:
+                  imageTag: v1.32.4
+                {{- if .Values.extensions.imageRepository }}
                   imageRepository: {{ .Values.extensions.imageRepository }}
                 {{- end }}
             - name: azuredisk-csi-driver

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -56,8 +56,10 @@ spec:
                     {{- if .Values.extensions.imageRepository }}
                     imageRepository: {{ .Values.extensions.imageRepository }}
                     {{- end }}
-                  {{- if .Values.extensions.imageRepository }}
+                    imageTag: v1.32.4
                   cloudNodeManager:
+                    imageTag: v1.32.4
+                  {{- if .Values.extensions.imageRepository }}
                     imageRepository: {{ .Values.extensions.imageRepository }}
                   {{- end }}
               - name: azuredisk-csi-driver

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-0-2-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-0-2-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-0-2-1
+  name: azure-hosted-cp-0-2-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 0.2.1
+      chart: azure-hosted-cp
+      version: 0.2.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-0-2-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-0-2-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-0-2-1
+  name: azure-standalone-cp-0-2-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 0.2.1
+      chart: azure-standalone-cp
+      version: 0.2.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
After upgrading k0s to v1.32.3, the Azure Cloud Controller Manager fails to deploy due to a limitation in the Helm chart, which determines the CCM image version. It does not currently handle Kubernetes version 1.32: https://github.com/Mirantis/helm-charts/blob/main/mirantis/cloud-provider-azure/templates/cloud-provider-azure.yaml#L22

As a result, `.cloudProviderAzureVersion` remains unset, which causes the generated image path to be empty: https://github.com/Mirantis/helm-charts/blob/main/mirantis/cloud-provider-azure/templates/_image.tpl#L7

When the imageTag is specified, the image path is generated properly.

Fixes #1420
