### PR TITLE
feat: Global values support for cluster and provider templates

### DIFF
--- a/config/dev/adopted-clusterdeployment.yaml
+++ b/config/dev/adopted-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: adopted-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: adopted-cluster-0-2-0
+  template: adopted-cluster-1-0-0
   credential: adopted-cluster-cred
   config:
     clusterLabels: {}

--- a/config/dev/aks-clusterdeployment.yaml
+++ b/config/dev/aks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-aks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-aks-0-2-0
+  template: azure-aks-1-0-0
   credential: azure-aks-credential
   propagateCredentials: false
   config:

--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-0-2-1
+  template: aws-standalone-cp-1-0-0
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-0-2-2
+  template: azure-standalone-cp-1-0-0
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/docker-clusterdeployment.yaml
+++ b/config/dev/docker-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: docker-hosted-cp-0-2-0
+  template: docker-hosted-cp-1-0-0
   credential: docker-stub-credential
   config:
     clusterLabels: {}

--- a/config/dev/eks-clusterdeployment.yaml
+++ b/config/dev/eks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-eks-0-2-0
+  template: aws-eks-1-0-0
   credential: "aws-cluster-identity-cred"
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-0-2-1
+  template: gcp-standalone-cp-1-0-0
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/gke-clusterdeployment.yaml
+++ b/config/dev/gke-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-gke-0-2-0
+  template: gcp-gke-1-0-0
   credential: gcp-credential
   propagateCredentials: false
   config:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-0-2-2
+  template: openstack-standalone-cp-1-0-0
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-0-2-1
+  template: remote-cluster-1-0-0
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-0-2-1
+  template: vsphere-standalone-cp-1-0-0
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/adopted-cluster/Chart.yaml
+++ b/templates/cluster/adopted-cluster/Chart.yaml
@@ -6,6 +6,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 1.0.0
 annotations:
   cluster.x-k8s.io/provider: infrastructure-internal

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 1.0.0
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0smotronControlPlane
 metadata:
@@ -9,6 +10,11 @@ spec:
   {{- with .Values.k0smotron.service }}
   service:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if $global.registry }}
+  image: {{ $global.registry }}/k0s
+  etcd:
+    image: "{{ $global.registry }}/etcd:v3.5.13"
   {{- end }}
   controllerPlaneFlags:
   - "--enable-cloud-provider=true"
@@ -28,30 +34,46 @@ spec:
         provider: calico
         calico:
           mode: ipip
+      {{- if $global.registry }}
+      images:
+        metricsserver:
+          image: "{{ $global.registry}}/k0sproject/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry}}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry}}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry}}/k0sproject/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry}}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry}}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+      {{- end }}
       extensions:
         helm:
+          {{- if not $global.registry }}
           repositories:
-          - name: mirantis
-            {{- if .Values.extensions.chartRepository }}
-            url: {{ .Values.extensions.chartRepository }}
-            {{- else }}
-            url: https://charts.mirantis.com
-            {{- end }}
-          - name: aws-ebs-csi-driver
-            {{- if .Values.extensions.chartRepository }}
-            url: {{ .Values.extensions.chartRepository }}
-            {{- else }}
-            url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
-            {{- end }}
+            - name: mirantis
+              url: https://charts.mirantis.com
+            - name: aws-ebs-csi-driver
+              url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+          {{- end }}
           charts:
           - name: aws-cloud-controller-manager
             namespace: kube-system
+            {{- if $global.registry }}
+            chartname: oci://{{ $global.registry}}/charts/aws-cloud-controller-manager
+            {{- else }}
             chartname: mirantis/aws-cloud-controller-manager
+            {{- end }}
             version: "0.0.9"
             values: |
               image:
-                {{- if .Values.extensions.imageRepository }}
-                repository: {{ .Values.extensions.imageRepository }}
+                {{- if $global.registry }}
+                repository: {{ $global.registry }}/provider-aws/cloud-controller-manager
                 {{- end }}
                 tag: v1.30.3
               args:
@@ -70,34 +92,38 @@ spec:
                 node-role.kubernetes.io/control-plane: null
           - name: aws-ebs-csi-driver
             namespace: kube-system
+            {{- if $global.registry }}
+            chartname: oci://{{ $global.registry}}/charts/aws-ebs-csi-driver
+            {{- else }}
             chartname: aws-ebs-csi-driver/aws-ebs-csi-driver
+            {{- end }}
             version: 2.33.0
             values: |
-              {{- if .Values.extensions.imageRepository }}
+              {{- if $global.registry }}
               image:
-                repository: {{ .Values.extensions.imageRepository }}
+                repository: {{ $global.registry }}/ebs-csi-driver/aws-ebs-csi-driver
               sidecars:
                 provisioner:
                   image:
-                    repository: {{ .Values.extensions.imageRepository }}
+                    repository: {{ $global.registry }}/kubernetes-csi/external-provisioner
                 attacher:
                   image:
-                    repository: {{ .Values.extensions.imageRepository }}
+                    repository: {{ $global.registry }}/kubernetes-csi/external-attacher
                 snapshotter:
                   image:
-                    repository: {{ .Values.extensions.imageRepository }}
+                    repository: {{ $global.registry }}kubernetes-csi/external-snapshotter/csi-snapshotter
                 livenessProbe:
                   image:
-                    repository: {{ .Values.extensions.imageRepository }}
+                    repository: {{ $global.registry }}/kubernetes-csi/livenessprobe
                 resizer:
                   image:
-                    repository: {{ .Values.extensions.imageRepository }}
+                    repository: {{ $global.registry }}/kubernetes-csi/external-resizer
                 nodeDriverRegistrar:
                   image:
-                    repository: {{ .Values.extensions.imageRepository }}
+                    repository: {{ $global.registry }}/kubernetes-csi/node-driver-registrar
                 volumemodifier:
                   image:
-                    repository: {{ .Values.extensions.imageRepository }}
+                    repository: {{ $global.registry }}/ebs-csi-driver/volume-modifier-for-k8s
               {{- end }}
               defaultStorageClass:
                 enabled: true

--- a/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
 metadata:
@@ -5,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      {{- if $global.k0sURL }}
+      downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -54,11 +54,5 @@ k0s:
   api:
     extraArgs: {}
 
-# extensions defines custom Helm and image repositories to use for pulling
-# k0s extensions.
-extensions:
-  chartRepository: ""
-  imageRepository: ""
-
 # Name of the management cluster that this template is being deployed on
 managementClusterName: ""

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
 metadata:
@@ -6,6 +7,9 @@ spec:
   replicas: {{ .Values.controlPlaneNumber }}
   version: {{ .Values.k0s.version }}
   k0sConfigSpec:
+    {{- if $global.k0sURL }}
+    downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+    {{- end }}
     args:
       - --enable-worker
       - --enable-cloud-provider
@@ -39,32 +43,48 @@ spec:
           provider: calico
           calico:
             mode: ipip
+        {{- if $global.registry }}
+        images:
+          metricsserver:
+            image: "{{ $global.registry}}/k0sproject/metrics-server"
+          kubeproxy:
+            image: "{{ $global.registry}}/k0sproject/kube-proxy"
+          coredns:
+            image: "{{ $global.registry}}/k0sproject/coredns"
+          pause:
+            image: "{{ $global.registry}}/k0sproject/pause"
+          calico:
+            cni:
+              image: "{{ $global.registry}}/k0sproject/calico-cni"
+            node:
+              image: "{{ $global.registry}}/k0sproject/calico-node"
+            kubecontrollers:
+              image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+        {{- end }}
         extensions:
           helm:
