### PR TITLE
fix(openstack-standalone-cp): make ssh config more uniform

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-0-2-1
+  template: openstack-standalone-cp-0-2-2
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
@@ -37,4 +37,6 @@ spec:
       {{- end }}
       {{- if not ( .Values.controlPlane.sshKeyName | empty) }}
       sshKeyName: {{ .Values.controlPlane.sshKeyName }}
+      {{- else if not ( .Values.controlPlane.sshPublicKey | empty) }}
+      sshKeyName: {{ .Values.controlPlane.sshPublicKey }}
       {{- end }}

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
@@ -35,6 +35,6 @@ spec:
       securityGroups:
         {{ .Values.controlPlane.securityGroups | toYaml | nindent 8 }}
       {{- end }}
-      {{- if not ( .Values.controlPlane.sshPublicKey | empty) }}
-      sshKeyName: {{ .Values.controlPlane.sshPublicKey }}
+      {{- if not ( .Values.controlPlane.sshKeyName | empty) }}
+      sshKeyName: {{ .Values.controlPlane.sshKeyName }}
       {{- end }}

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
@@ -35,8 +35,7 @@ spec:
       securityGroups:
         {{ .Values.controlPlane.securityGroups | toYaml | nindent 8 }}
       {{- end }}
-      {{- if not ( .Values.controlPlane.sshKeyName | empty) }}
-      sshKeyName: {{ .Values.controlPlane.sshKeyName }}
-      {{- else if not ( .Values.controlPlane.sshPublicKey | empty) }}
-      sshKeyName: {{ .Values.controlPlane.sshPublicKey }}
+      {{- $sshKey := .Values.controlPlane.sshKeyName | default .Values.controlPlane.sshPublicKey }}
+      {{- if $sshKey }}
+      sshKeyName: {{ $sshKey }}
       {{- end }}

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
@@ -37,4 +37,6 @@ spec:
       {{- end }}
       {{- if not ( .Values.worker.sshKeyName | empty) }}
       sshKeyName: {{ .Values.worker.sshKeyName }}
-      {{- end }}      
+      {{- else if not ( .Values.controlPlane.sshPublicKey | empty) }}
+      sshKeyName: {{ .Values.controlPlane.sshPublicKey }}
+      {{- end }}

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
@@ -35,8 +35,7 @@ spec:
       securityGroups:
         {{ .Values.worker.securityGroups | toYaml | nindent 8 }}
       {{- end }}
-      {{- if not ( .Values.worker.sshKeyName | empty) }}
-      sshKeyName: {{ .Values.worker.sshKeyName }}
-      {{- else if not ( .Values.controlPlane.sshPublicKey | empty) }}
-      sshKeyName: {{ .Values.controlPlane.sshPublicKey }}
+      {{- $sshKey := .Values.worker.sshKeyName | default .Values.worker.sshPublicKey }}
+      {{- if $sshKey }}
+      sshKeyName: {{ $sshKey }}
       {{- end }}

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
@@ -35,6 +35,6 @@ spec:
       securityGroups:
         {{ .Values.worker.securityGroups | toYaml | nindent 8 }}
       {{- end }}
-      {{- if not ( .Values.worker.sshPublicKey | empty) }}
-      sshKeyName: {{ .Values.worker.sshPublicKey }}
+      {{- if not ( .Values.worker.sshKeyName | empty) }}
+      sshKeyName: {{ .Values.worker.sshKeyName }}
       {{- end }}      

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -156,6 +156,10 @@
         "spec": {
           "type": "object",
           "properties": {
+	    "sshKeyName": {
+	      "type": "string",
+              "description": "SSH public key for accessing the bastion"
+	    },
             "providerID": {
               "type": ["string", "null"],
               "description": "Provider ID of the bastion server"
@@ -229,7 +233,7 @@
         "flavor"
       ],
       "properties": {
-        "sshPublicKey": {
+        "sshKeyName": {
           "type": "string",
           "description": "SSH public key for accessing nodes"
         },
@@ -387,7 +391,7 @@
         "flavor"
       ],
       "properties": {
-        "sshPublicKey": {
+        "sshKeyName": {
           "type": "string",
           "description": "SSH public key for accessing nodes"
         },

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -237,6 +237,11 @@
           "type": "string",
           "description": "SSH public key for accessing nodes"
         },
+	"sshPublicKey": {
+	  "type": "string",
+          "description": "SSH public key for accessing nodes",
+          "deprecated": true
+	},
         "providerID": {
           "type": ["string", "null"],
           "description": "Unique ID for the instance provider"
@@ -395,6 +400,11 @@
           "type": "string",
           "description": "SSH public key for accessing nodes"
         },
+	"sshPublicKey": {
+	  "type": "string",
+          "description": "SSH public key for accessing nodes",
+          "deprecated": true
+	},
         "providerID": {
           "type": ["string", "null"],
           "description": "Unique ID for the instance provider"

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -156,10 +156,10 @@
         "spec": {
           "type": "object",
           "properties": {
-	    "sshKeyName": {
-	      "type": "string",
+            "sshKeyName": {
+              "type": "string",
               "description": "SSH public key for accessing the bastion"
-	    },
+            },
             "providerID": {
               "type": ["string", "null"],
               "description": "Provider ID of the bastion server"
@@ -237,11 +237,11 @@
           "type": "string",
           "description": "SSH public key for accessing nodes"
         },
-	"sshPublicKey": {
-	  "type": "string",
+        "sshPublicKey": {
+          "type": "string",
           "description": "SSH public key for accessing nodes",
           "deprecated": true
-	},
+        },
         "providerID": {
           "type": ["string", "null"],
           "description": "Unique ID for the instance provider"
@@ -400,11 +400,11 @@
           "type": "string",
           "description": "SSH public key for accessing nodes"
         },
-	"sshPublicKey": {
-	  "type": "string",
+        "sshPublicKey": {
+          "type": "string",
           "description": "SSH public key for accessing nodes",
           "deprecated": true
-	},
+        },
         "providerID": {
           "type": ["string", "null"],
           "description": "Unique ID for the instance provider"

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -22,8 +22,8 @@ identityRef:
 
 bastion:
   enabled: false
-  sshKeyName: ""
   spec:
+    sshKeyName: ""
     providerID: ""
     flavor: ""
     image:

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -22,6 +22,7 @@ identityRef:
 
 bastion:
   enabled: false
+  sshKeyName: ""
   spec:
     providerID: ""
     flavor: ""
@@ -43,7 +44,7 @@ externalNetwork:
     name: ""
 
 controlPlane:
-  sshPublicKey: ""
+  sshKeyName: ""
   providerID: ""
   flavor: ""
   image:
@@ -59,7 +60,7 @@ controlPlane:
         projectID: ""
 
 worker:
-  sshPublicKey: ""
+  sshKeyName: ""
   providerID: ""
   flavor: ""
   image:

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-2-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-2-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-0-2-1
+  name: openstack-standalone-cp-0-2-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-standalone-cp
-      version: 0.2.1
+      version: 0.2.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
This patch replaces `sshPublicKey` in template values with `sshKeyName`
also used by upstream capi provider as well as bastion in this template.

values.schema.json now marks `sshPublickKey` as deprecated

By utilizing if-else block in template this change is backwards compatible
still allowing for use of `sshPublicKey` which might be needed for 
example when upgrading from 0-1-0 to 0-2-0 


