### PR TITLE
chore: update flux source v1beta2 to v1

### DIFF
--- a/api/v1beta1/servicetemplate_types.go
+++ b/api/v1beta1/servicetemplate_types.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -94,7 +93,7 @@ type LocalSourceRef struct {
 
 	// Namespace is the namespace of the local source. Cross-namespace references
 	// are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-	// [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+	// [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
 	// If the Kind is ConfigMap or Secret, the namespace will be ignored.
 	Namespace string `json:"namespace,omitempty"`
 }
@@ -126,9 +125,9 @@ type EmbeddedBucketSpec struct {
 	sourcev1.BucketSpec `json:",inline"`
 }
 
-// EmbeddedOCIRepositorySpec is the embedded [github.com/fluxcd/source-controller/api/v1beta2.OCIRepositorySpec].
+// EmbeddedOCIRepositorySpec is the embedded [github.com/fluxcd/source-controller/api/v1.OCIRepositorySpec].
 type EmbeddedOCIRepositorySpec struct {
-	sourcev1beta2.OCIRepositorySpec `json:",inline"`
+	sourcev1.OCIRepositorySpec `json:",inline"`
 }
 
 // ServiceTemplateStatus defines the observed state of ServiceTemplate
@@ -315,10 +314,10 @@ func (t *ServiceTemplate) LocalSourceObject() (client.Object, string) {
 		return &sourcev1.Bucket{
 			ObjectMeta: localSourceMeta,
 		}, sourcev1.BucketKind
-	case sourcev1beta2.OCIRepositoryKind:
-		return &sourcev1beta2.OCIRepository{
+	case sourcev1.OCIRepositoryKind:
+		return &sourcev1.OCIRepository{
 			ObjectMeta: localSourceMeta,
-		}, sourcev1beta2.OCIRepositoryKind
+		}, sourcev1.OCIRepositoryKind
 	default:
 		return nil, ""
 	}
@@ -352,10 +351,10 @@ func (t *ServiceTemplate) RemoteSourceObject() (client.Object, string) {
 			Spec:       remoteSourceSpec.Bucket.BucketSpec,
 		}, sourcev1.BucketKind
 	case remoteSourceSpec.OCI != nil:
