### PR TITLE
chore: add helmcharts typemeta explicitly

### DIFF
--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -310,6 +310,10 @@ func (r *ReleaseReconciler) reconcileKCMTemplates(ctx context.Context, releaseNa
 			Name:      kcmTemplatesName,
 			Namespace: r.SystemNamespace,
 		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       sourcev1.HelmChartKind,
+			APIVersion: sourcev1.GroupVersion.String(),
+		},
 	}
 
 	operation, err := ctrl.CreateOrUpdate(ctx, r.Client, helmChart, func() error {


### PR DESCRIPTION
Explicitly set TypeMeta to sourcev1.HelmChart objects during the setup of KCM Templates

Fixes #1531
