### PR TITLE
feat: Add provider toggables to `kcm-templates` Helm Chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,7 @@ dev-templates: templates-generate
 	helm template $(PROVIDER_TEMPLATES_DIR)/kcm-templates \
 		--namespace $(NAMESPACE) \
 		--values $(PROVIDER_TEMPLATES_DIR)/kcm-templates/values.yaml \
+		| $(YQ) eval 'select(.kind == "ClusterTemplate" or .kind == "ProviderTemplate")' - \
 		| $(KUBECTL) -n $(NAMESPACE) apply --force -f -
 
 KCM_REPO_URL ?= oci://ghcr.io/k0rdent/kcm/charts
@@ -383,13 +384,7 @@ stable-templates: yq
 
 .PHONY: dev-release
 dev-release: yq
-	@helm template $(PROVIDER_TEMPLATES_DIR)/kcm-templates \
-		--namespace $(NAMESPACE) \
-		--values $(PROVIDER_TEMPLATES_DIR)/kcm-templates/values.yaml \
-		--set createRelease=true \
-		| $(YQ) eval 'select(.kind == "Release")' - \
-		| $(YQ) e ".spec.version = \"${VERSION}\"" - \
-		| $(KUBECTL) -n $(NAMESPACE) apply -f -
+	@$(YQ) e ".spec.version = \"${VERSION}\"" $(PROVIDER_TEMPLATES_DIR)/kcm-templates/files/release.yaml | $(KUBECTL) -n $(NAMESPACE) apply -f -
 
 .PHONY: dev-adopted-creds
 dev-adopted-creds: envsubst

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -8,5 +8,6 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.2.0
 annotations:
+  k0rdent.mirantis.com/provider: aws
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -14,6 +14,7 @@ version: 0.2.1
 # It is recommended to use it with quotes.
 appVersion: "v1.32.3+k0s.0"
 annotations:
+  k0rdent.mirantis.com/provider: aws
   cluster.x-k8s.io/provider: infrastructure-aws, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
   cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -13,6 +13,7 @@ version: 0.2.1
 # It is recommended to use it with quotes.
 appVersion: "v1.32.3+k0s.0"
 annotations:
+  k0rdent.mirantis.com/provider: aws
   cluster.x-k8s.io/provider: infrastructure-aws, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
   cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/azure-aks/Chart.yaml
+++ b/templates/cluster/azure-aks/Chart.yaml
@@ -8,5 +8,6 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.2.0
 annotations:
+  k0rdent.mirantis.com/provider: azure
   cluster.x-k8s.io/provider: infrastructure-azure
   cluster.x-k8s.io/infrastructure-azure: v1beta1

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -14,6 +14,7 @@ version: 0.2.2
 # It is recommended to use it with quotes.
 appVersion: "v1.32.3+k0s.0"
 annotations:
+  k0rdent.mirantis.com/provider: azure
   cluster.x-k8s.io/provider: infrastructure-azure, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
   cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -13,6 +13,7 @@ version: 0.2.2
 # It is recommended to use it with quotes.
 appVersion: "v1.32.3+k0s.0"
 annotations:
+  k0rdent.mirantis.com/provider: azure
   cluster.x-k8s.io/provider: infrastructure-azure, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
   cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -13,6 +13,7 @@ version: 0.2.0
 # It is recommended to use it with quotes.
 appVersion: "v1.32.1+k0s.0"
 annotations:
+  k0rdent.mirantis.com/provider: docker
   cluster.x-k8s.io/provider: infrastructure-docker, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
   cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/gcp-gke/Chart.yaml
+++ b/templates/cluster/gcp-gke/Chart.yaml
@@ -8,5 +8,6 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.2.0
 annotations:
+  k0rdent.mirantis.com/provider: gcp
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -14,6 +14,7 @@ version: 0.2.1
 # It is recommended to use it with quotes.
 appVersion: "v1.32.3+k0s.0"
 annotations:
+  k0rdent.mirantis.com/provider: gcp
   cluster.x-k8s.io/provider: infrastructure-gcp, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
   cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -13,6 +13,7 @@ version: 0.2.1
 # It is recommended to use it with quotes.
 appVersion: "v1.32.3+k0s.0"
 annotations:
+  k0rdent.mirantis.com/provider: gcp
   cluster.x-k8s.io/provider: infrastructure-gcp, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
   cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -13,6 +13,7 @@ version: 0.2.2
 # It is recommended to use it with quotes.
 appVersion: "v1.32.3+k0s.0"
 annotations:
+  k0rdent.mirantis.com/provider: openstack
   cluster.x-k8s.io/provider: infrastructure-openstack, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
   cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -14,6 +14,7 @@ version: 0.2.1
 # It is recommended to use it with quotes.
 appVersion: "v1.32.3+k0s.0"
 annotations:
+  k0rdent.mirantis.com/provider: vsphere
   cluster.x-k8s.io/provider: infrastructure-vsphere, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   k0rdent.mirantis.com/type: deployment
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -13,6 +13,7 @@ version: 0.2.1
 # It is recommended to use it with quotes.
 appVersion: "v1.32.3+k0s.0"
 annotations:
