### PR TITLE
test: fix flapping unit-tests for statemanagementprovider reconciler

### DIFF
--- a/internal/controller/statemanagementprovider/reconciler.go
+++ b/internal/controller/statemanagementprovider/reconciler.go
@@ -523,6 +523,7 @@ func buildRBACRules(gvrList []schema.GroupVersionResource) []rbacv1.PolicyRule {
 	}
 	rules := make([]rbacv1.PolicyRule, 0, len(groupToResources)+1)
 	for group, resources := range groupToResources {
+		slices.Sort(resources)
 		rules = append(rules, rbacv1.PolicyRule{
 			APIGroups: []string{group},
 			Resources: resources,

--- a/internal/controller/statemanagementprovider/reconciler_test.go
+++ b/internal/controller/statemanagementprovider/reconciler_test.go
@@ -57,6 +57,17 @@ func TestReconciler_evaluateReadiness(t *testing.T) {
 		expectError    bool
 	}
 
+	f := func(t *testing.T, tc testCase) {
+		t.Helper()
+		res, err := evaluateReadiness(tc.object, tc.rule)
+		if tc.expectError {
+			require.Error(t, err)
+			return
+		}
+		require.NoError(t, err)
+		require.Equal(t, tc.expectedResult, res)
+	}
+
 	cases := map[string]testCase{
 		"deployment-ready-succeed": {
 			object: &unstructured.Unstructured{
@@ -109,17 +120,6 @@ self.status.availableReplicas == self.status.readyReplicas`,
 		},
 	}
 
-	f := func(t *testing.T, tc testCase) {
-		t.Helper()
-		res, err := evaluateReadiness(tc.object, tc.rule)
-		if tc.expectError {
-			require.Error(t, err)
-			return
-		}
-		require.NoError(t, err)
-		require.Equal(t, tc.expectedResult, res)
-	}
-
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -139,7 +139,7 @@ func TestReconciler_buildRBACRules(t *testing.T) {
 	f := func(t *testing.T, tc testCase) {
 		t.Helper()
 		rules := buildRBACRules(tc.gvrList)
-		require.ElementsMatch(t, tc.expectedRules, rules)
+		require.Equal(t, tc.expectedRules, rules)
 	}
 
 	cases := map[string]testCase{


### PR DESCRIPTION
This PR fixes flapping unit-tests for StateManagementProvider reconciler. Test failures were caused by non-deterministic order of resources in generated RBAC rules. Aside from that `require.ElementsMatch` does not check nested slices.

- replaced `ElementsMatch` with `Equal` assertion function
- added resource list sorting before adding it to RBAC rule

Tested by:
```
❯ go test github.com/K0rdent/kcm/internal/controller/statemanagementprovider -count 1000 -failfast
ok      github.com/K0rdent/kcm/internal/controller/statemanagementprovider      4.177s
```