+            {{- if not $global.registry }}
             repositories:
-              - name: aws-cloud-controller-manager
-                {{- if .Values.extensions.chartRepository }}
-                url: {{ .Values.extensions.chartRepository }}
-                {{- else }}
-                url: https://kubernetes.github.io/cloud-provider-aws
-                {{- end }}
+              - name: mirantis
+                url: https://charts.mirantis.com
               - name: aws-ebs-csi-driver
-                {{- if .Values.extensions.chartRepository }}
-                url: {{ .Values.extensions.chartRepository}}
-                {{- else }}
                 url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
-                {{- end }}
+            {{- end }}
             charts:
               - name: aws-cloud-controller-manager
                 namespace: kube-system
-                chartname: aws-cloud-controller-manager/aws-cloud-controller-manager
-                version: "0.0.8"
+                {{- if $global.registry }}
+                chartname: oci://{{ $global.registry}}/charts/aws-cloud-controller-manager
+                {{- else }}
+                chartname: mirantis/aws-cloud-controller-manager
+                {{- end }}
+                version: "0.0.9"
                 values: |
                   nodeSelector:
                     node-role.kubernetes.io/control-plane: "true"
                   image:
-                    {{- if .Values.extensions.imageRepository }}
-                    repository: {{ .Values.extensions.imageRepository }}
+                    {{- if $global.registry }}
+                    repository: {{ $global.registry }}/provider-aws/cloud-controller-manager
                     {{- end }}
                     tag: v1.30.3
                   args:
@@ -75,34 +95,38 @@ spec:
                     - --cluster-name={{ include "cluster.name" . }}
               - name: aws-ebs-csi-driver
                 namespace: kube-system
+                {{- if $global.registry }}
+                chartname: oci://{{ $global.registry}}/charts/aws-ebs-csi-driver
+                {{- else }}
                 chartname: aws-ebs-csi-driver/aws-ebs-csi-driver
+                {{- end }}
                 version: 2.33.0
                 values: |
-                  {{- if .Values.extensions.imageRepository }}
+                  {{- if $global.registry }}
                   image:
-                    repository: {{ .Values.extensions.imageRepository }}
+                    repository: {{ $global.registry }}/ebs-csi-driver/aws-ebs-csi-driver
                   sidecars:
                     provisioner:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}
+                        repository: {{ $global.registry }}/kubernetes-csi/external-provisioner
                     attacher:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}
+                        repository: {{ $global.registry }}/kubernetes-csi/external-attacher
                     snapshotter:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}
+                        repository: {{ $global.registry }}kubernetes-csi/external-snapshotter/csi-snapshotter
                     livenessProbe:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}
+                        repository: {{ $global.registry }}/kubernetes-csi/livenessprobe
                     resizer:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}
+                        repository: {{ $global.registry }}/kubernetes-csi/external-resizer
                     nodeDriverRegistrar:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}
+                        repository: {{ $global.registry }}/kubernetes-csi/node-driver-registrar
                     volumemodifier:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}
+                        repository: {{ $global.registry }}/ebs-csi-driver/volume-modifier-for-k8s
                   {{- end }}
                   defaultStorageClass:
                     enabled: true

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
 metadata:
@@ -5,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      {{- if $global.k0sURL }}
+      downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -75,8 +75,3 @@ k0s:
           - expression: "!user.username.startsWith('system:')"
             message: "username cannot use reserved system: prefix"
 
-# extensions defines custom Helm and image repositories to use for pulling
-# k0s extensions.
-extensions:
-  chartRepository: ""
-  imageRepository: ""

--- a/templates/cluster/azure-aks/Chart.yaml
+++ b/templates/cluster/azure-aks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 1.0.0
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure
   cluster.x-k8s.io/infrastructure-azure: v1beta1

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0smotronControlPlane
 metadata:
@@ -8,6 +9,11 @@ spec:
   {{- with .Values.k0smotron.service }}
   service:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if $global.registry }}
+  image: {{ $global.registry}}/k0s
+  etcd:
+    image: "{{ $global.registry}}/etcd:v3.5.13"
   {{- end }}
   controllerPlaneFlags:
   - "--enable-cloud-provider=true"
@@ -27,50 +33,70 @@ spec:
         provider: calico
         calico:
           mode: vxlan
+      {{- if $global.registry }}
+      images:
+        metricsserver:
+          image: "{{ $global.registry}}/k0sproject/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry}}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry}}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry}}/k0sproject/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry}}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry}}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+      {{- end }}
       extensions:
         helm:
+          {{- if not $global.registry }}
           repositories:
             - name: mirantis
-              {{- if .Values.extensions.chartRepository }}
-              url: {{ .Values.extensions.chartRepository }}
-              {{- else }}
               url: https://charts.mirantis.com
-              {{- end }}
             - name: azuredisk-csi-driver
-              {{- if .Values.extensions.chartRepository }}
-              url: {{ .Values.extensions.chartRepository }}
-              {{- else }}
               url: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
-              {{- end }}
+          {{- end }}
           charts:
             - name: cloud-provider-azure
               namespace: kube-system
+              {{- if $global.registry }}
+              chartname: oci://{{ $global.registry}}/charts/cloud-provider-azure
+              {{- else }}
               chartname: mirantis/cloud-provider-azure
+              {{- end }}
               version: 1.31.2
               order: 1
               values: |
                 cloudControllerManager:
                   cloudConfigSecretName: azure-cloud-provider
                   nodeSelector:
-                    node-role.kubernetes.io/control-plane: null
-                  {{- if .Values.extensions.imageRepository }}
-                  imageRepository: {{ .Values.extensions.imageRepository }}
+                    node-role.kubernetes.io/control-plane: "true"
+                  {{- if $global.registry }}
+                  imageRepository: {{ $global.registry }}
                   {{- end }}
                   imageTag: v1.32.4
                 cloudNodeManager:
                   imageTag: v1.32.4
-                {{- if .Values.extensions.imageRepository }}
-                  imageRepository: {{ .Values.extensions.imageRepository }}
+                {{- if $global.registry }}
+                  imageRepository: {{ $global.registry }}
                 {{- end }}
             - name: azuredisk-csi-driver
               namespace: kube-system
+              {{- if $global.registry }}
+              chartname: oci://{{ $global.registry}}/charts/azuredisk-csi-driver
+              {{- else }}
               chartname: azuredisk-csi-driver/azuredisk-csi-driver
+              {{- end }}
               version: 1.30.3
               order: 2
               values: |
-                {{- if .Values.extensions.imageRepository }}
+                {{- if $global.registry }}
                 image:
-                  baseRepo: {{ .Values.extensions.imageRepository }}
+                  baseRepo: {{ $global.registry }}
                 {{- end }}
                 controller:
                   cloudConfigSecretName: azure-cloud-provider

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -74,7 +74,7 @@ spec:
                 cloudControllerManager:
                   cloudConfigSecretName: azure-cloud-provider
                   nodeSelector:
-                    node-role.kubernetes.io/control-plane: "true"
+                    node-role.kubernetes.io/control-plane: null
                   {{- if $global.registry }}
                   imageRepository: {{ $global.registry }}
                   {{- end }}

--- a/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
 metadata:
@@ -5,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      {{- if $global.k0sURL }}
+      downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -53,9 +53,3 @@ k0s:
   version: v1.32.3+k0s.0
   api:
     extraArgs: {}
-
-# extensions defines custom Helm and image repositories to use for pulling
-# k0s extensions.
-extensions:
-  chartRepository: ""
-  imageRepository: ""

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
 metadata:
