### PR TITLE
ci: aireview timeout + concurrency cancel

### DIFF
--- a/.github/workflows/ai-codereview.yml
+++ b/.github/workflows/ai-codereview.yml
@@ -13,6 +13,10 @@ jobs:
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest
+    concurrency:
+      group: ai-codereview-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    timeout-minutes: 10
     outputs:
       jobname: ${{ steps.vars.outputs.jobname }}
     steps:


### PR DESCRIPTION
Sets timeout for the AI-Review WF and forces to be canceled if new commits / rebases arrive
