### PR TITLE
chore: bump openstack ORC to 2.1.0

### DIFF
--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -151,10 +151,10 @@ type ComponentStatus struct {
 	Template string `json:"template,omitempty"`
 	// Error stores as error message in case of failed installation
 	Error string `json:"error,omitempty"`
-	// Success represents if a component installation was successful
-	Success bool `json:"success,omitempty"`
 	// ExposedProviders is a list of CAPI providers this component exposes
 	ExposedProviders Providers `json:"exposedProviders,omitempty"`
+	// Success represents if a component installation was successful
+	Success bool `json:"success,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/providerinterface_types.go
+++ b/api/v1alpha1/providerinterface_types.go
@@ -37,14 +37,12 @@ type GroupVersionKind struct {
 
 // ProviderInterfaceSpec defines the desired state of ProviderInterface
 type ProviderInterfaceSpec struct {
-	// ClusterGVKs defines the Group-Version-Kind resources this provider can manage
-	ClusterGVKs []GroupVersionKind `json:"clusterGVKs,omitempty"`
-
-	// ClusterIdentityKinds defines the Kind of identity objects supported by this provider
-	ClusterIdentityKinds []string `json:"clusterIdentityKinds,omitempty"`
-
 	// Description provides a human-readable explanation of what this provider does
 	Description string `json:"description,omitempty"`
+	// ClusterGVKs defines the Group-Version-Kind resources this provider can manage
+	ClusterGVKs []GroupVersionKind `json:"clusterGVKs,omitempty"`
+	// ClusterIdentityKinds defines the Kind of identity objects supported by this provider
+	ClusterIdentityKinds []string `json:"clusterIdentityKinds,omitempty"`
 }
 
 // ProviderInterfaceStatus defines the observed state of ProviderInterface

--- a/api/v1beta1/management_types.go
+++ b/api/v1beta1/management_types.go
@@ -151,10 +151,10 @@ type ComponentStatus struct {
 	Template string `json:"template,omitempty"`
 	// Error stores as error message in case of failed installation
 	Error string `json:"error,omitempty"`
-	// Success represents if a component installation was successful
-	Success bool `json:"success,omitempty"`
 	// ExposedProviders is a list of CAPI providers this component exposes
 	ExposedProviders Providers `json:"exposedProviders,omitempty"`
+	// Success represents if a component installation was successful
+	Success bool `json:"success,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/providerinterface_types.go
+++ b/api/v1beta1/providerinterface_types.go
@@ -37,14 +37,12 @@ type GroupVersionKind struct {
 
 // ProviderInterfaceSpec defines the desired state of ProviderInterface
 type ProviderInterfaceSpec struct {
-	// ClusterGVKs defines the Group-Version-Kind resources this provider can manage
-	ClusterGVKs []GroupVersionKind `json:"clusterGVKs,omitempty"`
-
-	// ClusterIdentityKinds defines the Kind of identity objects supported by this provider
-	ClusterIdentityKinds []string `json:"clusterIdentityKinds,omitempty"`
-
 	// Description provides a human-readable explanation of what this provider does
 	Description string `json:"description,omitempty"`
+	// ClusterGVKs defines the Group-Version-Kind resources this provider can manage
+	ClusterGVKs []GroupVersionKind `json:"clusterGVKs,omitempty"`
+	// ClusterIdentityKinds defines the Kind of identity objects supported by this provider
+	ClusterIdentityKinds []string `json:"clusterIdentityKinds,omitempty"`
 }
 
 // ProviderInterfaceStatus defines the observed state of ProviderInterface

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/templates/orc-2-1-0.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/orc-2-1-0.yaml
@@ -1,0 +1,5155 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+    control-plane: controller-manager
+  name: orc-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: flavors.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Flavor
+    listKind: FlavorList
+    plural: flavors
+    singular: flavor
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Flavor is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      disk:
+                        description: disk is the size of the root disk in GiB.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      ram:
+                        description: ram is the memory of the flavor, measured in
+                          MB.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      vcpus:
+                        description: vcpus is the number of vcpus for the flavor.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  description:
+                    description: description contains a free form description of the
+                      flavor.
+                    maxLength: 65535
+                    minLength: 1
+                    type: string
+                  disk:
+                    description: |-
+                      disk is the size of the root disk that will be created in GiB. If 0
+                      the root disk will be set to exactly the size of the image used to
+                      deploy the instance. However, in this case the scheduler cannot
+                      select the compute host based on the virtual image size. Therefore,
+                      0 should only be used for volume booted instances or for testing
+                      purposes. Volume-backed instances can be enforced for flavors with
+                      zero root disk via the
+                      os_compute_api:servers:create:zero_disk_flavor policy rule.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  ephemeral:
+                    description: |-
+                      ephemeral is the size of the ephemeral disk that will be created, in GiB.
+                      Ephemeral disks may be written over on server state changes. So should only
+                      be used as a scratch space for applications that are aware of its
+                      limitations. Defaults to 0.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  isPublic:
+                    description: isPublic flags a flavor as being available to all
+                      projects or not.
+                    type: boolean
+                  name:
+                    description: |-
+                      name will be the name of the created resource. If not specified, the
+                      name of the ORC object will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  ram:
+                    description: ram is the memory of the flavor, measured in MB.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  swap:
+                    description: |-
+                      swap is the size of a dedicated swap disk that will be allocated, in
+                      MiB. If 0 (the default), no dedicated swap disk will be created.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  vcpus:
+                    description: vcpus is the number of vcpus for the flavor.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                required:
+                - disk
+                - ram
+                - vcpus
+                type: object
+                x-kubernetes-validations:
+                - message: FlavorResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 65535
+                    type: string
+                  disk:
+                    description: disk is the size of the root disk that will be created
+                      in GiB.
+                    format: int32
+                    type: integer
+                  ephemeral:
+                    description: ephemeral is the size of the ephemeral disk, in GiB.
+                    format: int32
+                    type: integer
+                  isPublic:
+                    description: isPublic flags a flavor as being available to all
+                      projects or not.
+                    type: boolean
+                  name:
+                    description: name is a Human-readable name for the flavor. Might
+                      not be unique.
+                    maxLength: 1024
+                    type: string
+                  ram:
+                    description: ram is the memory of the flavor, measured in MB.
+                    format: int32
+                    type: integer
+                  swap:
+                    description: |-
+                      swap is the size of a dedicated swap disk that will be allocated, in
+                      MiB.
+                    format: int32
+                    type: integer
+                  vcpus:
+                    description: vcpus is the number of vcpus for the flavor.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: images.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Image
+    listKind: ImageList
+    plural: images
+    singular: image
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Image is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      name:
+                        description: name specifies the name of a Glance image
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      tags:
+                        description: tags is the list of tags on the resource.
+                        items:
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  content:
+                    description: content specifies how to obtain the image content.
+                    properties:
+                      containerFormat:
+                        default: bare
+                        description: |-
+                          containerFormat is the format of the image container.
+                          qcow2 and raw images do not usually have a container. This is specified as "bare", which is also the default.
+                          Permitted values are ami, ari, aki, bare, compressed, ovf, ova, and docker.
+                        enum:
+                        - ami
+                        - ari
+                        - aki
+                        - bare
+                        - ovf
+                        - ova
+                        - docker
+                        - compressed
+                        type: string
+                      diskFormat:
+                        description: |-
+                          diskFormat is the format of the disk image.
+                          Normal values are "qcow2", or "raw". Glance may be configured to support others.
+                        enum:
+                        - ami
+                        - ari
+                        - aki
+                        - vhd
+                        - vhdx
+                        - vmdk
+                        - raw
+                        - qcow2
+                        - vdi
+                        - ploop
+                        - iso
+                        type: string
+                      download:
+                        description: |-
+                          download describes how to obtain image data by downloading it from a URL.
+                          Must be set when creating a managed image.
+                        properties:
+                          decompress:
+                            description: |-
+                              decompress specifies that the source data must be decompressed with the
+                              given compression algorithm before being stored. Specifying Decompress
+                              will disable the use of Glance's web-download, as web-download cannot
+                              currently deterministically decompress downloaded content.
+                            enum:
+                            - xz
+                            - gz
+                            - bz2
+                            type: string
+                          hash:
+                            description: |-
+                              hash is a hash which will be used to verify downloaded data, i.e.
+                              before any decompression. If not specified, no hash verification will be
+                              performed. Specifying a Hash will disable the use of Glance's
+                              web-download, as web-download cannot currently deterministically verify
+                              the hash of downloaded content.
+                            properties:
+                              algorithm:
+                                description: algorithm is the hash algorithm used
+                                  to generate value.
+                                enum:
+                                - md5
+                                - sha1
+                                - sha256
+                                - sha512
+                                type: string
+                              value:
+                                description: value is the hash of the image data using
+                                  Algorithm. It must be hex encoded using lowercase
+                                  letters.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^[0-9a-f]+$
+                                type: string
+                            required:
+                            - algorithm
+                            - value
+                            type: object
+                            x-kubernetes-validations:
+                            - message: hash is immutable
+                              rule: self == oldSelf
+                          url:
+                            description: url containing image data
+                            format: uri
+                            maxLength: 2048
+                            type: string
+                        required:
+                        - url
+                        type: object
+                    required:
+                    - diskFormat
+                    - download
+                    type: object
+                    x-kubernetes-validations:
+                    - message: content is immutable
+                      rule: self == oldSelf
+                  name:
+                    description: |-
+                      name will be the name of the created Glance image. If not specified, the
+                      name of the Image object will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  properties:
+                    description: properties is metadata available to consumers of
+                      the image
+                    properties:
+                      architecture:
+                        description: architecture is the CPU architecture that must
+                          be supported by the hypervisor.
+                        enum:
+                        - aarch64
+                        - alpha
+                        - armv7l
+                        - cris
+                        - i686
+                        - ia64
+                        - lm32
+                        - m68k
+                        - microblaze
+                        - microblazeel
+                        - mips
+                        - mipsel
+                        - mips64
+                        - mips64el
+                        - openrisc
+                        - parisc
+                        - parisc64
+                        - ppc
+                        - ppc64
+                        - ppcemb
+                        - s390
+                        - s390x
+                        - sh4
+                        - sh4eb
+                        - sparc
+                        - sparc64
+                        - unicore32
+                        - x86_64
+                        - xtensa
+                        - xtensaeb
+                        type: string
+                      hardware:
+                        description: |-
+                          hardware is a set of properties which control the virtual hardware
+                          created by Nova.
+                        properties:
+                          cdromBus:
+                            description: cdromBus specifies the type of disk controller
+                              to attach CD-ROM devices to.
+                            enum:
+                            - scsi
+                            - virtio
+                            - uml
+                            - xen
+                            - ide
+                            - usb
+                            - lxc
+                            type: string
+                          cpuCores:
+                            description: cpuCores is the preferred number of cores
+                              to expose to the guest
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          cpuPolicy:
+                            description: |-
+                              cpuPolicy is used to pin the virtual CPUs (vCPUs) of instances to the
+                              host's physical CPU cores (pCPUs). Host aggregates should be used to
+                              separate these pinned instances from unpinned instances as the latter
+                              will not respect the resourcing requirements of the former.
+
+                              Permitted values are shared (the default), and dedicated.
+
+                              shared: The guest vCPUs will be allowed to freely float across host
+                              pCPUs, albeit potentially constrained by NUMA policy.
+
+                              dedicated: The guest vCPUs will be strictly pinned to a set of host
+                              pCPUs. In the absence of an explicit vCPU topology request, the
+                              drivers typically expose all vCPUs as sockets with one core and one
+                              thread. When strict CPU pinning is in effect the guest CPU topology
+                              will be setup to match the topology of the CPUs to which it is
+                              pinned. This option implies an overcommit ratio of 1.0. For example,
+                              if a two vCPU guest is pinned to a single host core with two threads,
+                              then the guest will get a topology of one socket, one core, two
+                              threads.
+                            enum:
+                            - shared
+                            - dedicated
+                            type: string
+                          cpuSockets:
+                            description: cpuSockets is the preferred number of sockets
+                              to expose to the guest
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          cpuThreadPolicy:
+                            description: |-
+                              cpuThreadPolicy further refines a CPUPolicy of 'dedicated' by stating
+                              how hardware CPU threads in a simultaneous multithreading-based (SMT)
+                              architecture be used. SMT-based architectures include Intel
+                              processors with Hyper-Threading technology. In these architectures,
+                              processor cores share a number of components with one or more other
+                              cores. Cores in such architectures are commonly referred to as
+                              hardware threads, while the cores that a given core share components
+                              with are known as thread siblings.
+
+                              Permitted values are prefer (the default), isolate, and require.
+
+                              prefer: The host may or may not have an SMT architecture. Where an
+                              SMT architecture is present, thread siblings are preferred.
+
+                              isolate: The host must not have an SMT architecture or must emulate a
+                              non-SMT architecture. If the host does not have an SMT architecture,
+                              each vCPU is placed on a different core as expected. If the host does
+                              have an SMT architecture - that is, one or more cores have thread
+                              siblings - then each vCPU is placed on a different physical core. No
+                              vCPUs from other guests are placed on the same core. All but one
+                              thread sibling on each utilized core is therefore guaranteed to be
+                              unusable.
+
+                              require: The host must have an SMT architecture. Each vCPU is
+                              allocated on thread siblings. If the host does not have an SMT
+                              architecture, then it is not used. If the host has an SMT
+                              architecture, but not enough cores with free thread siblings are
+                              available, then scheduling fails.
+                            enum:
+                            - prefer
+                            - isolate
+                            - require
+                            type: string
+                          cpuThreads:
+                            description: cpuThreads is the preferred number of threads
+                              to expose to the guest
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          diskBus:
+                            description: diskBus specifies the type of disk controller
+                              to attach disk devices to.
+                            enum:
+                            - scsi
+                            - virtio
+                            - uml
+                            - xen
+                            - ide
+                            - usb
+                            - lxc
+                            type: string
+                          qemuGuestAgent:
+                            description: qemuGuestAgent enables QEMU guest agent.
+                            type: boolean
+                          rngModel:
+                            description: |-
+                              rngModel adds a random-number generator device to the image’s instances.
+                              This image property by itself does not guarantee that a hardware RNG will be used;
+                              it expresses a preference that may or may not be satisfied depending upon Nova configuration.
+                            maxLength: 255
+                            type: string
+                          scsiModel:
+                            description: |-
+                              scsiModel enables the use of VirtIO SCSI (virtio-scsi) to provide
+                              block device access for compute instances; by default, instances use
+                              VirtIO Block (virtio-blk). VirtIO SCSI is a para-virtualized SCSI
+                              controller device that provides improved scalability and performance,
+                              and supports advanced SCSI hardware.
+
+                              The only permitted value is virtio-scsi.
+                            enum:
+                            - virtio-scsi
+                            type: string
+                          vifModel:
+                            description: |-
+                              vifModel specifies the model of virtual network interface device to use.
+
+                              Permitted values are e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio,
+                              and vmxnet3.
+                            enum:
+                            - e1000
+                            - e1000e
+                            - ne2k_pci
+                            - pcnet
+                            - rtl8139
+                            - virtio
+                            - vmxnet3
+                            type: string
+                        type: object
+                      hypervisorType:
+                        description: hypervisorType is the hypervisor type
+                        enum:
+                        - hyperv
+                        - ironic
+                        - lxc
+                        - qemu
+                        - uml
+                        - vmware
+                        - xen
+                        type: string
+                      minDiskGB:
+                        description: minDiskGB is the minimum amount of disk space
+                          in GB that is required to boot the image
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      minMemoryMB:
+                        description: minMemoryMB is the minimum amount of RAM in MB
+                          that is required to boot the image.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      operatingSystem:
+                        description: |-
+                          operatingSystem is a set of properties that specify and influence the behavior
+                          of the operating system within the virtual machine.
+                        properties:
+                          distro:
+                            description: distro is the common name of the operating
+                              system distribution in lowercase.
+                            enum:
+                            - arch
+                            - centos
+                            - debian
+                            - fedora
+                            - freebsd
+                            - gentoo
+                            - mandrake
+                            - mandriva
+                            - mes
+                            - msdos
+                            - netbsd
+                            - netware
+                            - openbsd
+                            - opensolaris
+                            - opensuse
+                            - rocky
+                            - rhel
+                            - sled
+                            - ubuntu
+                            - windows
+                            type: string
+                          version:
+                            description: version is the operating system version as
+                              specified by the distributor.
+                            maxLength: 255
+                            type: string
+                        type: object
+                    type: object
+                  protected:
+                    description: |-
+                      protected specifies that the image is protected from deletion.
+                      If not specified, the default is false.
+                    type: boolean
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      image. A tag has a maximum length of 255 characters.
+                    items:
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                  visibility:
+                    description: visibility of the image
+                    enum:
+                    - public
+                    - private
+                    - shared
+                    - community
+                    type: string
+                    x-kubernetes-validations:
+                    - message: visibility is immutable
+                      rule: self == oldSelf
+                type: object
+                x-kubernetes-validations:
+                - message: name is immutable
+                  rule: 'has(self.name) ? self.name == oldSelf.name : !has(oldSelf.name)'
+                - message: name is immutable
+                  rule: 'has(self.protected) ? self.protected == oldSelf.protected
+                    : !has(oldSelf.protected)'
+                - message: tags is immutable
+                  rule: 'has(self.tags) ? self.tags == oldSelf.tags : !has(oldSelf.tags)'
+                - message: visibility is immutable
+                  rule: 'has(self.visibility) ? self.visibility == oldSelf.visibility
+                    : !has(oldSelf.visibility)'
+                - message: properties is immutable
+                  rule: 'has(self.properties) ? self.properties == oldSelf.properties
+                    : !has(oldSelf.properties)'
+                - message: ImageResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+            - message: resource content must be specified when not importing
+              rule: '!has(self.__import__) ? has(self.resource.content) : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              downloadAttempts:
+                description: downloadAttempts is the number of times the controller
+                  has attempted to download the image contents
+                format: int32
+                type: integer
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  hash:
+                    description: |-
+                      hash is the hash of the image data published by Glance. Note that this is
+                      a hash of the data stored internally by Glance, which will have been
+                      decompressed and potentially format converted depending on server-side
+                      configuration which is not visible to clients. It is expected that this
+                      hash will usually differ from the download hash.
+                    properties:
+                      algorithm:
+                        description: algorithm is the hash algorithm used to generate
+                          value.
+                        enum:
+                        - md5
+                        - sha1
+                        - sha256
+                        - sha512
+                        type: string
+                      value:
+                        description: value is the hash of the image data using Algorithm.
+                          It must be hex encoded using lowercase letters.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[0-9a-f]+$
+                        type: string
+                    required:
+                    - algorithm
+                    - value
+                    type: object
+                  name:
+                    description: name is a Human-readable name for the image. Might
+                      not be unique.
+                    maxLength: 1024
+                    type: string
+                  protected:
+                    description: protected specifies that the image is protected from
+                      deletion.
+                    type: boolean
+                  sizeB:
+                    description: sizeB is the size of the image data, in bytes
+                    format: int64
+                    type: integer
+                  status:
+                    description: status is the image status as reported by Glance
+                    maxLength: 1024
+                    type: string
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  virtualSizeB:
+                    description: virtualSizeB is the size of the disk the image data
+                      represents, in bytes
+                    format: int64
+                    type: integer
+                  visibility:
+                    description: visibility of the image
+                    maxLength: 1024
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: networks.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Network is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      description:
+                        description: description of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      external:
+                        description: |-
+                          external indicates whether the network has an external routing
+                          facility that’s not managed by the networking service.
+                        type: boolean
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  adminStateUp:
+                    description: adminStateUp is the administrative state of the network,
+                      which is up (true) or down (false)
+                    type: boolean
+                  availabilityZoneHints:
+                    description: availabilityZoneHints is the availability zone candidate
+                      for the network.
+                    items:
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 255
+                    minLength: 1
+                    type: string
+                  dnsDomain:
+                    description: dnsDomain is the DNS domain of the network
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[A-Za-z0-9]{1,63}(.[A-Za-z0-9-]{1,63})*(.[A-Za-z]{2,63})*.?$
+                    type: string
+                  external:
+                    description: |-
+                      external indicates whether the network has an external routing
+                      facility that’s not managed by the networking service.
+                    type: boolean
+                  mtu:
+                    description: |-
+                      mtu is the the maximum transmission unit value to address
+                      fragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.
+                      Defaults to 1500.
+                    format: int32
+                    maximum: 9216
+                    minimum: 68
+                    type: integer
+                  name:
+                    description: |-
+                      name will be the name of the created resource. If not specified, the
+                      name of the ORC object will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  portSecurityEnabled:
+                    description: |-
+                      portSecurityEnabled is the port security status of the network.
+                      Valid values are enabled (true) and disabled (false). This value is
+                      used as the default value of port_security_enabled field of a newly
+                      created port.
+                    type: boolean
+                  shared:
+                    description: |-
+                      shared indicates whether this resource is shared across all
+                      projects. By default, only administrative users can change this
+                      value.
+                    type: boolean
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      network.
+                    items:
+                      description: |-
+                        NeutronTag represents a tag on a Neutron resource.
+                        It may not be empty and may not contain commas.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 64
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+                x-kubernetes-validations:
+                - message: NetworkResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  adminStateUp:
+                    description: |-
+                      adminStateUp is the administrative state of the network,
+                      which is up (true) or down (false).
+                    type: boolean
+                  availabilityZoneHints:
+                    description: |-
+                      availabilityZoneHints is the availability zone candidate for the
+                      network.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  createdAt:
+                    description: createdAt shows the date and time when the resource
+                      was created. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 1024
+                    type: string
+                  dnsDomain:
+                    description: dnsDomain is the DNS domain of the network
+                    maxLength: 1024
+                    type: string
+                  external:
+                    description: |-
+                      external defines whether the network may be used for creation of
+                      floating IPs. Only networks with this flag may be an external
+                      gateway for routers. The network must have an external routing
+                      facility that is not managed by the networking service. If the
+                      network is updated from external to internal the unused floating IPs
+                      of this network are automatically deleted when extension
+                      floatingip-autodelete-internal is present.
+                    type: boolean
+                  mtu:
+                    description: |-
+                      mtu is the the maximum transmission unit value to address
+                      fragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.
+                    format: int32
+                    type: integer
+                  name:
+                    description: name is a Human-readable name for the network. Might
+                      not be unique.
+                    maxLength: 1024
+                    type: string
+                  portSecurityEnabled:
+                    description: |-
+                      portSecurityEnabled is the port security status of the network.
+                      Valid values are enabled (true) and disabled (false). This value is
+                      used as the default value of port_security_enabled field of a newly
+                      created port.
+                    type: boolean
+                  projectID:
+                    description: projectID is the project owner of the network.
+                    maxLength: 1024
+                    type: string
+                  provider:
+                    description: provider contains provider-network properties.
+                    properties:
+                      networkType:
+                        description: |-
+                          networkType is the type of physical network that this
+                          network should be mapped to. Supported values are flat, vlan, vxlan, and gre.
+                          Valid values depend on the networking back-end.
+                        maxLength: 1024
+                        type: string
+                      physicalNetwork:
+                        description: |-
+                          physicalNetwork is the physical network where this network
+                          should be implemented. The Networking API v2.0 does not provide a
+                          way to list available physical networks. For example, the Open
+                          vSwitch plug-in configuration file defines a symbolic name that maps
+                          to specific bridges on each compute host.
+                        maxLength: 1024
+                        type: string
+                      segmentationID:
+                        description: |-
+                          segmentationID is the ID of the isolated segment on the
+                          physical network. The network_type attribute defines the
+                          segmentation model. For example, if the network_type value is vlan,
+                          this ID is a vlan identifier. If the network_type value is gre, this
+                          ID is a gre key.
+                        format: int32
+                        type: integer
+                    type: object
+                  revisionNumber:
+                    description: revisionNumber optionally set via extensions/standard-attr-revisions
+                    format: int64
+                    type: integer
+                  shared:
+                    description: |-
+                      shared specifies whether the network resource can be accessed by any
+                      tenant.
+                    type: boolean
+                  status:
+                    description: |-
+                      status indicates whether network is currently operational. Possible values
+                      include `ACTIVE', `DOWN', `BUILD', or `ERROR'. Plug-ins might define
+                      additional values.
+                    maxLength: 1024
+                    type: string
+                  subnets:
+                    description: subnets associated with this network.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  updatedAt:
+                    description: updatedAt shows the date and time when the resource
+                      was updated. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: ports.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Port
+    listKind: PortList
+    plural: ports
+    singular: port
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Allocated IP addresses
+      jsonPath: .status.resource.fixedIPs[*].ip
+      name: Addresses
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Port is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      description:
+                        description: description of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      networkRef:
+                        description: networkRef is a reference to the ORC Network
+                          which this port is associated with.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  addresses:
+                    description: addresses are the IP addresses for the port.
+                    items:
+                      properties:
+                        ip:
+                          description: |-
+                            ip contains a fixed IP address assigned to the port. It must belong
+                            to the referenced subnet's CIDR. If not specified, OpenStack
+                            allocates an available IP from the referenced subnet.
+                          maxLength: 45
+                          minLength: 1
+                          type: string
+                        subnetRef:
+                          description: |-
+                            subnetRef references the subnet from which to allocate the IP
+                            address.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - subnetRef
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  allowedAddressPairs:
+                    description: allowedAddressPairs are allowed addresses associated
+                      with this port.
+                    items:
+                      properties:
+                        ip:
+                          description: |-
+                            ip contains an IP address which a server connected to the port can
+                            send packets with. It can be an IP Address or a CIDR (if supported
+                            by the underlying extension plugin).
+                          maxLength: 45
+                          minLength: 1
+                          type: string
+                        mac:
+                          description: |-
+                            mac contains a MAC address which a server connected to the port can
+                            send packets with. Defaults to the MAC address of the port.
+                          maxLength: 17
+                          minLength: 1
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 255
+                    minLength: 1
+                    type: string
+                  name:
+                    description: name is a human-readable name of the port. If not
+                      set, the object's name will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  networkRef:
+                    description: networkRef is a reference to the ORC Network which
+                      this port is associated with.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  portSecurity:
+                    default: Inherit
+                    description: |-
+                      portSecurity controls port security for this port.
+                      When set to Enabled, port security is enabled.
+                      When set to Disabled, port security is disabled and SecurityGroupRefs must be empty.
+                      When set to Inherit (default), it takes the value from the network level.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    - Inherit
+                    type: string
+                  securityGroupRefs:
+                    description: |-
+                      securityGroupRefs are the names of the security groups associated
+                      with this port.
+                    items:
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[^,]+$
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      port.
+                    items:
+                      description: |-
+                        NeutronTag represents a tag on a Neutron resource.
+                        It may not be empty and may not contain commas.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                  vnicType:
+                    description: |-
+                      vnicType specifies the type of vNIC which this port should be
+                      attached to. This is used to determine which mechanism driver(s) to
+                      be used to bind the port. The valid values are normal, macvtap,
+                      direct, baremetal, direct-physical, virtio-forwarder, smart-nic and
+                      remote-managed, although these values will not be validated in this
+                      API to ensure compatibility with future neutron changes or custom
+                      implementations. What type of vNIC is actually available depends on
+                      deployments. If not specified, the Neutron default value is used.
+                    maxLength: 64
+                    type: string
+                required:
+                - networkRef
+                type: object
+                x-kubernetes-validations:
+                - message: PortResourceSpec is immutable
+                  rule: self == oldSelf
+                - message: securityGroupRefs must be empty when portSecurity is set
+                    to Disabled
+                  rule: 'has(self.portSecurity) && self.portSecurity == ''Disabled''
+                    ? !has(self.securityGroupRefs) : true'
+                - message: allowedAddressPairs must be empty when portSecurity is
+                    set to Disabled
+                  rule: 'has(self.portSecurity) && self.portSecurity == ''Disabled''
+                    ? !has(self.allowedAddressPairs) : true'
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  adminStateUp:
+                    description: |-
+                      adminStateUp is the administrative state of the port,
+                      which is up (true) or down (false).
+                    type: boolean
+                  allowedAddressPairs:
+                    description: |-
+                      allowedAddressPairs is a set of zero or more allowed address pair
+                      objects each where address pair object contains an IP address and
+                      MAC address.
+                    items:
+                      properties:
+                        ip:
+                          description: |-
+                            ip contains an IP address which a server connected to the port can
+                            send packets with.
+                          maxLength: 1024
+                          type: string
+                        mac:
+                          description: |-
+                            mac contains a MAC address which a server connected to the port can
+                            send packets with.
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  createdAt:
+                    description: createdAt shows the date and time when the resource
+                      was created. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 1024
+                    type: string
+                  deviceID:
+                    description: deviceID is the ID of the device that uses this port.
+                    maxLength: 1024
+                    type: string
+                  deviceOwner:
+                    description: deviceOwner is the entity type that uses this port.
+                    maxLength: 1024
+                    type: string
+                  fixedIPs:
+                    description: |-
+                      fixedIPs is a set of zero or more fixed IP objects each where fixed
+                      IP object contains an IP address and subnet ID from which the IP
+                      address is assigned.
+                    items:
+                      properties:
+                        ip:
+                          description: ip contains a fixed IP address assigned to
+                            the port.
+                          maxLength: 1024
+                          type: string
+                        subnetID:
+                          description: subnetID is the ID of the subnet this IP is
+                            allocated from.
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  macAddress:
+                    description: macAddress is the MAC address of the port.
+                    maxLength: 1024
+                    type: string
+                  name:
+                    description: name is the human-readable name of the resource.
+                      Might not be unique.
+                    maxLength: 1024
+                    type: string
+                  networkID:
+                    description: networkID is the ID of the attached network.
+                    maxLength: 1024
+                    type: string
+                  portSecurityEnabled:
+                    description: portSecurityEnabled indicates whether port security
+                      is enabled or not.
+                    type: boolean
+                  projectID:
+                    description: projectID is the project owner of the resource.
+                    maxLength: 1024
+                    type: string
+                  propagateUplinkStatus:
+                    description: |-
+                      propagateUplinkStatus represents the uplink status propagation of
+                      the port.
+                    type: boolean
+                  revisionNumber:
+                    description: revisionNumber optionally set via extensions/standard-attr-revisions
+                    format: int64
+                    type: integer
+                  securityGroups:
+                    description: securityGroups contains the IDs of security groups
+                      applied to the port.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  status:
+                    description: status indicates the current status of the resource.
+                    maxLength: 1024
+                    type: string
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  updatedAt:
+                    description: updatedAt shows the date and time when the resource
+                      was updated. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                  vnicType:
+                    description: vnicType is the type of vNIC which this port is attached
+                      to.
+                    maxLength: 64
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: projects.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Project
+    listKind: ProjectList
+    plural: projects
+    singular: project
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Project is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      name:
+                        description: name of the existing resource
+                        maxLength: 64
+                        minLength: 1
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 80
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 80
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 80
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 80
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  description:
+                    description: description contains a free form description of the
+                      project.
+                    maxLength: 65535
+                    minLength: 1
+                    type: string
+                  enabled:
+                    description: enabled defines whether a project is enabled or not.
+                      Default is true.
+                    type: boolean
+                  name:
+                    description: |-
+                      name will be the name of the created resource. If not specified, the
+                      name of the ORC object will be used.
+                    maxLength: 64
+                    minLength: 1
+                    type: string
+                  tags:
+                    description: |-
+                      tags is list of simple strings assigned to a project.
+                      Tags can be used to classify projects into groups.
+                    items:
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 80
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+                x-kubernetes-validations:
+                - message: ProjectResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 65535
+                    type: string
+                  enabled:
+                    description: enabled represents whether a project is enabled or
+                      not.
+                    type: boolean
+                  name:
+                    description: name is a Human-readable name for the project. Might
+                      not be unique.
+                    maxLength: 1024
+                    type: string
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 80
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: routerinterfaces.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: RouterInterface
+    listKind: RouterInterfaceList
+    plural: routerinterfaces
+    singular: routerinterface
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RouterInterface is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              routerRef:
+                description: routerRef references the router to which this interface
+                  belongs.
+                maxLength: 253
+                minLength: 1
+                type: string
+              subnetRef:
+                description: subnetRef references the subnet the router interface
+                  is created on.
+                maxLength: 253
+                minLength: 1
+                type: string
+              type:
+                description: type specifies the type of the router interface.
+                enum:
+                - Subnet
+                maxLength: 8
+                minLength: 1
+                type: string
+            required:
+            - routerRef
+            - type
+            type: object
+            x-kubernetes-validations:
+            - message: subnetRef is required when type is 'Subnet' and not permitted
+                otherwise
+              rule: 'self.type == ''Subnet'' ? has(self.subnetRef) : !has(self.subnetRef)'
+            - message: RouterInterfaceResourceSpec is immutable
+              rule: self == oldSelf
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the port created for the
+                  router interface
+                maxLength: 1024
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: routers.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Router
+    listKind: RouterList
+    plural: routers
+    singular: router
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Router is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      description:
+                        description: description of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  adminStateUp:
+                    description: |-
+                      adminStateUp represents the administrative state of the resource,
+                      which is up (true) or down (false). Default is true.
+                    type: boolean
+                  availabilityZoneHints:
+                    description: availabilityZoneHints is the availability zone candidate
+                      for the router.
+                    items:
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 255
+                    minLength: 1
+                    type: string
+                  distributed:
+                    description: |-
+                      distributed indicates whether the router is distributed or not. It
+                      is available when dvr extension is enabled.
+                    type: boolean
+                  externalGateways:
+                    description: externalGateways is a list of external gateways for
+                      the router.
+                    items:
+                      properties:
+                        networkRef:
+                          description: |-
+                            networkRef is a reference to the ORC Network which the external
+                            gateway is on.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - networkRef
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  name:
+                    description: |-
+                      name is a human-readable name of the router. If not set, the
+                      object's name will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      router.
+                    items:
+                      description: |-
+                        NeutronTag represents a tag on a Neutron resource.
+                        It may not be empty and may not contain commas.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+                x-kubernetes-validations:
+                - message: RouterResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  adminStateUp:
+                    description: |-
+                      adminStateUp is the administrative state of the router,
+                      which is up (true) or down (false).
+                    type: boolean
+                  availabilityZoneHints:
+                    description: |-
+                      availabilityZoneHints is the availability zone candidate for the
+                      router.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 1024
+                    type: string
+                  externalGateways:
+                    description: externalGateways is a list of external gateways for
+                      the router.
+                    items:
+                      properties:
+                        networkID:
+                          description: networkID is the ID of the network the gateway
+                            is on.
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  name:
+                    description: name is the human-readable name of the resource.
+                      Might not be unique.
+                    maxLength: 1024
+                    type: string
+                  projectID:
+                    description: projectID is the project owner of the resource.
+                    maxLength: 1024
+                    type: string
+                  status:
+                    description: status indicates the current status of the resource.
+                    maxLength: 1024
+                    type: string
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: securitygroups.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: SecurityGroup
+    listKind: SecurityGroupList
+    plural: securitygroups
+    singular: securitygroup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SecurityGroup is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      description:
+                        description: description of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 255
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
+                  name:
+                    description: |-
+                      name will be the name of the created resource. If not specified, the
+                      name of the ORC object will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
+                  rules:
+                    description: rules is a list of security group rules belonging
+                      to this SG.
+                    items:
+                      description: SecurityGroupRule defines a Security Group rule
+                      minProperties: 1
+                      properties:
+                        description:
+                          description: description is a human-readable description
+                            for the resource.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        direction:
+                          description: |-
+                            direction represents the direction in which the security group rule
+                            is applied. Can be ingress or egress.
+                          enum:
+                          - ingress
+                          - egress
+                          type: string
+                        ethertype:
+                          description: |-
+                            ethertype must be IPv4 or IPv6, and addresses represented in CIDR
+                            must match the ingress or egress rules.
+                          enum:
+                          - IPv4
+                          - IPv6
+                          type: string
+                        portRange:
+                          description: |-
+                            portRange sets the minimum and maximum ports range that the security group rule
+                            matches. If the protocol is [tcp, udp, dccp sctp,udplite] PortRange.Min must be less than
+                            or equal to the PortRange.Max attribute value.
+                            If the protocol is ICMP, this PortRamge.Min must be an ICMP code and PortRange.Max
+                            should be an ICMP type
+                          properties:
+                            max:
+                              description: |-
+                                max is the maximum port number in the range that is matched by the security group rule.
+                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be greater than or equal
+                                to the port_range_min attribute value. If the protocol is ICMP, this value must be an ICMP code.
+                              format: int32
+                              maximum: 65535
+                              minimum: 0
+                              type: integer
+                            min:
+                              description: |-
+                                min is the minimum port number in the range that is matched by the security group rule.
+                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be less than or equal
+                                to the port_range_max attribute value. If the protocol is ICMP, this value must be an ICMP type
+                              format: int32
+                              maximum: 65535
+                              minimum: 0
+                              type: integer
+                          required:
+                          - max
+                          - min
+                          type: object
+                        protocol:
+                          description: protocol is the IP protocol is represented
+                            by a string
+                          enum:
+                          - ah
+                          - dccp
+                          - egp
+                          - esp
+                          - gre
+                          - icmp
+                          - icmpv6
+                          - igmp
+                          - ipip
+                          - ipv6-encap
+                          - ipv6-frag
+                          - ipv6-icmp
+                          - ipv6-nonxt
+                          - ipv6-opts
+                          - ipv6-route
+                          - ospf
+                          - pgm
+                          - rsvp
+                          - sctp
+                          - tcp
+                          - udp
+                          - udplite
+                          - vrrp
+                          type: string
+                        remoteIPPrefix:
+                          description: remoteIPPrefix is an IP address block. Should
+                            match the Ethertype (IPv4 or IPv6)
+                          format: cidr
+                          maxLength: 49
+                          minLength: 1
+                          type: string
+                      required:
+                      - ethertype
+                      type: object
+                      x-kubernetes-validations:
+                      - message: portRangeMax should be equal or greater than portRange.min
+                        rule: (!has(self.portRange)|| !(self.protocol == 'tcp'|| self.protocol
+                          == 'udp' || self.protocol == 'dccp' || self.protocol ==
+                          'sctp' || self.protocol == 'udplite') || (self.portRange.min
+                          <= self.portRange.max))
+                      - message: When protocol is ICMP or ICMPv6 portRange.min should
+                          be between 0 and 255
+                        rule: '!(self.protocol == ''icmp'' || self.protocol == ''icmpv6'')
+                          || !has(self.portRange)|| (self.portRange.min >= 0 && self.portRange.min
+                          <= 255)'
+                      - message: When protocol is ICMP or ICMPv6 portRange.max should
+                          be between 0 and 255
+                        rule: '!(self.protocol == ''icmp'' || self.protocol == ''icmpv6'')
+                          || !has(self.portRange)|| (self.portRange.max >= 0 && self.portRange.max
+                          <= 255)'
+                    maxItems: 256
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  stateful:
+                    description: stateful indicates if the security group is stateful
+                      or stateless.
+                    type: boolean
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      security group.
+                    items:
+                      description: |-
+                        NeutronTag represents a tag on a Neutron resource.
+                        It may not be empty and may not contain commas.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                    x-kubernetes-validations:
+                    - message: Property is immutable
+                      rule: self == oldSelf
+                type: object
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  createdAt:
+                    description: createdAt shows the date and time when the resource
+                      was created. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 1024
+                    type: string
+                  name:
+                    description: name is a Human-readable name for the security group.
+                      Might not be unique.
+                    maxLength: 1024
+                    type: string
+                  projectID:
+                    description: projectID is the project owner of the security group.
+                    maxLength: 1024
+                    type: string
+                  revisionNumber:
+                    description: revisionNumber optionally set via extensions/standard-attr-revisions
+                    format: int64
+                    type: integer
+                  rules:
+                    description: rules is a list of security group rules belonging
+                      to this SG.
+                    items:
+                      properties:
+                        description:
+                          description: description is a human-readable description
+                            for the resource.
+                          maxLength: 1024
+                          type: string
+                        direction:
+                          description: |-
+                            direction represents the direction in which the security group rule
+                            is applied. Can be ingress or egress.
+                          maxLength: 1024
+                          type: string
+                        ethertype:
+                          description: |-
+                            ethertype must be IPv4 or IPv6, and addresses represented in CIDR
+                            must match the ingress or egress rules.
+                          maxLength: 1024
+                          type: string
+                        id:
+                          description: id is the ID of the security group rule.
+                          maxLength: 1024
+                          type: string
+                        portRange:
+                          description: |-
+                            portRange sets the minimum and maximum ports range that the security group rule
+                            matches. If the protocol is [tcp, udp, dccp sctp,udplite] PortRange.Min must be less than
+                            or equal to the PortRange.Max attribute value.
+                            If the protocol is ICMP, this PortRamge.Min must be an ICMP code and PortRange.Max
+                            should be an ICMP type
+                          properties:
+                            max:
+                              description: |-
+                                max is the maximum port number in the range that is matched by the security group rule.
+                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be greater than or equal
+                                to the port_range_min attribute value. If the protocol is ICMP, this value must be an ICMP code.
+                              format: int32
+                              type: integer
+                            min:
+                              description: |-
+                                min is the minimum port number in the range that is matched by the security group rule.
+                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be less than or equal
+                                to the port_range_max attribute value. If the protocol is ICMP, this value must be an ICMP type
+                              format: int32
+                              type: integer
+                          type: object
+                        protocol:
+                          description: |-
+                            protocol is the IP protocol can be represented by a string, an
+                            integer, or null
+                          maxLength: 1024
+                          type: string
+                        remoteGroupID:
+                          description: |-
+                            remoteGroupID is the remote group UUID to associate with this security group rule
+                            RemoteGroupID
+                          maxLength: 1024
+                          type: string
+                        remoteIPPrefix:
+                          description: remoteIPPrefix is an IP address block. Should
+                            match the Ethertype (IPv4 or IPv6)
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 256
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  stateful:
+                    description: stateful indicates if the security group is stateful
+                      or stateless.
+                    type: boolean
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  updatedAt:
+                    description: updatedAt shows the date and time when the resource
+                      was updated. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: servers.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Server
+    listKind: ServerList
+    plural: servers
+    singular: server
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Server is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          maxLength: 80
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          maxLength: 80
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          maxLength: 80
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          maxLength: 80
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  flavorRef:
+                    description: flavorRef references the flavor to use for the server
+                      instance.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  imageRef:
+                    description: |-
+                      imageRef references the image to use for the server instance.
+                      NOTE: This is not required in case of boot from volume.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  name:
+                    description: |-
+                      name will be the name of the created resource. If not specified, the
+                      name of the ORC object will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  ports:
+                    description: ports defines a list of ports which will be attached
+                      to the server.
+                    items:
+                      maxProperties: 1
+                      minProperties: 1
+                      properties:
+                        portRef:
+                          description: |-
+                            portRef is a reference to a Port object. Server creation will wait for
+                            this port to be created and available.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      server.
+                    items:
+                      maxLength: 80
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                  userData:
+                    description: |-
+                      userData specifies data which will be made available to the server at
+                      boot time, either via the metadata service or a config drive. It is
+                      typically read by a configuration service such as cloud-init or ignition.
+                    maxProperties: 1
+                    minProperties: 1
+                    properties:
+                      secretRef:
+                        description: secretRef is a reference to a Secret containing
+                          the user data for this server.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    type: object
+                required:
+                - flavorRef
+                - imageRef
+                - ports
+                type: object
+                x-kubernetes-validations:
+                - message: ServerResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  hostID:
+                    description: hostID is the host where the server is located in
+                      the cloud.
+                    maxLength: 1024
+                    type: string
+                  imageID:
+                    description: imageID indicates the OS image used to deploy the
+                      server.
+                    maxLength: 1024
+                    type: string
+                  name:
+                    description: name is the human-readable name of the resource.
+                      Might not be unique.
+                    maxLength: 1024
+                    type: string
+                  status:
+                    description: |-
+                      status contains the current operational status of the server,
+                      such as IN_PROGRESS or ACTIVE.
+                    maxLength: 1024
+                    type: string
+                  tags:
+                    description: tags is the list of tags on the resource.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  name: subnets.openstack.k-orc.cloud
+spec:
+  group: openstack.k-orc.cloud
+  names:
+    categories:
+    - openstack
+    kind: Subnet
+    listKind: SubnetList
+    plural: subnets
+    singular: subnet
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Resource ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Availability status of resource
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - description: Message describing current progress status
+      jsonPath: .status.conditions[?(@.type=='Progressing')].message
+      name: Message
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Subnet is the Schema for an ORC resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec specifies the desired state of the resource.
+            properties:
+              cloudCredentialsRef:
+                description: cloudCredentialsRef points to a secret containing OpenStack
+                  credentials
+                properties:
+                  cloudName:
+                    description: cloudName specifies the name of the entry in the
+                      clouds.yaml file to use.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of a secret in the same namespace as the resource being provisioned.
+                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - cloudName
+                - secretName
+                type: object
+              import:
+                description: |-
+                  import refers to an existing OpenStack resource which will be imported instead of
+                  creating a new one.
+                maxProperties: 1
+                minProperties: 1
+                properties:
+                  filter:
+                    description: |-
+                      filter contains a resource query which is expected to return a single
+                      result. The controller will continue to retry if filter returns no
+                      results. If filter returns multiple results the controller will set an
+                      error state and will not continue to retry.
+                    minProperties: 1
+                    properties:
+                      cidr:
+                        description: cidr of the existing resource
+                        format: cidr
+                        maxLength: 49
+                        minLength: 1
+                        type: string
+                      description:
+                        description: description of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      gatewayIP:
+                        description: gatewayIP is the IP address of the gateway of
+                          the existing resource
+                        maxLength: 45
+                        minLength: 1
+                        type: string
+                      ipVersion:
+                        description: ipVersion of the existing resource
+                        enum:
+                        - 4
+                        - 6
+                        format: int32
+                        type: integer
+                      ipv6:
+                        description: ipv6 options of the existing resource
+                        minProperties: 1
+                        properties:
+                          addressMode:
+                            description: addressMode specifies mechanisms for assigning
+                              IPv6 IP addresses.
+                            enum:
+                            - slaac
+                            - dhcpv6-stateful
+                            - dhcpv6-stateless
+                            type: string
+                          raMode:
+                            description: |-
+                              raMode specifies the IPv6 router advertisement mode. It specifies whether
+                              the networking service should transmit ICMPv6 packets.
+                            enum:
+                            - slaac
+                            - dhcpv6-stateful
+                            - dhcpv6-stateless
+                            type: string
+                        type: object
+                      name:
+                        description: name of the existing resource
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      networkRef:
+                        description: networkRef is a reference to the ORC Network
+                          which this subnet is associated with.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      notTags:
+                        description: |-
+                          notTags is a list of tags to filter by. If specified, resources which
+                          contain all of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      notTagsAny:
+                        description: |-
+                          notTagsAny is a list of tags to filter by. If specified, resources
+                          which contain any of the given tags will be excluded from the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tags:
+                        description: |-
+                          tags is a list of tags to filter by. If specified, the resource must
+                          have all of the tags specified to be included in the result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                      tagsAny:
+                        description: |-
+                          tagsAny is a list of tags to filter by. If specified, the resource
+                          must have at least one of the tags specified to be included in the
+                          result.
+                        items:
+                          description: |-
+                            NeutronTag represents a tag on a Neutron resource.
+                            It may not be empty and may not contain commas.
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-type: set
+                    type: object
+                  id:
+                    description: |-
+                      id contains the unique identifier of an existing OpenStack resource. Note
+                      that when specifying an import by ID, the resource MUST already exist.
+                      The ORC object will enter an error state if the resource does not exist.
+                    format: uuid
+                    type: string
+                type: object
+              managedOptions:
+                description: managedOptions specifies options which may be applied
+                  to managed objects.
+                properties:
+                  onDelete:
+                    default: delete
+                    description: |-
+                      onDelete specifies the behaviour of the controller when the ORC
+                      object is deleted. Options are `delete` - delete the OpenStack resource;
+                      `detach` - do not delete the OpenStack resource. If not specified, the
+                      default is `delete`.
+                    enum:
+                    - delete
+                    - detach
+                    type: string
+                type: object
+              managementPolicy:
+                default: managed
+                description: |-
+                  managementPolicy defines how ORC will treat the object. Valid values are
+                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                  ORC will import an existing resource, and will not apply updates to it or
+                  delete it.
+                enum:
+                - managed
+                - unmanaged
+                type: string
+                x-kubernetes-validations:
+                - message: managementPolicy is immutable
+                  rule: self == oldSelf
+              resource:
+                description: |-
+                  resource specifies the desired state of the resource.
+
+                  resource may not be specified if the management policy is `unmanaged`.
+
+                  resource must be specified if the management policy is `managed`.
+                properties:
+                  allocationPools:
+                    description: |-
+                      allocationPools are IP Address pools that will be available for DHCP. IP
+                      addresses must be in CIDR.
+                    items:
+                      properties:
+                        end:
+                          description: end is the last IP address in the allocation
+                            pool.
+                          maxLength: 45
+                          minLength: 1
+                          type: string
+                        start:
+                          description: start is the first IP address in the allocation
+                            pool.
+                          maxLength: 45
+                          minLength: 1
+                          type: string
+                      required:
+                      - end
+                      - start
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  cidr:
+                    description: cidr is the address CIDR of the subnet. It must match
+                      the IP version specified in IPVersion.
+                    format: cidr
+                    maxLength: 49
+                    minLength: 1
+                    type: string
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 255
+                    minLength: 1
+                    type: string
+                  dnsNameservers:
+                    description: dnsNameservers are the nameservers to be set via
+                      DHCP.
+                    items:
+                      maxLength: 45
+                      minLength: 1
+                      type: string
+                    maxItems: 16
+                    type: array
+                    x-kubernetes-list-type: set
+                  dnsPublishFixedIP:
+                    description: |-
+                      dnsPublishFixedIP will either enable or disable the publication of
+                      fixed IPs to the DNS. Defaults to false.
+                    type: boolean
+                  enableDHCP:
+                    description: enableDHCP will either enable to disable the DHCP
+                      service.
+                    type: boolean
+                  gateway:
+                    description: |-
+                      gateway specifies the default gateway of the subnet. If not specified,
+                      neutron will add one automatically. To disable this behaviour, specify a
+                      gateway with a type of None.
+                    properties:
+                      ip:
+                        description: |-
+                          ip is the IP address of the default gateway, which must be specified if
+                          Type is `IP`. It must be a valid IP address, either IPv4 or IPv6,
+                          matching the IPVersion in SubnetResourceSpec.
+                        maxLength: 45
+                        minLength: 1
+                        type: string
+                      type:
+                        description: |-
+                          type specifies how the default gateway will be created. `Automatic`
+                          specifies that neutron will automatically add a default gateway. This is
+                          also the default if no Gateway is specified. `None` specifies that the
+                          subnet will not have a default gateway. `IP` specifies that the subnet
+                          will use a specific address as the default gateway, which must be
+                          specified in `IP`.
+                        enum:
+                        - None
+                        - Automatic
+                        - IP
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  hostRoutes:
+                    description: hostRoutes are any static host routes to be set via
+                      DHCP.
+                    items:
+                      properties:
+                        destination:
+                          description: destination for the additional route.
+                          format: cidr
+                          maxLength: 49
+                          minLength: 1
+                          type: string
+                        nextHop:
+                          description: nextHop for the additional route.
+                          maxLength: 45
+                          minLength: 1
+                          type: string
+                      required:
+                      - destination
+                      - nextHop
+                      type: object
+                    maxItems: 256
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  ipVersion:
+                    description: ipVersion is the IP version for the subnet.
+                    enum:
+                    - 4
+                    - 6
+                    format: int32
+                    type: integer
+                  ipv6:
+                    description: ipv6 contains IPv6-specific options. It may only
+                      be set if IPVersion is 6.
+                    minProperties: 1
+                    properties:
+                      addressMode:
+                        description: addressMode specifies mechanisms for assigning
+                          IPv6 IP addresses.
+                        enum:
+                        - slaac
+                        - dhcpv6-stateful
+                        - dhcpv6-stateless
+                        type: string
+                      raMode:
+                        description: |-
+                          raMode specifies the IPv6 router advertisement mode. It specifies whether
+                          the networking service should transmit ICMPv6 packets.
+                        enum:
+                        - slaac
+                        - dhcpv6-stateful
+                        - dhcpv6-stateless
+                        type: string
+                    type: object
+                  name:
+                    description: name is a human-readable name of the subnet. If not
+                      set, the object's name will be used.
+                    maxLength: 255
+                    minLength: 1
+                    pattern: ^[^,]+$
+                    type: string
+                  networkRef:
+                    description: networkRef is a reference to the ORC Network which
+                      this subnet is associated with.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  routerRef:
+                    description: routerRef specifies a router to attach the subnet
+                      to
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  tags:
+                    description: tags is a list of tags which will be applied to the
+                      subnet.
+                    items:
+                      description: |-
+                        NeutronTag represents a tag on a Neutron resource.
+                        It may not be empty and may not contain commas.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: set
+                required:
+                - cidr
+                - ipVersion
+                - networkRef
+                type: object
+                x-kubernetes-validations:
+                - message: SubnetResourceSpec is immutable
+                  rule: self == oldSelf
+            required:
+            - cloudCredentialsRef
+            type: object
+            x-kubernetes-validations:
+            - message: resource must be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+            - message: import may not be specified when policy is managed
+              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
+                : true'
+            - message: resource may not be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
+                : true'
+            - message: import must be specified when policy is unmanaged
+              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
+                : true'
+            - message: managedOptions may only be provided when policy is managed
+              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
+                : true'
+          status:
+            description: status defines the observed state of the resource.
+            properties:
+              conditions:
+                description: |-
+                  conditions represents the observed status of the object.
+                  Known .status.conditions.type are: "Available", "Progressing"
+
+                  Available represents the availability of the OpenStack resource. If it is
+                  true then the resource is ready for use.
+
+                  Progressing indicates whether the controller is still attempting to
+                  reconcile the current state of the OpenStack resource to the desired
+                  state. Progressing will be False either because the desired state has
+                  been achieved, or because some terminal error prevents it from ever being
+                  achieved and the controller is no longer attempting to reconcile. If
+                  Progressing is True, an observer waiting on the resource should continue
+                  to wait.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: id is the unique identifier of the OpenStack resource.
+                type: string
+              resource:
+                description: resource contains the observed state of the OpenStack
+                  resource.
+                properties:
+                  allocationPools:
+                    description: |-
+                      allocationPools is a list of sub-ranges within CIDR available for dynamic
+                      allocation to ports.
+                    items:
+                      properties:
+                        end:
+                          description: end is the last IP address in the allocation
+                            pool.
+                          maxLength: 1024
+                          type: string
+                        start:
+                          description: start is the first IP address in the allocation
+                            pool.
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  cidr:
+                    description: cidr representing IP range for this subnet, based
+                      on IP version.
+                    maxLength: 1024
+                    type: string
+                  createdAt:
+                    description: createdAt shows the date and time when the resource
+                      was created. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                  description:
+                    description: description is a human-readable description for the
+                      resource.
+                    maxLength: 1024
+                    type: string
+                  dnsNameservers:
+                    description: dnsNameservers is a list of name servers used by
+                      hosts in this subnet.
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 16
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  dnsPublishFixedIP:
+                    description: dnsPublishFixedIP specifies whether the fixed IP
+                      addresses are published to the DNS.
+                    type: boolean
+                  enableDHCP:
+                    description: enableDHCP specifies whether DHCP is enabled for
+                      this subnet or not.
+                    type: boolean
+                  gatewayIP:
+                    description: gatewayIP is the default gateway used by devices
+                      in this subnet, if any.
+                    maxLength: 1024
+                    type: string
+                  hostRoutes:
+                    description: |-
+                      hostRoutes is a list of routes that should be used by devices with IPs
+                      from this subnet (not including local subnet route).
+                    items:
+                      properties:
+                        destination:
+                          description: destination for the additional route.
+                          maxLength: 1024
+                          type: string
+                        nextHop:
+                          description: nextHop for the additional route.
+                          maxLength: 1024
+                          type: string
+                      type: object
+                    maxItems: 256
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  ipVersion:
+                    description: ipVersion specifies IP version, either `4' or `6'.
+                    format: int32
+                    type: integer
+                  ipv6AddressMode:
+                    description: ipv6AddressMode specifies mechanisms for assigning
+                      IPv6 IP addresses.
+                    maxLength: 1024
+                    type: string
+                  ipv6RAMode:
+                    description: |-
+                      ipv6RAMode is the IPv6 router advertisement mode. It specifies
+                      whether the networking service should transmit ICMPv6 packets.
+                    maxLength: 1024
+                    type: string
+                  name:
+                    description: name is the human-readable name of the subnet. Might
+                      not be unique.
+                    maxLength: 1024
+                    type: string
+                  networkID:
+                    description: networkID is the ID of the network to which the subnet
+                      belongs.
+                    maxLength: 1024
+                    type: string
+                  projectID:
+                    description: projectID is the project owner of the subnet.
+                    maxLength: 1024
+                    type: string
+                  revisionNumber:
+                    description: revisionNumber optionally set via extensions/standard-attr-revisions
+                    format: int64
+                    type: integer
+                  subnetPoolID:
+                    description: subnetPoolID is the id of the subnet pool associated
+                      with the subnet.
+                    maxLength: 1024
+                    type: string
+                  tags:
+                    description: tags optionally set via extensions/attributestags
+                    items:
+                      maxLength: 1024
+                      type: string
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  updatedAt:
+                    description: updatedAt shows the date and time when the resource
+                      was updated. The date and time stamp format is ISO 8601
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-controller-manager
+  namespace: orc-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-leader-election-role
+  namespace: orc-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-image-editor-role
+rules:
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - images
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - images/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-image-viewer-role
+rules:
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - images
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - images/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orc-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - flavors
+  - images
+  - networks
+  - ports
+  - projects
+  - routerinterfaces
+  - routers
+  - securitygroups
+  - servers
+  - subnets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - openstack.k-orc.cloud
+  resources:
+  - flavors/status
+  - images/status
+  - networks/status
+  - ports/status
+  - projects/status
+  - routerinterfaces/status
+  - routers/status
+  - securitygroups/status
+  - servers/status
+  - subnets/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orc-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orc-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-leader-election-rolebinding
+  namespace: orc-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: orc-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: orc-controller-manager
+  namespace: orc-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+  name: orc-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: orc-manager-role
+subjects:
+- kind: ServiceAccount
+  name: orc-controller-manager
+  namespace: orc-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orc-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: orc-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: orc-controller-manager
+  namespace: orc-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+    control-plane: controller-manager
+  name: orc-controller-manager-metrics-service
+  namespace: orc-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: orc
+    control-plane: controller-manager
+  name: orc-controller-manager
+  namespace: orc-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        command:
+        - /manager
+        image: quay.io/orc/openstack-resource-controller:v2.1.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: orc-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/templates/provider/cluster-api-provider-openstack/values.yaml
+++ b/templates/provider/cluster-api-provider-openstack/values.yaml
@@ -6,5 +6,3 @@ configSecret:
 config: {}
 
 manager: {}
-
-orcVersion: "1.0.0"

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -20,7 +20,7 @@ spec:
     - name: cluster-api-provider-aws
       template: cluster-api-provider-aws-0-3-0
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-0-3-1
+      template: cluster-api-provider-openstack-0-3-2
     - name: cluster-api-provider-docker
       template: cluster-api-provider-docker-0-3-0
     - name: cluster-api-provider-gcp

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-0-3-1
+  name: cluster-api-provider-openstack-0-3-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 0.3.1
+      version: 0.3.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
* bump OpenStack ORC resources to v2.1.0
* preserve the v1.0.0 manifest for bw-comp
* pin ORC version in the Makefile
* bump CAPI OS provider version accordingly
* small field alignments at ProviderInterface
  and Management API types (alpha,beta)