### PR TITLE
feat: automatically update stuck sveltos tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
+	k8s.io/kubectl v0.33.1
 	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979
 	kubevirt.io/api v1.5.1
 	kubevirt.io/containerized-data-importer-api v1.62.0
@@ -182,7 +183,6 @@ require (
 	k8s.io/component-base v0.33.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/kubectl v0.33.1 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 	oras.land/oras-go/v2 v2.5.0 // indirect
 	sigs.k8s.io/gateway-api v1.1.0 // indirect

--- a/internal/controller/backup/suite_test.go
+++ b/internal/controller/backup/suite_test.go
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.29.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error

--- a/internal/controller/ipam/suite_test.go
+++ b/internal/controller/ipam/suite_test.go
@@ -90,7 +90,7 @@ var _ = BeforeSuite(func() {
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.29.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	// cfg is defined in this file globally.

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -111,7 +111,7 @@ var _ = BeforeSuite(func() {
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.29.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			MutatingWebhooks: mutatingWebhooks,
 		},

--- a/internal/controller/sveltos/cluster_controller.go
+++ b/internal/controller/sveltos/cluster_controller.go
@@ -1,0 +1,299 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sveltos
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	apiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/cluster-api/util/patch"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+	"github.com/K0rdent/kcm/internal/utils/ratelimit"
+)
+
+// ClusterReconciler reconciles a SveltosCluster object.
+type ClusterReconciler struct {
+	client.Client
+
+	config *rest.Config
+}
+
+func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	l := ctrl.LoggerFrom(ctx)
+	l.Info("Reconciling")
+
+	sveltosCluster := new(libsveltosv1beta1.SveltosCluster)
+	if err := r.Get(ctx, req.NamespacedName, sveltosCluster); err != nil {
+		l.Error(err, "unable to fetch SveltosCluster")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	patchHelper, err := patch.NewHelper(sveltosCluster, r.Client)
+	if err != nil {
+		l.Error(err, "failed to construct patch helper for SveltosCluster")
+		return ctrl.Result{}, err
+	}
+
+	caData, err := getInClusterCAData()
+	if err != nil {
+		l.Error(err, "failed to fetch CA data")
+		return ctrl.Result{}, err
+	}
+
+	libsveltosLogger := ctrl.LoggerFrom(ctx).WithName("libsveltos")
+	data, err := clusterproxy.GetSveltosSecretData(ctx, libsveltosLogger, r.Client, sveltosCluster.Namespace, sveltosCluster.Name)
+	if err != nil {
+		l.Error(err, "failed to get sveltos secret data")
+		return ctrl.Result{}, fmt.Errorf("failed to get sveltos secret data: %w", err)
+	}
+
+	unstructuredConfig := &unstructured.Unstructured{}
+	if _, _, err := scheme.Codecs.UniversalDeserializer().Decode(data, nil, unstructuredConfig); err != nil {
+		l.Error(err, "failed to decode \"k8s.io/client-go/tools/clientcmd/api/v1\".Config data")
+		return ctrl.Result{}, fmt.Errorf("failed to decode \"k8s.io/client-go/tools/clientcmd/api/v1\".Config (%.50s): %w", string(data), err)
+	}
+
+	config := new(apiv1.Config)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredConfig.UnstructuredContent(), config); err != nil {
+		l.Error(err, "failed to convert unstructured data to \"k8s.io/client-go/tools/clientcmd/api/v1\".Config")
+		return ctrl.Result{}, fmt.Errorf("failed to convert unstructured data to \"k8s.io/client-go/tools/clientcmd/api/v1\".Config: %w", err)
+	}
+
+	const renewalConfigKey = "re-kubeconfig"
+	for i := range config.Contexts {
+		cc := &config.Contexts[i]
+
+		saNamespace := cc.Context.Namespace
+		saName := cc.Context.AuthInfo
+
+		if sveltosCluster.Spec.TokenRequestRenewalOption.SANamespace != "" && sveltosCluster.Spec.TokenRequestRenewalOption.SAName != "" {
+			saNamespace = sveltosCluster.Spec.TokenRequestRenewalOption.SANamespace
+			saName = sveltosCluster.Spec.TokenRequestRenewalOption.SAName
+		}
+
+		// https://github.com/projectsveltos/sveltoscluster-manager/blob/31ff86a077fb6cb4d4c426440ef2fe4f2ff578ce/controllers/sveltoscluster_controller.go#L331
+
+		saExpirationInSecond := sveltosCluster.Spec.TokenRequestRenewalOption.RenewTokenRequestInterval.Seconds()
+		// Minimum duration for a TokenRequest is 10 minutes. SveltosCluster reconciler always set the expiration to be
+		// sveltosCluster.Spec.TokenRequestRenewalOption.RenewTokenRequestInterval plus 30 minutes. That will also allow
+		// reconciler to renew it again before it current tokenRequest expires
+		const secondsToAddToTokenRequest = 30 * 60 // 30 minutes
+		saExpirationInSecond += float64(secondsToAddToTokenRequest)
+
+		tokenRequest, err := r.getServiceAccountTokenRequest(ctx, saNamespace, saName, saExpirationInSecond)
+		if err != nil {
+			l.Error(err, "failed to get TokenRequest")
+			return ctrl.Result{}, fmt.Errorf("failed to get TokenRequest: %w", err)
+		}
+
+		// it's sveltoscluster-manager controller responsibility to update renew token request interval
+		// and we want to interfere with this controller as little as possible
+
+		l.V(1).Info("Get Kubeconfig from TokenRequest")
+		data := r.getKubeconfigFromToken(saNamespace, saName, tokenRequest.Token, caData)
+
+		if err := clusterproxy.UpdateSveltosSecretData(ctx, libsveltosLogger, r.Client, sveltosCluster.Namespace, sveltosCluster.Name, data, renewalConfigKey); err != nil {
+			l.Error(err, "failed to update Secret")
+			return ctrl.Result{}, fmt.Errorf("failed to update Secret: %w", err)
+		}
+
+		// set updates to spec/status
+		// WARN: interferes with another controller
+		if sveltosCluster.Spec.KubeconfigKeyName != renewalConfigKey {
+			sveltosCluster.Spec.KubeconfigKeyName = renewalConfigKey
+		}
+		sveltosCluster.Status.LastReconciledTokenRequestAt = time.Now().Format(time.RFC3339)
+	}
+
+	// NOTE: set neither failure messages nor health status, it's sveltoscluster-manager controller responsibility
+	// we only update the config with a new token and set (if not) the new key along with the last update time
+
+	// patch both spec/status
+	// WARN: interferes with another controller
+	if err := patchHelper.Patch(ctx, sveltosCluster); err != nil {
+		l.Error(err, "failed to patch SveltosCluster")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClusterReconciler) getServiceAccountTokenRequest(ctx context.Context, saNs, saName string, saExpirationInSecond float64) (*authenticationv1.TokenRequestStatus, error) {
+	clientset, err := kubernetes.NewForConfig(r.config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct ClientSet from manager's config: %w", err)
+	}
+
+	expiration := int64(saExpirationInSecond)
+	tokenRequest, err := clientset.CoreV1().ServiceAccounts(saNs).CreateToken(ctx, saName, &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			ExpirationSeconds: &expiration,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token for ServiceAccount '%s/%s': %w", saNs, saName, err)
+	}
+
+	return &tokenRequest.Status, nil
+}
+
+func (r *ClusterReconciler) getKubeconfigFromToken(namespace, serviceAccountName, token string, caData []byte) string {
+	const template = `apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: %s
+    certificate-authority-data: "%s"
+users:
+- name: %s
+  user:
+    token: %s
+contexts:
+- name: sveltos-context
+  context:
+    cluster: local
+    namespace: %s
+    user: %s
+current-context: sveltos-context`
+
+	data := fmt.Sprintf(template,
+		r.config.Host,
+		base64.StdEncoding.EncodeToString(caData),
+		serviceAccountName,
+		token,
+		namespace,
+		serviceAccountName)
+
+	return data
+}
+
+func getInClusterCAData() ([]byte, error) {
+	fi, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	inCluster := os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
+		os.Getenv("KUBERNETES_SERVICE_PORT") != "" &&
+		err == nil && !fi.IsDir()
+
+	if !inCluster { // sanity check
+		return []byte{}, nil
+	}
+
+	const rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	content, err := os.ReadFile(rootCAFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA file: %w", err)
+	}
+
+	return content, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.config = mgr.GetConfig()
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("sveltos_cluster_controller").
+		For(&libsveltosv1beta1.SveltosCluster{}).
+		WithOptions(controller.TypedOptions[ctrl.Request]{
+			RateLimiter: ratelimit.DefaultFastSlow(),
+		}).
+		WithEventFilter(predicate.Funcs{
+			GenericFunc: func(event.TypedGenericEvent[client.Object]) bool { return false },
+			CreateFunc:  func(event.TypedCreateEvent[client.Object]) bool { return false },
+			DeleteFunc:  func(event.TypedDeleteEvent[client.Object]) bool { return false },
+			UpdateFunc: func(tue event.TypedUpdateEvent[client.Object]) bool {
+				// consider only new incoming object
+				sveltosCluster, ok := tue.ObjectNew.(*libsveltosv1beta1.SveltosCluster)
+				if !ok {
+					return false
+				}
+
+				// consider only mgmt sveltos cluster
+				if v, ok := sveltosCluster.Labels[kcmv1.K0rdentManagementClusterLabelKey]; !ok || v != kcmv1.K0rdentManagementClusterLabelValue {
+					return false
+				}
+
+				// consider only those clusters that have auto-renewal
+				if sveltosCluster.Spec.TokenRequestRenewalOption == nil {
+					return false
+				}
+
+				// consider only clusters that have been updated at least once
+				if sveltosCluster.Status.LastReconciledTokenRequestAt == "" {
+					return false
+				}
+
+				// consider only if new status is down (healthy/empty is not the case)
+				if sveltosCluster.Status.ConnectionStatus == libsveltosv1beta1.ConnectionHealthy ||
+					sveltosCluster.Status.ConnectionStatus == "" {
+					return false
+				}
+
+				// consider only clusters with failures
+				if sveltosCluster.Status.FailureMessage == nil {
+					return false
+				}
+
+				// consider only auth issues, since we have only strings, then no chance to check properly as error instance
+				if !strings.Contains(*sveltosCluster.Status.FailureMessage, "the server has asked for the client to provide credentials") &&
+					!strings.Contains(*sveltosCluster.Status.FailureMessage, "Unauthorized") {
+					return false
+				}
+
+				// the logic below is referenced from
+				// https://github.com/projectsveltos/sveltoscluster-manager/blob/31ff86a077fb6cb4d4c426440ef2fe4f2ff578ce/controllers/sveltoscluster_controller.go#L289
+				currentTime := time.Now()
+
+				lastRenewal := sveltosCluster.CreationTimestamp
+				parsedTime, err := time.Parse(time.RFC3339, sveltosCluster.Status.LastReconciledTokenRequestAt)
+				if err == nil { // if NO error
+					lastRenewal = metav1.Time{Time: parsedTime}
+				}
+
+				renewalInterval := sveltosCluster.Spec.TokenRequestRenewalOption.RenewTokenRequestInterval.Seconds()
+				const tenMinutes = 10 * 60
+				var renewalThreshold time.Duration
+				if renewalInterval > tenMinutes {
+					renewalThreshold = time.Duration(renewalInterval-tenMinutes) * time.Second
+				} else {
+					renewalThreshold = time.Duration(renewalInterval) * time.Second
+				}
+
+				elapsed := currentTime.Sub(lastRenewal.Time)
+				return elapsed.Seconds() > renewalThreshold.Seconds()
+			},
+		}).
+		Complete(r)
+}

--- a/internal/controller/sveltos/cluster_controller_test.go
+++ b/internal/controller/sveltos/cluster_controller_test.go
@@ -1,0 +1,196 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sveltos
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	apiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var _ = Describe("SveltosCluster Controller Integration Tests", func() {
+	var (
+		ctx     context.Context
+		cancel  context.CancelFunc
+		testEnv *envtest.Environment
+		cl      client.Client
+		config  *rest.Config
+	)
+
+	BeforeEach(func() {
+		RegisterFailHandler(Fail)
+
+		logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+		ctx, cancel = context.WithCancel(context.TODO())
+		testEnv = &envtest.Environment{
+			CRDDirectoryPaths: []string{
+				filepath.Join("..", "..", "..", "templates", "provider", "kcm", "templates", "crds"),
+				filepath.Join("..", "..", "..", "bin", "crd"),
+			},
+			ErrorIfCRDPathMissing: true,
+
+			// The BinaryAssetsDirectory is only required if you want to run the tests directly
+			// without call the makefile target test. If not informed it will look for the
+			// default path defined in controller-runtime which is /usr/local/kubebuilder/.
+			// Note that you must have the required binaries setup under the bin directory to perform
+			// the tests directly. When we run make test it will be setup and used automatically.
+			BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
+				fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+		}
+
+		cfg, err := testEnv.Start()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg).NotTo(BeNil())
+		config = cfg
+
+		Expect(libsveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+		cl, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cl).NotTo(BeNil())
+	})
+
+	AfterEach(func() {
+		Expect(testEnv.Stop()).NotTo(HaveOccurred())
+		cancel()
+	})
+
+	It("Should create a new TokenRequest and update the secret", func() {
+		const (
+			testClusterName = "test-cluster"
+			testSAName      = "test-sa"
+		)
+
+		timeBeforeNode := time.Now().UTC().Add(-time.Hour)
+
+		// Create a test SveltosCluster
+		sveltosCluster := &libsveltosv1beta1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testClusterName,
+				Namespace: metav1.NamespaceDefault,
+			},
+			Spec: libsveltosv1beta1.SveltosClusterSpec{
+				TokenRequestRenewalOption: &libsveltosv1beta1.TokenRequestRenewalOption{
+					SANamespace: metav1.NamespaceDefault,
+					SAName:      testSAName,
+				},
+			},
+		}
+		Expect(cl.Create(ctx, sveltosCluster)).NotTo(HaveOccurred())
+
+		// Create SA to generate TokenRequest for
+		Expect(cl.Create(ctx, &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testSAName,
+				Namespace: metav1.NamespaceDefault,
+			},
+		})).NotTo(HaveOccurred())
+
+		// Create Sveltos Secret with a fake data
+		secretName, _, err := clusterproxy.GetSveltosSecretNameAndKey(ctx, logf.Log, cl, sveltosCluster.Namespace, sveltosCluster.Name)
+		Expect(err).NotTo(HaveOccurred())
+
+		fakeBB, err := json.Marshal(&apiv1.Config{
+			APIVersion: "v1",
+			Kind:       "Config",
+			Contexts: []apiv1.NamedContext{
+				{
+					Name: "fake",
+					Context: apiv1.Context{
+						AuthInfo:  testSAName,
+						Namespace: metav1.NamespaceDefault,
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		sveltosSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: sveltosCluster.Namespace,
+			},
+			Data: map[string][]byte{"kubeconfig": fakeBB},
+		}
+		Expect(cl.Create(ctx, sveltosSecret)).NotTo(HaveOccurred())
+
+		// Run the controller
+		_, err = (&ClusterReconciler{
+			Client: cl,
+			config: config,
+		}).Reconcile(ctx, ctrl.Request{
+			NamespacedName: client.ObjectKeyFromObject(sveltosCluster),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify the KubeconfigKeyName and LastReconciledTokenRequestAt is updated
+		const renewalConfigKey = "re-kubeconfig"
+		Eventually(func() bool {
+			updatedCluster := new(libsveltosv1beta1.SveltosCluster)
+			if err := cl.Get(ctx, client.ObjectKeyFromObject(sveltosCluster), updatedCluster); err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get SveltosCluster: %v", err)
+				return false
+			}
+			updatedAt, err := time.Parse(time.RFC3339, updatedCluster.Status.LastReconciledTokenRequestAt)
+			if err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to parse LastReconciledTokenRequestAt: %v", err)
+				return false
+			}
+
+			if updatedCluster.Spec.KubeconfigKeyName != renewalConfigKey {
+				_, _ = fmt.Fprintf(GinkgoWriter, "KubeconfigKeyName %s != %s", updatedCluster.Spec.KubeconfigKeyName, renewalConfigKey)
+				return false
+			}
+
+			if !updatedAt.After(timeBeforeNode) {
+				_, _ = fmt.Fprintf(GinkgoWriter, "LastReconciledTokenRequestAt %s is not after %s", updatedCluster.Status.LastReconciledTokenRequestAt, timeBeforeNode.Format(time.RFC3339))
+				return false
+			}
+
+			return true
+		}).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(BeTrue())
+
+		// Verify the sveltos secret is updated
+		updatedSecret := new(corev1.Secret)
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(sveltosSecret), updatedSecret)).NotTo(HaveOccurred())
+
+		// Verify the token is present in the secret
+		Expect(updatedSecret.Data).To(HaveKey(renewalConfigKey))
+	})
+})
+
+func TestControllerIntegration(t *testing.T) {
+	RunSpecs(t, "SveltosCluster Controller Integration Tests")
+}

