### PR TITLE
feat: Mount registry certificate secret in CAPI operator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -282,6 +282,7 @@ func main() {
 		IsDisabledValidationWH: !enableWebhook,
 		GlobalRegistry:         globalRegistry,
 		GlobalK0sURL:           globalK0sURL,
+		RegistryCertSecret:     registryCertSecret,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Management")
 		os.Exit(1)


### PR DESCRIPTION
If `RegistryCertSecret` is set, add a new volume and volumeMount referencing the certificate from that secret to the CAPI operator's values.

This allows the CAPI operator to fetch provider components from the private registry signed by an unknown authority.

Also, refactor the component values overrides (all internal logic from `enableAdditionalComponents` was moved to the HelmRelease level without overwriting the Management spec, all component values overrides were moved to a single function).

Fixes #1571
