### PR TITLE
chore: bump k0smotron to v1.5.4

### DIFF
--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.5.2"
+appVersion: "v1.5.4"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron, control-plane-k0sproject-k0smotron
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -12,7 +12,7 @@ spec:
     template: cluster-api-1-0-2
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
-      template: cluster-api-provider-k0sproject-k0smotron-1-0-2
+      template: cluster-api-provider-k0sproject-k0smotron-1-0-3
     - name: cluster-api-provider-azure
       template: cluster-api-provider-azure-1-0-2
     - name: cluster-api-provider-vsphere

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-k0sproject-k0smotron-1-0-2
+  name: cluster-api-provider-k0sproject-k0smotron-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-k0sproject-k0smotron
-      version: 1.0.2
+      version: 1.0.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
k0smotron bump to the latest release `v1.5.4`