+  k0rdent.mirantis.com/provider: vsphere
   cluster.x-k8s.io/provider: infrastructure-vsphere, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   k0rdent.mirantis.com/type: deployment
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/provider/cluster-api-provider-aws/Chart.yaml
+++ b/templates/provider/cluster-api-provider-aws/Chart.yaml
@@ -20,6 +20,7 @@ version: 0.2.2
 # It is recommended to use it with quotes.
 appVersion: "2.8.2"
 annotations:
+  k0rdent.mirantis.com/provider: aws
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/v1alpha3: v1alpha3
   cluster.x-k8s.io/v1alpha4: v1alpha4

--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -20,5 +20,6 @@ version: 0.2.3
 # It is recommended to use it with quotes.
 appVersion: "1.19.2"
 annotations:
+  k0rdent.mirantis.com/provider: azure
   cluster.x-k8s.io/provider: infrastructure-azure
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/cluster-api-provider-docker/Chart.yaml
+++ b/templates/provider/cluster-api-provider-docker/Chart.yaml
@@ -20,5 +20,6 @@ version: 0.2.1
 # It is recommended to use it with quotes.
 appVersion: "v1.9.6"
 annotations:
+  k0rdent.mirantis.com/provider: docker
   cluster.x-k8s.io/provider: infrastructure-docker
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/cluster-api-provider-gcp/Chart.yaml
+++ b/templates/provider/cluster-api-provider-gcp/Chart.yaml
@@ -20,5 +20,6 @@ version: 0.2.1
 # It is recommended to use it with quotes.
 appVersion: "1.8.1"
 annotations:
+  k0rdent.mirantis.com/provider: gcp
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -20,5 +20,6 @@ version: 0.2.1
 # It is recommended to use it with quotes.
 appVersion: "v0.12.2"
 annotations:
+  k0rdent.mirantis.com/provider: openstack
   cluster.x-k8s.io/provider: infrastructure-openstack
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/cluster-api-provider-vsphere/Chart.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/Chart.yaml
@@ -20,5 +20,6 @@ version: 0.2.1
 # It is recommended to use it with quotes.
 appVersion: "1.12.0"
 annotations:
+  k0rdent.mirantis.com/provider: vsphere
   cluster.x-k8s.io/provider: infrastructure-vsphere
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -13,17 +13,29 @@ spec:
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
       template: cluster-api-provider-k0sproject-k0smotron-0-2-2
+{{- if .Values.providers.azure }}
     - name: cluster-api-provider-azure
       template: cluster-api-provider-azure-0-2-3
+{{- end }}
+{{- if .Values.providers.vsphere }}
     - name: cluster-api-provider-vsphere
       template: cluster-api-provider-vsphere-0-2-1
+{{- end }}
+{{- if .Values.providers.aws }}
     - name: cluster-api-provider-aws
       template: cluster-api-provider-aws-0-2-2
+{{- end }}
+{{- if .Values.providers.openstack }}
     - name: cluster-api-provider-openstack
       template: cluster-api-provider-openstack-0-2-1
+{{- end }}
+{{- if .Values.providers.docker }}
     - name: cluster-api-provider-docker
       template: cluster-api-provider-docker-0-2-1
+{{- end }}
+{{- if .Values.providers.gcp }}
     - name: cluster-api-provider-gcp
       template: cluster-api-provider-gcp-0-2-1
+{{- end }}
     - name: projectsveltos
       template: projectsveltos-0-52-2

--- a/templates/provider/kcm-templates/files/templates/adopted-cluster-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/adopted-cluster-0-2-0.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:

--- a/templates/provider/kcm-templates/files/templates/aws-eks-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-0-2-0.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.aws }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-0-2-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-0-2-1.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.aws }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-0-2-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-0-2-1.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.aws }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/azure-aks-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-aks-0-2-0.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.azure }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-0-2-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-0-2-2.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.azure }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-0-2-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-0-2-2.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.azure }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.aws }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.azure }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.docker }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.gcp }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.openstack }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.vsphere }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/cluster-api.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-0-2-0.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.docker }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/gcp-gke-0-2-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-gke-0-2-0.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.gcp }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-0-2-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-0-2-1.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.gcp }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-0-2-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-0-2-1.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.gcp }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-2-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-2-2.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.openstack }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/projectsveltos.yaml
+++ b/templates/provider/kcm-templates/files/templates/projectsveltos.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-0-2-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-0-2-1.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-0-2-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-0-2-1.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.vsphere }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-0-2-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-0-2-1.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.providers.vsphere }}
+---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
@@ -13,3 +15,4 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: kcm-templates
+{{ end }}

--- a/templates/provider/kcm-templates/templates/pprov-aws.yaml
+++ b/templates/provider/kcm-templates/templates/pprov-aws.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.providers.aws }}
 ---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: PluggableProvider
@@ -18,3 +19,4 @@ spec:
     - AWSClusterRoleIdentity
     - AWSClusterControllerIdentity
   description: "AWS infrastructure provider for Cluster API"
+{{ end }}

