### PR TITLE
feat: add non-root volumes to AWS Templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMG_TAG = $(shell echo $(IMG) | cut -d: -f2)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.32.0
 
-KCM_STABLE_VERSION = $(shell git ls-remote --tags --sort v:refname --exit-code --refs https://github.com/k0rdent/kcm | tail -n1 | cut -d '/' -f3)
+KCM_STABLE_VERSION = $(shell git ls-remote --tags --sort v:refname --exit-code --refs https://github.com/k0rdent/kcm | grep -v -e "-rc[0-9]\+$$" | tail -n1 | cut -d '/' -f3)
 
 HOSTOS := $(shell go env GOHOSTOS)
 HOSTARCH := $(shell go env GOHOSTARCH)

--- a/README.md
+++ b/README.md
@@ -232,26 +232,7 @@ spec:
     k0s:
       api:
         extraArgs: {}
-      auth:
-        config:
-          apiVersion: apiserver.config.k8s.io/v1beta1
-          jwt:
-          - claimMappings:
-              groups:
-                claim: groups
-                prefix: ""
-              username:
-                claim: email
-                prefix: ""
-            issuer:
-              audiences:
-              - your-audience
-              url: https://your-jwt-issuer.com
-            userValidationRules:
-            - expression: '!user.username.startsWith(''system:'')'
-              message: 'username cannot use reserved system: prefix'
-          kind: AuthenticationConfiguration
-        enabled: false
+      files: []
       version: v1.32.3+k0s.0
     publicIP: false
     region: ""

--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-0
+  template: aws-standalone-cp-1-0-1
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-eks/templates/awsmachinetemplate-worker.yaml
+++ b/templates/cluster/aws-eks/templates/awsmachinetemplate-worker.yaml
@@ -17,6 +17,10 @@ spec:
       publicIP: {{ .Values.publicIP }}
       rootVolume:
         size: {{ .Values.worker.rootVolumeSize }}
+      {{- with .Values.worker.nonRootVolumes }}
+      nonRootVolumes: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      uncompressedUserData: {{ .Values.worker.uncompressedUserData }}
       {{- if not (quote .Values.sshKeyName | empty) }}
       sshKeyName: {{ .Values.sshKeyName | quote }}
       {{- end }}

--- a/templates/cluster/aws-eks/values.schema.json
+++ b/templates/cluster/aws-eks/values.schema.json
@@ -1,298 +1,319 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-        "addons": {
-            "description": "The EKS addons to enable with the EKS cluster",
-            "items": {
-                "properties": {
-                    "configuration": {
-                        "description": "Optional configuration of the EKS addon in YAML format",
-                        "type": [
-                            "string"
-                        ]
-                    },
-                    "conflictResolution": {
-                        "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none",
-                        "enum": [
-                            "overwrite",
-                            "none"
-                        ],
-                        "type": [
-                            "string"
-                        ]
-                    },
-                    "name": {
-                        "description": "The name of the addon",
-                        "type": [
-                            "string"
-                        ]
-                    },
-                    "serviceAccountRoleARN": {
-                        "description": "ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account",
-                        "type": [
-                            "string",
-                            "null"
-                        ]
-                    },
-                    "version": {
-                        "description": "The version of the addon to use",
-                        "type": [
-                            "string"
-                        ]
-                    }
-                },
-                "type": "object"
-            },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM template to deploy a K8s managed cluster (EKS) on AWS",
+  "properties": {
+    "addons": {
+      "description": "The EKS addons to enable with the EKS cluster",
+      "items": {
+        "properties": {
+          "configuration": {
+            "description": "Optional configuration of the EKS addon in YAML format",
             "type": [
-                "array"
+              "string"
             ]
-        },
-        "associateOIDCProvider": {
-            "description": "Automatically create an identity provider for the controller for use with IAM roles for service accounts",
-            "type": [
-                "boolean"
-            ]
-        },
-        "clusterAnnotations": {
-            "additionalProperties": true,
-            "description": "Annotations to apply to the cluster",
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterIdentity": {
-            "description": "AWS Cluster Identity object reference",
-            "properties": {
-                "kind": {
-                    "description": "AWS Cluster Identity object reference",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "name": {
-                    "description": "AWS ClusterIdentity object name",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "required": [
-                "name",
-                "kind"
-            ],
-            "type": "object"
-        },
-        "clusterLabels": {
-            "additionalProperties": true,
-            "description": "Labels to apply to the cluster",
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterNetwork": {
-            "description": "The cluster network configuration",
-            "properties": {
-                "pods": {
-                    "description": "The network ranges from which Pod networks are allocated",
-                    "properties": {
-                        "cidrBlocks": {
-                            "description": "A list of CIDR blocks",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "services": {
-                    "description": "The network ranges from which service VIPs are allocated",
-                    "properties": {
-                        "cidrBlocks": {
-                            "description": "A list of CIDR blocks",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "eksClusterName": {
-            "description": "The name of the EKS cluster in AWS. If unset, the default name will be created based on the namespace and name of the managed control plane",
-            "type": [
-                "string"
-            ]
-        },
-        "kubeProxy": {
-            "description": "Managed attributes of the kube-proxy daemonset",
-            "properties": {
-                "disable": {
-                    "description": "Disable set to true indicates that kube-proxy should be disabled. With EKS clusters kube-proxy is automatically installed into the cluster",
-                    "type": [
-                        "boolean"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "kubernetes": {
-            "description": "Kubernetes parameters",
-            "properties": {
-                "version": {
-                    "description": "Kubernetes version to use",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "required": [
-                "version"
+          },
+          "conflictResolution": {
+            "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none",
+            "enum": [
+              "overwrite",
+              "none"
             ],
             "type": [
-                "object"
+              "string"
             ]
-        },
-        "oidcIdentityProviderConfig": {
-            "description": "The oidc provider config to be attached with this eks cluster",
-            "properties": {},
+          },
+          "name": {
+            "description": "The name of the addon",
             "type": [
-                "object"
+              "string"
             ]
-        },
-        "publicIP": {
-            "description": "Specifies whether the instance should get a public IP",
+          },
+          "serviceAccountRoleARN": {
+            "description": "ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account",
             "type": [
-                "boolean"
+              "string",
+              "null"
             ]
-        },
-        "region": {
-            "description": "AWS region to deploy the cluster in",
+          },
+          "version": {
+            "description": "The version of the addon to use",
             "type": [
-                "string"
+              "string"
             ]
+          }
         },
-        "sshKeyName": {
-            "description": "The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
-            "type": [
-                "string",
-                "null"
-            ]
-        },
-        "vpcCni": {
-            "description": "The configuration options for the VPC CNI plugin",
-            "properties": {
-                "disable": {
-                    "description": "Indicates that the Amazon VPC CNI should be disabled",
-                    "type": [
-                        "boolean"
-                    ]
-                },
-                "env": {
-                    "description": "A list of environment variables to apply to the aws-node DaemonSet",
-                    "type": [
-                        "array"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "worker": {
-            "description": "The configuration of the worker machines",
-            "properties": {
-                "amiID": {
-                    "description": "The ID of Amazon Machine Image",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "iamInstanceProfile": {
-                    "description": "The name of an IAM instance profile to assign to the instance",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "imageLookup": {
-                    "description": "AMI lookup parameters",
-                    "properties": {
-                        "baseOS": {
-                            "description": "OS name which can be used in format string",
-                            "type": [
-                                "string"
-                            ]
-                        },
-                        "format": {
-                            "description": "Format string which will be used for image lookup",
-                            "type": [
-                                "string"
-                            ]
-                        },
-                        "org": {
-                            "description": "AWS org ID which owns the AMI",
-                            "type": [
-                                "string"
-                            ]
-                        }
-                    },
-                    "required": [
-                        "format",
-                        "org"
-                    ],
-                    "type": [
-                        "object"
-                    ]
-                },
-                "instanceType": {
-                    "description": "The ID of Amazon Machine Image",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "rootVolumeSize": {
-                    "description": "The size of the root volume of the instance (GB)",
-                    "type": [
-                        "integer"
-                    ]
-                }
-            },
-            "required": [
-                "iamInstanceProfile"
-            ],
-            "type": [
-                "object"
-            ]
-        },
-        "workersNumber": {
-            "description": "The number of the worker machines",
-            "minimum": 1,
-            "type": [
-                "number"
-            ]
-        }
+        "type": "object"
+      },
+      "type": [
+        "array"
+      ]
     },
-    "required": [
-        "workersNumber",
-        "region",
-        "clusterIdentity"
-    ],
-    "type": "object"
+    "associateOIDCProvider": {
+      "description": "Automatically create an identity provider for the controller for use with IAM roles for service accounts",
+      "type": [
+        "boolean"
+      ]
+    },
+    "clusterAnnotations": {
+      "additionalProperties": true,
+      "description": "Annotations to apply to the cluster",
+      "properties": {},
+      "type": [
+        "object"
+      ]
+    },
+    "clusterIdentity": {
+      "description": "A reference to an identity to be used when reconciling the managed control plane",
+      "properties": {
+        "kind": {
+          "description": "Kind of the identity",
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "Name of the identity",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "kind"
+      ],
+      "type": [
+        "object"
+      ]
+    },
+    "clusterLabels": {
+      "additionalProperties": true,
+      "description": "Labels to apply to the cluster",
+      "properties": {},
+      "type": [
+        "object"
+      ]
+    },
+    "clusterNetwork": {
+      "description": "The cluster network configuration",
+      "properties": {
+        "pods": {
+          "description": "The network ranges from which Pod networks are allocated",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "services": {
+          "description": "The network ranges from which service VIPs are allocated",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "type": [
+        "object"
+      ]
+    },
+    "eksClusterName": {
+      "description": "The name of the EKS cluster in AWS. If unset, the default name will be created based on the namespace and name of the managed control plane",
+      "type": [
+        "string"
+      ]
+    },
+    "kubeProxy": {
+      "description": "Managed attributes of the kube-proxy daemonset",
+      "properties": {
+        "disable": {
+          "description": "Disable set to true indicates that kube-proxy should be disabled. With EKS clusters kube-proxy is automatically installed into the cluster",
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "type": [
+        "object"
+      ]
+    },
+    "kubernetes": {
+      "description": "Kubernetes parameters",
+      "properties": {
+        "version": {
+          "description": "Kubernetes version to use",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "required": [
+        "version"
+      ],
+      "type": [
+        "object"
+      ]
+    },
+    "oidcIdentityProviderConfig": {
+      "description": "The oidc provider config to be attached with this eks cluster",
+      "properties": {},
+      "type": [
+        "object"
+      ]
+    },
+    "publicIP": {
+      "description": "Specifies whether the instance should get a public IP",
+      "type": [
+        "boolean"
+      ]
+    },
+    "region": {
+      "description": "AWS region to deploy the cluster in",
+      "type": [
+        "string"
+      ]
+    },
+    "sshKeyName": {
+      "description": "The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "vpcCni": {
+      "description": "The configuration options for the VPC CNI plugin",
+      "properties": {
+        "disable": {
+          "description": "Indicates that the Amazon VPC CNI should be disabled",
+          "type": [
+            "boolean"
+          ]
+        },
+        "env": {
+          "description": "A list of environment variables to apply to the aws-node DaemonSet",
+          "type": [
+            "array"
+          ]
+        }
+      },
+      "type": [
+        "object"
+      ]
+    },
+    "worker": {
+      "description": "The configuration of the worker machines",
+      "properties": {
+        "amiID": {
+          "description": "The ID of Amazon Machine Image",
+          "type": [
+            "string"
+          ]
+        },
+        "iamInstanceProfile": {
+          "description": "A name of an IAM instance profile to assign to the instance",
+          "type": [
+            "string"
+          ]
+        },
+        "imageLookup": {
+          "description": "AMI lookup parameters",
+          "properties": {
+            "baseOS": {
+              "description": "The name of the base operating system to use for image lookup the AMI is not set",
+              "type": [
+                "string"
+              ]
+            },
+            "format": {
+              "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
+              "type": [
+                "string"
+              ]
+            },
+            "org": {
+              "description": "The AWS Organization ID to use for image lookup if AMI is not set",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "required": [
+            "format",
+            "org"
+          ],
+          "type": [
+            "object"
+          ]
+        },
+        "instanceType": {
+          "description": "The type of instance to create. Example: m4.xlarge",
+          "type": [
+            "string"
+          ]
+        },
+        "nonRootVolumes": {
+          "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
+          "items": {
+            "type": "object"
+          },
+          "title": "Non-root storage volumes",
+          "type": [
+            "array"
+          ]
+        },
+        "rootVolumeSize": {
+          "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
+          "minimum": 8,
+          "type": [
+            "integer"
+          ]
+        },
+        "uncompressedUserData": {
+          "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "required": [
+        "iamInstanceProfile",
+        "instanceType"
+      ],
+      "type": [
+        "object"
+      ]
+    },
+    "workersNumber": {
+      "description": "The number of the worker machines",
+      "minimum": 1,
+      "type": [
+        "number"
+      ]
+    }
+  },
+  "required": [
+    "workersNumber",
+    "region",
+    "clusterIdentity"
+  ],
+  "type": "object"
 }

--- a/templates/cluster/aws-eks/values.yaml
+++ b/templates/cluster/aws-eks/values.yaml
@@ -1,3 +1,7 @@
+# Schema generation:
+# $ helm plugin install https://github.com/losisin/helm-values-schema-json.git
+# $ helm schema --draft 2020 --indent 2 --noAdditionalProperties=false --schemaRoot.description='A KCM template to deploy a K8s managed cluster (EKS) on AWS' --input ./templates/cluster/aws-eks/values.yaml --output ./templates/cluster/aws-eks/values.schema.json
+
 # Cluster parameters
 workersNumber: 1 # @schema description: The number of the worker machines; type: number; minimum: 1; required: true
 
@@ -15,7 +19,7 @@ clusterAnnotations: {} # @schema description: Annotations to apply to the cluste
 # EKS cluster parameters
 eksClusterName: "" # @schema description: The name of the EKS cluster in AWS. If unset, the default name will be created based on the namespace and name of the managed control plane; type: string
 region: "" # @schema description: AWS region to deploy the cluster in; type: string; required: true
-sshKeyName: "" # @schema description: The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name); type: string,null
+sshKeyName: "" # @schema description: The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name); type: [string, null]
 publicIP: false # @schema description: Specifies whether the instance should get a public IP; type: boolean
 
 associateOIDCProvider: false # @schema description: Automatically create an identity provider for the controller for use with IAM roles for service accounts; type: boolean
@@ -28,20 +32,22 @@ vpcCni: # @schema description: The configuration options for the VPC CNI plugin;
 kubeProxy: # @schema description: Managed attributes of the kube-proxy daemonset; type: object
   disable: false # @schema description: Disable set to true indicates that kube-proxy should be disabled. With EKS clusters kube-proxy is automatically installed into the cluster; type: boolean
 
-clusterIdentity: # @schema description: AWS Cluster Identity object reference; required: true
-  name: "aws-cluster-identity" # @schema description: AWS ClusterIdentity object name; type: string; required: true
-  kind: "AWSClusterStaticIdentity" # @schema description: AWS Cluster Identity object reference; type: string; required: true
+clusterIdentity: # @schema description: A reference to an identity to be used when reconciling the managed control plane; type: object; required: true
+  name: "aws-cluster-identity" # @schema description: Name of the identity; type: string; required: true
+  kind: "AWSClusterStaticIdentity" # @schema description: Kind of the identity; type: string; required: true
 
 # EKS machines parameters
 worker: # @schema description: The configuration of the worker machines; type: object
   amiID: "" # @schema description: The ID of Amazon Machine Image; type: string
-  iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io # @schema description: The name of an IAM instance profile to assign to the instance; type: string; required: true
-  instanceType: "t3.small" # @schema description: The ID of Amazon Machine Image; type: string
-  rootVolumeSize: 30 # @schema description: The size of the root volume of the instance (GB); type: integer
+  iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io # @schema description: A name of an IAM instance profile to assign to the instance; type: string; required: true
+  instanceType: "t3.small" # @schema description: The type of instance to create. Example: m4.xlarge; type: string; required: true
+  rootVolumeSize: 30 # @schema description: Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater); type: integer; minimum: 8
+  nonRootVolumes: [] # @schema title: Non-root storage volumes; description: Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes; type: array; item: object
   imageLookup: # @schema description: AMI lookup parameters; type: object
-    format: "" # @schema description: Format string which will be used for image lookup; type: string; required: true
-    org: "" # @schema description: AWS org ID which owns the AMI; type: string; required: true
-    baseOS: "" # @schema description: OS name which can be used in format string; type: string
+    format: "" # @schema description: The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set; type: string; required: true
+    org: "" # @schema description: The AWS Organization ID to use for image lookup if AMI is not set; type: string; required: true
+    baseOS: "" # @schema description: The name of the base operating system to use for image lookup the AMI is not set; type: string
+  uncompressedUserData: false # @schema description: Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed; type: boolean
 
 addons: # @schema description: The EKS addons to enable with the EKS cluster; type: array
 - name: aws-ebs-csi-driver # @schema description: The name of the addon; type: string
@@ -50,7 +56,7 @@ addons: # @schema description: The EKS addons to enable with the EKS cluster; ty
     defaultStorageClass:
       enabled: true
   conflictResolution: "none" # @schema description: ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none; enum: overwrite,none; type: string
-  serviceAccountRoleARN: null # @schema description: ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account; type: string,null
+  serviceAccountRoleARN: null # @schema description: ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account; type: [string, null]
 
 # Kubernetes version
 kubernetes: # @schema description: Kubernetes parameters; type: object

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/awsmachinetemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/awsmachinetemplate.yaml
@@ -26,4 +26,7 @@ spec:
       publicIP: {{ .Values.publicIP }}
       rootVolume:
         size: {{ .Values.rootVolumeSize }}
+      {{- with .Values.nonRootVolumes }}
+      nonRootVolumes: {{- toYaml . | nindent 8 }}
+      {{- end }}
       uncompressedUserData: {{ .Values.uncompressedUserData }}

--- a/templates/cluster/aws-hosted-cp/values.schema.json
+++ b/templates/cluster/aws-hosted-cp/values.schema.json
@@ -1,248 +1,349 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a k8s cluster on AWS with control plane components within the management cluster.",
-  "type": "object",
-  "required": [
-    "workersNumber",
-    "vpcID",
-    "region",
-    "amiID",
-    "iamInstanceProfile",
-    "instanceType",
-    "securityGroupIDs",
-    "clusterIdentity",
-    "managementClusterName"
-  ],
+  "description": "A KCM template to deploy a k8s cluster on AWS with control plane components within the management cluster",
   "properties": {
-    "managementClusterName" : {
-      "description": "The name of the management cluster that this template is being deployed on",
-      "type": "string"
-    },
-    "workersNumber": {
-      "description": "The number of the worker machines",
-      "type": "integer",
-      "minimum": 1
-    },
-    "clusterNetwork": {
-      "type": "object",
-      "properties": {
-        "pods": {
-          "type": "object",
-          "properties": {
-            "cidrBlocks": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
-            }
-          }
-        },
-        "services": {
-          "type": "object",
-          "properties": {
-            "cidrBlocks": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
-            }
-          }
-        }
-      }
-    },
-    "clusterLabels": {
-      "type": "object",
-      "description": "Labels to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },    
-    "clusterAnnotations": {
-      "type": "object",
-      "description": "Annotations to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },    
-    "vpcID": {
-      "description": "The VPC ID to deploy the cluster in",
-      "type": "string"
-    },
-    "region": {
-      "description": "AWS region to deploy the cluster in",
-      "type": "string"
-    },
-    "sshKeyName": {
-      "description": "The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
-      "type": ["string", "null"]
-    },
-    "publicIP": {
-      "description": "Specifies whether the instance should get a public IP",
-      "type": "boolean"
-    },
-    "subnets": {
-      "description": "Subnets configuration",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "description": "ID defines a unique identifier to reference this resource",
-            "type": "string"
-          },
-          "availabilityZone": {
-            "description": "AvailabilityZone defines the availability zone to use for this subnet in the cluster's region",
-            "type": "string"
-          }
-        }
-      },
-      "minItems": 1,
-      "uniqueItems": true
-    },
-    "bastion": {
-      "type": "object",
-      "description": "The configuration of the bastion host",
-      "required": [],
-      "properties": {
-          "enabled": {
-              "type": "boolean"
-          },
-          "disableIngressRules": {
-              "type": "boolean"
-          },
-          "allowedCIDRBlocks": {
-              "type": "array",
-              "items": {},
-              "uniqueItems": true
-          },
-          "instanceType": {
-              "type": "string"
-          },
-          "ami": {
-              "type": "string"
-          }
-      }
-    },
-    "clusterIdentity": {
-      "type": "object",
-      "description": "AWS Cluster Identity object reference",
-      "required": [
-        "name",
-	"kind"
-      ],
-      "properties": {
-        "name": {
-	  "description": "AWS ClusterIdentity object name",
-          "type": "string"
-        },
-        "kind": {
-	  "description": "AWS ClusterIdentity object kind",
-          "type": "string"
-        }
-      }
-    },
     "amiID": {
       "description": "The ID of Amazon Machine Image",
-      "type": "string"
+      "type": [
+        "string"
+      ]
+    },
+    "bastion": {
+      "description": "The configuration of the bastion host",
+      "properties": {
+        "allowedCIDRBlocks": {
+          "description": "A list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0)",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array"
+          ]
+        },
+        "ami": {
+          "description": "Uses the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space",
+          "type": [
+            "string"
+          ]
+        },
+        "disableIngressRules": {
+          "description": "Ensures ensure there are no Ingress rules in the bastion host's security group. Requires allowedCIDRBlocks to be empty",
+          "type": [
+            "boolean"
+          ]
+        },
+        "enabled": {
+          "description": "Allows this provider to create a bastion host instance with a public ip to access the VPC private network",
+          "type": [
+            "boolean"
+          ]
+        },
+        "instanceType": {
+          "description": "Use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "type": [
+        "object"
+      ]
+    },
+    "clusterAnnotations": {
+      "additionalProperties": true,
+      "description": "Annotations to apply to the cluster",
+      "properties": {},
+      "type": [
+        "object"
+      ]
+    },
+    "clusterIdentity": {
+      "description": "A reference to an identity to be used when reconciling the managed control plane",
+      "properties": {
+        "kind": {
+          "description": "Kind of the identity",
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "Name of the identity",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "kind"
+      ],
+      "type": [
+        "object"
+      ]
+    },
+    "clusterLabels": {
+      "additionalProperties": true,
+      "description": "Labels to apply to the cluster",
+      "properties": {},
+      "type": [
+        "object"
+      ]
+    },
+    "clusterNetwork": {
+      "description": "The cluster network configuration",
+      "properties": {
+        "pods": {
+          "description": "The network ranges from which Pod networks are allocated",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "services": {
+          "description": "The network ranges from which service VIPs are allocated",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "type": [
+        "object"
+      ]
+    },
+    "iamInstanceProfile": {
+      "description": "A name of an IAM instance profile to assign to the instance",
+      "type": [
+        "string"
+      ]
     },
     "imageLookup": {
       "description": "AMI lookup parameters",
-      "type": "object",
+      "properties": {
+        "baseOS": {
+          "description": "The name of the base operating system to use for image lookup the AMI is not set",
+          "type": [
+            "string"
+          ]
+        },
+        "format": {
+          "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
+          "type": [
+            "string"
+          ]
+        },
+        "org": {
+          "description": "The AWS Organization ID to use for image lookup if AMI is not set",
+          "type": [
+            "string"
+          ]
+        }
+      },
       "required": [
         "format",
         "org"
       ],
-      "properties": {
-        "format": {
-	  "description": "Format string which will be used for image lookup",
-          "type": "string"
-        },
-        "org": {
-	  "description": "AWS org ID which owns the AMI",
-          "type": "string"
-        },
-        "baseOS": {
-	  "description": "OS name which can be used in format string",
-          "type": "string"
-        }
-      }
-    },
-    "iamInstanceProfile": {
-      "description": "The name of an IAM instance profile to assign to the instance",
-      "type": "string"
+      "type": [
+        "object"
+      ]
     },
     "instanceType": {
-      "description": "The type of instance to create",
-      "type": "string"
+      "description": "The type of instance to create. Example: m4.xlarge",
+      "type": [
+        "string"
+      ]
     },
-    "securityGroupIDs": {
-      "description": "The ID of security group that should be applied to the instance",
-      "type": "array",
-      "items": {
-        "type": "string",
-        "minItems": 1,
-        "uniqueItems": true
-      }
+    "k0s": {
+      "description": "K0s parameters",
+      "properties": {
+        "api": {
+          "description": "Kubernetes API server parameters",
+          "properties": {
+            "extraArgs": {
+              "additionalProperties": true,
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "properties": {},
+              "type": [
+                "object"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "version": {
+          "description": "K0s version",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "required": [
+        "version"
+      ],
+      "type": [
+        "object"
+      ]
     },
     "k0smotron": {
       "description": "K0smotron parameters",
-      "type": "object",
       "properties": {
         "service": {
-          "description": "The configuration of a K0smotron service",
+          "description": "The API service configuration",
           "properties": {
+            "apiPort": {
+              "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": [
+                "number"
+              ]
+            },
+            "konnectivityPort": {
+              "description": "The konnectivity port. If empty k0smotron will pick it automatically",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": [
+                "number"
+              ]
+            },
             "type": {
-              "description": "Ingress methods for a k0smotron service",
+              "description": "An ingress methods for a service",
               "enum": [
                 "ClusterIP",
                 "NodePort",
                 "LoadBalancer"
               ],
-              "type": "string"
-            },
-            "apiPort": {
-              "description": "The kubernetes API port for a k0smotron service",
-              "type": "number",
-              "minimum": 1,
-              "maximum": 65535
-            },
-            "konnectivityPort": {
-              "description": "The konnectivity port",
-              "type": "number",
-              "minimum": 1,
-              "maximum": 65535
+              "type": [
+                "string"
+              ]
             }
-          }
+          },
+          "type": [
+            "object"
+          ]
         }
-      }
+      },
+      "type": [
+        "object"
+      ]
     },
-    "k0s": {
-      "description": "K0s parameters",
-      "type": "object",
-      "required": [
-        "version"
+    "managementClusterName": {
+      "description": "The name of the management cluster that this template is being deployed on",
+      "type": [
+        "string"
+      ]
+    },
+    "nonRootVolumes": {
+      "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
+      "items": {
+        "type": "object"
+      },
+      "title": "Non-root storage volumes",
+      "type": [
+        "array"
+      ]
+    },
+    "publicIP": {
+      "description": "Specifies whether the instance should get a public IP",
+      "type": [
+        "boolean"
+      ]
+    },
+    "region": {
+      "description": "AWS region to deploy the cluster in",
+      "type": [
+        "string"
+      ]
+    },
+    "rootVolumeSize": {
+      "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
+      "minimum": 8,
+      "type": [
+        "integer"
+      ]
+    },
+    "securityGroupIDs": {
+      "description": "An array of security groups' IDs that should be applied to the instance",
+      "items": {
+        "type": "string"
+      },
+      "type": [
+        "array"
       ],
-      "properties": {
-        "version":{
-          "description": "K0s version to use",
-          "type": "string"
-        },
-        "api": {
-          "description": "Kubernetes api-server parameters",
-          "type": "object",
-          "properties": {
-            "extraArgs": {
-              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      }
+      "uniqueItems": true
+    },
+    "sshKeyName": {
+      "description": "The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "subnets": {
+      "description": "Subnets configuration",
+      "items": {
+        "type": "object"
+      },
+      "minItems": 1,
+      "type": [
+        "array"
+      ],
+      "uniqueItems": true
+    },
+    "uncompressedUserData": {
+      "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
+      "type": [
+        "boolean"
+      ]
+    },
+    "vpcID": {
+      "description": "The VPC ID to deploy the cluster in",
+      "type": [
+        "string"
+      ]
+    },
+    "workersNumber": {
+      "description": "The number of the worker machines",
+      "minimum": 1,
+      "type": [
+        "integer"
+      ]
     }
-  }
+  },
+  "required": [
+    "workersNumber",
+    "managementClusterName",
+    "vpcID",
+    "region",
+    "clusterIdentity",
+    "iamInstanceProfile",
+    "instanceType",
+    "securityGroupIDs"
+  ],
+  "type": "object"
 }

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -1,58 +1,63 @@
-# Cluster parameters
-workersNumber: 2
+# Schema generation:
+# $ helm plugin install https://github.com/losisin/helm-values-schema-json.git
+# $ helm schema --draft 2020 --indent 2 --noAdditionalProperties=false --schemaRoot.description='A KCM template to deploy a k8s cluster on AWS with control plane components within the management cluster' --input ./templates/cluster/aws-hosted-cp/values.yaml --output ./templates/cluster/aws-hosted-cp/values.schema.json
 
-clusterNetwork:
-  pods:
-    cidrBlocks:
+# Cluster parameters
+workersNumber: 2 # @schema description: The number of the worker machines; minimum: 1; type: integer; required: true
+
+managementClusterName: "" # @schema description: The name of the management cluster that this template is being deployed on; type: string; required: true
+
+clusterNetwork: # @schema description: The cluster network configuration; type: object
+  pods: # @schema description: The network ranges from which Pod networks are allocated; type: object
+    cidrBlocks: # @schema description: A list of CIDR blocks; type: array; item: string
       - "10.244.0.0/16"
-  services:
-    cidrBlocks:
+  services: # @schema description: The network ranges from which service VIPs are allocated; type: object
+    cidrBlocks: # @schema description: A list of CIDR blocks; type: array; item: string
       - "10.96.0.0/12"
 
-clusterLabels: {}
-clusterAnnotations: {}
+clusterLabels: {} # @schema description: Labels to apply to the cluster; type: object; additionalProperties: true
+clusterAnnotations: {} # @schema description: Annotations to apply to the cluster; type: object; additionalProperties: true
 
 # AWS cluster parameters
-vpcID: ""
-region: ""
-sshKeyName: ""
-publicIP: false
-subnets:
-  - id: ""
-    availabilityZone: ""
-bastion:
-  enabled: false
-  disableIngressRules: false
-  allowedCIDRBlocks: []
-  instanceType: t2.micro
-  ami: ""
-clusterIdentity:
-  name: ""
-  kind: "AWSClusterStaticIdentity"
+vpcID: "" # @schema description: The VPC ID to deploy the cluster in; type: string; required: true
+region: "" # @schema description: AWS region to deploy the cluster in; type: string; required: true
+sshKeyName: "" # @schema description: The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name); type: [string, null]
+publicIP: false # @schema description: Specifies whether the instance should get a public IP; type: boolean
+subnets: # @schema description: Subnets configuration; type: array; item: object; uniqueItems: true; minItems: 1
+  - id: "" # @schema description: ID defines a unique identifier to reference this resource; type: string
+    availabilityZone: "" # @schema description: ID defines a unique identifier to reference this resource; type: string
+bastion: # @schema description: The configuration of the bastion host; type: object
+  enabled: false # @schema description: Allows this provider to create a bastion host instance with a public ip to access the VPC private network; type: boolean; required: true
+  disableIngressRules: false # @schema description: Ensures ensure there are no Ingress rules in the bastion host's security group. Requires allowedCIDRBlocks to be empty; type: boolean
+  allowedCIDRBlocks: [] # @schema description: A list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0); type: array; item: string
+  instanceType: t2.micro # @schema description: Use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default; type: string
+  ami: "" # @schema description: Uses the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space; type: string
+clusterIdentity: # @schema description: A reference to an identity to be used when reconciling the managed control plane; type: object; required: true
+  name: "" # @schema description: Name of the identity; type: string; required: true
+  kind: "AWSClusterStaticIdentity" # @schema description: Kind of the identity; type: string; required: true
+
 # AWS machines parameters
-amiID: ""
-imageLookup:
-  format: "amzn2-ami-hvm*-gp2"
-  org: "137112412989"
-  baseOS: ""
-iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
-instanceType: ""
-securityGroupIDs: []
-rootVolumeSize: 8
-uncompressedUserData: false
+amiID: "" # @schema description: The ID of Amazon Machine Image; type: string
+imageLookup: # @schema description: AMI lookup parameters; type: object
+  format: "amzn2-ami-hvm*-gp2" # @schema description: The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set; type: string; required: true
+  org: "137112412989" # @schema description: The AWS Organization ID to use for image lookup if AMI is not set; type: string; required: true
+  baseOS: "" # @schema description: The name of the base operating system to use for image lookup the AMI is not set; type: string
+iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io # @schema description: A name of an IAM instance profile to assign to the instance; type: string; required: true
+instanceType: "" # @schema description: The type of instance to create. Example: m4.xlarge; type: string; required: true
+securityGroupIDs: [] # @schema description: An array of security groups' IDs that should be applied to the instance; type: array; item: string; required: true; uniqueItems: true
+rootVolumeSize: 8 # @schema description: Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater); type: integer; minimum: 8
+uncompressedUserData: false # @schema description: Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed; type: boolean
+nonRootVolumes: [] # @schema title: Non-root storage volumes; description: Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes; type: array; item: object
 
 # K0smotron parameters
-k0smotron:
-  service:
-    type: LoadBalancer
-    apiPort: 6443
-    konnectivityPort: 8132
+k0smotron: # @schema description: K0smotron parameters; type: object
+  service: # @schema description: The API service configuration; type: object
+    type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
+    apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
+    konnectivityPort: 8132 # @schema description: The konnectivity port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
 
 # K0s parameters
-k0s:
-  version: v1.32.3+k0s.0
-  api:
-    extraArgs: {}
-
-# Name of the management cluster that this template is being deployed on
-managementClusterName: ""
+k0s: # @schema description: K0s parameters; type: object
+  version: v1.32.3+k0s.0 # @schema description: K0s version; type: string; required: true
+  api: # @schema description: Kubernetes API server parameters; type: object
+    extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-controlplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-controlplane.yaml
@@ -22,4 +22,7 @@ spec:
       publicIP: {{ .Values.publicIP }}
       rootVolume:
         size: {{ .Values.controlPlane.rootVolumeSize }}
+      {{- with .Values.controlPlane.nonRootVolumes }}
+      nonRootVolumes: {{- toYaml . | nindent 8 }}
+      {{- end }}
       uncompressedUserData: {{ .Values.controlPlane.uncompressedUserData }}

--- a/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-worker.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-worker.yaml
@@ -22,4 +22,7 @@ spec:
       publicIP: {{ .Values.publicIP }}
       rootVolume:
         size: {{ .Values.worker.rootVolumeSize }}
+      {{- with .Values.worker.nonRootVolumes }}
+      nonRootVolumes: {{- toYaml . | nindent 8 }}
+      {{- end }}
       uncompressedUserData: {{ .Values.worker.uncompressedUserData }}

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -15,15 +15,19 @@ spec:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
       - --disable-components=konnectivity-server
+    {{- $auth := .Values.k0s.auth }}
+    {{- $files := .Values.k0s.files }}
+    {{- if or (and $auth $auth.enabled) $files }}
     files:
-      {{- if .Values.k0s.auth.enabled }}
-      - content: |
-          {{- with .Values.k0s.auth.config }}
-          {{- toYaml . | nindent 14 }}
-          {{- end }}
-        permissions: "0644"
-        path: /etc/k0s/auth/auth-config.yaml
-      {{- end }}
+    {{- if and $auth $auth.enabled }}
+    - content: | {{ toYaml $auth.config | nindent 8 }}
+      permissions: "0644"
+      path: /etc/k0s/auth/auth-config.yaml
+    {{- end }}
+    {{- range $file := $files }}
+    - {{ toYaml $file | trim | nindent 6 }}
+    {{- end }}
+    {{- end }}
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: ClusterConfig
@@ -33,7 +37,7 @@ spec:
         api:
           extraArgs:
             anonymous-auth: "true"
-            {{- if .Values.k0s.auth.enabled }}
+            {{- if and (.Values.k0s.auth) (.Values.k0s.auth.enabled) }}
             authentication-config: "/etc/k0s/auth/auth-config.yaml"
             {{- end }}
           {{- with .Values.k0s.api.extraArgs }}

--- a/templates/cluster/aws-standalone-cp/values.schema.json
+++ b/templates/cluster/aws-standalone-cp/values.schema.json
@@ -1,262 +1,381 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a k0s cluster on AWS with bootstrapped control plane nodes.",
-  "type": "object",
+  "description": "A KCM template to deploy a k0s cluster on AWS with bootstrapped control plane nodes",
+  "properties": {
+    "bastion": {
+      "description": "The configuration of the bastion host",
+      "properties": {
+        "allowedCIDRBlocks": {
+          "description": "A list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0)",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array"
+          ]
+        },
+        "ami": {
+          "description": "Uses the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space",
+          "type": [
+            "string"
+          ]
+        },
+        "disableIngressRules": {
+          "description": "Ensures ensure there are no Ingress rules in the bastion host's security group. Requires allowedCIDRBlocks to be empty",
+          "type": [
+            "boolean"
+          ]
+        },
+        "enabled": {
+          "description": "Allows this provider to create a bastion host instance with a public ip to access the VPC private network",
+          "type": [
+            "boolean"
+          ]
+        },
+        "instanceType": {
+          "description": "Use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "required": [
+        "enabled"
+      ],
+      "type": [
+        "object"
+      ]
+    },
+    "clusterAnnotations": {
+      "additionalProperties": true,
+      "description": "Annotations to apply to the cluster",
+      "properties": {},
+      "type": [
+        "object"
+      ]
+    },
+    "clusterIdentity": {
+      "description": "A reference to an identity to be used when reconciling the managed control plane",
+      "properties": {
+        "kind": {
+          "description": "Kind of the identity",
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "Name of the identity",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "kind"
+      ],
+      "type": [
+        "object"
+      ]
+    },
+    "clusterLabels": {
+      "additionalProperties": true,
+      "description": "Labels to apply to the cluster",
+      "properties": {},
+      "type": [
+        "object"
+      ]
+    },
+    "clusterNetwork": {
+      "description": "The cluster network configuration",
+      "properties": {
+        "pods": {
+          "description": "The network ranges from which Pod networks are allocated",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "services": {
+          "description": "The network ranges from which service VIPs are allocated",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      },
+      "type": [
+        "object"
+      ]
+    },
+    "controlPlane": {
+      "description": "The configuration of the control plane machines",
+      "properties": {
+        "amiID": {
+          "description": "The ID of Amazon Machine Image",
+          "type": [
+            "string"
+          ]
+        },
+        "iamInstanceProfile": {
+          "description": "A name of an IAM instance profile to assign to the instance",
+          "type": [
+            "string"
+          ]
+        },
+        "imageLookup": {
+          "description": "AMI lookup parameters",
+          "properties": {
+            "baseOS": {
+              "description": "The name of the base operating system to use for image lookup the AMI is not set",
+              "type": [
+                "string"
+              ]
+            },
+            "format": {
+              "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
+              "type": [
+                "string"
+              ]
+            },
+            "org": {
+              "description": "The AWS Organization ID to use for image lookup if AMI is not set",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "required": [
+            "format",
+            "org"
+          ],
+          "type": [
+            "object"
+          ]
+        },
+        "instanceType": {
+          "description": "The type of instance to create. Example: m4.xlarge",
+          "type": [
+            "string"
+          ]
+        },
+        "nonRootVolumes": {
+          "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
+          "items": {
+            "type": "object"
+          },
+          "title": "Non-root storage volumes",
+          "type": [
+            "array"
+          ]
+        },
+        "rootVolumeSize": {
+          "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
+          "minimum": 8,
+          "type": [
+            "integer"
+          ]
+        },
+        "uncompressedUserData": {
+          "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "required": [
+        "iamInstanceProfile",
+        "instanceType"
+      ],
+      "type": [
+        "object"
+      ]
+    },
+    "controlPlaneNumber": {
+      "description": "The number of the control-plane machines",
+      "minimum": 1,
+      "type": [
+        "integer"
+      ]
+    },
+    "k0s": {
+      "additionalProperties": true,
+      "description": "K0s parameters",
+      "properties": {
+        "api": {
+          "description": "Kubernetes API server parameters",
+          "properties": {
+            "extraArgs": {
+              "additionalProperties": true,
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "properties": {},
+              "type": [
+                "object"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "files": {
+          "description": "Specifies extra files to be passed to user_data upon creation",
+          "items": {
+            "type": "object"
+          },
+          "type": [
+            "array"
+          ]
+        },
+        "version": {
+          "description": "K0s version",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "required": [
+        "version"
+      ],
+      "type": [
+        "object"
+      ]
+    },
+    "publicIP": {
+      "description": "Specifies whether the instance should get a public IP",
+      "type": [
+        "boolean"
+      ]
+    },
+    "region": {
+      "description": "AWS region to deploy the cluster in",
+      "type": [
+        "string"
+      ]
+    },
+    "sshKeyName": {
+      "description": "The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "worker": {
+      "description": "The configuration of the worker machines",
+      "properties": {
+        "amiID": {
+          "description": "The ID of Amazon Machine Image",
+          "type": [
+            "string"
+          ]
+        },
+        "iamInstanceProfile": {
+          "description": "A name of an IAM instance profile to assign to the instance",
+          "type": [
+            "string"
+          ]
+        },
+        "imageLookup": {
+          "description": "AMI lookup parameters",
+          "properties": {
+            "baseOS": {
+              "description": "The name of the base operating system to use for image lookup the AMI is not set",
+              "type": [
+                "string"
+              ]
+            },
+            "format": {
+              "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
+              "type": [
+                "string"
+              ]
+            },
+            "org": {
+              "description": "The AWS Organization ID to use for image lookup if AMI is not set",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "required": [
+            "format",
+            "org"
+          ],
+          "type": [
+            "object"
+          ]
+        },
+        "instanceType": {
+          "description": "The type of instance to create. Example: m4.xlarge",
+          "type": [
+            "string"
+          ]
+        },
+        "nonRootVolumes": {
+          "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
+          "items": {
+            "type": "object"
+          },
+          "title": "Non-root storage volumes",
+          "type": [
+            "array"
+          ]
+        },
+        "rootVolumeSize": {
+          "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
+          "minimum": 8,
+          "type": [
+            "integer"
+          ]
+        },
+        "uncompressedUserData": {
+          "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "required": [
+        "iamInstanceProfile",
+        "instanceType"
+      ],
+      "type": [
+        "object"
+      ]
+    },
+    "workersNumber": {
+      "description": "The number of the worker machines",
+      "minimum": 1,
+      "type": [
+        "integer"
+      ]
+    }
+  },
   "required": [
     "controlPlaneNumber",
     "workersNumber",
     "region",
     "clusterIdentity"
   ],
-  "properties": {
-    "controlPlaneNumber": {
-      "description": "The number of the control plane machines",
-      "type": "number",
-      "minimum": 1
-    },
-    "workersNumber": {
-      "description": "The number of the worker machines",
-      "type": "number",
-      "minimum": 1
-    },
-    "clusterNetwork": {
-      "type": "object",
-      "properties": {
-        "pods": {
-          "type": "object",
-          "properties": {
-            "cidrBlocks": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
-            }
-          }
-        },
-        "services": {
-          "type": "object",
-          "properties": {
-            "cidrBlocks": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
-            }
-          }
-        }
-      }
-    },
-    "clusterLabels": {
-      "type": "object",
-      "description": "Labels to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },    
-    "clusterAnnotations": {
-      "type": "object",
-      "description": "Annotations to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },    
-    "region": {
-      "description": "AWS region to deploy the cluster in",
-      "type": "string"
-    },
-    "sshKeyName": {
-      "description": "The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
-      "type": ["string", "null"]
-    },
-    "publicIP": {
-      "description": "Specifies whether the instance should get a public IP",
-      "type": "boolean"
-    },
-    "bastion": {
-      "type": "object",
-      "description": "The configuration of the bastion host",
-      "required": [],
-      "properties": {
-          "enabled": {
-              "type": "boolean"
-          },
-          "disableIngressRules": {
-              "type": "boolean"
-          },
-          "allowedCIDRBlocks": {
-              "type": "array",
-              "items": {},
-              "uniqueItems": true
-          },
-          "instanceType": {
-              "type": "string"
-          },
-          "ami": {
-              "type": "string"
-          }
-      }
-    },
-    "clusterIdentity": {
-      "type": "object",
-      "description": "AWS Cluster Identity object reference",
-      "required": [
-        "name",
-	"kind"
-      ],
-      "properties": {
-        "name": {
-	  "description": "AWS ClusterIdentity object name",
-          "type": "string"
-        },
-        "kind": {
-	  "description": "AWS ClusterIdentity object kind",
-          "type": "string"
-        }
-      }
-    },
-    "controlPlane": {
-      "description": "The configuration of the control plane machines",
-      "type": "object",
-      "required": [
-        "iamInstanceProfile",
-        "instanceType"
-      ],
-      "properties": {
-        "amiID": {
-          "description": "The ID of Amazon Machine Image",
-          "type": "string"
-        },
-        "iamInstanceProfile": {
-          "description": "The name of an IAM instance profile to assign to the instance",
-          "type": "string"
-        },
-        "instanceType": {
-          "description": "The type of instance to create",
-          "type": "string"
-        },
-        "additionalSecurityGroupIDs": {
-          "description": "An array of references to security groups that should be applied to the instance",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-	"rootVolumeSize": {
-	  "description": "The size of the root volume of the instance (GB)",
-          "type": "integer"
-        },
-        "imageLookup": {
-	  "description": "AMI lookup parameters",
-          "type": "object",
-          "required": [
-            "format",
-            "org"
-          ],
-          "properties": {
-            "format": {
-	      "description": "Format string which will be used for image lookup",
-              "type": "string"
-            },
-            "org": {
-	      "description": "AWS org ID which owns the AMI",
-              "type": "string"
-            },
-            "baseOS": {
-	      "description": "OS name which can be used in format string",
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
-    "worker": {
-      "description": "The configuration of the worker machines",
-      "type": "object",
-      "required": [
-        "iamInstanceProfile",
-        "instanceType"
-      ],
-      "properties": {
-        "amiID": {
-          "description": "The ID of Amazon Machine Image",
-          "type": "string"
-        },
-        "iamInstanceProfile": {
-          "description": "The name of an IAM instance profile to assign to the instance",
-          "type": "string"
-        },
-        "instanceType": {
-          "description": "The type of instance to create",
-          "type": "string"
-        },
-        "additionalSecurityGroupIDs": {
-          "description": "An array of references to security groups that should be applied to the instance",
-          "type": "array"
-        },
-	"rootVolumeSize": {
-	  "description": "The size of the root volume of the instance (GB)",
-          "type": "integer"
-        },
-	"imageLookup": {
-	  "description": "AMI lookup parameters",
-          "type": "object",
-          "required": [
-            "format",
-            "org"
-          ],
-          "properties": {
-            "format": {
-	      "description": "Format string which will be used for image lookup",
-              "type": "string"
-            },
-            "org": {
-	      "description": "AWS org ID which owns the AMI",
-              "type": "string"
-            },
-            "baseOS": {
-	      "description": "OS name which can be used in format string",
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
-    "k0s": {
-      "description": "K0s parameters",
-      "type": "object",
-      "required": [
-        "version"
-      ],
-      "properties": {
-        "version":{
-          "description": "K0s version to use",
-          "type": "string"
-        },
-        "api": {
-          "description": "Kubernetes api-server parameters",
-          "type": "object",
-          "properties": {
-            "extraArgs": {
-              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "auth": {
-          "description": "Kubernetes AuthenticationConfiguration file",
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean"
-            }
-          }
-        }
-      }
-    }
-  }
+  "type": "object"
 }

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -1,77 +1,65 @@
-# Cluster parameters
-controlPlaneNumber: 3
-workersNumber: 2
+# Schema generation:
+# $ helm plugin install https://github.com/losisin/helm-values-schema-json.git
+# $ helm schema --draft 2020 --indent 2 --noAdditionalProperties=false --schemaRoot.description='A KCM template to deploy a k0s cluster on AWS with bootstrapped control plane nodes' --input ./templates/cluster/aws-standalone-cp/values.yaml --output ./templates/cluster/aws-standalone-cp/values.schema.json
 
-clusterNetwork:
-  pods:
-    cidrBlocks:
+# Cluster parameters
+controlPlaneNumber: 3 # @schema description: The number of the control-plane machines; minimum: 1; type: integer; required: true
+workersNumber: 2 # @schema description: The number of the worker machines; minimum: 1; type: integer; required: true
+
+clusterNetwork: # @schema description: The cluster network configuration; type: object
+  pods: # @schema description: The network ranges from which Pod networks are allocated; type: object
+    cidrBlocks: # @schema description: A list of CIDR blocks; type: array; item: string
       - "10.244.0.0/16"
-  services:
-    cidrBlocks:
+  services: # @schema description: The network ranges from which service VIPs are allocated; type: object
+    cidrBlocks: # @schema description: A list of CIDR blocks; type: array; item: string
       - "10.96.0.0/12"
 
-clusterLabels: {}
-clusterAnnotations: {}
+clusterLabels: {} # @schema description: Labels to apply to the cluster; type: object; additionalProperties: true
+clusterAnnotations: {} # @schema description: Annotations to apply to the cluster; type: object; additionalProperties: true
 
 # AWS cluster parameters
-region: ""
-sshKeyName: ""
-publicIP: false
-bastion:
-  enabled: false
-  disableIngressRules: false
-  allowedCIDRBlocks: []
-  instanceType: t2.micro
-  ami: ""
-clusterIdentity:
-  name: ""
-  kind: "AWSClusterStaticIdentity"
-# AWS machines parameters
-controlPlane:
-  amiID: ""
-  iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
-  instanceType: ""
-  rootVolumeSize: 8
-  imageLookup:
-    format: "amzn2-ami-hvm*-gp2"
-    org: "137112412989"
-    baseOS: ""
-  uncompressedUserData: false
+region: "" # @schema description: AWS region to deploy the cluster in; type: string; required: true
+sshKeyName: "" # @schema description: The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name); type: [string, null]
+publicIP: false # @schema description: Specifies whether the instance should get a public IP; type: boolean
+bastion: # @schema description: The configuration of the bastion host; type: object
+  enabled: false # @schema description: Allows this provider to create a bastion host instance with a public ip to access the VPC private network; type: boolean; required: true
+  disableIngressRules: false # @schema description: Ensures ensure there are no Ingress rules in the bastion host's security group. Requires allowedCIDRBlocks to be empty; type: boolean
+  allowedCIDRBlocks: [] # @schema description: A list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0); type: array; item: string
+  instanceType: t2.micro # @schema description: Use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default; type: string
+  ami: "" # @schema description: Uses the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space; type: string
+clusterIdentity: # @schema description: A reference to an identity to be used when reconciling the managed control plane; type: object; required: true
+  name: "" # @schema description: Name of the identity; type: string; required: true
+  kind: "AWSClusterStaticIdentity" # @schema description: Kind of the identity; type: string; required: true
 
-worker:
-  amiID: ""
-  iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io
-  instanceType: ""
-  rootVolumeSize: 8
-  imageLookup:
-    format: "amzn2-ami-hvm*-gp2"
-    org: "137112412989"
-    baseOS: ""
-  uncompressedUserData: false
+# AWS machines parameters
+controlPlane: # @schema description: The configuration of the control plane machines; type: object
+  amiID: "" # @schema description: The ID of Amazon Machine Image; type: string
+  iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io # @schema description: A name of an IAM instance profile to assign to the instance; type: string; required: true
+  instanceType: "" # @schema description: The type of instance to create. Example: m4.xlarge; type: string; required: true
+  rootVolumeSize: 8 # @schema description: Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater); type: integer; minimum: 8
+  imageLookup: # @schema description: AMI lookup parameters; type: object
+    format: "amzn2-ami-hvm*-gp2" # @schema description: The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set; type: string; required: true
+    org: "137112412989" # @schema description: The AWS Organization ID to use for image lookup if AMI is not set; type: string; required: true
+    baseOS: "" # @schema description: The name of the base operating system to use for image lookup the AMI is not set; type: string
+  uncompressedUserData: false # @schema description: Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed; type: boolean
+  nonRootVolumes: [] # @schema title: Non-root storage volumes; description: Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes; type: array; item: object
+
+worker: # @schema description: The configuration of the worker machines; type: object
+  amiID: "" # @schema description: The ID of Amazon Machine Image; type: string
+  iamInstanceProfile: control-plane.cluster-api-provider-aws.sigs.k8s.io # @schema description: A name of an IAM instance profile to assign to the instance; type: string; required: true
+  instanceType: "" # @schema description: The type of instance to create. Example: m4.xlarge; type: string; required: true
+  rootVolumeSize: 8 # @schema description: Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater); type: integer; minimum: 8
+  imageLookup: # @schema description: AMI lookup parameters; type: object
+    format: "amzn2-ami-hvm*-gp2" # @schema description: The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set; type: string; required: true
+    org: "137112412989" # @schema description: The AWS Organization ID to use for image lookup if AMI is not set; type: string; required: true
+    baseOS: "" # @schema description: The name of the base operating system to use for image lookup the AMI is not set; type: string
+  uncompressedUserData: false # @schema description: Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed; type: boolean
+  nonRootVolumes: [] # @schema title: Non-root storage volumes; description: Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes; type: array; item: object
 
 # K0s parameters
-k0s:
-  version: v1.32.3+k0s.0
-  api:
-    extraArgs: {}
-  auth:
-    enabled: false
-    config:
-      apiVersion: apiserver.config.k8s.io/v1beta1
-      kind: AuthenticationConfiguration
-      jwt:
-        - issuer:
-            url: "https://your-jwt-issuer.com"
-            audiences:
-            - "your-audience"
-          claimMappings:
-            username:
-              claim: email
-              prefix: ""
-            groups:
-              claim: groups
-              prefix: ""
-          userValidationRules:
-          - expression: "!user.username.startsWith('system:')"
-            message: "username cannot use reserved system: prefix"
-
+# # NOTE: .k0s additional properties are to support prior .k0s.auth implementation
+k0s: # @schema description: K0s parameters; type: object; additionalProperties: true
+  version: v1.32.3+k0s.0 # @schema description: K0s version; type: string; required: true
+  api: # @schema description: Kubernetes API server parameters; type: object
+    extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+  files: [] # @schema description: Specifies extra files to be passed to user_data upon creation; type: array; item: object

--- a/templates/provider/kcm-templates/files/templates/aws-eks-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-0
+  name: aws-eks-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.0
+      chart: aws-eks
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-0
+  name: aws-hosted-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.0
+      chart: aws-hosted-cp
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-eks-1-0-0
+  name: aws-standalone-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-eks
-      version: 1.0.0
+      chart: aws-standalone-cp
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Added `nonRootVolumes` configuration to the AWS ClusterTemplates (standalone, EKS, hosted).

Updated JSON Schema validations to be generated along with instructions on how to do it.

Bumped the corresponding templates' versions.

Generalized the approach of the `aws-standalone-cp` to set up OIDC, preserving backward-compatibility

Fixes #1482 