### PR TITLE
fix: Rework `PluggableProvider` controller reconcile

### DIFF
--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -53,7 +53,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	"github.com/K0rdent/kcm/api/v1alpha1"
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
 	"github.com/K0rdent/kcm/internal/certmanager"
 	"github.com/K0rdent/kcm/internal/helm"
@@ -114,7 +113,7 @@ func (r *ManagementReconciler) getRequestedProvidersList(ctx context.Context, ma
 	}
 
 	for _, el := range objList.Items {
-		if !slices.ContainsFunc(list, func(e v1alpha1.Provider) bool { return e.Name == el.Name }) {
+		if !slices.ContainsFunc(list, func(e kcm.Provider) bool { return e.Name == el.Name }) {
 			list = append(list,
 				kcm.Provider{
 					Name:      el.Name,

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -171,6 +171,12 @@ func (r *ManagementReconciler) update(ctx context.Context, management *kcm.Manag
 		return ctrl.Result{}, err
 	}
 
+	/*
+		Sets management.Status.RequestedProviders without updating actual status.
+		The full status update occurs at reconcile function's end.
+		For IsDisabledValidationWH case, setting this field must happen before
+		calling validateManagement, as that method requires this field to be populated.
+	*/
 	err = r.setRequestedProvidersList(ctx, management)
 	if err != nil {
 		l.Error(err, "failed to ensure RequestedProviders list")

--- a/internal/controller/pluggableprovider_controller.go
+++ b/internal/controller/pluggableprovider_controller.go
@@ -16,15 +16,20 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kcm "github.com/K0rdent/kcm/api/v1alpha1"
 	"github.com/K0rdent/kcm/internal/utils"
@@ -41,10 +46,12 @@ func (r *PluggableProviderReconciler) getProviderTemplate(ctx context.Context, p
 	if pprov.Spec.Template != "" {
 		return pprov.Spec.Template
 	}
+
 	management := &kcm.Management{}
 	if err := r.Get(ctx, client.ObjectKey{Name: kcm.ManagementName}, management); err != nil {
 		return ""
 	}
+
 	return management.Status.Components[pprov.Name].Template
 }
 
@@ -53,7 +60,9 @@ func (r *PluggableProviderReconciler) getExposedProviders(ctx context.Context, p
 	if template == "" {
 		return "", nil
 	}
+
 	templateObj := &kcm.ProviderTemplate{}
+
 	err := r.Get(ctx, types.NamespacedName{Name: template}, templateObj)
 	if err != nil {
 		return "", err
@@ -72,44 +81,141 @@ func (r *PluggableProviderReconciler) updateStatus(ctx context.Context, pprov *k
 	if err != nil {
 		return err
 	}
+
 	if exposedProviders == "" {
 		return nil
 	}
 
 	pprov.Status.ExposedProviders = exposedProviders
 	if err := r.Client.Status().Update(ctx, pprov); err != nil {
-		return fmt.Errorf("failed to update PluggableProvider %s/%s status: %w", pprov.Namespace, pprov.Name, err)
+		return fmt.Errorf("failed to update PluggableProvider %q status: %w", pprov.Name, err)
 	}
 
 	return nil
 }
 
-func (r *PluggableProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, err error) {
+func (r *PluggableProviderReconciler) update(ctx context.Context, pprov *kcm.PluggableProvider) (_ ctrl.Result, err error) {
 	l := ctrl.LoggerFrom(ctx)
-	l.Info("PluggableProvider reconcile start")
-
-	pprov := &kcm.PluggableProvider{}
-	if err := r.Get(ctx, req.NamespacedName, pprov); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
+	l.Info("PluggableProvider object event")
 
 	if err := r.addLabels(ctx, pprov); err != nil {
-		return ctrl.Result{}, err
+		l.Error(err, "PluggableProvider adding labels error")
+		return ctrl.Result{RequeueAfter: r.syncPeriod}, err
 	}
 
-	return ctrl.Result{RequeueAfter: r.syncPeriod}, errors.Join(err, r.updateStatus(ctx, pprov))
+	if err := r.updateStatus(ctx, pprov); err != nil {
+		l.Error(err, "PluggableProvider update status error")
+		return ctrl.Result{RequeueAfter: r.syncPeriod}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *PluggableProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	l := ctrl.LoggerFrom(ctx)
+	l.V(6).Info("PluggableProvider reconcile start")
+
+	var pprov kcm.PluggableProvider
+
+	if err := r.Get(ctx, req.NamespacedName, &pprov); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		l.Error(err, "PluggableProvider reconcile error")
+		return ctrl.Result{RequeueAfter: r.syncPeriod}, err
+	}
+
+	return r.update(ctx, &pprov)
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *PluggableProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	const defaultSyncPeriod = 1 * time.Minute
+	const defaultSyncPeriod = 5 * time.Minute
 
 	r.syncPeriod = defaultSyncPeriod
+
+	respFunc := func(ctx context.Context, _ client.Object) []ctrl.Request {
+		objList := new(kcm.PluggableProviderList)
+
+		if err := mgr.GetClient().List(ctx, objList,
+			client.MatchingLabels{kcm.GenericComponentNameLabel: kcm.GenericComponentLabelValueKCM},
+		); err != nil {
+			return nil
+		}
+
+		resp := make([]ctrl.Request, 0, len(objList.Items))
+		for _, el := range objList.Items {
+			resp = append(resp, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&el)})
+		}
+
+		return resp
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.TypedOptions[ctrl.Request]{
 			RateLimiter: ratelimit.DefaultFastSlow(),
 		}).
 		For(&kcm.PluggableProvider{}).
+		Watches(&kcm.ProviderTemplate{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+			return respFunc(ctx, obj)
+		}), builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return utils.HasLabel(e.Object, kcm.GenericComponentNameLabel)
+			},
+			DeleteFunc: func(event.DeleteEvent) bool {
+				return true
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				if !utils.HasLabel(e.ObjectNew, kcm.GenericComponentNameLabel) {
+					return false
+				}
+
+				oldObj, ok := e.ObjectOld.(*kcm.ProviderTemplate)
+				if !ok {
+					return false
+				}
+
+				newObj, ok := e.ObjectNew.(*kcm.ProviderTemplate)
+				if !ok {
+					return false
+				}
+
+				return !equality.Semantic.DeepEqual(oldObj.Status.Providers, newObj.Status.Providers)
+			},
+			GenericFunc: func(event.GenericEvent) bool {
+				return false
+			},
+		})).
+		Watches(&kcm.Management{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
+			return respFunc(ctx, obj)
+		}), builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return utils.HasLabel(e.Object, kcm.GenericComponentNameLabel)
+			},
+			DeleteFunc: func(event.DeleteEvent) bool {
+				return true
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				if !utils.HasLabel(e.ObjectNew, kcm.GenericComponentNameLabel) {
+					return false
+				}
+
+				oldObj, ok := e.ObjectOld.(*kcm.Management)
+				if !ok {
+					return false
+				}
+
+				newObj, ok := e.ObjectNew.(*kcm.Management)
+				if !ok {
+					return false
+				}
+
+				return !equality.Semantic.DeepEqual(oldObj.Status, newObj.Status)
+			},
+			GenericFunc: func(event.GenericEvent) bool {
+				return false
+			},
+		})).
 		Complete(r)
 }

