### PR TITLE
ci: Change the module name to uppercase

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -165,7 +165,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            LD_FLAGS=-s -w -X github.com/k0rdent/kcm/internal/build.Version=${{ needs.lint-test.outputs.version }}
+            LD_FLAGS=-s -w -X github.com/K0rdent/kcm/internal/build.Version=${{ needs.lint-test.outputs.version }}
           context: .
           platforms: linux/amd64
           tags: |


### PR DESCRIPTION
It was accidentally renamed to k0rdent in one of the previous PRs.