### PR TITLE
fix: unify infrastructure providers naming

### DIFF
--- a/api/v1alpha1/pluggableprovider_types.go
+++ b/api/v1alpha1/pluggableprovider_types.go
@@ -58,7 +58,7 @@ type PluggableProviderStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=pprov,scope=Cluster
-// +kubebuilder:printcolumn:name="providers",type=string,JSONPath=`.status.exposedProviders`
+// +kubebuilder:printcolumn:name="Providers",type=string,JSONPath=`.status.exposedProviders`
 // +kubebuilder:printcolumn:name="Description",type=string,JSONPath=`.spec.description`
 
 // PluggableProvider is the Schema for the PluggableProvider API

--- a/internal/webhook/clusterdeployment_webhook_test.go
+++ b/internal/webhook/clusterdeployment_webhook_test.go
@@ -418,7 +418,11 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tt.existingObjects...).Build()
+			c := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithRuntimeObjects(tt.existingObjects...).
+				WithIndex(&v1alpha1.PluggableProvider{}, v1alpha1.PluggableProviderInfrastructureIndexKey, v1alpha1.ExtractPluggableProviderInfrastructure).
+				Build()
 			validator := &ClusterDeploymentValidator{Client: c}
 			warn, err := validator.ValidateCreate(ctx, tt.ClusterDeployment)
 			if tt.err != "" {
@@ -757,7 +761,11 @@ func TestClusterDeploymentValidateUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tt.existingObjects...).Build()
+			c := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithRuntimeObjects(tt.existingObjects...).
+				WithIndex(&v1alpha1.PluggableProvider{}, v1alpha1.PluggableProviderInfrastructureIndexKey, v1alpha1.ExtractPluggableProviderInfrastructure).
+				Build()
 			validator := &ClusterDeploymentValidator{Client: c, ValidateClusterUpgradePath: !tt.skipUpgradePathValidation}
 			warn, err := validator.ValidateUpdate(ctx, tt.oldClusterDeployment, tt.newClusterDeployment)
 			if tt.err != "" {
@@ -840,7 +848,11 @@ func TestClusterDeploymentDefault(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(tt.existingObjects...).Build()
+			c := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithRuntimeObjects(tt.existingObjects...).
+				WithIndex(&v1alpha1.PluggableProvider{}, v1alpha1.PluggableProviderInfrastructureIndexKey, v1alpha1.ExtractPluggableProviderInfrastructure).
+				Build()
 			validator := &ClusterDeploymentValidator{Client: c}
 			err := validator.Default(ctx, tt.input)
 			if tt.err != "" {

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_pluggableproviders.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_pluggableproviders.yaml
@@ -18,7 +18,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.exposedProviders
-      name: providers
+      name: Providers
       type: string
     - jsonPath: .spec.description
       name: Description


### PR DESCRIPTION
There was an inconsistency in the infrastructure providers' naming
(for example, searched for `infrastructure-aws` in one place and `aws` in another),
which breaks the removal of the blocking finalizer from the ClusterDeployment.

Now, the full provider name with the infrastructure prefix is being used.

Also, added an indexer for the PluggableProvider object to fetch all the exposed infrastructure providers.

Fixes #1438
