### PR TITLE
Remove namespace from AWSClusterStaticIdentity reference

### DIFF
--- a/config/dev/aws-credentials.yaml
+++ b/config/dev/aws-credentials.yaml
@@ -36,7 +36,6 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: AWSClusterStaticIdentity
     name: aws-cluster-identity
-    namespace: ${NAMESPACE}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
AWSClusterStaticIdentity is cluster-scoped