--- a/templates/provider/kcm-templates/templates/pprov-azure.yaml
+++ b/templates/provider/kcm-templates/templates/pprov-azure.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.providers.azure }}
 ---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: PluggableProvider
@@ -17,3 +18,4 @@ spec:
     - AzureClusterIdentity
     - Secret
   description: "Azure infrastructure provider for Cluster API"
+{{ end }}

--- a/templates/provider/kcm-templates/templates/pprov-docker.yaml
+++ b/templates/provider/kcm-templates/templates/pprov-docker.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.providers.docker }}
 ---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: PluggableProvider
@@ -13,3 +14,4 @@ spec:
   clusterIdentityKinds:
     - Secret
   description: "Docker infrastructure provider for Cluster API"
+{{ end }}

--- a/templates/provider/kcm-templates/templates/pprov-gcp.yaml
+++ b/templates/provider/kcm-templates/templates/pprov-gcp.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.providers.gcp }}
 ---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: PluggableProvider
@@ -16,3 +17,4 @@ spec:
   clusterIdentityKinds:
     - Secret
   description: "GCP infrastructure provider for Cluster API"
+{{ end }}

--- a/templates/provider/kcm-templates/templates/pprov-openstack.yaml
+++ b/templates/provider/kcm-templates/templates/pprov-openstack.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.providers.openstack }}
 ---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: PluggableProvider
@@ -13,3 +14,4 @@ spec:
   clusterIdentityKinds:
     - Secret
   description: "OpenStack infrastructure provider for Cluster API"
+{{ end }}

--- a/templates/provider/kcm-templates/templates/pprov-vsphere.yaml
+++ b/templates/provider/kcm-templates/templates/pprov-vsphere.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.providers.vsphere }}
 ---
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: PluggableProvider
@@ -13,3 +14,4 @@ spec:
   clusterIdentityKinds:
     - VSphereClusterIdentity
   description: "vSphere infrastructure provider for Cluster API"
+{{ end }}

--- a/templates/provider/kcm-templates/templates/release.yaml
+++ b/templates/provider/kcm-templates/templates/release.yaml
@@ -1,3 +1,4 @@
 {{- if .Values.createRelease }}
-{{ $.Files.Get "files/release.yaml" }}
+{{- $releaseContent := $.Files.Get "files/release.yaml" }}
+{{- tpl $releaseContent . }}
 {{- end }}

--- a/templates/provider/kcm-templates/templates/templates.yaml
+++ b/templates/provider/kcm-templates/templates/templates.yaml
@@ -1,10 +1,39 @@
-{{ range $path, $_ :=  .Files.Glob  "files/templates/*.yaml" }}
-{{- $content := $.Files.Get $path | fromYaml }}
-{{- $apiVersion := $content.apiVersion }}
-{{- $kind := $content.kind }}
-{{- $name := $content.metadata.name }}
-{{- if not (lookup $apiVersion $kind $.Release.Namespace $name) }}
-{{ $.Files.Get $path }}
+{{ range $path, $_ := .Files.Glob "files/templates/*.yaml" }}
+{{- $rawContent := $.Files.Get $path -}}
+{{- /* First render the template content */ -}}
+{{- $rendered := tpl $rawContent $ -}}
+
+{{- /* Now try to parse the rendered content as YAML */ -}}
+{{- $content := fromYaml $rendered -}}
+
+{{- if not $content -}}
+# WARNING: After rendering, file {{ $path }} could not be parsed as valid YAML
+# Skipping this file and continuing with next item
+{{- else -}}
+  {{- /* Output the rendered content as raw YAML instead of trying to process the map */ -}}
+  {{- if not $content.apiVersion -}}
+    {{- fail (printf "ERROR: After rendering, file %s is missing required field 'apiVersion'" $path) -}}
+  {{- end -}}
+
+  {{- if not $content.kind -}}
+    {{- fail (printf "ERROR: After rendering, file %s is missing required field 'kind'" $path) -}}
+  {{- end -}}
+
+  {{- if not $content.metadata -}}
+    {{- fail (printf "ERROR: After rendering, file %s is missing required field 'metadata'" $path) -}}
+  {{- end -}}
+
+  {{- if not $content.metadata.name -}}
+    {{- fail (printf "ERROR: After rendering, file %s is missing required field 'metadata.name'" $path) -}}
+  {{- end -}}
+
+  {{- $apiVersion := $content.apiVersion -}}
+  {{- $kind := $content.kind -}}
+  {{- $name := $content.metadata.name -}}
+
+  {{- if not (lookup $apiVersion $kind $.Release.Namespace $name) -}}
+{{ $rendered }}
 ---
-{{- end }}
-{{- end }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/templates/provider/kcm-templates/values.yaml
+++ b/templates/provider/kcm-templates/values.yaml
@@ -1,1 +1,9 @@
 createRelease: false
+
+providers:
+  aws: true
+  azure: true
+  docker: true
+  gcp: true
+  openstack: true
+  vsphere: true


### PR DESCRIPTION
PR add the ability to disable providers installation via `kcm-templates` Helm Chart, right now it is mostly useful for development and for consumers that install k0rdent in advanced way.