--- a/internal/controller/pluggableprovider_controller.go
+++ b/internal/controller/pluggableprovider_controller.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -100,12 +99,12 @@ func (r *PluggableProviderReconciler) update(ctx context.Context, pprov *kcm.Plu
 
 	if err := r.addLabels(ctx, pprov); err != nil {
 		l.Error(err, "PluggableProvider adding labels error")
-		return ctrl.Result{RequeueAfter: r.syncPeriod}, err
+		return ctrl.Result{}, err
 	}
 
 	if err := r.updateStatus(ctx, pprov); err != nil {
 		l.Error(err, "PluggableProvider update status error")
-		return ctrl.Result{RequeueAfter: r.syncPeriod}, err
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/pluggableprovider_controller.go
+++ b/internal/controller/pluggableprovider_controller.go
@@ -112,7 +112,7 @@ func (r *PluggableProviderReconciler) update(ctx context.Context, pprov *kcm.Plu
 
 func (r *PluggableProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := ctrl.LoggerFrom(ctx)
-	l.V(6).Info("PluggableProvider reconcile start")
+	l.Info("PluggableProvider reconcile start")
 
 	var pprov kcm.PluggableProvider
 

--- a/internal/controller/pluggableprovider_controller.go
+++ b/internal/controller/pluggableprovider_controller.go
@@ -206,6 +206,10 @@ func (r *PluggableProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return false
 				}
 
+				if len(oldObj.Status.Components) != len(newObj.Status.Components) {
+					return true
+				}
+
 				return !equality.Semantic.DeepEqual(oldObj.Status, newObj.Status)
 			},
 			GenericFunc: func(event.GenericEvent) bool {

--- a/internal/controller/pluggableprovider_controller.go
+++ b/internal/controller/pluggableprovider_controller.go
@@ -162,10 +162,6 @@ func (r *PluggableProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return true
 			},
 			UpdateFunc: func(e event.UpdateEvent) bool {
-				if !utils.HasLabel(e.ObjectNew, kcm.GenericComponentNameLabel) {
-					return false
-				}
-
 				oldObj, ok := e.ObjectOld.(*kcm.ProviderTemplate)
 				if !ok {
 					return false
@@ -176,7 +172,7 @@ func (r *PluggableProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return false
 				}
 
-				return !equality.Semantic.DeepEqual(oldObj.Status.Providers, newObj.Status.Providers)
+				return len(oldObj.Status.Providers) != len(newObj.Status.Providers)
 			},
 			GenericFunc: func(event.GenericEvent) bool {
 				return false
@@ -210,7 +206,7 @@ func (r *PluggableProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return true
 				}
 
-				return !equality.Semantic.DeepEqual(oldObj.Status, newObj.Status)
+				return !equality.Semantic.DeepEqual(oldObj.Status.Components, newObj.Status.Components)
 			},
 			GenericFunc: func(event.GenericEvent) bool {
 				return false

--- a/internal/controller/pluggableprovider_controller.go
+++ b/internal/controller/pluggableprovider_controller.go
@@ -118,12 +118,8 @@ func (r *PluggableProviderReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	var pprov kcm.PluggableProvider
 
 	if err := r.Get(ctx, req.NamespacedName, &pprov); err != nil {
-		if apierrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-
 		l.Error(err, "PluggableProvider reconcile error")
-		return ctrl.Result{RequeueAfter: r.syncPeriod}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	return r.update(ctx, &pprov)

--- a/internal/utils/validation/mgmt.go
+++ b/internal/utils/validation/mgmt.go
@@ -49,7 +49,7 @@ func GetIncompatibleContracts(ctx context.Context, cl client.Client, release *kc
 	}
 
 	incompatibleContracts := strings.Builder{}
-	for _, p := range mgmt.Status.RequestedProviders { // (s3rj1k): https://github.com/k0rdent/kcm/pull/1394#discussion_r2058706474
+	for _, p := range mgmt.Status.RequestedProviders {
 		tplName := p.Template
 		if tplName == "" {
 			tplName = release.ProviderTemplate(p.Name)

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -186,7 +186,6 @@ rules:
   - get
   - patch
   - update
-# (s3rj1k): consider expanding RBAC rules for `pluggableproviders`
 - apiGroups:
   - k0rdent.mirantis.com
   resources:

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -186,7 +186,7 @@ rules:
   - get
   - patch
   - update
-# (s3rj1k) RBAC rules for `pluggableproviders` should be expanded
+# (s3rj1k): consider expanding RBAC rules for `pluggableproviders`
 - apiGroups:
   - k0rdent.mirantis.com
   resources:

--- a/templates/provider/kcm/templates/rbac/user-facing/pluggableproviders-editor.yaml
+++ b/templates/provider/kcm/templates/rbac/user-facing/pluggableproviders-editor.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k0rdent.mirantis.com/aggregate-to-global-admin: "true"
+  name: {{ include "kcm.fullname" . }}-pluggableproviders-editor-role
+rules:
+- apiGroups:
+  - k0rdent.mirantis.com
+  resources:
+  - pluggableproviders
+  - pluggableproviders/status
+  verbs: {{ include "rbac.editorVerbs" . | nindent 6 }}

--- a/templates/provider/kcm/templates/rbac/user-facing/pluggableproviders-viewer.yaml
+++ b/templates/provider/kcm/templates/rbac/user-facing/pluggableproviders-viewer.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k0rdent.mirantis.com/aggregate-to-global-viewer: "true"
+  name: {{ include "kcm.fullname" . }}-pluggableproviders-viewer-role
+rules:
+- apiGroups:
+  - k0rdent.mirantis.com
+  resources:
+  - pluggableproviders
+  - pluggableproviders/status
+  verbs: {{ include "rbac.viewerVerbs" . | nindent 6 }}


### PR DESCRIPTION
PR Reworks `PluggableProvider` controller reconcile by adding additional watchers for `ProviderTemplate` and `Management` object update events.