### PR TITLE
chore: update the Release, helm charts and README.md with the 0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Detailed documentation is available in [k0rdent Docs](https://docs.k0rdent.io)
 ### TL;DR
 
 ```bash
-helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 0.2.0 -n kcm-system --create-namespace
+helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 0.3.0 -n kcm-system --create-namespace
 ```
 
 Then follow the [Deploy a cluster deployment](#create-a-clusterdeployment) guide to
@@ -80,7 +80,7 @@ spec:
   - name: cluster-api-provider-openstack
   - name: cluster-api-provider-k0sproject-k0smotron
   - name: projectsveltos
-  release: kcm-0-2-0
+  release: kcm-0-3-0
 ```
 
 There are two options to override the default management configuration

--- a/templates/provider/kcm-templates/Chart.yaml
+++ b/templates/provider/kcm-templates/Chart.yaml
@@ -13,4 +13,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: Release
 metadata:
-  name: kcm-0-2-0
+  name: kcm-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  version: 0.2.0
+  version: 0.3.0
   kcm:
-    template: kcm-0-2-0
+    template: kcm-0-3-0
   capi:
     template: cluster-api-0-2-2
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: kcm-0-2-0
+  name: kcm-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 0.2.0
+      version: 0.3.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 dependencies:
   - name: flux2


### PR DESCRIPTION
This PR includes the following changes:
1. Updates the KCM version in the Release object within the `kcm-templates` helm chart
2. Bump kcm and kcm-templates to the 0.3.0 version
3. Updates README.md to reflect the 0.3.0 release