@@ -6,6 +7,9 @@ spec:
   replicas: {{ .Values.controlPlaneNumber }}
   version: {{ .Values.k0s.version }}
   k0sConfigSpec:
+    {{- if $global.k0sURL }}
+    downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+    {{- end }}
     args:
       - --enable-worker
       - --enable-cloud-provider
@@ -27,25 +31,41 @@ spec:
           provider: calico
           calico:
             mode: vxlan
+        {{- if $global.registry }}
+        images:
+          metricsserver:
+            image: "{{ $global.registry}}/k0sproject/metrics-server"
+          kubeproxy:
+            image: "{{ $global.registry}}/k0sproject/kube-proxy"
+          coredns:
+            image: "{{ $global.registry}}/k0sproject/coredns"
+          pause:
+            image: "{{ $global.registry}}/k0sproject/pause"
+          calico:
+            cni:
+              image: "{{ $global.registry}}/k0sproject/calico-cni"
+            node:
+              image: "{{ $global.registry}}/k0sproject/calico-node"
+            kubecontrollers:
+              image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+        {{- end }}
         extensions:
           helm:
+            {{- if not $global.registry }}
             repositories:
               - name: mirantis
-                {{- if .Values.extensions.chartRepository }}
-                url: {{ .Values.extensions.chartRepository }}
-                {{- else }}
                 url: https://charts.mirantis.com
-                {{- end }}
               - name: azuredisk-csi-driver
-                {{- if .Values.extensions.chartRepository }}
-                url: {{ .Values.extensions.chartRepository }}
-                {{- else }}
                 url: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
-                {{- end }}
+            {{- end }}
             charts:
               - name: cloud-provider-azure
                 namespace: kube-system
+                {{- if $global.registry }}
+                chartname: oci://{{ $global.registry}}/charts/cloud-provider-azure
+                {{- else }}
                 chartname: mirantis/cloud-provider-azure
+                {{- end }}
                 version: 1.31.2
                 order: 1
                 values: |
@@ -53,24 +73,28 @@ spec:
                     cloudConfigSecretName: azure-cloud-provider
                     nodeSelector:
                       node-role.kubernetes.io/control-plane: "true"
-                    {{- if .Values.extensions.imageRepository }}
-                    imageRepository: {{ .Values.extensions.imageRepository }}
+                    {{- if $global.registry }}
+                    imageRepository: {{ $global.registry }}
                     {{- end }}
                     imageTag: v1.32.4
                   cloudNodeManager:
                     imageTag: v1.32.4
-                  {{- if .Values.extensions.imageRepository }}
-                    imageRepository: {{ .Values.extensions.imageRepository }}
+                  {{- if $global.registry }}
+                    imageRepository: {{ $global.registry }}
                   {{- end }}
               - name: azuredisk-csi-driver
                 namespace: kube-system
+                {{- if $global.registry }}
+                chartname: oci://{{ $global.registry}}/charts/azuredisk-csi-driver
+                {{- else }}
                 chartname: azuredisk-csi-driver/azuredisk-csi-driver
+                {{- end }}
                 version: 1.30.3
                 order: 2
                 values: |
-                  {{- if .Values.extensions.imageRepository }}
+                  {{- if $global.registry }}
                   image:
-                    baseRepo: {{ .Values.extensions.imageRepository }}
+                    baseRepo: {{ $global.registry }}
                   {{- end }}
                   controller:
                     cloudConfigSecretName: azure-cloud-provider

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
 metadata:
@@ -5,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      {{- if $global.k0sURL }}
+      downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/azure-standalone-cp/values.yaml
+++ b/templates/cluster/azure-standalone-cp/values.yaml
@@ -51,9 +51,3 @@ k0s:
   version: v1.32.3+k0s.0
   api:
     extraArgs: {}
-
-# extensions defines custom Helm and image repositories to use for pulling
-# k0s extensions.
-extensions:
-  chartRepository: ""
-  imageRepository: ""

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-gke/Chart.yaml
+++ b/templates/cluster/gcp-gke/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 1.0.0
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0smotronControlPlane
 metadata:
@@ -8,6 +9,11 @@ spec:
   {{- with .Values.k0smotron.service }}
   service:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if $global.registry }}
+  image: {{ $global.registry }}/k0s
+  etcd:
+    image: "{{ $global.registry }}/etcd:v3.5.13"
   {{- end }}
   controllerPlaneFlags:
   - "--enable-cloud-provider=true"
@@ -27,19 +33,39 @@ spec:
         provider: calico
         calico:
           mode: vxlan
+      {{- if $global.registry }}
+      images:
+        metricsserver:
+          image: "{{ $global.registry}}/k0sproject/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry}}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry}}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry}}/k0sproject/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry}}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry}}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+      {{- end }}
       extensions:
         helm:
+          {{- if not $global.registry }}
           repositories:
             - name: mirantis
-              {{- if .Values.extensions.chartRepository }}
-              url: {{ .Values.extensions.chartRepository }}
-              {{- else }}
               url: https://charts.mirantis.com
-              {{- end }}
+          {{- end }}
           charts:
             - name: gcp-cloud-controller-manager
               namespace: kube-system
+              {{- if $global.registry }}
+              chartname: oci://{{ $global.registry}}/charts/gcp-cloud-controller-manager
+              {{- else }}
               chartname: mirantis/gcp-cloud-controller-manager
+              {{- end }}
               version: "0.0.1"
               values: |
                 cloudConfig:
@@ -50,13 +76,17 @@ spec:
                   secretKey: cloud-sa.json
                 clusterCIDR: {{ first .Values.clusterNetwork.pods.cidrBlocks }}
                 image:
-                  {{- if .Values.extensions.imageRepository }}
-                  repository: {{ .Values.extensions.imageRepository }}/cloud-controller-manager
+                  {{- if $global.registry }}
+                  repository: {{ $global.registry }}/k8s-staging-cloud-provider-gcp/cloud-controller-manager
                   {{- end }}
                   tag: v32.2.3
             - name: gcp-compute-persistent-disk-csi-driver
               namespace: kube-system
+              {{- if $global.registry }}
+              chartname: oci://{{ $global.registry}}/charts/gcp-compute-persistent-disk-csi-driver
+              {{- else }}
               chartname: mirantis/gcp-compute-persistent-disk-csi-driver
+              {{- end }}
               version: "0.0.2"
               values: |
                 cloudCredentials:
@@ -70,27 +100,27 @@ spec:
                     enabled: false
                 defaultStorageClass:
                   enabled: true
-                {{- if .Values.extensions.imageRepository }}
+                  {{- if $global.registry }}
                 controller:
                   provisioner:
                     image:
-                      repository: {{ .Values.extensions.imageRepository }}/csi-provisioner
+                      repository: {{ $global.registry }}/sig-storage/csi-provisioner
                   attacher:
                     image:
-                      repository: {{ .Values.extensions.imageRepository }}/csi-attacher
+                      repository: {{ $global.registry }}/sig-storage/csi-attacher
                   resizer:
                     image:
-                      repository: {{ .Values.extensions.imageRepository }}/csi-resizer
+                      repository: {{ $global.registry }}/sig-storage/csi-resizer
                   snapshotter:
                     image:
-                      repository: {{ .Values.extensions.imageRepository }}/csi-snapshotter
+                      repository: {{ $global.registry }}/sig-storage/csi-snapshotter
                   driver:
                     image:
-                      repository: {{ .Values.extensions.imageRepository }}/csi-gcp-compute-persistent-disk-csi-driver
+                      repository: {{ $global.registry }}/cloud-provider-gcp/csi-gcp-compute-persistent-disk-csi-driver
                 node:
                   registrar:
