### PR TITLE
feat: Add support for mounting registry and k0s URL certificates

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-1
+  template: aws-standalone-cp-1-0-2
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-0
+  template: azure-standalone-cp-1-0-1
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-1
+  template: gcp-standalone-cp-1-0-2
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-0
+  template: openstack-standalone-cp-1-0-1
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-0
+  template: remote-cluster-1-0-1
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-0
+  template: vsphere-standalone-cp-1-0-1
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -37,20 +37,20 @@ spec:
       {{- if $global.registry }}
       images:
         metricsserver:
-          image: "{{ $global.registry}}/k0sproject/metrics-server"
+          image: "{{ $global.registry }}/k0sproject/metrics-server"
         kubeproxy:
-          image: "{{ $global.registry}}/k0sproject/kube-proxy"
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
         coredns:
-          image: "{{ $global.registry}}/k0sproject/coredns"
+          image: "{{ $global.registry }}/k0sproject/coredns"
         pause:
-          image: "{{ $global.registry}}/k0sproject/pause"
+          image: "{{ $global.registry }}/k0sproject/pause"
         calico:
           cni:
-            image: "{{ $global.registry}}/k0sproject/calico-cni"
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
           node:
-            image: "{{ $global.registry}}/k0sproject/calico-node"
+            image: "{{ $global.registry }}/k0sproject/calico-node"
           kubecontrollers:
-            image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:
@@ -65,7 +65,7 @@ spec:
           - name: aws-cloud-controller-manager
             namespace: kube-system
             {{- if $global.registry }}
-            chartname: oci://{{ $global.registry}}/charts/aws-cloud-controller-manager
+            chartname: oci://{{ $global.registry }}/charts/aws-cloud-controller-manager
             {{- else }}
             chartname: mirantis/aws-cloud-controller-manager
             {{- end }}
@@ -93,7 +93,7 @@ spec:
           - name: aws-ebs-csi-driver
             namespace: kube-system
             {{- if $global.registry }}
-            chartname: oci://{{ $global.registry}}/charts/aws-ebs-csi-driver
+            chartname: oci://{{ $global.registry }}/charts/aws-ebs-csi-driver
             {{- else }}
             chartname: aws-ebs-csi-driver/aws-ebs-csi-driver
             {{- end }}

--- a/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,6 +9,22 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      files:
+        {{- range $path, $secret := $certs }}
+        {{- if $secret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $secret }}
+              key: tls.crt
+          permissions: "0664"
+          path: /usr/local/share/ca-certificates/{{ $path }}
+        {{- end }}
+        {{- end }}
+      preStartCommands:
+      - "sudo update-ca-certificates"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,8 +9,8 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
         {{- if $secret }}

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -15,21 +15,10 @@ spec:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
       - --disable-components=konnectivity-server
-    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     {{- $auth := .Values.k0s.auth }}
     {{- $files := .Values.k0s.files }}
     {{- if or (and $auth $auth.enabled) $files $global.registryCertSecret $global.k0sURLCertSecret }}
     files:
-      {{- range $path, $secret := $certs }}
-      {{- if $secret }}
-      - contentFrom:
-          secretRef:
-            name: {{ $secret }}
-            key: tls.crt
-        permissions: "0664"
-        path: /usr/local/share/ca-certificates/{{ $path }}
-      {{- end }}
-      {{- end }}
     {{- if and $auth $auth.enabled }}
     - content: | {{ toYaml $auth.config | nindent 8 }}
       permissions: "0644"
@@ -37,6 +26,17 @@ spec:
     {{- end }}
     {{- range $file := $files }}
     - {{ toYaml $file | trim | nindent 6 }}
