### PR TITLE
chore: Bump CAPG to 1.9.0

### DIFF
--- a/config/dev/gke-clusterdeployment.yaml
+++ b/config/dev/gke-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-gke-1-0-0
+  template: gcp-gke-1-0-1
   credential: gcp-credential
   propagateCredentials: false
   config:

--- a/templates/cluster/gcp-gke/Chart.yaml
+++ b/templates/cluster/gcp-gke/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-gke/templates/gcpmanagedcontrolplane.yaml
+++ b/templates/cluster/gcp-gke/templates/gcpmanagedcontrolplane.yaml
@@ -9,6 +9,7 @@ metadata:
     # deletion to get stuck due to the missing cluster.
     helm.sh/resource-policy: keep
 spec:
+  version: {{ .Values.version }}
   gkeClusterName: {{ .Values.gkeClusterName }}
   project: {{ .Values.project }}
   location: {{ .Values.location | default .Values.region }}

--- a/templates/cluster/gcp-gke/values.schema.json
+++ b/templates/cluster/gcp-gke/values.schema.json
@@ -321,6 +321,12 @@
                 "string"
             ]
         },
+        "version": {
+            "description": "Version represents the version of the GKE control plane",
+            "type": [
+                "string"
+            ]
+        },
         "workersNumber": {
             "description": "The number of the worker nodes. Should be divisible by the number of zones in machines.nodeLocations. If nodeLocations is not specified, must be divisible by the number of zones in this region (default: 3)",
             "minimum": 1,

--- a/templates/cluster/gcp-gke/values.yaml
+++ b/templates/cluster/gcp-gke/values.yaml
@@ -51,3 +51,5 @@ machines: # @schema description: Managed machines' parameters; type: object
   management: # @schema description: The node pool management options; type: object
     autoUpgrade: true # @schema description: AutoUpgrade specifies whether node auto-upgrade is enabled for the node pool. If enabled, node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes; type: boolean
     autoRepair: false # @schema description: AutoRepair specifies whether the node auto-repair is enabled for the node pool. If enabled, the nodes in this node pool will be monitored and, if they fail health checks too many times, an automatic repair action will be triggered; type: boolean
+
+version: 1.32.3-gke.1927002 # @schema description: Version represents the version of the GKE control plane; type: string

--- a/templates/provider/cluster-api-provider-gcp/Chart.yaml
+++ b/templates/provider/cluster-api-provider-gcp/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.8.1"
+appVersion: "1.9.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/cluster-api-provider-gcp/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-gcp/templates/provider.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-{{- $version := "v1.8.1" }}
+{{- $version := "v1.9.0" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -24,7 +24,7 @@ spec:
     - name: cluster-api-provider-docker
       template: cluster-api-provider-docker-1-0-0
     - name: cluster-api-provider-gcp
-      template: cluster-api-provider-gcp-1-0-0
+      template: cluster-api-provider-gcp-1-0-1
     - name: cluster-api-provider-ipam
       template: cluster-api-provider-ipam-1-0-0
     - name: cluster-api-provider-infoblox

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-gcp-1-0-0
+  name: cluster-api-provider-gcp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-gcp
-      version: 1.0.0
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-gke-1-0-0
+  name: gcp-gke-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-gke
-      version: 1.0.0
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
This PR updates Cluster API Provider GCP to 1.9.0 and updates the `gcp-gke` cluster template to explicitly set the `spec.version` field in the `GCPManagedControlPlane` resource, as recommended in the [CAPG 1.9.0 release notes](https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/tag/v1.9.0).

Verification:
1. K0rdent upgrade from `1.0.0` to the latest version using an existing `1.0.0` GKE cluster completed successfully with no manual intervention required.
2. GKE cluster upgrade from gcp-gke `1.0.0` to `1.0.1` was verified with no issues.

Fixes #1542 