-                    repository: {{ .Values.extensions.imageRepository }}/csi-node-driver-registrar
+                    repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
                   driver:
                     image:
-                      repository: {{ .Values.extensions.imageRepository }}/csi-gcp-compute-persistent-disk-csi-driver
+                      repository: {{ $global.registry }}/cloud-provider-gcp/csi-gcp-compute-persistent-disk-csi-driver
                 {{- end }}

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
 metadata:
@@ -5,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      {{- if $global.k0sURL }}
+      downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -56,9 +56,3 @@ k0s: # @schema description: K0s parameters; type: object
   version: v1.32.3+k0s.0 # @schema description: K0s version; type: string
   api: # @schema description: Kubernetes API server parameters; type: object; additionalProperties: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
-
-# extensions defines custom Helm and image repositories to use for pulling
-# k0s extensions.
-extensions: # @schema description: Defines custom Helm and image repositories to use for pulling k0s extensions; type: object
-  chartRepository: "" # @schema description: Custom Helm repository; type: string
-  imageRepository: "" # @schema description: Custom images' repository; type: string

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
 metadata:
@@ -6,6 +7,9 @@ spec:
   replicas: {{ .Values.controlPlaneNumber }}
   version: {{ .Values.k0s.version }}
   k0sConfigSpec:
+    {{- if $global.k0sURL }}
+    downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+    {{- end }}
     args:
       - --enable-worker
       - --enable-cloud-provider
@@ -27,19 +31,39 @@ spec:
           provider: calico
           calico:
             mode: ipip
+        {{- if $global.registry }}
+        images:
+          metricsserver:
+            image: "{{ $global.registry}}/k0sproject/metrics-server"
+          kubeproxy:
+            image: "{{ $global.registry}}/k0sproject/kube-proxy"
+          coredns:
+            image: "{{ $global.registry}}/k0sproject/coredns"
+          pause:
+            image: "{{ $global.registry}}/k0sproject/pause"
+          calico:
+            cni:
+              image: "{{ $global.registry}}/k0sproject/calico-cni"
+            node:
+              image: "{{ $global.registry}}/k0sproject/calico-node"
+            kubecontrollers:
+              image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+        {{- end }}
         extensions:
           helm:
+            {{- if not $global.registry }}
             repositories:
               - name: mirantis
-                {{- if .Values.extensions.chartRepository }}
-                url: {{ .Values.extensions.chartRepository }}
-                {{- else }}
                 url: https://charts.mirantis.com
-                {{- end }}
+            {{- end }}
             charts:
               - name: gcp-cloud-controller-manager
                 namespace: kube-system
+                {{- if $global.registry }}
+                chartname: oci://{{ $global.registry}}/charts/gcp-cloud-controller-manager
+                {{- else }}
                 chartname: mirantis/gcp-cloud-controller-manager
+                {{- end }}
                 version: "0.0.1"
                 values: |
                   cloudConfig:
@@ -52,13 +76,17 @@ spec:
                     secretKey: cloud-sa.json
                   clusterCIDR: {{ first .Values.clusterNetwork.pods.cidrBlocks }}
                   image:
-                    {{- if .Values.extensions.imageRepository }}
-                    repository: {{ .Values.extensions.imageRepository }}/cloud-controller-manager
+                    {{- if $global.registry }}
+                    repository: {{ $global.registry }}/k8s-staging-cloud-provider-gcp/cloud-controller-manager
                     {{- end }}
                     tag: v32.2.3
               - name: gcp-compute-persistent-disk-csi-driver
                 namespace: kube-system
+                {{- if $global.registry }}
+                chartname: oci://{{ $global.registry}}/charts/gcp-compute-persistent-disk-csi-driver
+                {{- else }}
                 chartname: mirantis/gcp-compute-persistent-disk-csi-driver
+                {{- end }}
                 version: "0.0.2"
                 values: |
                   cloudCredentials:
@@ -72,29 +100,29 @@ spec:
                       enabled: false
                   defaultStorageClass:
                     enabled: true
-                  {{- if .Values.extensions.imageRepository }}
+                  {{- if $global.registry }}
                   controller:
                     provisioner:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}/csi-provisioner
+                        repository: {{ $global.registry }}/sig-storage/csi-provisioner
                     attacher:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}/csi-attacher
+                        repository: {{ $global.registry }}/sig-storage/csi-attacher
                     resizer:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}/csi-resizer
+                        repository: {{ $global.registry }}/sig-storage/csi-resizer
                     snapshotter:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}/csi-snapshotter
+                        repository: {{ $global.registry }}/sig-storage/csi-snapshotter
                     driver:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}/csi-gcp-compute-persistent-disk-csi-driver
+                        repository: {{ $global.registry }}/cloud-provider-gcp/csi-gcp-compute-persistent-disk-csi-driver
                   node:
                     registrar:
-                      repository: {{ .Values.extensions.imageRepository }}/csi-node-driver-registrar
+                      repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
                     driver:
                       image:
-                        repository: {{ .Values.extensions.imageRepository }}/csi-gcp-compute-persistent-disk-csi-driver
+                        repository: {{ $global.registry }}/cloud-provider-gcp/csi-gcp-compute-persistent-disk-csi-driver
                   {{- end }}
   machineTemplate:
     infrastructureRef:

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
 metadata:
@@ -5,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      {{- if $global.k0sURL }}
+      downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/gcp-standalone-cp/values.yaml
+++ b/templates/cluster/gcp-standalone-cp/values.yaml
@@ -66,9 +66,3 @@ k0s: # @schema description: K0s parameters; type: object
   version: v1.32.3+k0s.0 # @schema description: K0s version; type: string
   api: # @schema description: Kubernetes API server parameters; type: object; additionalProperties: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
-
-# extensions defines custom Helm and image repositories to use for pulling
-# k0s extensions.
-extensions: # @schema description: Defines custom Helm and image repositories to use for pulling k0s extensions; type: object
-  chartRepository: "" # @schema description: Custom Helm repository; type: string
-  imageRepository: "" # @schema description: Custom images' repository; type: string

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,9 +1,15 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
 metadata:
   name: {{ include "k0scontrolplane.name" . }}
 spec:
+  replicas: {{ .Values.controlPlaneNumber }}
+  version: {{ .Values.k0s.version }}
   k0sConfigSpec:
+    {{- if $global.k0sURL }}
+    downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+    {{- end }}
     args:
       - --enable-worker
       - --enable-cloud-provider
