### PR TITLE
fix(cld): flapping delete conditions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -112,6 +112,8 @@ jobs:
         with:
           path: |
             ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -162,6 +164,7 @@ jobs:
         with:
           path: |
             ~/go/pkg/mod
+            ~/.cache/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -221,6 +224,7 @@ jobs:
         with:
           path: |
             ~/go/pkg/mod
+            ~/.cache/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -295,6 +299,7 @@ jobs:
         with:
           path: |
             ~/go/pkg/mod
+            ~/.cache/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
@@ -373,6 +378,7 @@ jobs:
         with:
           path: |
             ~/go/pkg/mod
+            ~/.cache/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-

--- a/.github/workflows/post-merge-push.yaml
+++ b/.github/workflows/post-merge-push.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           path: |
             ~/go/pkg/mod
+            ~/.cache/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           path: |
             ~/go/pkg/mod
+            ~/.cache/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-


### PR DESCRIPTION
**What this PR does / why we need it**:
Record Delete events on setting DeletionTimestamp or sending a Delete request so the root object still exists at the moment

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #1547
