### PR TITLE
fix: helm values for servicetemplates not showing in status.config

### DIFF
--- a/internal/controller/servicetemplate_controller.go
+++ b/internal/controller/servicetemplate_controller.go
@@ -87,9 +87,7 @@ func (r *ServiceTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}()
 
 	switch {
-	case serviceTemplate.HelmChartSpec() != nil:
-		fallthrough
-	case serviceTemplate.HelmChartRef() != nil:
+	case serviceTemplate.HelmChartSpec() != nil, serviceTemplate.HelmChartRef() != nil:
 		l.V(1).Info("reconciling helm chart")
 		return r.ReconcileTemplate(ctx, serviceTemplate)
 	case serviceTemplate.LocalSourceRef() != nil:


### PR DESCRIPTION
# Description

Fixes https://github.com/k0rdent/kcm/issues/1467.

This issue in ServiceTemplates installed from https://catalog.k0rdent.io happened because the helm charts for the services in catalog are actually wrappers for the actual app.

# Verification

Installed the ServiceTemplate `ingress-nginx-4-11-3` via the catalog:
```yaml
apiVersion: source.toolkit.fluxcd.io/v1
kind: HelmRepository
metadata:
  name: k0rdent-catalog
  namespace: kcm-system
  labels:
    k0rdent.mirantis.com/managed: "true"
spec:
  insecure: true
  interval: 10m0s
  provider: generic
  type: oci
  url: oci://ghcr.io/k0rdent/kcm/charts
---
apiVersion: k0rdent.mirantis.com/v1alpha1
kind: ServiceTemplate
metadata:
  name: ingress-nginx-4-11-3
  annotations:
    helm.sh/resource-policy: keep
spec:
  helm:
    chartSpec:
      chart: ingress-nginx
      version: 4.11.3
      interval: 10m0s
      sourceRef:
        kind: HelmRepository
        name: k0rdent-catalog
```

After reconciling, we can see that the default helm values are now showing up in `status.config`:
```yaml
apiVersion: k0rdent.mirantis.com/v1beta1
kind: ServiceTemplate
metadata:
  annotations:
    helm.sh/resource-policy: keep
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"k0rdent.mirantis.com/v1alpha1","kind":"ServiceTemplate","metadata":{"annotations":{"helm.sh/resource-policy":"keep"},"name":"ingress-nginx-4-11-3","namespace":"kcm-system"},"spec":{"helm":{"chartSpec":{"chart":"ingress-nginx","interval":"10m0s","sourceRef":{"kind":"HelmRepository","name":"k0rdent-catalog"},"version":"4.11.3"}}}}
  creationTimestamp: "2025-05-22T18:52:16Z"
  generation: 1
  labels:
    k0rdent.mirantis.com/component: kcm
  name: ingress-nginx-4-11-3
  namespace: kcm-system
  resourceVersion: "34991"
  uid: 8cfd688b-4cda-468d-8bbc-0129cc04b7d6
spec:
  helm:
    chartSpec:
      chart: ingress-nginx
      interval: 10m0s
      reconcileStrategy: ChartVersion
      sourceRef:
        kind: HelmRepository
        name: k0rdent-catalog
      version: 4.11.3
status:
  chartRef:
    kind: HelmChart
    name: ingress-nginx-4-11-3
    namespace: kcm-system
  chartVersion: 4.11.3
  config:
    commonLabels: {}
    controller:
      addHeaders: {}
      admissionWebhooks:
        annotations: {}
        certManager:
          admissionCert:
            duration: ""
          enabled: false
          rootCert:
            duration: ""
        certificate: /usr/local/certificates/cert
        createSecretJob:
          name: create
          resources: {}
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 65532
            seccompProfile:
              type: RuntimeDefault
        enabled: true
        existingPsp: ""
        extraEnvs: []
        failurePolicy: Fail
        key: /usr/local/certificates/key
        labels: {}
        name: admission
        namespaceSelector: {}
        objectSelector: {}
        patch:
          enabled: true
          image:
            digest: sha256:a9f03b34a3cbfbb26d103a14046ab2c5130a80c3d69d526ff8063d2b37b9fd3f
            image: ingress-nginx/kube-webhook-certgen
            pullPolicy: IfNotPresent
            registry: registry.k8s.io
            tag: v1.4.4
          labels: {}
          networkPolicy:
            enabled: false
          nodeSelector:
            kubernetes.io/os: linux
          podAnnotations: {}
          priorityClassName: ""
          rbac:
            create: true
          securityContext: {}
          serviceAccount:
            automountServiceAccountToken: true
            create: true
            name: ""
          tolerations: []
        patchWebhookJob:
          name: patch
          resources: {}
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 65532
            seccompProfile:
              type: RuntimeDefault
        port: 8443
        service:
          annotations: {}
          externalIPs: []
          loadBalancerSourceRanges: []
          servicePort: 443
          type: ClusterIP
      affinity: {}
      allowSnippetAnnotations: false
      annotations: {}
      autoscaling:
        annotations: {}
        behavior: {}
        enabled: false
        maxReplicas: 11
        minReplicas: 1
        targetCPUUtilizationPercentage: 50
        targetMemoryUtilizationPercentage: 50
      autoscalingTemplate: []
      config: {}
      configAnnotations: {}
      configMapNamespace: ""
      containerName: controller
      containerPort:
        http: 80
        https: 443
      containerSecurityContext: {}
      customTemplate:
        configMapKey: ""
        configMapName: ""
      disableLeaderElection: false
      dnsConfig: {}
      dnsPolicy: ClusterFirst
      electionID: ""
      electionTTL: ""
      enableAnnotationValidations: false
      enableMimalloc: true
      enableTopologyAwareRouting: false
      existingPsp: ""
      extraArgs: {}
      extraContainers: []
      extraEnvs: []
      extraInitContainers: []
      extraModules: []
      extraVolumeMounts: []
      extraVolumes: []
      healthCheckHost: ""
      healthCheckPath: /healthz
      hostAliases: []
      hostNetwork: false
      hostPort:
        enabled: false
        ports:
          http: 80
          https: 443
      hostname: {}
      image:
        allowPrivilegeEscalation: false
        chroot: false
        digest: sha256:d56f135b6462cfc476447cfe564b83a45e8bb7da2774963b00d12161112270b7
        digestChroot: sha256:22701f0fc0f2dd209ef782f4e281bfe2d8cccd50ededa00aec88e0cdbe7edd14
        image: ingress-nginx/controller
        pullPolicy: IfNotPresent
        readOnlyRootFilesystem: false
        registry: registry.k8s.io
        runAsNonRoot: true
        runAsUser: 101
        seccompProfile:
          type: RuntimeDefault
        tag: v1.11.3
      ingressClass: nginx
      ingressClassByName: false
      ingressClassResource:
        aliases: []
        annotations: {}
        controllerValue: k8s.io/ingress-nginx
        default: false
        enabled: true
        name: nginx
        parameters: {}
      keda:
        apiVersion: keda.sh/v1alpha1
        behavior: {}
        cooldownPeriod: 300
        enabled: false
        maxReplicas: 11
        minReplicas: 1
        pollingInterval: 30
        restoreToOriginalReplicaCount: false
        scaledObject:
          annotations: {}
        triggers: []
      kind: Deployment
      labels: {}
      lifecycle:
        preStop:
          exec:
            command:
            - /wait-shutdown
      livenessProbe:
        failureThreshold: 5
        httpGet:
          path: /healthz
          port: 10254
          scheme: HTTP
        initialDelaySeconds: 10
        periodSeconds: 10
        successThreshold: 1
        timeoutSeconds: 1
      maxmindLicenseKey: ""
      metrics:
        enabled: false
        port: 10254
        portName: metrics
        prometheusRule:
          additionalLabels: {}
          enabled: false
          rules: []
        service:
          annotations: {}
          externalIPs: []
          labels: {}
          loadBalancerSourceRanges: []
          servicePort: 10254
          type: ClusterIP
        serviceMonitor:
          additionalLabels: {}
          annotations: {}
          enabled: false
          metricRelabelings: []
          namespace: ""
          namespaceSelector: {}
          relabelings: []
          scrapeInterval: 30s
          targetLabels: []
      minAvailable: 1
      minReadySeconds: 0
      name: controller
      networkPolicy:
        enabled: false
      nodeSelector:
        kubernetes.io/os: linux
      opentelemetry:
        containerSecurityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          readOnlyRootFilesystem: true
          runAsNonRoot: true
          runAsUser: 65532
          seccompProfile:
            type: RuntimeDefault
        enabled: false
        image:
          digest: sha256:f7604ac0547ed64d79b98d92133234e66c2c8aade3c1f4809fed5eec1fb7f922
          distroless: true
          image: ingress-nginx/opentelemetry-1.25.3
          registry: registry.k8s.io
          tag: v20240813-b933310d
        name: opentelemetry
        resources: {}
      podAnnotations: {}
      podLabels: {}
      podSecurityContext: {}
      priorityClassName: ""
      proxySetHeaders: {}
      publishService:
        enabled: true
        pathOverride: ""
      readinessProbe:
        failureThreshold: 3
        httpGet:
          path: /healthz
          port: 10254
          scheme: HTTP
        initialDelaySeconds: 10
        periodSeconds: 10
        successThreshold: 1
        timeoutSeconds: 1
      replicaCount: 1
      reportNodeInternalIp: false
      resources:
        requests:
          cpu: 100m
          memory: 90Mi
      scope:
        enabled: false
        namespace: ""
        namespaceSelector: ""
      service:
        annotations: {}
        appProtocol: true
        clusterIP: ""
        enableHttp: true
        enableHttps: true
        enabled: true
        external:
          enabled: true
        externalIPs: []
        externalTrafficPolicy: ""
        internal:
          annotations: {}
          appProtocol: true
          clusterIP: ""
          enabled: false
          externalIPs: []
          externalTrafficPolicy: ""
          ipFamilies:
          - IPv4
          ipFamilyPolicy: SingleStack
          loadBalancerClass: ""
          loadBalancerIP: ""
          loadBalancerSourceRanges: []
          nodePorts:
            http: ""
            https: ""
            tcp: {}
            udp: {}
          ports: {}
          sessionAffinity: ""
          targetPorts: {}
          type: ""
        ipFamilies:
        - IPv4
        ipFamilyPolicy: SingleStack
        labels: {}
        loadBalancerClass: ""
        loadBalancerIP: ""
        loadBalancerSourceRanges: []
        nodePorts:
          http: ""
          https: ""
          tcp: {}
          udp: {}
        ports:
          http: 80
          https: 443
        sessionAffinity: ""
        targetPorts:
          http: http
          https: https
        type: LoadBalancer
      shareProcessNamespace: false
      sysctls: {}
      tcp:
        annotations: {}
        configMapNamespace: ""
      terminationGracePeriodSeconds: 300
      tolerations: []
      topologySpreadConstraints: []
      udp:
        annotations: {}
        configMapNamespace: ""
      updateStrategy: {}
      watchIngressWithoutClass: false
    defaultBackend:
      affinity: {}
      autoscaling:
        annotations: {}
        enabled: false
        maxReplicas: 2
        minReplicas: 1
        targetCPUUtilizationPercentage: 50
        targetMemoryUtilizationPercentage: 50
      containerSecurityContext: {}
      enabled: false
      existingPsp: ""
      extraArgs: {}
      extraConfigMaps: []
      extraEnvs: []
      extraVolumeMounts: []
      extraVolumes: []
      image:
        allowPrivilegeEscalation: false
        image: defaultbackend-amd64
        pullPolicy: IfNotPresent
        readOnlyRootFilesystem: true
        registry: registry.k8s.io
        runAsNonRoot: true
        runAsUser: 65534
        seccompProfile:
          type: RuntimeDefault
        tag: "1.5"
      labels: {}
      livenessProbe:
        failureThreshold: 3
        initialDelaySeconds: 30
        periodSeconds: 10
        successThreshold: 1
        timeoutSeconds: 5
      minAvailable: 1
      minReadySeconds: 0
      name: defaultbackend
      networkPolicy:
        enabled: false
      nodeSelector:
        kubernetes.io/os: linux
      podAnnotations: {}
      podLabels: {}
      podSecurityContext: {}
      port: 8080
      priorityClassName: ""
      readinessProbe:
        failureThreshold: 6
        initialDelaySeconds: 0
        periodSeconds: 5
        successThreshold: 1
        timeoutSeconds: 5
      replicaCount: 1
      resources: {}
      service:
        annotations: {}
        externalIPs: []
        loadBalancerSourceRanges: []
        servicePort: 80
        type: ClusterIP
      serviceAccount:
        automountServiceAccountToken: true
        create: true
        name: ""
      tolerations: []
      topologySpreadConstraints: []
      updateStrategy: {}
    dhParam: ""
    imagePullSecrets: []
    namespaceOverride: ""
    podSecurityPolicy:
      enabled: false
    portNamePrefix: ""
    rbac:
      create: true
      scope: false
    revisionHistoryLimit: 10
    serviceAccount:
      annotations: {}
      automountServiceAccountToken: true
      create: true
      name: ""
    tcp: {}
    udp: {}
  description: Ingress controller for Kubernetes using NGINX as a reverse proxy and
    load balancer
  observedGeneration: 1
  valid: true
```