### PR TITLE
fix: optimize calls to management status updates

### DIFF
--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -135,7 +135,7 @@ func (r *ManagementReconciler) getRequestedProvidersList(ctx context.Context, ma
 	return list, nil
 }
 
-func (r *ManagementReconciler) ensureRequestedProvidersList(ctx context.Context, management *kcm.Management) error {
+func (r *ManagementReconciler) setRequestedProvidersList(ctx context.Context, management *kcm.Management) error {
 	rprov, err := r.getRequestedProvidersList(ctx, management)
 	if err != nil {
 		return err
@@ -147,7 +147,7 @@ func (r *ManagementReconciler) ensureRequestedProvidersList(ctx context.Context,
 
 	management.Status.RequestedProviders = rprov
 
-	return r.updateStatus(ctx, management)
+	return nil
 }
 
 func (r *ManagementReconciler) update(ctx context.Context, management *kcm.Management) (ctrl.Result, error) {
@@ -175,17 +175,17 @@ func (r *ManagementReconciler) update(ctx context.Context, management *kcm.Manag
 		return ctrl.Result{}, err
 	}
 
+	err = r.setRequestedProvidersList(ctx, management)
+	if err != nil {
+		l.Error(err, "failed to ensure RequestedProviders list")
+		return ctrl.Result{}, err
+	}
+
 	if r.IsDisabledValidationWH {
 		valid, err := r.validateManagement(ctx, management, release)
 		if !valid {
 			return ctrl.Result{}, err
 		}
-	}
-
-	err = r.ensureRequestedProvidersList(ctx, management)
-	if err != nil {
-		l.Error(err, "failed to ensure RequestedProviders list")
-		return ctrl.Result{}, err
 	}
 
 	if err := r.cleanupRemovedComponents(ctx, management); err != nil {
@@ -231,9 +231,6 @@ func (r *ManagementReconciler) update(ctx context.Context, management *kcm.Manag
 
 	r.setReadyCondition(management)
 
-	// (s3rj1k): status updates are called in multiple places
-	// During the `update` method lifecycle this should be revisited
-	// and optimized to reduce the number of calls
 	errs = errors.Join(errs, r.updateStatus(ctx, management))
 	if errs != nil {
 		l.Error(errs, "Multiple errors during Management reconciliation")

--- a/internal/utils/validation/mgmt.go
+++ b/internal/utils/validation/mgmt.go
@@ -49,7 +49,7 @@ func GetIncompatibleContracts(ctx context.Context, cl client.Client, release *kc
 	}
 
 	incompatibleContracts := strings.Builder{}
-	for _, p := range mgmt.Status.RequestedProviders { // (s3rj1k): https://github.com/k0rdent/kcm/pull/1394#discussion_r2058706474
+	for _, p := range mgmt.Status.RequestedProviders {
 		tplName := p.Template
 		if tplName == "" {
 			tplName = release.ProviderTemplate(p.Name)

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -186,7 +186,7 @@ rules:
   - get
   - patch
   - update
-# (s3rj1k) RBAC rules for `pluggableproviders` should be expanded
+# (s3rj1k): consider expanding RBAC rules for `pluggableproviders`
 - apiGroups:
   - k0rdent.mirantis.com
   resources:


### PR DESCRIPTION
PR removes redundant call to management object status update, fixes `DisabledValidation` branching for PluggableProviders