### PR TITLE
chore(bump): flux helm chart 2.16.0

### DIFF
--- a/templates/provider/kcm/Chart.lock
+++ b/templates/provider/kcm/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: flux2
   repository: https://fluxcd-community.github.io/helm-charts
-  version: 2.15.0
+  version: 2.16.0
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.17.2
@@ -11,5 +11,5 @@ dependencies:
 - name: velero
   repository: https://vmware-tanzu.github.io/helm-charts
   version: 9.1.2
-digest: sha256:53f29607cd8ff5b2c713c6b69b1094fae4186cee12e74623d73b72072b0822f7
-generated: "2025-05-14T09:08:40.617324+07:00"
+digest: sha256:4d10cda15fd4179f23eab6e0908a7de05f2427e9c6d3926e9efff4b8426e382d
+generated: "2025-06-06T13:22:30.472392+04:00"

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -17,7 +17,7 @@ version: 1.0.0
 
 dependencies:
   - name: flux2
-    version: 2.15.0
+    version: 2.16.0
     repository: https://fluxcd-community.github.io/helm-charts
     condition: flux2.enabled
   - name: cert-manager


### PR DESCRIPTION
Continuation of https://github.com/k0rdent/kcm/pull/1600 and https://github.com/k0rdent/kcm/pull/1602.

Flux source-controller API for OCIRepository [migrated](https://github.com/fluxcd/source-controller/blob/v1.6.0/CHANGELOG.md) from v1beta2 to the stable v1 but flux 2.15.0 has OCIRepository with v1beta2 which causes the kcm-controller to fail with:

```
2025-06-06T09:16:27Z    ERROR   controller-runtime.source.Kind  if kind is a CRD, it should be installed before calling Start   {"kind": "OCIRepository.source.toolkit.fluxcd.io", "error": "no matches for kind \"OCIRepository\" in version \"source.toolkit.fluxcd.io/v1\""}
```