@@ -21,18 +27,50 @@ spec:
             {{- with .Values.k0s.api.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+        network:
+          provider: calico
+          calico:
+            mode: vxlan
+        {{- if $global.registry }}
+        images:
+          metricsserver:
+            image: "{{ $global.registry}}/k0sproject/metrics-server"
+          kubeproxy:
+            image: "{{ $global.registry}}/k0sproject/kube-proxy"
+          coredns:
+            image: "{{ $global.registry}}/k0sproject/coredns"
+          pause:
+            image: "{{ $global.registry}}/k0sproject/pause"
+          calico:
+            cni:
+              image: "{{ $global.registry}}/k0sproject/calico-cni"
+            node:
+              image: "{{ $global.registry}}/k0sproject/calico-node"
+            kubecontrollers:
+              image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+        {{- end }}
         extensions:
           helm:
+            {{- if not $global.registry }}
             repositories:
               - name: openstack
                 url: https://kubernetes.github.io/cloud-provider-openstack/
-            charts: 
+            {{- end }}
+            charts:
               - name: openstack-ccm
+                {{- if $global.registry }}
+                chartname: oci://{{ $global.registry}}/charts/openstack-cloud-controller-manager
+                {{- else }}
                 chartname: openstack/openstack-cloud-controller-manager
+                {{- end }}
                 version: 2.31.1
                 order: 1
                 namespace: kube-system
                 values: |
+                  {{- if $global.registry }}
+                  image:
+                    repository: {{ $global.registry}}/provider-os/openstack-cloud-controller-manager
+                  {{- end }}
                   secret:
                     enabled: true
                     name: openstack-cloud-config
@@ -51,7 +89,11 @@ spec:
                     - name: OS_CCM_REGIONAL
                       value: {{ .Values.ccmRegional | quote }}
               - name: openstack-csi
+                {{- if $global.registry }}
+                chartname: oci://{{ $global.registry}}/charts/openstack-cinder-csi
+                {{- else }}
                 chartname: openstack/openstack-cinder-csi
+                {{- end }}
                 version: 2.31.2
                 order: 2
                 namespace: kube-system
@@ -69,18 +111,36 @@ spec:
                     name: openstack-cloud-config
                     create: false
                   csi:
+                    {{- if $global.registry }}
+                    attacher
+                      image:
+                        repository: {{ $global.registry}}/sig-storage/csi-attacher
+                    provisioner:
+                      image:
+                        repository: {{ $global.registry}}/sig-storage/csi-provisioner
+                    snapshotter:
+                      image:
+                        repository: {{ $global.registry}}/sig-storage/csi-snapshotter
+                    resizer:
+                      image:
+                        repository: {{ $global.registry}}/sig-storage/csi-resizer
+                    livenessprobe:
+                      image:
+                        repository: {{ $global.registry}}/sig-storage/livenessprobe
+                    nodeDriverRegistrar:
+                      image:
+                        repository: {{ $global.registry}}/sig-storage/csi-node-driver-registrar
+                    {{- end }}
                     plugin:
+                      {{- if $global.registry }}
+                      image:
+                        repository: {{ $global.registry}}/provider-os/cinder-csi-plugin
+                      {{- end }}
                       nodePlugin:
                         kubeletDir: /var/lib/k0s/kubelet
-        network:
-          provider: calico
-          calico:
-            mode: vxlan
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OpenStackMachineTemplate
       name: {{ include "openstackmachinetemplate.controlplane.name" . }}
       namespace: {{ .Release.Namespace }}
-  replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version }}

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
 metadata:
@@ -5,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      {{- if $global.k0sURL }}
+      downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+      {{- end }}
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -79,3 +79,4 @@ k0s:
   version: v1.32.3+k0s.0
   api:
     extraArgs: {}
+

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0smotronControlPlane
 metadata:
@@ -13,6 +14,11 @@ spec:
   service:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if $global.registry }}
+  image: {{ $global.registry }}/k0s
+  etcd:
+    image: "{{ $global.registry }}/etcd:v3.5.13"
+  {{- end }}
   k0sConfig:
     apiVersion: k0s.k0sproject.io/v1beta1
     kind: ClusterConfig
@@ -27,6 +33,24 @@ spec:
       {{- with .Values.k0s.network }}
       network:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if $global.registry }}
+      images:
+        metricsserver:
+          image: "{{ $global.registry}}/k0sproject/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry}}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry}}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry}}/k0sproject/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry}}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry}}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 {{- range $index, $machine := .Values.machines }}
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Machine
@@ -25,6 +26,9 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   version: {{ $.Values.k0s.version }}
+  {{- if $global.k0sURL }}
+  downloadURL: "{{ $global.k0sURL }}/k0s-{{ $.Values.k0s.version }}-amd64"
+  {{- end }}
   {{- if and $machine.k0s $machine.k0s.args }}
   args:
     {{- toYaml $machine.k0s.args | nindent 4 }}

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0smotronControlPlane
 metadata:
@@ -8,6 +9,11 @@ spec:
   {{- with .Values.k0smotron.service }}
   service:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if $global.registry }}
+  image: {{ $global.registry }}/k0s
+  etcd:
+    image: "{{ $global.registry }}/etcd:v3.5.13"
   {{- end }}
   controllerPlaneFlags:
   - "--enable-cloud-provider=true"
@@ -27,24 +33,40 @@ spec:
         provider: calico
         calico:
           mode: vxlan
+      {{- if $global.registry }}
+      images:
+        metricsserver:
+          image: "{{ $global.registry}}/k0sproject/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry}}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry}}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry}}/k0sproject/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry}}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry}}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+      {{- end }}
       extensions:
         helm:
+          {{- if not $global.registry }}
           repositories:
-          - name: vsphere-cpi
-            {{- if .Values.extensions.chartRepository }}
-            url: {{ .Values.extensions.chartRepository }}
-            {{- else }}
-            url: https://kubernetes.github.io/cloud-provider-vsphere
-            {{- end }}
-          - name: mirantis
-            {{- if .Values.extensions.chartRepository }}
-            url: {{ .Values.extensions.chartRepository }}
-            {{- else }}
-            url: https://charts.mirantis.com
-            {{- end }}
+            - name: vsphere-cpi
+              url: https://kubernetes.github.io/cloud-provider-vsphere
+            - name: mirantis
+              url: https://charts.mirantis.com
+          {{- end }}
           charts:
           - name: vsphere-cpi
+            {{- if $global.registry }}
+            chartname: oci://{{ $global.registry}}/charts/vsphere-cpi
+            {{- else }}
             chartname: vsphere-cpi/vsphere-cpi
+            {{- end }}
             version: 1.31.0
             order: 1
             namespace: kube-system
@@ -53,8 +75,8 @@ spec:
                 enabled: false
               daemonset:
                 affinity: null
-                {{- if .Values.extensions.imageRepository }}
-                image: {{ .Values.extensions.imageRepository }}/cloud-provider-vsphere
+                {{- if $global.registry }}
+                image: {{ $global.registry }}/cloud-pv-vsphere/cloud-provider-vsphere
                 {{- end }}
                 tolerations:
                   - effect: NoSchedule
@@ -73,8 +95,12 @@ spec:
                     effect: NoExecute
                     operator: Exists
           - name: vsphere-csi-driver
+            {{- if $global.registry }}
+            chartname: oci://{{ $global.registry}}/charts/vsphere-csi-driver
+            {{- else }}
             chartname: mirantis/vsphere-csi-driver
-            version: 0.0.2
+            {{- end }}
+            version: 0.0.3
             order: 2
             namespace: kube-system
             values: |
@@ -87,27 +113,27 @@ spec:
               defaultStorageClass:
                 enabled: true
               images:
