### PR TITLE
fix: Rework the helm-push Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,13 +307,14 @@ helm-push: helm-package
 		chart_name="$${base%-"$$chart_version"}"; \
 		echo "Verifying if chart $$chart_name, version $$chart_version already exists in $(REGISTRY_REPO)"; \
 		if $(REGISTRY_IS_OCI); then \
-			chart_exists=$$($(HELM) pull $$repo_flag $(REGISTRY_REPO)/$$chart_name --version $$chart_version --destination /tmp 2>&1 | grep "not found" || true); \
+			pull_output=$$($(HELM) pull $$repo_flag $(REGISTRY_REPO)/$$chart_name --version $$chart_version --destination /tmp 2>&1); \
 		else \
-			chart_exists=$$($(HELM) pull $$repo_flag $(REGISTRY_REPO) $$chart_name --version $$chart_version --destination /tmp 2>&1 | grep "not found" || true); \
+			pull_output=$$($(HELM) pull $$repo_flag $(REGISTRY_REPO) $$chart_name --version $$chart_version --destination /tmp 2>&1); \
 		fi; \
-		if [ -z "$$chart_exists" ]; then \
+		if echo "$$pull_output" | grep -q "Pulled:"; then \
 			echo "Chart $$chart_name version $$chart_version already exists in the repository."; \
 		else \
+			echo "Chart does not exist or not accessible (pull output: $$pull_output). Proceeding to push."; \
 			if $(REGISTRY_IS_OCI); then \
 				echo "Pushing $$chart to $(REGISTRY_REPO)"; \
 				$(HELM) push "$$chart" $(REGISTRY_REPO); \


### PR DESCRIPTION
Treat any failed pull (including 403 or other errors) as if the chart does not exist, and always attempt to push it.

Currently, pull errors like 403 Forbidden are silently ignored and incorrectly interpreted as if the chart already exists in the repository. This prevents charts from being pushed when they actually should be.