+    {{- end }}
+    {{- end }}
+    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+    {{- range $path, $secret := $certs }}
+    {{- if $secret }}
+    - contentFrom:
+        secretRef:
+          name: {{ $secret }}
+          key: tls.crt
+      permissions: "0664"
+      path: /usr/local/share/ca-certificates/{{ $path }}
     {{- end }}
     {{- end }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -15,10 +15,21 @@ spec:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
       - --disable-components=konnectivity-server
+    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     {{- $auth := .Values.k0s.auth }}
     {{- $files := .Values.k0s.files }}
-    {{- if or (and $auth $auth.enabled) $files }}
+    {{- if or (and $auth $auth.enabled) $files $global.registryCertSecret $global.k0sURLCertSecret }}
     files:
+      {{- range $path, $secret := $certs }}
+      {{- if $secret }}
+      - contentFrom:
+          secretRef:
+            name: {{ $secret }}
+            key: tls.crt
+        permissions: "0664"
+        path: /usr/local/share/ca-certificates/{{ $path }}
+      {{- end }}
+      {{- end }}
     {{- if and $auth $auth.enabled }}
     - content: | {{ toYaml $auth.config | nindent 8 }}
       permissions: "0644"
@@ -27,6 +38,10 @@ spec:
     {{- range $file := $files }}
     - {{ toYaml $file | trim | nindent 6 }}
     {{- end }}
+    {{- end }}
+    {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    preStartCommands:
+    - "sudo update-ca-certificates"
     {{- end }}
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
@@ -50,20 +65,20 @@ spec:
         {{- if $global.registry }}
         images:
           metricsserver:
-            image: "{{ $global.registry}}/k0sproject/metrics-server"
+            image: "{{ $global.registry }}/k0sproject/metrics-server"
           kubeproxy:
-            image: "{{ $global.registry}}/k0sproject/kube-proxy"
+            image: "{{ $global.registry }}/k0sproject/kube-proxy"
           coredns:
-            image: "{{ $global.registry}}/k0sproject/coredns"
+            image: "{{ $global.registry }}/k0sproject/coredns"
           pause:
-            image: "{{ $global.registry}}/k0sproject/pause"
+            image: "{{ $global.registry }}/k0sproject/pause"
           calico:
             cni:
-              image: "{{ $global.registry}}/k0sproject/calico-cni"
+              image: "{{ $global.registry }}/k0sproject/calico-cni"
             node:
-              image: "{{ $global.registry}}/k0sproject/calico-node"
+              image: "{{ $global.registry }}/k0sproject/calico-node"
             kubecontrollers:
-              image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+              image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
         {{- end }}
         extensions:
           helm:
@@ -78,7 +93,7 @@ spec:
               - name: aws-cloud-controller-manager
                 namespace: kube-system
                 {{- if $global.registry }}
-                chartname: oci://{{ $global.registry}}/charts/aws-cloud-controller-manager
+                chartname: oci://{{ $global.registry }}/charts/aws-cloud-controller-manager
                 {{- else }}
                 chartname: mirantis/aws-cloud-controller-manager
                 {{- end }}
@@ -100,7 +115,7 @@ spec:
               - name: aws-ebs-csi-driver
                 namespace: kube-system
                 {{- if $global.registry }}
-                chartname: oci://{{ $global.registry}}/charts/aws-ebs-csi-driver
+                chartname: oci://{{ $global.registry }}/charts/aws-ebs-csi-driver
                 {{- else }}
                 chartname: aws-ebs-csi-driver/aws-ebs-csi-driver
                 {{- end }}

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,6 +9,22 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      files:
+        {{- range $path, $secret := $certs }}
+        {{- if $secret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $secret }}
+              key: tls.crt
+          permissions: "0664"
+          path: /usr/local/share/ca-certificates/{{ $path }}
+        {{- end }}
+        {{- end }}
+      preStartCommands:
+      - "sudo update-ca-certificates"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,8 +9,8 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
         {{- if $secret }}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -11,9 +11,9 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- if $global.registry }}
-  image: {{ $global.registry}}/k0s
+  image: {{ $global.registry }}/k0s
   etcd:
-    image: "{{ $global.registry}}/etcd:v3.5.13"
+    image: "{{ $global.registry }}/etcd:v3.5.13"
   {{- end }}
   controllerPlaneFlags:
   - "--enable-cloud-provider=true"
@@ -36,20 +36,20 @@ spec:
       {{- if $global.registry }}
       images:
         metricsserver:
-          image: "{{ $global.registry}}/k0sproject/metrics-server"
+          image: "{{ $global.registry }}/k0sproject/metrics-server"
         kubeproxy:
-          image: "{{ $global.registry}}/k0sproject/kube-proxy"
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
         coredns:
-          image: "{{ $global.registry}}/k0sproject/coredns"
+          image: "{{ $global.registry }}/k0sproject/coredns"
         pause:
-          image: "{{ $global.registry}}/k0sproject/pause"
+          image: "{{ $global.registry }}/k0sproject/pause"
         calico:
           cni:
-            image: "{{ $global.registry}}/k0sproject/calico-cni"
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
           node:
-            image: "{{ $global.registry}}/k0sproject/calico-node"
+            image: "{{ $global.registry }}/k0sproject/calico-node"
           kubecontrollers:
-            image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:
@@ -64,7 +64,7 @@ spec:
             - name: cloud-provider-azure
               namespace: kube-system
               {{- if $global.registry }}
-              chartname: oci://{{ $global.registry}}/charts/cloud-provider-azure
+              chartname: oci://{{ $global.registry }}/charts/cloud-provider-azure
               {{- else }}
               chartname: mirantis/cloud-provider-azure
               {{- end }}
@@ -87,7 +87,7 @@ spec:
             - name: azuredisk-csi-driver
               namespace: kube-system
               {{- if $global.registry }}
-              chartname: oci://{{ $global.registry}}/charts/azuredisk-csi-driver
+              chartname: oci://{{ $global.registry }}/charts/azuredisk-csi-driver
               {{- else }}
               chartname: azuredisk-csi-driver/azuredisk-csi-driver
               {{- end }}

--- a/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,6 +9,22 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      files:
+        {{- range $path, $secret := $certs }}
+        {{- if $secret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $secret }}
+              key: tls.crt
+          permissions: "0664"
+          path: /usr/local/share/ca-certificates/{{ $path }}
+        {{- end }}
+        {{- end }}
+      preStartCommands:
+      - "sudo update-ca-certificates"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,8 +9,8 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
         {{- if $secret }}

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -10,8 +10,8 @@ spec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
     {{- end }}
-    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     files:
       {{- range $path, $secret := $certs }}
       {{- if $secret }}

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -10,6 +10,22 @@ spec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
     {{- end }}