-                driver:
-                  {{- if .Values.extensions.imageRepository }}
-                  repo: {{ .Values.extensions.imageRepository }}/csi-vsphere/driver
-                  {{- end }}
-                  tag: v3.1.2
-                syncer:
-                  {{- if .Values.extensions.imageRepository }}
-                  repo: {{ .Values.extensions.imageRepository }}/csi-vsphere/syncer
-                  {{- end }}
-                  tag: v3.1.2
-                {{- if .Values.extensions.imageRepository }}
-                nodeDriverRegistrar:
-                  repo: {{ .Values.extensions.imageRepository }}/sig-storage/csi-node-driver-registrar
-                csiAttacher:
-                  repo: {{ .Values.extensions.imageRepository }}/sig-storage/csi-attacher
-                csiResizer:
-                  repo: {{ .Values.extensions.imageRepository }}/sig-storage/csi-resizer
-                csiProvisioner:
-                  repo: {{ .Values.extensions.imageRepository }}/sig-storage/csi-provisioner
-                csiSnapshotter:
-                  repo: {{ .Values.extensions.imageRepository }}/sig-storage/csi-snapshotter
-                livenessProbe:
-                  repo: {{ .Values.extensions.imageRepository }}/csi-vsphere/livenessprobe
-                {{- end }}
+               driver:
+                 {{- if $global.registry }}
+                 repo: {{ $global.registry }}/csi-vsphere/driver
+                 {{- end }}
+                 tag: v3.1.2
+               syncer:
+                 {{- if $global.registry }}
+                 repo: {{ $global.registry }}/csi-vsphere/syncer
+                 {{- end }}
+                 tag: v3.1.2
+               {{- if $global.registry }}
+               nodeDriverRegistrar:
+                 repo: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
+               csiAttacher:
+                 repo: {{ $global.registry }}/sig-storage/csi-attacher
+               csiResizer:
+                 repo: {{ $global.registry }}/sig-storage/csi-resizer
+               csiProvisioner:
+                 repo: {{ $global.registry }}/sig-storage/csi-provisioner
+               csiSnapshotter:
+                 repo: {{ $global.registry }}/sig-storage/csi-snapshotter
+               livenessProbe:
+                 repo: {{ $global.registry }}/sig-storage/livenessprobe
+               {{- end }}

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -113,27 +113,27 @@ spec:
               defaultStorageClass:
                 enabled: true
               images:
-               driver:
-                 {{- if $global.registry }}
-                 repo: {{ $global.registry }}/csi-vsphere/driver
-                 {{- end }}
-                 tag: v3.1.2
-               syncer:
-                 {{- if $global.registry }}
-                 repo: {{ $global.registry }}/csi-vsphere/syncer
-                 {{- end }}
-                 tag: v3.1.2
-               {{- if $global.registry }}
-               nodeDriverRegistrar:
-                 repo: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
-               csiAttacher:
-                 repo: {{ $global.registry }}/sig-storage/csi-attacher
-               csiResizer:
-                 repo: {{ $global.registry }}/sig-storage/csi-resizer
-               csiProvisioner:
-                 repo: {{ $global.registry }}/sig-storage/csi-provisioner
-               csiSnapshotter:
-                 repo: {{ $global.registry }}/sig-storage/csi-snapshotter
-               livenessProbe:
-                 repo: {{ $global.registry }}/sig-storage/livenessprobe
-               {{- end }}
+                driver:
+                  {{- if $global.registry }}
+                  repo: {{ $global.registry }}/csi-vsphere/driver
+                  {{- end }}
+                  tag: v3.1.2
+                syncer:
+                  {{- if $global.registry }}
+                  repo: {{ $global.registry }}/csi-vsphere/syncer
+                  {{- end }}
+                  tag: v3.1.2
+                {{- if $global.registry }}
+                nodeDriverRegistrar:
+                  repo: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
+                csiAttacher:
+                  repo: {{ $global.registry }}/sig-storage/csi-attacher
+                csiResizer:
+                  repo: {{ $global.registry }}/sig-storage/csi-resizer
+                csiProvisioner:
+                  repo: {{ $global.registry }}/sig-storage/csi-provisioner
+                csiSnapshotter:
+                  repo: {{ $global.registry }}/sig-storage/csi-snapshotter
+                livenessProbe:
+                  repo: {{ $global.registry }}/sig-storage/livenessprobe
+                {{- end }}

--- a/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
 metadata:
@@ -5,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      {{- if $global.k0sURL }}
+      downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       files:
         - path: /home/{{ .Values.ssh.user }}/.ssh/authorized_keys

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -47,9 +47,3 @@ k0s:
   version: v1.32.3+k0s.0
   api:
     extraArgs: {}
-
-# extensions defines custom Helm and image repositories to use for pulling
-# k0s extensions.
-extensions:
-  chartRepository: ""
-  imageRepository: ""

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0sControlPlane
 metadata:
@@ -6,6 +7,9 @@ spec:
   replicas: {{ .Values.controlPlaneNumber }}
   version: {{ .Values.k0s.version }}
   k0sConfigSpec:
+    {{- if $global.k0sURL }}
+    downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+    {{- end }}
     files:
       - path: /home/{{ .Values.controlPlane.ssh.user }}/.ssh/authorized_keys
         permissions: "0600"
@@ -34,8 +38,27 @@ spec:
           provider: calico
           calico:
             mode: vxlan
+        {{- if $global.registry }}
+        images:
+          metricsserver:
+            image: "{{ $global.registry}}/k0sproject/metrics-server"
+          kubeproxy:
+            image: "{{ $global.registry}}/k0sproject/kube-proxy"
+          coredns:
+            image: "{{ $global.registry}}/k0sproject/coredns"
+          pause:
+            image: "{{ $global.registry}}/k0sproject/pause"
+          calico:
+            cni:
+              image: "{{ $global.registry}}/k0sproject/calico-cni"
+            node:
+              image: "{{ $global.registry}}/k0sproject/calico-node"
+            kubecontrollers:
+              image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+        {{- end }}
         extensions:
           helm:
+            {{- if not $global.registry }}
             repositories:
             - name: kube-vip
               url: https://kube-vip.github.io/helm-charts
@@ -43,16 +66,21 @@ spec:
               url: https://kubernetes.github.io/cloud-provider-vsphere
             - name: mirantis
               url: https://charts.mirantis.com
+            {{- end }}
             charts:
             - name: kube-vip
+              {{- if $global.registry }}
+              chartname: oci://{{ $global.registry}}/charts/kube-vip
+              {{- else }}
               chartname: kube-vip/kube-vip
+              {{- end }}
               version: 0.6.1
               order: 1
               namespace: kube-system
               values: |
-                {{- if .Values.extensions.imageRepository }}
+                {{- if $global.registry }}
                 image:
-                  repository: {{ .Values.extensions.imageRepository }}/kube-vip
+                  repository: {{ $global.registry }}/kube-vip
                 {{- end }}
                 config:
                   address: {{ .Values.controlPlaneEndpointIP }}
@@ -73,7 +101,11 @@ spec:
                     key: node.cloudprovider.kubernetes.io/uninitialized
                     value: "true"
             - name: vsphere-cpi
+              {{- if $global.registry }}
+              chartname: oci://{{ $global.registry}}/charts/vsphere-cpi
+              {{- else }}
               chartname: vsphere-cpi/vsphere-cpi
+              {{- end }}
               version: 1.31.0
               order: 2
               namespace: kube-system
@@ -81,8 +113,8 @@ spec:
                 config:
                   enabled: false
                 daemonset:
-                  {{- if .Values.extensions.imageRepository }}
-                  image: {{ .Values.extensions.imageRepository }}/cloud-provider-vsphere
+                  {{- if $global.registry }}
+                  image: {{ $global.registry }}/cloud-pv-vsphere/cloud-provider-vsphere
                   {{- end }}
                   tolerations:
                     - effect: NoSchedule
@@ -101,8 +133,12 @@ spec:
                       effect: NoExecute
                       operator: Exists
             - name: vsphere-csi-driver
+              {{- if $global.registry }}
+              chartname: oci://{{ $global.registry}}/charts/vsphere-csi-driver
+              {{- else }}
               chartname: mirantis/vsphere-csi-driver
-              version: 0.0.2
+              {{- end }}
+              version: 0.0.3
               order: 3
               namespace: kube-system
               values: |
@@ -114,28 +150,28 @@ spec:
                   enabled: true
                 images:
                   driver:
-                    {{- if .Values.extensions.imageRepository }}
-                    repo: {{ .Values.extensions.imageRepository }}/csi-vsphere/driver
+                    {{- if $global.registry }}
+                    repo: {{ $global.registry }}/csi-vsphere/driver
                     {{- end }}
                     tag: v3.1.2
                   syncer:
-                    {{- if .Values.extensions.imageRepository }}
-                    repo: {{ .Values.extensions.imageRepository }}/csi-vsphere/syncer
+                    {{- if $global.registry }}
+                    repo: {{ $global.registry }}/csi-vsphere/syncer
                     {{- end }}
                     tag: v3.1.2
-                  {{- if .Values.extensions.imageRepository }}
+                  {{- if $global.registry }}
                   nodeDriverRegistrar:
-                    repo: {{ .Values.extensions.imageRepository }}/sig-storage/csi-node-driver-registrar
+                    repo: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
                   csiAttacher:
-                    repo: {{ .Values.extensions.imageRepository }}/sig-storage/csi-attacher
+                    repo: {{ $global.registry }}/sig-storage/csi-attacher
                   csiResizer:
-                    repo: {{ .Values.extensions.imageRepository }}/sig-storage/csi-resizer
+                    repo: {{ $global.registry }}/sig-storage/csi-resizer
                   csiProvisioner:
-                    repo: {{ .Values.extensions.imageRepository }}/sig-storage/csi-provisioner
+                    repo: {{ $global.registry }}/sig-storage/csi-provisioner
                   csiSnapshotter:
-                    repo: {{ .Values.extensions.imageRepository }}/sig-storage/csi-snapshotter
+                    repo: {{ $global.registry }}/sig-storage/csi-snapshotter
                   livenessProbe:
-                    repo: {{ .Values.extensions.imageRepository }}/csi-vsphere/livenessprobe
+                    repo: {{ $global.registry }}/sig-storage/livenessprobe
                   {{- end }}
   machineTemplate:
     infrastructureRef:

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
 metadata:
@@ -5,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      {{- if $global.k0sURL }}
+      downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       files:
         - path: /home/{{ .Values.worker.ssh.user }}/.ssh/authorized_keys

--- a/templates/cluster/vsphere-standalone-cp/values.yaml
+++ b/templates/cluster/vsphere-standalone-cp/values.yaml
@@ -59,9 +59,3 @@ k0s:
   version: v1.32.3+k0s.0
   api:
     extraArgs: {}
-
-# extensions defines custom Helm and image repositories to use for pulling
-# k0s extensions.
-extensions:
-  chartRepository: ""
-  imageRepository: ""

--- a/templates/provider/cluster-api-provider-aws/Chart.yaml
+++ b/templates/provider/cluster-api-provider-aws/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-aws/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-aws/templates/provider.yaml
@@ -1,12 +1,22 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := "v2.8.2" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: aws
 spec:
-  version: v2.8.2
+  version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
   manager: {{ include "spec.manager" . | nindent 4 }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-provider-aws-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/cluster-api-aws-controller:{{ $version }}
+  {{- end }}

--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-azure/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-azure/templates/provider.yaml
@@ -1,15 +1,25 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := "v1.19.4" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: azure
 spec:
-  version: v1.19.4
+  version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
   manager: {{- toYaml .Values.manager | nindent 4 }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-provider-azure-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/cluster-api-azure-controller:{{ $version }}
+  {{- end }}
   manifestPatches:
     - |
       apiVersion: v1

--- a/templates/provider/cluster-api-provider-docker/Chart.yaml
+++ b/templates/provider/cluster-api-provider-docker/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-docker/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-docker/templates/provider.yaml
@@ -1,12 +1,22 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := "v1.9.6" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: docker
 spec:
-  version: v1.9.6
+  version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
   manager: {{- toYaml .Values.manager | nindent 4 }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-provider-docker-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/capd-manager:{{ $version }}
+  {{- end }}

--- a/templates/provider/cluster-api-provider-gcp/Chart.yaml
+++ b/templates/provider/cluster-api-provider-gcp/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-gcp/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-gcp/templates/provider.yaml
@@ -1,13 +1,22 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := "v1.8.1" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: gcp
 spec:
-  version: v1.8.1
+  version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
   manager: {{ include "spec.manager" . | nindent 4 }}
-
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-provider-gcp-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/cluster-api-gcp-controller:{{ $version }}
+  {{- end }}

--- a/templates/provider/cluster-api-provider-infoblox/Chart.yaml
+++ b/templates/provider/cluster-api-provider-infoblox/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-infoblox/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-infoblox/templates/provider.yaml
@@ -1,8 +1,19 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := "v0.1.0-alpha.8" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: IPAMProvider
 metadata:
   name: infoblox
 spec:
-  version: v0.1.0-alpha.8
+  version: {{ $version }}
+  {{- if $global.registry }}
   fetchConfig:
-    url:  https://github.com/telekom/cluster-api-ipam-provider-infoblox/releases/download/v0.1.0-alpha.8/ipam-components.yaml
+    oci: {{ $global.registry }}/capi/cluster-api-ipam-infoblox-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/cluster-api-ipam-provider-infoblox:{{ $version }}
+  {{- else }}
+  fetchConfig:
+    url: https://github.com/telekom/cluster-api-ipam-provider-infoblox/releases/download/{{ $version }}/ipam-components.yaml
+  {{- end }}

--- a/templates/provider/cluster-api-provider-ipam/Chart.yaml
+++ b/templates/provider/cluster-api-provider-ipam/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-ipam/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-ipam/templates/provider.yaml
@@ -1,6 +1,16 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := "v1.0.0" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: IPAMProvider
 metadata:
   name: in-cluster
 spec:
-  version: v1.0.0
+  version: {{ $version }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-ipam-in-cluster-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/cluster-api-ipam-in-cluster-controller:{{ $version }}
+  {{- end }}

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/providers.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/providers.yaml
@@ -1,13 +1,23 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := "v1.5.2" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: k0sproject-k0smotron
 spec:
-  version: v1.5.2
+  version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  {{- end }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-provider-k0sproject-k0smotron-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/k0smotron:{{ $version }}
   {{- end }}
 ---
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -15,11 +25,19 @@ kind: BootstrapProvider
 metadata:
   name: k0sproject-k0smotron
 spec:
-  version: v1.5.2
+  version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  {{- end }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-provider-k0sproject-k0smotron-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/k0smotron:{{ $version }}
   {{- end }}
 ---
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
@@ -27,9 +45,17 @@ kind: ControlPlaneProvider
 metadata:
   name: k0sproject-k0smotron
 spec:
-  version: v1.5.2
+  version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  {{- end }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-provider-k0sproject-k0smotron-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/k0smotron:{{ $version }}
   {{- end }}

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
@@ -1,12 +1,22 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := "v0.12.3" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: openstack
 spec:
-  version: v0.12.3
+  version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
   manager: {{- toYaml .Values.manager | nindent 4 }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-provider-openstack-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/capi-openstack-controller:{{ $version }}
+  {{- end }}

--- a/templates/provider/cluster-api-provider-vsphere/Chart.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-vsphere/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/templates/provider.yaml
@@ -1,12 +1,22 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := "v1.13.0" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:
   name: vsphere
 spec:
-  version: v1.13.0
+  version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
   manager: {{- toYaml .Values.manager | nindent 4 }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-provider-vsphere-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/cluster-api-vsphere-controller:{{ $version }}
+  {{- end }}

--- a/templates/provider/cluster-api/Chart.yaml
+++ b/templates/provider/cluster-api/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api/templates/provider.yaml
+++ b/templates/provider/cluster-api/templates/provider.yaml
@@ -1,12 +1,22 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := "v1.10.1" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: CoreProvider
 metadata:
   name: cluster-api
 spec:
-  version: v1.10.1
+  version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
     name: {{ .Values.configSecret.name }}
     namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
   {{- end }}
   manager: {{- toYaml .Values.manager | nindent 4 }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-components:{{ $version }}
+  deployment:
+    containers:
+      - name: manager
+        imageUrl: {{ $global.registry }}/capi/cluster-api-controller:{{ $version }}
+  {{- end }}

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -9,25 +9,25 @@ spec:
   kcm:
     template: kcm-1-0-0-rc1
   capi:
-    template: cluster-api-0-3-0
+    template: cluster-api-0-4-0
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
-      template: cluster-api-provider-k0sproject-k0smotron-0-3-0
+      template: cluster-api-provider-k0sproject-k0smotron-0-4-0
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-0-3-2
+      template: cluster-api-provider-azure-0-4-0
     - name: cluster-api-provider-vsphere
-      template: cluster-api-provider-vsphere-0-3-1
+      template: cluster-api-provider-vsphere-0-4-0
     - name: cluster-api-provider-aws
-      template: cluster-api-provider-aws-0-3-0
+      template: cluster-api-provider-aws-0-4-0
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-0-3-2
+      template: cluster-api-provider-openstack-0-4-0
     - name: cluster-api-provider-docker
-      template: cluster-api-provider-docker-0-3-0
+      template: cluster-api-provider-docker-0-4-0
     - name: cluster-api-provider-gcp
-      template: cluster-api-provider-gcp-0-3-0
+      template: cluster-api-provider-gcp-0-4-0
     - name: cluster-api-provider-ipam
-      template: cluster-api-provider-ipam-0-3-0
+      template: cluster-api-provider-ipam-0-4-0
     - name: cluster-api-provider-infoblox
-      template: cluster-api-provider-infoblox-0-3-0
+      template: cluster-api-provider-infoblox-0-4-0
     - name: projectsveltos
       template: projectsveltos-0-54-0

--- a/templates/provider/kcm-templates/files/templates/adopted-cluster-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/adopted-cluster-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-gke-0-2-0
+  name: adopted-cluster-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-gke
-      version: 0.2.0
+      chart: adopted-cluster
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-eks-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-0-3-0
+  name: aws-eks-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 0.3.0
+      chart: aws-eks
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-0-3-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-0-3-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-0-2-1
+  name: aws-hosted-cp-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 0.2.1
+      chart: aws-hosted-cp
+      version: 0.3.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: docker-hosted-cp-0-2-0
+  name: aws-hosted-cp-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: docker-hosted-cp
-      version: 0.2.0
+      chart: aws-hosted-cp
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-0-3-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-0-3-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-0-2-2
+  name: aws-standalone-cp-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 0.2.2
+      chart: aws-standalone-cp
+      version: 0.3.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-0-3-0
+  name: aws-standalone-cp-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 0.3.0
+      chart: aws-standalone-cp
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-aks-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-aks-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-0-3-0
+  name: azure-aks-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 0.3.0
+      chart: azure-aks
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-0-3-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-0-3-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-0-2-2
+  name: azure-hosted-cp-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: azure-hosted-cp
-      version: 0.2.2
+      version: 0.3.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-0-3-0
+  name: azure-hosted-cp-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 0.3.0
+      chart: azure-hosted-cp
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-0-3-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-0-3-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-0-2-1
+  name: azure-standalone-cp-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 0.2.1
+      chart: azure-standalone-cp
+      version: 0.3.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-0-3-0
+  name: azure-standalone-cp-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 0.3.0
+      chart: azure-standalone-cp
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-aws-0-3-0
+  name: cluster-api-provider-aws-0-4-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-aws
-      version: 0.3.0
+      version: 0.4.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-0-3-2
+  name: cluster-api-provider-azure-0-4-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-azure
-      version: 0.3.2
+      version: 0.4.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-docker-0-3-0
+  name: cluster-api-provider-docker-0-4-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-docker
-      version: 0.3.0
+      version: 0.4.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-gcp-0-3-0
+  name: cluster-api-provider-gcp-0-4-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-gcp
-      version: 0.3.0
+      version: 0.4.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-infoblox.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-infoblox.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-infoblox-0-3-0
+  name: cluster-api-provider-infoblox-0-4-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-infoblox
-      version: 0.3.0
+      version: 0.4.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-ipam.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-ipam.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-ipam-0-3-0
+  name: cluster-api-provider-ipam-0-4-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-ipam
-      version: 0.3.0
+      version: 0.4.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-k0sproject-k0smotron-0-3-0
+  name: cluster-api-provider-k0sproject-k0smotron-0-4-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-k0sproject-k0smotron
-      version: 0.3.0
+      version: 0.4.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-0-3-2
+  name: cluster-api-provider-openstack-0-4-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 0.3.2
+      version: 0.4.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-vsphere-0-3-1
+  name: cluster-api-provider-vsphere-0-4-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-vsphere
-      version: 0.3.1
+      version: 0.4.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-0-3-0
+  name: cluster-api-0-4-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api
-      version: 0.3.0
+      version: 0.4.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-0-3-0
+  name: docker-hosted-cp-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 0.3.0
+      chart: docker-hosted-cp
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-aks-0-2-0
+  name: gcp-gke-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-aks
-      version: 0.2.0
+      chart: gcp-gke
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-0-3-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-0-3-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-0-2-1
+  name: gcp-hosted-cp-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-hosted-cp
-      version: 0.2.1
+      version: 0.3.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: adopted-cluster-0-2-0
+  name: gcp-hosted-cp-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: adopted-cluster
-      version: 0.2.0
+      chart: gcp-hosted-cp
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-0-3-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-0-3-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-0-2-1
+  name: gcp-standalone-cp-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 0.2.1
+      chart: gcp-standalone-cp
+      version: 0.3.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-0-3-0
+  name: gcp-standalone-cp-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 0.3.0
+      chart: gcp-standalone-cp
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-3-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-0-3-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-0-2-1
+  name: openstack-standalone-cp-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 0.2.1
+      chart: openstack-standalone-cp
+      version: 0.3.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-0-3-0
+  name: openstack-standalone-cp-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 0.3.0
+      chart: openstack-standalone-cp
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-0-3-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-0-3-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-0-2-1
+  name: remote-cluster-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 0.2.1
+      chart: remote-cluster
+      version: 0.3.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-0-3-0
+  name: remote-cluster-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 0.3.0
+      chart: remote-cluster
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-0-3-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-0-3-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-0-2-1
+  name: vsphere-hosted-cp-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 0.2.1
+      chart: vsphere-hosted-cp
+      version: 0.3.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-eks-0-2-0
+  name: vsphere-hosted-cp-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-eks
-      version: 0.2.0
+      chart: vsphere-hosted-cp
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-0-3-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-0-3-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-0-2-2
+  name: vsphere-standalone-cp-0-3-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 0.2.2
+      chart: vsphere-standalone-cp
+      version: 0.3.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-0.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-0-3-0
+  name: vsphere-standalone-cp-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 0.3.0
+      chart: vsphere-standalone-cp
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Resolves #1502 

Tested installation and aws cluster creation with/without global values. All templates rendered via `helm template` and checked that all rendered correctly. If global values aren't set the template will behave exactly the same as before these changes.

I didn't touch templates where this makes no sense: managed Kubernetes (like EKS) clusters or adopted clusters.