--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
         {{- end }}
         {{- end }}
         - --pprof-bind-address={{ .Values.controller.debug.pprofBindAddress }}
+        {{- if .Values.controller.enableSveltosExpiredCtrl }}
+        - --enable-sveltos-expire-ctrl={{ .Values.controller.enableSveltosExpiredCtrl }}
+        {{- end }}
         command:
         - /manager
         env:

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -216,10 +216,15 @@ rules:
   - vsphereclusteridentities
   verbs: {{ include "rbac.viewerVerbs" . | nindent 2 }}
 - apiGroups:
-    - lib.projectsveltos.io
+  - lib.projectsveltos.io
   resources:
-    - sveltosclusters
-  verbs: {{ include "rbac.viewerVerbs" . | nindent 4 }}
+  - sveltosclusters
+  - sveltosclusters/status
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
 - apiGroups:
   - config.projectsveltos.io
   resources:
@@ -250,7 +255,17 @@ rules:
   - ""
   resources:
   - secrets
-  verbs: {{ include "rbac.viewerVerbs" . | nindent 2 }}
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
 - apiGroups:
   - ""
   resources:
@@ -290,29 +305,29 @@ rules:
   verbs:
   - list
 - apiGroups:
-    - k0rdent.mirantis.com
+  - k0rdent.mirantis.com
   resources:
-    - clusteripamclaims
-    - clusteripams
+  - clusteripamclaims
+  - clusteripams
   verbs: {{ include "rbac.editorVerbs" . | nindent 4 }}
 - apiGroups:
-    - k0rdent.mirantis.com
+  - k0rdent.mirantis.com
   resources:
-    - clusteripamclaims/status
-    - clusteripams/status
+  - clusteripamclaims/status
+  - clusteripams/status
   verbs:
-    - get
-    - patch
-    - update
+  - get
+  - patch
+  - update
 - apiGroups:
-    - ipam.cluster.x-k8s.io
+  - ipam.cluster.x-k8s.io
   resources:
-    - ipaddressclaims
+  - ipaddressclaims
   verbs: {{ include "rbac.editorVerbs" . | nindent 4 }}
 - apiGroups:
-    - ipam.cluster.x-k8s.io
+  - ipam.cluster.x-k8s.io
   resources:
-    - inclusterippools
+  - inclusterippools
   verbs: {{ include "rbac.editorVerbs" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -1,13 +1,11 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Helm Chart to deploy KCM manager controller and its related components",
   "properties": {
     "admissionWebhook": {
       "properties": {
         "certDir": {
           "type": "string"
-        },
-        "enabled": {
-          "type": "boolean"
         },
         "port": {
           "type": "integer"
@@ -95,6 +93,13 @@
     },
     "controller": {
       "properties": {
+        "affinity": {
+          "description": "Affinity rules for pod scheduling",
+          "properties": {},
+          "type": [
+            "object"
+          ]
+        },
         "createAccessManagement": {
           "type": "boolean"
         },
@@ -120,17 +125,20 @@
           },
           "type": "object"
         },
-        "templatesRepoURL": {
-          "type": "string"
-        },
-	"globalRegistry": {
-          "type": "string"
-	},
-	"globalK0sURL": {
-          "type": "string"
+        "enableSveltosExpiredCtrl": {
+          "description": "Enables SveltosCluster controller, updating stuck (expired) sveltos management cluster kubeconfig tokens",
+          "type": [
+            "boolean"
+          ]
         },
         "enableTelemetry": {
           "type": "boolean"
+        },
+        "globalK0sURL": {
+          "type": "string"
+        },
+        "globalRegistry": {
+          "type": "string"
         },
         "insecureRegistry": {
           "type": "boolean"
@@ -192,13 +200,9 @@
             }
           },
           "title": "Logger Settings",
-          "type": "object"
-        },
-        "registryCredsSecret": {
-          "type": "string"
-        },
-        "registryCertSecret": {
-          "type": "string"
+          "type": [
+            "object"
+          ]
         },
         "nodeSelector": {
           "description": "Node selector to constrain the pod to run on specific nodes",
@@ -207,12 +211,14 @@
             "object"
           ]
         },
-        "affinity": {
-          "description": "Affinity rules for pod scheduling",
-          "properties": {},
-          "type": [
-            "object"
-          ]
+        "registryCertSecret": {
+          "type": "string"
+        },
+        "registryCredsSecret": {
+          "type": "string"
+        },
+        "templatesRepoURL": {
+          "type": "string"
         },
         "tolerations": {
           "description": "Tolerations to allow the pod to schedule on tainted nodes",
@@ -359,19 +365,6 @@
     },
     "nameOverride": {
       "type": "string"
-    },
-    "projectsveltos": {
-      "properties": {
-        "crds": {
-          "properties": {
-            "enabled": {
-              "type": "boolean"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "type": "object"
     },
     "replicas": {
       "type": "integer"

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -1,3 +1,7 @@
+# Schema generation:
+# $ helm plugin install https://github.com/losisin/helm-values-schema-json.git
+# $ helm schema --draft 2020 --indent 2 --noAdditionalProperties=false --schemaRoot.description='Helm Chart to deploy KCM manager controller and its related components' --input ./templates/provider/kcm/values.yaml --output ./templates/provider/kcm/values.schema.json
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -22,7 +26,8 @@ controller:
   affinity: {} # @schema type: object; description: Affinity rules for pod scheduling
   tolerations: [] # @schema type: array; description: Tolerations to allow the pod to schedule on tainted nodes
   validateClusterUpgradePath: true # @schema type: boolean; description: Specifies whether the ClusterDeployment upgrade path should be validated
-  logger: # @schema title: Logger Settings ; description: Global controllers logger settings
+  enableSveltosExpiredCtrl: false # @schema type: boolean; description: Enables SveltosCluster controller, updating stuck (expired) sveltos management cluster kubeconfig tokens
+  logger: # @schema title: Logger Settings; description: Global controllers logger settings; type: object
     devel: false # @schema type: boolean; description: Development defaults(encoder=console,logLevel=debug,stackTraceLevel=warn) Production defaults(encoder=json,logLevel=info,stackTraceLevel=error)
     encoder: "" # @schema enum:[json, console, ""] ; type: string
     log-level: "" # @schema enum:[info, debug, error, ""] ; type: string


### PR DESCRIPTION
Adds new controller that determines if there is a stuck unhealthy management SveltosCluster due to expired token and updates the corresponding secret data with a new token, so the other sveltos controllers can proceed theirs logic working with the new kubeconfig.

Bumps binary assets data to 1.32 to be on par with the current envtest k8s version in use.

Fixes #995 