+    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+    {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    files:
+      {{- range $path, $secret := $certs }}
+      {{- if $secret }}
+      - contentFrom:
+          secretRef:
+            name: {{ $secret }}
+            key: tls.crt
+        permissions: "0664"
+        path: /usr/local/share/ca-certificates/{{ $path }}
+      {{- end }}
+      {{- end }}
+    preStartCommands:
+    - "sudo update-ca-certificates"
+    {{- end }}
     args:
       - --enable-worker
       - --enable-cloud-provider
@@ -34,20 +50,20 @@ spec:
         {{- if $global.registry }}
         images:
           metricsserver:
-            image: "{{ $global.registry}}/k0sproject/metrics-server"
+            image: "{{ $global.registry }}/k0sproject/metrics-server"
           kubeproxy:
-            image: "{{ $global.registry}}/k0sproject/kube-proxy"
+            image: "{{ $global.registry }}/k0sproject/kube-proxy"
           coredns:
-            image: "{{ $global.registry}}/k0sproject/coredns"
+            image: "{{ $global.registry }}/k0sproject/coredns"
           pause:
-            image: "{{ $global.registry}}/k0sproject/pause"
+            image: "{{ $global.registry }}/k0sproject/pause"
           calico:
             cni:
-              image: "{{ $global.registry}}/k0sproject/calico-cni"
+              image: "{{ $global.registry }}/k0sproject/calico-cni"
             node:
-              image: "{{ $global.registry}}/k0sproject/calico-node"
+              image: "{{ $global.registry }}/k0sproject/calico-node"
             kubecontrollers:
-              image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+              image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
         {{- end }}
         extensions:
           helm:
@@ -62,7 +78,7 @@ spec:
               - name: cloud-provider-azure
                 namespace: kube-system
                 {{- if $global.registry }}
-                chartname: oci://{{ $global.registry}}/charts/cloud-provider-azure
+                chartname: oci://{{ $global.registry }}/charts/cloud-provider-azure
                 {{- else }}
                 chartname: mirantis/cloud-provider-azure
                 {{- end }}
@@ -85,7 +101,7 @@ spec:
               - name: azuredisk-csi-driver
                 namespace: kube-system
                 {{- if $global.registry }}
-                chartname: oci://{{ $global.registry}}/charts/azuredisk-csi-driver
+                chartname: oci://{{ $global.registry }}/charts/azuredisk-csi-driver
                 {{- else }}
                 chartname: azuredisk-csi-driver/azuredisk-csi-driver
                 {{- end }}

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,6 +9,22 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      files:
+        {{- range $path, $secret := $certs }}
+        {{- if $secret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $secret }}
+              key: tls.crt
+          permissions: "0664"
+          path: /usr/local/share/ca-certificates/{{ $path }}
+        {{- end }}
+        {{- end }}
+      preStartCommands:
+      - "sudo update-ca-certificates"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,8 +9,8 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
         {{- if $secret }}

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -36,20 +36,20 @@ spec:
       {{- if $global.registry }}
       images:
         metricsserver:
-          image: "{{ $global.registry}}/k0sproject/metrics-server"
+          image: "{{ $global.registry }}/k0sproject/metrics-server"
         kubeproxy:
-          image: "{{ $global.registry}}/k0sproject/kube-proxy"
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
         coredns:
-          image: "{{ $global.registry}}/k0sproject/coredns"
+          image: "{{ $global.registry }}/k0sproject/coredns"
         pause:
-          image: "{{ $global.registry}}/k0sproject/pause"
+          image: "{{ $global.registry }}/k0sproject/pause"
         calico:
           cni:
-            image: "{{ $global.registry}}/k0sproject/calico-cni"
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
           node:
-            image: "{{ $global.registry}}/k0sproject/calico-node"
+            image: "{{ $global.registry }}/k0sproject/calico-node"
           kubecontrollers:
-            image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:
@@ -62,7 +62,7 @@ spec:
             - name: gcp-cloud-controller-manager
               namespace: kube-system
               {{- if $global.registry }}
-              chartname: oci://{{ $global.registry}}/charts/gcp-cloud-controller-manager
+              chartname: oci://{{ $global.registry }}/charts/gcp-cloud-controller-manager
               {{- else }}
               chartname: mirantis/gcp-cloud-controller-manager
               {{- end }}
@@ -90,7 +90,7 @@ spec:
             - name: gcp-compute-persistent-disk-csi-driver
               namespace: kube-system
               {{- if $global.registry }}
-              chartname: oci://{{ $global.registry}}/charts/gcp-compute-persistent-disk-csi-driver
+              chartname: oci://{{ $global.registry }}/charts/gcp-compute-persistent-disk-csi-driver
               {{- else }}
               chartname: mirantis/gcp-compute-persistent-disk-csi-driver
               {{- end }}

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,6 +9,22 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      files:
+        {{- range $path, $secret := $certs }}
+        {{- if $secret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $secret }}
+              key: tls.crt
+          permissions: "0664"
+          path: /usr/local/share/ca-certificates/{{ $path }}
+        {{- end }}
+        {{- end }}
+      preStartCommands:
+      - "sudo update-ca-certificates"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,8 +9,8 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
         {{- if $secret }}

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -10,6 +10,22 @@ spec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
     {{- end }}
+    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+    {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    files:
+      {{- range $path, $secret := $certs }}
+      {{- if $secret }}
+      - contentFrom:
+          secretRef:
+            name: {{ $secret }}
+            key: tls.crt
+        permissions: "0664"
+        path: /usr/local/share/ca-certificates/{{ $path }}
+      {{- end }}
+      {{- end }}
+    preStartCommands:
+    - "sudo update-ca-certificates"
+    {{- end }}
     args:
       - --enable-worker
       - --enable-cloud-provider
@@ -34,20 +50,20 @@ spec:
         {{- if $global.registry }}
         images:
           metricsserver:
-            image: "{{ $global.registry}}/k0sproject/metrics-server"
+            image: "{{ $global.registry }}/k0sproject/metrics-server"
           kubeproxy:
-            image: "{{ $global.registry}}/k0sproject/kube-proxy"
+            image: "{{ $global.registry }}/k0sproject/kube-proxy"
           coredns:
-            image: "{{ $global.registry}}/k0sproject/coredns"
+            image: "{{ $global.registry }}/k0sproject/coredns"
           pause:
-            image: "{{ $global.registry}}/k0sproject/pause"
+            image: "{{ $global.registry }}/k0sproject/pause"
           calico:
             cni:
-              image: "{{ $global.registry}}/k0sproject/calico-cni"
+              image: "{{ $global.registry }}/k0sproject/calico-cni"
             node:
-              image: "{{ $global.registry}}/k0sproject/calico-node"
+              image: "{{ $global.registry }}/k0sproject/calico-node"
             kubecontrollers:
-              image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+              image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
         {{- end }}
         extensions:
           helm:
@@ -60,7 +76,7 @@ spec:
               - name: gcp-cloud-controller-manager
                 namespace: kube-system
                 {{- if $global.registry }}
-                chartname: oci://{{ $global.registry}}/charts/gcp-cloud-controller-manager
+                chartname: oci://{{ $global.registry }}/charts/gcp-cloud-controller-manager
                 {{- else }}
                 chartname: mirantis/gcp-cloud-controller-manager
                 {{- end }}
@@ -90,7 +106,7 @@ spec:
               - name: gcp-compute-persistent-disk-csi-driver
                 namespace: kube-system
                 {{- if $global.registry }}
-                chartname: oci://{{ $global.registry}}/charts/gcp-compute-persistent-disk-csi-driver
+                chartname: oci://{{ $global.registry }}/charts/gcp-compute-persistent-disk-csi-driver
                 {{- else }}
                 chartname: mirantis/gcp-compute-persistent-disk-csi-driver
                 {{- end }}

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -10,8 +10,8 @@ spec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
     {{- end }}
-    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     files:
       {{- range $path, $secret := $certs }}
       {{- if $secret }}

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,6 +9,22 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      files:
+        {{- range $path, $secret := $certs }}
+        {{- if $secret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $secret }}
+              key: tls.crt
+          permissions: "0664"
+          path: /usr/local/share/ca-certificates/{{ $path }}
+        {{- end }}
+        {{- end }}
+      preStartCommands:
+      - "sudo update-ca-certificates"
+      {{- end }}
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,8 +9,8 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
         {{- if $secret }}

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -10,6 +10,22 @@ spec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
     {{- end }}
+    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+    {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    files:
+      {{- range $path, $secret := $certs }}
+      {{- if $secret }}
+      - contentFrom:
+          secretRef:
+            name: {{ $secret }}
+            key: tls.crt
+        permissions: "0664"
+        path: /usr/local/share/ca-certificates/{{ $path }}
+      {{- end }}
+      {{- end }}
+    preStartCommands:
+    - "sudo update-ca-certificates"
+    {{- end }}
     args:
       - --enable-worker
       - --enable-cloud-provider
@@ -34,20 +50,20 @@ spec:
         {{- if $global.registry }}
         images:
           metricsserver:
-            image: "{{ $global.registry}}/k0sproject/metrics-server"
+            image: "{{ $global.registry }}/k0sproject/metrics-server"
           kubeproxy:
-            image: "{{ $global.registry}}/k0sproject/kube-proxy"
+            image: "{{ $global.registry }}/k0sproject/kube-proxy"
           coredns:
-            image: "{{ $global.registry}}/k0sproject/coredns"
+            image: "{{ $global.registry }}/k0sproject/coredns"
           pause:
-            image: "{{ $global.registry}}/k0sproject/pause"
+            image: "{{ $global.registry }}/k0sproject/pause"
           calico:
             cni:
-              image: "{{ $global.registry}}/k0sproject/calico-cni"
+              image: "{{ $global.registry }}/k0sproject/calico-cni"
             node:
-              image: "{{ $global.registry}}/k0sproject/calico-node"
+              image: "{{ $global.registry }}/k0sproject/calico-node"
             kubecontrollers:
-              image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+              image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
         {{- end }}
         extensions:
           helm:
@@ -59,7 +75,7 @@ spec:
             charts:
               - name: openstack-ccm
                 {{- if $global.registry }}
-                chartname: oci://{{ $global.registry}}/charts/openstack-cloud-controller-manager
+                chartname: oci://{{ $global.registry }}/charts/openstack-cloud-controller-manager
                 {{- else }}
                 chartname: openstack/openstack-cloud-controller-manager
                 {{- end }}
@@ -69,7 +85,7 @@ spec:
                 values: |
                   {{- if $global.registry }}
                   image:
-                    repository: {{ $global.registry}}/provider-os/openstack-cloud-controller-manager
+                    repository: {{ $global.registry }}/provider-os/openstack-cloud-controller-manager
                   {{- end }}
                   secret:
                     enabled: true
@@ -90,7 +106,7 @@ spec:
                       value: {{ .Values.ccmRegional | quote }}
               - name: openstack-csi
                 {{- if $global.registry }}
-                chartname: oci://{{ $global.registry}}/charts/openstack-cinder-csi
+                chartname: oci://{{ $global.registry }}/charts/openstack-cinder-csi
                 {{- else }}
                 chartname: openstack/openstack-cinder-csi
                 {{- end }}
@@ -112,29 +128,29 @@ spec:
                     create: false
                   csi:
                     {{- if $global.registry }}
-                    attacher
+                    attacher:
                       image:
-                        repository: {{ $global.registry}}/sig-storage/csi-attacher
+                        repository: {{ $global.registry }}/sig-storage/csi-attacher
                     provisioner:
                       image:
-                        repository: {{ $global.registry}}/sig-storage/csi-provisioner
+                        repository: {{ $global.registry }}/sig-storage/csi-provisioner
                     snapshotter:
                       image:
-                        repository: {{ $global.registry}}/sig-storage/csi-snapshotter
+                        repository: {{ $global.registry }}/sig-storage/csi-snapshotter
                     resizer:
                       image:
-                        repository: {{ $global.registry}}/sig-storage/csi-resizer
+                        repository: {{ $global.registry }}/sig-storage/csi-resizer
                     livenessprobe:
                       image:
-                        repository: {{ $global.registry}}/sig-storage/livenessprobe
+                        repository: {{ $global.registry }}/sig-storage/livenessprobe
                     nodeDriverRegistrar:
                       image:
-                        repository: {{ $global.registry}}/sig-storage/csi-node-driver-registrar
+                        repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
                     {{- end }}
                     plugin:
                       {{- if $global.registry }}
                       image:
-                        repository: {{ $global.registry}}/provider-os/cinder-csi-plugin
+                        repository: {{ $global.registry }}/provider-os/cinder-csi-plugin
                       {{- end }}
                       nodePlugin:
                         kubeletDir: /var/lib/k0s/kubelet

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -10,8 +10,8 @@ spec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
     {{- end }}
-    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     files:
       {{- range $path, $secret := $certs }}
       {{- if $secret }}

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,8 +9,8 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
         {{- if $secret }}

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,6 +9,22 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      files:
+        {{- range $path, $secret := $certs }}
+        {{- if $secret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $secret }}
+              key: tls.crt
+          permissions: "0664"
+          path: /usr/local/share/ca-certificates/{{ $path }}
+        {{- end }}
+        {{- end }}
+      preStartCommands:
+      - "sudo update-ca-certificates"
+      {{- end }}
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
@@ -37,20 +37,20 @@ spec:
       {{- if $global.registry }}
       images:
         metricsserver:
-          image: "{{ $global.registry}}/k0sproject/metrics-server"
+          image: "{{ $global.registry }}/k0sproject/metrics-server"
         kubeproxy:
-          image: "{{ $global.registry}}/k0sproject/kube-proxy"
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
         coredns:
-          image: "{{ $global.registry}}/k0sproject/coredns"
+          image: "{{ $global.registry }}/k0sproject/coredns"
         pause:
-          image: "{{ $global.registry}}/k0sproject/pause"
+          image: "{{ $global.registry }}/k0sproject/pause"
         calico:
           cni:
-            image: "{{ $global.registry}}/k0sproject/calico-cni"
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
           node:
-            image: "{{ $global.registry}}/k0sproject/calico-node"
+            image: "{{ $global.registry }}/k0sproject/calico-node"
           kubecontrollers:
-            image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -29,6 +29,27 @@ spec:
   {{- if $global.k0sURL }}
   downloadURL: "{{ $global.k0sURL }}/k0s-{{ $.Values.k0s.version }}-amd64"
   {{- end }}
+  {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+  files:
+  {{- if $global.registryCertSecret }}
+  - contentFrom:
+      secretRef:
+        name: {{ $global.registryCertSecret }}
+        key: tls.crt
+    permissions: "0664"
+    path: /usr/local/share/ca-certificates/registry-cert.crt
+  {{- end }}
+  {{- if $global.k0sURLCertSecret }}
+  - contentFrom:
+      secretRef:
+        name: {{ $global.k0sURLCertSecret }}
+        key: tls.crt
+    permissions: "0664"
+    path: /usr/local/share/ca-certificates/k0s-url-cert.crt
+  {{- end }}
+  preStartCommands:
+    - "sudo update-ca-certificates"
+  {{- end }}
   {{- if and $machine.k0s $machine.k0s.args }}
   args:
     {{- toYaml $machine.k0s.args | nindent 4 }}

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -30,23 +30,18 @@ spec:
   downloadURL: "{{ $global.k0sURL }}/k0s-{{ $.Values.k0s.version }}-amd64"
   {{- end }}
   {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+  {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
   files:
-  {{- if $global.registryCertSecret }}
-  - contentFrom:
-      secretRef:
-        name: {{ $global.registryCertSecret }}
-        key: tls.crt
-    permissions: "0664"
-    path: /usr/local/share/ca-certificates/registry-cert.crt
-  {{- end }}
-  {{- if $global.k0sURLCertSecret }}
-  - contentFrom:
-      secretRef:
-        name: {{ $global.k0sURLCertSecret }}
-        key: tls.crt
-    permissions: "0664"
-    path: /usr/local/share/ca-certificates/k0s-url-cert.crt
-  {{- end }}
+    {{- range $path, $secret := $certs }}
+    {{- if $secret }}
+    - contentFrom:
+        secretRef:
+          name: {{ $secret }}
+          key: tls.crt
+      permissions: "0664"
+      path: /usr/local/share/ca-certificates/{{ $path }}
+    {{- end }}
+    {{- end }}
   preStartCommands:
     - "sudo update-ca-certificates"
   {{- end }}

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -36,20 +36,20 @@ spec:
       {{- if $global.registry }}
       images:
         metricsserver:
-          image: "{{ $global.registry}}/k0sproject/metrics-server"
+          image: "{{ $global.registry }}/k0sproject/metrics-server"
         kubeproxy:
-          image: "{{ $global.registry}}/k0sproject/kube-proxy"
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
         coredns:
-          image: "{{ $global.registry}}/k0sproject/coredns"
+          image: "{{ $global.registry }}/k0sproject/coredns"
         pause:
-          image: "{{ $global.registry}}/k0sproject/pause"
+          image: "{{ $global.registry }}/k0sproject/pause"
         calico:
           cni:
-            image: "{{ $global.registry}}/k0sproject/calico-cni"
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
           node:
-            image: "{{ $global.registry}}/k0sproject/calico-node"
+            image: "{{ $global.registry }}/k0sproject/calico-node"
           kubecontrollers:
-            image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:
@@ -63,7 +63,7 @@ spec:
           charts:
           - name: vsphere-cpi
             {{- if $global.registry }}
-            chartname: oci://{{ $global.registry}}/charts/vsphere-cpi
+            chartname: oci://{{ $global.registry }}/charts/vsphere-cpi
             {{- else }}
             chartname: vsphere-cpi/vsphere-cpi
             {{- end }}
@@ -96,7 +96,7 @@ spec:
                     operator: Exists
           - name: vsphere-csi-driver
             {{- if $global.registry }}
-            chartname: oci://{{ $global.registry}}/charts/vsphere-csi-driver
+            chartname: oci://{{ $global.registry }}/charts/vsphere-csi-driver
             {{- else }}
             chartname: mirantis/vsphere-csi-driver
             {{- end }}

--- a/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -14,5 +14,22 @@ spec:
         - path: /home/{{ .Values.ssh.user }}/.ssh/authorized_keys
           permissions: "0600"
           content: "{{ trim .Values.ssh.publicKey }}"
+        {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+        {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+        {{- range $path, $secret := $certs }}
+        {{- if $secret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $secret }}
+              key: tls.crt
+          permissions: "0664"
+          path: /usr/local/share/ca-certificates/{{ $path }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
       preStartCommands:
         - chown {{ .Values.ssh.user }} /home/{{ .Values.ssh.user }}/.ssh/authorized_keys
+        {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+        - "sudo update-ca-certificates"
+        {{- end }}
+

--- a/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -14,8 +14,8 @@ spec:
         - path: /home/{{ .Values.ssh.user }}/.ssh/authorized_keys
           permissions: "0600"
           content: "{{ trim .Values.ssh.publicKey }}"
-        {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
         {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+        {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
         {{- range $path, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -14,8 +14,8 @@ spec:
       - path: /home/{{ .Values.controlPlane.ssh.user }}/.ssh/authorized_keys
         permissions: "0600"
         content: "{{ trim .Values.controlPlane.ssh.publicKey }}"
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- range $path, $secret := $certs }}
       {{- if $secret }}
       - contentFrom:

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -14,9 +14,25 @@ spec:
       - path: /home/{{ .Values.controlPlane.ssh.user }}/.ssh/authorized_keys
         permissions: "0600"
         content: "{{ trim .Values.controlPlane.ssh.publicKey }}"
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- range $path, $secret := $certs }}
+      {{- if $secret }}
+      - contentFrom:
+          secretRef:
+            name: {{ $secret }}
+            key: tls.crt
+        permissions: "0664"
+        path: /usr/local/share/ca-certificates/{{ $path }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
     preStartCommands:
       - chown {{ .Values.controlPlane.ssh.user }} /home/{{ .Values.controlPlane.ssh.user }}/.ssh/authorized_keys
       - sed -i 's/"externalAddress":"{{ .Values.controlPlaneEndpointIP }}",//' /etc/k0s.yaml
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      - "sudo update-ca-certificates"
+      {{- end }}
     args:
       - --enable-worker
       - --disable-components=konnectivity-server
@@ -41,20 +57,20 @@ spec:
         {{- if $global.registry }}
         images:
           metricsserver:
-            image: "{{ $global.registry}}/k0sproject/metrics-server"
+            image: "{{ $global.registry }}/k0sproject/metrics-server"
           kubeproxy:
-            image: "{{ $global.registry}}/k0sproject/kube-proxy"
+            image: "{{ $global.registry }}/k0sproject/kube-proxy"
           coredns:
-            image: "{{ $global.registry}}/k0sproject/coredns"
+            image: "{{ $global.registry }}/k0sproject/coredns"
           pause:
-            image: "{{ $global.registry}}/k0sproject/pause"
+            image: "{{ $global.registry }}/k0sproject/pause"
           calico:
             cni:
-              image: "{{ $global.registry}}/k0sproject/calico-cni"
+              image: "{{ $global.registry }}/k0sproject/calico-cni"
             node:
-              image: "{{ $global.registry}}/k0sproject/calico-node"
+              image: "{{ $global.registry }}/k0sproject/calico-node"
             kubecontrollers:
-              image: "{{ $global.registry}}/k0sproject/calico-kube-controllers"
+              image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
         {{- end }}
         extensions:
           helm:
@@ -70,7 +86,7 @@ spec:
             charts:
             - name: kube-vip
               {{- if $global.registry }}
-              chartname: oci://{{ $global.registry}}/charts/kube-vip
+              chartname: oci://{{ $global.registry }}/charts/kube-vip
               {{- else }}
               chartname: kube-vip/kube-vip
               {{- end }}
@@ -102,7 +118,7 @@ spec:
                     value: "true"
             - name: vsphere-cpi
               {{- if $global.registry }}
-              chartname: oci://{{ $global.registry}}/charts/vsphere-cpi
+              chartname: oci://{{ $global.registry }}/charts/vsphere-cpi
               {{- else }}
               chartname: vsphere-cpi/vsphere-cpi
               {{- end }}
@@ -134,7 +150,7 @@ spec:
                       operator: Exists
             - name: vsphere-csi-driver
               {{- if $global.registry }}
-              chartname: oci://{{ $global.registry}}/charts/vsphere-csi-driver
+              chartname: oci://{{ $global.registry }}/charts/vsphere-csi-driver
               {{- else }}
               chartname: mirantis/vsphere-csi-driver
               {{- end }}

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -14,8 +14,8 @@ spec:
         - path: /home/{{ .Values.worker.ssh.user }}/.ssh/authorized_keys
           permissions: "0600"
           content: "{{ trim .Values.worker.ssh.publicKey }}"
-        {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
         {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+        {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
         {{- range $path, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -14,5 +14,21 @@ spec:
         - path: /home/{{ .Values.worker.ssh.user }}/.ssh/authorized_keys
           permissions: "0600"
           content: "{{ trim .Values.worker.ssh.publicKey }}"
+        {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+        {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+        {{- range $path, $secret := $certs }}
+        {{- if $secret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $secret }}
+              key: tls.crt
+          permissions: "0664"
+          path: /usr/local/share/ca-certificates/{{ $path }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
       preStartCommands:
         - chown {{ .Values.worker.ssh.user }} /home/{{ .Values.worker.ssh.user }}/.ssh/authorized_keys
+        {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+        - "sudo update-ca-certificates"
+        {{- end }}

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-0
+  name: aws-hosted-cp-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.0
+      chart: aws-hosted-cp
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-1
+  name: aws-standalone-cp-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: aws-standalone-cp
-      version: 1.0.1
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-0
+  name: azure-hosted-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.0
+      chart: azure-hosted-cp
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-0
+  name: azure-standalone-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.0
+      chart: azure-standalone-cp
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-0
+  name: gcp-hosted-cp-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.0
+      chart: gcp-hosted-cp
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-0
+  name: gcp-standalone-cp-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.0
+      chart: gcp-standalone-cp
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-1.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-1
+  name: openstack-standalone-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
+      chart: openstack-standalone-cp
       version: 1.0.1
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-1.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-1
+  name: remote-cluster-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
+      chart: remote-cluster
       version: 1.0.1
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-1.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-1
+  name: vsphere-hosted-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
+      chart: vsphere-hosted-cp
       version: 1.0.1
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-0
+  name: vsphere-standalone-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.0
+      chart: vsphere-standalone-cp
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Adapt all cluster templates to accept registry and k0s URL secrets and mount them as certificate files. This is necessary to support custom self-signed registries.

Closes #1563