-		return &sourcev1beta2.OCIRepository{
+		return &sourcev1.OCIRepository{
 			ObjectMeta: fluxSourceMeta,
 			Spec:       remoteSourceSpec.OCI.OCIRepositorySpec,
-		}, sourcev1beta2.OCIRepositoryKind
+		}, sourcev1.OCIRepositoryKind
 	default:
 		return nil, ""
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,6 @@ import (
 
 	hcv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	infobloxv1alpha1 "github.com/telekom/cluster-api-ipam-provider-infoblox/api/v1alpha1"
@@ -77,7 +76,6 @@ func init() {
 
 	utilruntime.Must(kcmv1.AddToScheme(scheme))
 	utilruntime.Must(sourcev1.AddToScheme(scheme))
-	utilruntime.Must(sourcev1beta2.AddToScheme(scheme))
 	utilruntime.Must(hcv2.AddToScheme(scheme))
 	utilruntime.Must(sveltosv1beta1.AddToScheme(scheme))
 	utilruntime.Must(libsveltosv1beta1.AddToScheme(scheme))

--- a/internal/controller/ipam/suite_test.go
+++ b/internal/controller/ipam/suite_test.go
@@ -24,7 +24,6 @@ import (
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
@@ -100,7 +99,6 @@ var _ = BeforeSuite(func() {
 
 	Expect(kcmv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(sourcev1.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(sourcev1beta2.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(helmcontrollerv2.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(sveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(capioperator.AddToScheme(scheme.Scheme)).To(Succeed())

--- a/internal/controller/servicetemplate_controller.go
+++ b/internal/controller/servicetemplate_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -121,7 +120,7 @@ func (r *ServiceTemplateReconciler) reconcileLocalSource(ctx context.Context, te
 			status.ValidationError = err.Error()
 		} else {
 			switch status.SourceStatus.Kind {
-			case sourcev1.GitRepositoryKind, sourcev1.BucketKind, sourcev1beta2.OCIRepositoryKind:
+			case sourcev1.GitRepositoryKind, sourcev1.BucketKind, sourcev1.OCIRepositoryKind:
 				status.Valid = slices.ContainsFunc(status.SourceStatus.Conditions, func(c metav1.Condition) bool {
 					return c.Type == kcm.ReadyCondition && c.Status == metav1.ConditionTrue
 				})
@@ -145,7 +144,7 @@ func (r *ServiceTemplateReconciler) reconcileLocalSource(ctx context.Context, te
 		return fmt.Errorf("failed to get common source status from %s %s: %w", kind, key, err)
 	}
 	switch kind {
-	case sourcev1.GitRepositoryKind, sourcev1.BucketKind, sourcev1beta2.OCIRepositoryKind:
+	case sourcev1.GitRepositoryKind, sourcev1.BucketKind, sourcev1.OCIRepositoryKind:
 		if err = r.sourceStatusFromFluxObject(localSource, status.SourceStatus); err != nil {
 			return fmt.Errorf("failed to get source status from %s %s: %w", kind, key, err)
 		}
@@ -203,7 +202,7 @@ func (r *ServiceTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			RateLimiter: ratelimit.DefaultFastSlow(),
 		}).
 		For(&kcm.ServiceTemplate{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Owns(&sourcev1beta2.OCIRepository{}).
+		Owns(&sourcev1.OCIRepository{}).
 		Owns(&sourcev1.GitRepository{}).
 		Owns(&sourcev1.Bucket{}).
 		Complete(r)
@@ -241,7 +240,7 @@ func (*ServiceTemplateReconciler) sourceStatusFromFluxObject(obj client.Object, 
 		artifact = source.GetArtifact()
 		conditions = make([]metav1.Condition, len(source.Status.Conditions))
 		copy(conditions, source.Status.Conditions)
-	case *sourcev1beta2.OCIRepository:
+	case *sourcev1.OCIRepository:
 		artifact = source.GetArtifact()
 		conditions = make([]metav1.Condition, len(source.Status.Conditions))
 		copy(conditions, source.Status.Conditions)

--- a/internal/controller/servicetemplate_controller_test.go
+++ b/internal/controller/servicetemplate_controller_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -38,7 +37,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 		serviceTemplate kcm.ServiceTemplate
 		gitRepository   sourcev1.GitRepository
 		bucket          sourcev1.Bucket
-		ociRepository   sourcev1beta2.OCIRepository
+		ociRepository   sourcev1.OCIRepository
 	)
 
 	Context("When reconciling ServiceTemplate", func() {
@@ -433,7 +432,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 						DeploymentType: "Remote",
 						RemoteSourceSpec: &kcm.RemoteSourceSpec{
 							OCI: &kcm.EmbeddedOCIRepositorySpec{
-								OCIRepositorySpec: sourcev1beta2.OCIRepositorySpec{
+								OCIRepositorySpec: sourcev1.OCIRepositorySpec{
 									URL: "oci://ghcr.io/test/test",
 								},
 							},
@@ -450,7 +449,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&serviceTemplate), &serviceTemplate)).To(Succeed())
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&serviceTemplate), &ociRepository)).To(Succeed())
 					g.Expect(serviceTemplate.Status.SourceStatus).NotTo(BeNil())
-					g.Expect(serviceTemplate.Status.SourceStatus.Kind).To(Equal(sourcev1beta2.OCIRepositoryKind))
+					g.Expect(serviceTemplate.Status.SourceStatus.Kind).To(Equal(sourcev1.OCIRepositoryKind))
 					g.Expect(serviceTemplate.Status.SourceStatus.Name).To(Equal(serviceTemplate.Name))
 					g.Expect(serviceTemplate.Status.SourceStatus.Namespace).To(Equal(serviceTemplate.Namespace))
 					g.Expect(serviceTemplate.Status.Valid).To(BeFalse())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -28,7 +28,6 @@ import (
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
@@ -124,7 +123,6 @@ var _ = BeforeSuite(func() {
 
 	Expect(kcmv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(sourcev1.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(sourcev1beta2.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(helmcontrollerv2.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(sveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(capioperator.AddToScheme(scheme.Scheme)).To(Succeed())

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
@@ -1121,7 +1121,7 @@ spec:
                             description: |-
                               Namespace is the namespace of the local source. Cross-namespace references
                               are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
                               If the Kind is ConfigMap or Secret, the namespace will be ignored.
                             type: string
                         required:
@@ -1525,9 +1525,6 @@ spec:
                                   authenticating with a certificate; the CA cert is useful if
                                   you are using a self-signed server certificate. The Secret must
                                   be of type `Opaque` or `kubernetes.io/tls`.
-
-                                  Note: Support for the `caFile`, `certFile` and `keyFile` keys have
-                                  been deprecated.
                                 properties:
                                   name:
                                     description: Name of the referent.

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
@@ -1122,7 +1122,7 @@ spec:
                             description: |-
                               Namespace is the namespace of the local source. Cross-namespace references
                               are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
                               If the Kind is ConfigMap or Secret, the namespace will be ignored.
                             type: string
                         required:
@@ -1526,9 +1526,6 @@ spec:
                                   authenticating with a certificate; the CA cert is useful if
                                   you are using a self-signed server certificate. The Secret must
                                   be of type `Opaque` or `kubernetes.io/tls`.
-
-                                  Note: Support for the `caFile`, `certFile` and `keyFile` keys have
-                                  been deprecated.
                                 properties:
                                   name:
                                     description: Name of the referent.

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
@@ -2523,7 +2523,7 @@ spec:
                             description: |-
                               Namespace is the namespace of the local source. Cross-namespace references
                               are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
                               If the Kind is ConfigMap or Secret, the namespace will be ignored.
                             type: string
                         required:
@@ -2927,9 +2927,6 @@ spec:
                                   authenticating with a certificate; the CA cert is useful if
                                   you are using a self-signed server certificate. The Secret must
                                   be of type `Opaque` or `kubernetes.io/tls`.
-
-                                  Note: Support for the `caFile`, `certFile` and `keyFile` keys have
-                                  been deprecated.
                                 properties:
                                   name:
                                     description: Name of the referent.
@@ -3336,7 +3333,7 @@ spec:
                         description: |-
                           Namespace is the namespace of the local source. Cross-namespace references
                           are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                          [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+                          [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
                           If the Kind is ConfigMap or Secret, the namespace will be ignored.
                         type: string
                     required:
@@ -3739,9 +3736,6 @@ spec:
                               authenticating with a certificate; the CA cert is useful if
                               you are using a self-signed server certificate. The Secret must
                               be of type `Opaque` or `kubernetes.io/tls`.
-
-                              Note: Support for the `caFile`, `certFile` and `keyFile` keys have
-                              been deprecated.
                             properties:
                               name:
                                 description: Name of the referent.
@@ -3985,7 +3979,7 @@ spec:
                         description: |-
                           Namespace is the namespace of the local source. Cross-namespace references
                           are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                          [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1beta2.OCIRepository].
+                          [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
                           If the Kind is ConfigMap or Secret, the namespace will be ignored.
                         type: string
                     required:
@@ -4388,9 +4382,6 @@ spec:
                               authenticating with a certificate; the CA cert is useful if
                               you are using a self-signed server certificate. The Secret must
                               be of type `Opaque` or `kubernetes.io/tls`.
-
-                              Note: Support for the `caFile`, `certFile` and `keyFile` keys have
-                              been deprecated.
                             properties:
                               name:
                                 description: Name of the referent.


### PR DESCRIPTION
This is the continuation of #1600 because `flux` `source-controller` API for `OCIRepository` [migrated](https://github.com/fluxcd/source-controller/blob/v1.6.0/CHANGELOG.md) from `v1beta2` to the stable `v1`
