### PR TITLE
fix: Set configure-cloud-routes=false in gcp ccm parameters

### DIFF
--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-0
+  template: gcp-standalone-cp-1-0-1
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -80,6 +80,13 @@ spec:
                   repository: {{ $global.registry }}/k8s-staging-cloud-provider-gcp/cloud-controller-manager
                   {{- end }}
                   tag: v32.2.3
+                args:
+                  - --cloud-provider=gce
+                  - --leader-elect=true
+                  - --use-service-account-credentials=true
+                  - --allocate-node-cidrs=true
+                  - --configure-cloud-routes=false
+                  - --v=2
             - name: gcp-compute-persistent-disk-csi-driver
               namespace: kube-system
               {{- if $global.registry }}

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -80,6 +80,13 @@ spec:
                     repository: {{ $global.registry }}/k8s-staging-cloud-provider-gcp/cloud-controller-manager
                     {{- end }}
                     tag: v32.2.3
+                  args:
+                    - --cloud-provider=gce
+                    - --leader-elect=true
+                    - --use-service-account-credentials=true
+                    - --allocate-node-cidrs=true
+                    - --configure-cloud-routes=false
+                    - --v=2
               - name: gcp-compute-persistent-disk-csi-driver
                 namespace: kube-system
                 {{- if $global.registry }}

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-0
+  name: gcp-hosted-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.0
+      chart: gcp-hosted-cp
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-0
+  name: gcp-standalone-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.0
+      chart: gcp-standalone-cp
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
This PR configures the internal GCP CCM arguments with `--configure-cloud-routes=false` to fix an issue related to ClusterDeployment stuck deletion.

The fix prevents GCP CCM from creating `kubernetes-*` routes tied to VM instances which is redundant for our network setup.

Closes #1476
