### PR TITLE
chore(lint): bump lint@v2.1.6, add new rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,8 @@ linters:
     - errname
     - errorlint
     - exhaustive
+    - exptostd
+    - fatcontext
     - forbidigo
     - forcetypeassert
     - ginkgolinter
@@ -36,15 +38,20 @@ linters:
     - gocyclo
     - goprintffuncname
     - govet
+    - iface
+    - importas
     - ineffassign
     - interfacebloat
     - intrange
     - loggercheck
     - maintidx
+    - makezero
+    - mirror
     - misspell
     - musttag
     - nakedret
     - nilerr
+    - nilnesserr
     - nilnil
     - noctx
     - nolintlint
@@ -54,8 +61,12 @@ linters:
     - prealloc
     - predeclared
     - promlinter
+    - reassign
+    - recvcheck
     - revive
     - staticcheck
+    - tagalign
+    - testableexamples
     - testifylint
     - thelper
     - tparallel
@@ -96,6 +107,11 @@ linters:
       disable-default-exclusions: true
       check-type-assertions: true
       check-blank: false
+    iface:
+      enable:
+        - identical # Identifies interfaces in the same package that have identical method sets.
+        - unused # Identifies interfaces that are not used anywhere in the same package where the interface is defined.
+        - opaque # Identifies functions that return interfaces, but the actual returned value is always a single concrete implementation.
     govet:
       disable-all: true
       enable:
@@ -116,6 +132,7 @@ linters:
         - fieldalignment
         - findcall
         - framepointer
+        - httpmux
         - httpresponse
         - ifaceassert
         - loopclosure
@@ -130,15 +147,56 @@ linters:
         - slog
         - sortslice
         - stdmethods
+        - stdversion
         - stringintconv
         - structtag
         - testinggoroutine
         - tests
+        - timeformat
         - unmarshal
         - unreachable
         - unsafeptr
         - unusedresult
         - unusedwrite
+        - waitgroup
+    importas:
+      alias:
+        - pkg: github.com/K0rdent/kcm/api/v1beta1
+          alias: kcmv1
+        - pkg: k8s.io/api/apps/v1
+          alias: appsv1
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/api/rbac/v1
+          alias: rbacv1
+        - pkg: k8s.io/api/authentication/v1
+          alias: authenticationv1
+        - pkg: k8s.io/api/admission/v1
+          alias: admissionv1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextv1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/api/storage/v1
+          alias: storagev1
+        - pkg: github.com/fluxcd/pkg/apis/meta
+          alias: fluxmeta
+        - pkg: github.com/fluxcd/pkg/runtime/conditions
+          alias: fluxconditions
+        - pkg: sigs.k8s.io/cluster-api/api/v1beta1
+          alias: clusterapiv1
+        - pkg: kubevirt.io/api/core/(v[\w\d]+)
+          alias: kubevirt$1
+        - pkg: github.com/fluxcd/helm-controller/api/(v[\w\d]+)
+          alias: helmcontroller$1
+        - pkg: github.com/fluxcd/source-controller/api/(v[\w\d]+)
+          alias: source$1
+        - pkg: github.com/projectsveltos/addon-controller/api/(v[\w\d]+)
+          alias: addoncontroller$1
+        - pkg: github.com/projectsveltos/libsveltos/api/(v[\w\d]+)
+          alias: libsveltos$1
     loggercheck:
       kitlog: false
       klog: false
@@ -283,6 +341,7 @@ linters:
         - name: var-naming
         - name: waitgroup-by-value
     staticcheck:
+      # https://staticcheck.dev/docs/checks
       checks:
         - all
         - -ST1000
@@ -333,7 +392,7 @@ linters:
         text: 'shadow: declaration of "err" shadows declaration'
       - linters:
           - govet
-        path: (.*_test\.go|test\/|api\/?.*\/.*_types\.go)
+        path: (.*_test\.go|test\/)
         text: 'fieldalignment: '
       - linters:
           - revive

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ manifests: controller-gen ## Generate CustomResourceDefinition objects.
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt",year="2025" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt",year="$(shell date +%Y)" paths="./..."
 
 .PHONY: set-kcm-version
 set-kcm-version: yq
@@ -628,7 +628,7 @@ SUPPORT_BUNDLE_CLI ?= $(LOCALBIN)/support-bundle-$(SUPPORT_BUNDLE_CLI_VERSION)
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= release-0.20
-GOLANGCI_LINT_VERSION ?= v2.0.2
+GOLANGCI_LINT_VERSION ?= v2.1.6
 GOLANGCI_LINT_TIMEOUT ?= 1m
 HELM_VERSION ?= v3.17.2
 KIND_VERSION ?= v0.29.0

--- a/api/v1alpha1/clusterdeployment_types.go
+++ b/api/v1alpha1/clusterdeployment_types.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -54,7 +54,7 @@ type ClusterDeploymentSpec struct {
 	// Config allows to provide parameters for template customization.
 	// If no Config provided, the field will be populated with the default values for
 	// the template and DryRun will be enabled.
-	Config *apiextensionsv1.JSON `json:"config,omitempty"`
+	Config *apiextv1.JSON `json:"config,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
@@ -105,7 +105,7 @@ type ClusterDeploymentStatus struct {
 // +kubebuilder:printcolumn:name="DryRun",type="string",JSONPath=`.spec.dryRun`,description="Dry Run",priority=1
 
 // ClusterDeployment is the Schema for the ClusterDeployments API
-type ClusterDeployment struct {
+type ClusterDeployment struct { //nolint:govet // deprecated API version
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
@@ -133,7 +133,7 @@ func (in *ClusterDeployment) SetHelmValues(values map[string]any) error {
 		return fmt.Errorf("error marshalling helm values for clusterTemplate %s: %w", in.Spec.Template, err)
 	}
 
-	in.Spec.Config = &apiextensionsv1.JSON{Raw: b}
+	in.Spec.Config = &apiextv1.JSON{Raw: b}
 	return nil
 }
 

--- a/api/v1alpha1/management_backup_types.go
+++ b/api/v1alpha1/management_backup_types.go
@@ -83,7 +83,7 @@ func (s *ManagementBackup) TimestampedBackupName(timestamp time.Time) string {
 // +kubebuilder:printcolumn:name="Error",type=string,JSONPath=`.status.error`,description="Error during creation",priority=1
 
 // ManagementBackup is the Schema for the managementbackups API
-type ManagementBackup struct {
+type ManagementBackup struct { //nolint:govet // deprecated API version
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 

--- a/api/v1alpha1/management_types.go
+++ b/api/v1alpha1/management_types.go
@@ -15,7 +15,7 @@
 package v1alpha1
 
 import (
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -74,13 +74,13 @@ type Component struct {
 	// Config allows to provide parameters for management component customization.
 	// If no Config provided, the field will be populated with the default
 	// values for the template.
-	Config *apiextensionsv1.JSON `json:"config,omitempty"`
+	Config *apiextv1.JSON `json:"config,omitempty"`
 	// Template is the name of the Template associated with this component.
 	// If not specified, will be taken from the Release object.
 	Template string `json:"template,omitempty"`
 }
 
-type Provider struct {
+type Provider struct { //nolint:recvcheck // deprecated API version
 	Component `json:",inline"`
 	// Name of the provider.
 	Name string `json:"name"`

--- a/api/v1alpha1/multiclusterservice_types.go
+++ b/api/v1alpha1/multiclusterservice_types.go
@@ -15,7 +15,7 @@
 package v1alpha1
 
 import (
-	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -99,7 +99,7 @@ type Service struct {
 	// It will default to Name if not provided.
 	Namespace string `json:"namespace,omitempty"`
 	// ValuesFrom can reference a ConfigMap or Secret containing helm values.
-	ValuesFrom []sveltosv1beta1.ValueFrom `json:"valuesFrom,omitempty"`
+	ValuesFrom []addoncontrollerv1beta1.ValueFrom `json:"valuesFrom,omitempty"`
 	// Disable can be set to disable handling of this service.
 	Disable bool `json:"disable,omitempty"`
 }
@@ -116,11 +116,11 @@ type ServiceSpec struct {
 	Services []Service `json:"services,omitempty"`
 	// TemplateResourceRefs is a list of resources to collect from the management cluster,
 	// the values from which can be used in templates.
-	TemplateResourceRefs []sveltosv1beta1.TemplateResourceRef `json:"templateResourceRefs,omitempty"`
+	TemplateResourceRefs []addoncontrollerv1beta1.TemplateResourceRef `json:"templateResourceRefs,omitempty"`
 	// DriftIgnore specifies resources to ignore for drift detection.
 	DriftIgnore []libsveltosv1beta1.PatchSelector `json:"driftIgnore,omitempty"`
 	// DriftExclusions specifies specific configurations of resources to ignore for drift detection.
-	DriftExclusions []sveltosv1beta1.DriftExclusion `json:"driftExclusions,omitempty"`
+	DriftExclusions []addoncontrollerv1beta1.DriftExclusion `json:"driftExclusions,omitempty"`
 
 	// +kubebuilder:default:=100
 	// +kubebuilder:validation:Minimum=1

--- a/api/v1alpha1/providerinterface_types.go
+++ b/api/v1alpha1/providerinterface_types.go
@@ -58,7 +58,7 @@ type ProviderInterfaceStatus struct {
 // +kubebuilder:printcolumn:name="Description",type=string,JSONPath=`.spec.description`
 
 // ProviderInterface is the Schema for the ProviderInterface API
-type ProviderInterface struct {
+type ProviderInterface struct { //nolint:govet // deprecated API version
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 

--- a/api/v1alpha1/templatechain_common.go
+++ b/api/v1alpha1/templatechain_common.go
@@ -115,7 +115,7 @@ func (s *TemplateChainSpec) findAllUpgradePaths(templateName string) ([][]string
 		for _, upgrade := range template.AvailableUpgrades {
 			upgradePath := make([]string, len(path))
 			copy(upgradePath, path)
-			upgradePath = append(upgradePath, upgrade.Name)
+			upgradePath = append(upgradePath, upgrade.Name) //nolint:makezero // deprecated API version
 			result = append(result, upgradePath)
 			findPaths(upgrade.Name, upgradePath, visited)
 		}

--- a/api/v1alpha1/templates_common.go
+++ b/api/v1alpha1/templates_common.go
@@ -22,8 +22,8 @@ import (
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -77,7 +77,7 @@ func (s *HelmSpec) String() string {
 type TemplateStatusCommon struct {
 	// Config demonstrates available parameters for template customization,
 	// that can be used when creating ClusterDeployment objects.
-	Config *apiextensionsv1.JSON `json:"config,omitempty"`
+	Config *apiextv1.JSON `json:"config,omitempty"`
 	// ChartRef is a reference to a source controller resource containing the
 	// Helm chart representing the template.
 	ChartRef *helmcontrollerv2.CrossNamespaceSourceReference `json:"chartRef,omitempty"`
@@ -108,7 +108,7 @@ func getProvidersList(providers Providers, annotations map[string]string) Provid
 		return slices.Compact(res)
 	}
 
-	providersFromAnno := annotations[clusterapiv1beta1.ProviderNameLabel]
+	providersFromAnno := annotations[clusterapiv1.ProviderNameLabel]
 	if len(providersFromAnno) == 0 {
 		return Providers{}
 	}

--- a/api/v1beta1/clusterdeployment_types.go
+++ b/api/v1beta1/clusterdeployment_types.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -54,7 +54,7 @@ type ClusterDeploymentSpec struct {
 	// Config allows to provide parameters for template customization.
 	// If no Config provided, the field will be populated with the default values for
 	// the template and DryRun will be enabled.
-	Config *apiextensionsv1.JSON `json:"config,omitempty"`
+	Config *apiextv1.JSON `json:"config,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
@@ -125,7 +125,7 @@ type ClusterDeploymentStatus struct {
 // +kubebuilder:printcolumn:name="DryRun",type="string",JSONPath=`.spec.dryRun`,description="Dry Run",priority=1
 
 // ClusterDeployment is the Schema for the ClusterDeployments API
-type ClusterDeployment struct {
+type ClusterDeployment struct { //nolint:govet // false-positive
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
@@ -153,7 +153,7 @@ func (in *ClusterDeployment) SetHelmValues(values map[string]any) error {
 		return fmt.Errorf("error marshalling helm values for clusterTemplate %s: %w", in.Spec.Template, err)
 	}
 
-	in.Spec.Config = &apiextensionsv1.JSON{Raw: b}
+	in.Spec.Config = &apiextv1.JSON{Raw: b}
 	return nil
 }
 

--- a/api/v1beta1/clusteripam_types.go
+++ b/api/v1beta1/clusteripam_types.go
@@ -15,7 +15,7 @@
 package v1beta1
 
 import (
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -49,7 +49,7 @@ type ClusterIPAMStatus struct {
 
 type ClusterIPAMProviderData struct {
 	// Data is the IPAM provider specific data
-	Data *apiextensionsv1.JSON `json:"config,omitempty"`
+	Data *apiextv1.JSON `json:"config,omitempty"`
 	// Name of the IPAM provider data
 	Name string `json:"name,omitempty"`
 	// Ready indicates that the IPAM provider data is ready

--- a/api/v1beta1/management_backup_types.go
+++ b/api/v1beta1/management_backup_types.go
@@ -84,7 +84,7 @@ func (s *ManagementBackup) TimestampedBackupName(timestamp time.Time) string {
 // +kubebuilder:printcolumn:name="Error",type=string,JSONPath=`.status.error`,description="Error during creation",priority=1
 
 // ManagementBackup is the Schema for the managementbackups API
-type ManagementBackup struct {
+type ManagementBackup struct { //nolint:govet // false-positive
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 

--- a/api/v1beta1/management_types.go
+++ b/api/v1beta1/management_types.go
@@ -15,7 +15,7 @@
 package v1beta1
 
 import (
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -74,13 +74,13 @@ type Component struct {
 	// Config allows to provide parameters for management component customization.
 	// If no Config provided, the field will be populated with the default
 	// values for the template.
-	Config *apiextensionsv1.JSON `json:"config,omitempty"`
+	Config *apiextv1.JSON `json:"config,omitempty"`
 	// Template is the name of the Template associated with this component.
 	// If not specified, will be taken from the Release object.
 	Template string `json:"template,omitempty"`
 }
 
-type Provider struct {
+type Provider struct { //nolint:recvcheck // false-positive
 	Component `json:",inline"`
 	// Name of the provider.
 	Name string `json:"name"`

--- a/api/v1beta1/multiclusterservice_types.go
+++ b/api/v1beta1/multiclusterservice_types.go
@@ -15,7 +15,7 @@
 package v1beta1
 
 import (
-	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -99,7 +99,7 @@ type Service struct {
 	// It will default to Name if not provided.
 	Namespace string `json:"namespace,omitempty"`
 	// ValuesFrom can reference a ConfigMap or Secret containing helm values.
-	ValuesFrom []sveltosv1beta1.ValueFrom `json:"valuesFrom,omitempty"`
+	ValuesFrom []addoncontrollerv1beta1.ValueFrom `json:"valuesFrom,omitempty"`
 	// Disable can be set to disable handling of this service.
 	Disable bool `json:"disable,omitempty"`
 }
@@ -116,11 +116,11 @@ type ServiceSpec struct {
 	Services []Service `json:"services,omitempty"`
 	// TemplateResourceRefs is a list of resources to collect from the management cluster,
 	// the values from which can be used in templates.
-	TemplateResourceRefs []sveltosv1beta1.TemplateResourceRef `json:"templateResourceRefs,omitempty"`
+	TemplateResourceRefs []addoncontrollerv1beta1.TemplateResourceRef `json:"templateResourceRefs,omitempty"`
 	// DriftIgnore specifies resources to ignore for drift detection.
 	DriftIgnore []libsveltosv1beta1.PatchSelector `json:"driftIgnore,omitempty"`
 	// DriftExclusions specifies specific configurations of resources to ignore for drift detection.
-	DriftExclusions []sveltosv1beta1.DriftExclusion `json:"driftExclusions,omitempty"`
+	DriftExclusions []addoncontrollerv1beta1.DriftExclusion `json:"driftExclusions,omitempty"`
 
 	// +kubebuilder:default:=100
 	// +kubebuilder:validation:Minimum=1

--- a/api/v1beta1/providerinterface_types.go
+++ b/api/v1beta1/providerinterface_types.go
@@ -59,7 +59,7 @@ type ProviderInterfaceStatus struct {
 // +kubebuilder:printcolumn:name="Description",type=string,JSONPath=`.spec.description`
 
 // ProviderInterface is the Schema for the ProviderInterface API
-type ProviderInterface struct {
+type ProviderInterface struct { //nolint:govet // false-positive
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 

--- a/api/v1beta1/statemanagementprovider_types.go
+++ b/api/v1beta1/statemanagementprovider_types.go
@@ -111,12 +111,6 @@ const (
 
 // StateManagementProviderSpec defines the desired state of StateManagementProvider
 type StateManagementProviderSpec struct {
-	// +kubebuilder:default=false
-
-	// Suspend suspends the StateManagementProvider. Suspending a StateManagementProvider
-	// will prevent the adapter from reconciling any resources.
-	Suspend bool `json:"suspend"`
-
 	// Adapter is an operator with translates the k0rdent API objects into provider-specific API objects.
 	// It is represented as a reference to operator object
 	Adapter ResourceReference `json:"adapter"`
@@ -129,6 +123,11 @@ type StateManagementProviderSpec struct {
 	// ProvisionerCRDs is a set of references to provider-specific CustomResourceDefinition objects,
 	// which are required for the provider to operate.
 	ProvisionerCRDs []ProvisionerCRD `json:"provisionerCRDs"`
+	// +kubebuilder:default=false
+
+	// Suspend suspends the StateManagementProvider. Suspending a StateManagementProvider
+	// will prevent the adapter from reconciling any resources.
+	Suspend bool `json:"suspend"`
 }
 
 // ResourceReference is a cross-namespace reference to a resource

--- a/api/v1beta1/templatechain_common.go
+++ b/api/v1beta1/templatechain_common.go
@@ -113,10 +113,12 @@ func (s *TemplateChainSpec) findAllUpgradePaths(templateName string) ([][]string
 
 		// Iterate through available upgrades and find subsequent available upgrades
 		for _, upgrade := range template.AvailableUpgrades {
-			upgradePath := make([]string, len(path))
+			upgradePath := make([]string, len(path)+1)
 			copy(upgradePath, path)
-			upgradePath = append(upgradePath, upgrade.Name)
+			upgradePath[len(path)] = upgrade.Name
+
 			result = append(result, upgradePath)
+
 			findPaths(upgrade.Name, upgradePath, visited)
 		}
 	}

--- a/api/v1beta1/templates_common.go
+++ b/api/v1beta1/templates_common.go
@@ -22,8 +22,8 @@ import (
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -77,7 +77,7 @@ func (s *HelmSpec) String() string {
 type TemplateStatusCommon struct {
 	// Config demonstrates available parameters for template customization,
 	// that can be used when creating ClusterDeployment objects.
-	Config *apiextensionsv1.JSON `json:"config,omitempty"`
+	Config *apiextv1.JSON `json:"config,omitempty"`
 	// ChartRef is a reference to a source controller resource containing the
 	// Helm chart representing the template.
 	ChartRef *helmcontrollerv2.CrossNamespaceSourceReference `json:"chartRef,omitempty"`
@@ -108,7 +108,7 @@ func getProvidersList(providers Providers, annotations map[string]string) Provid
 		return slices.Compact(res)
 	}
 
-	providersFromAnno := annotations[clusterapiv1beta1.ProviderNameLabel]
+	providersFromAnno := annotations[clusterapiv1.ProviderNameLabel]
 	if len(providersFromAnno) == 0 {
 		return Providers{}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"strings"
 
-	hcv2 "github.com/fluxcd/helm-controller/api/v2"
+	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	infobloxv1alpha1 "github.com/telekom/cluster-api-ipam-provider-infoblox/api/v1alpha1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -77,8 +77,8 @@ func init() {
 
 	utilruntime.Must(kcmv1.AddToScheme(scheme))
 	utilruntime.Must(sourcev1.AddToScheme(scheme))
-	utilruntime.Must(hcv2.AddToScheme(scheme))
-	utilruntime.Must(sveltosv1beta1.AddToScheme(scheme))
+	utilruntime.Must(helmcontrollerv2.AddToScheme(scheme))
+	utilruntime.Must(addoncontrollerv1beta1.AddToScheme(scheme))
 	utilruntime.Must(libsveltosv1beta1.AddToScheme(scheme))
 	utilruntime.Must(ipamv1.AddToScheme(scheme))
 	utilruntime.Must(capioperatorv1.AddToScheme(scheme)) // required only for the mgmt status updates

--- a/internal/controller/accessmanagement_controller_test.go
+++ b/internal/controller/accessmanagement_controller_test.go
@@ -26,7 +26,7 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	am "github.com/K0rdent/kcm/test/objects/accessmanagement"
 	"github.com/K0rdent/kcm/test/objects/credential"
 	tc "github.com/K0rdent/kcm/test/objects/templatechain"
@@ -81,10 +81,10 @@ var _ = Describe("Template Management Controller", func() {
 		}
 		namespace3 := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace3Name}}
 
-		accessRules := []kcm.AccessRule{
+		accessRules := []kcmv1.AccessRule{
 			{
 				// Target namespaces: namespace1, namespace2
-				TargetNamespaces: kcm.TargetNamespaces{
+				TargetNamespaces: kcmv1.TargetNamespaces{
 					Selector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
 							{
@@ -100,7 +100,7 @@ var _ = Describe("Template Management Controller", func() {
 			},
 			{
 				// Target namespace: namespace1
-				TargetNamespaces: kcm.TargetNamespaces{
+				TargetNamespaces: kcmv1.TargetNamespaces{
 					StringSelector: "environment=dev",
 				},
 				ClusterTemplateChains: []string{ctChainName},
@@ -109,7 +109,7 @@ var _ = Describe("Template Management Controller", func() {
 			},
 			{
 				// Target namespace: namespace3
-				TargetNamespaces: kcm.TargetNamespaces{
+				TargetNamespaces: kcmv1.TargetNamespaces{
 					List: []string{namespace3Name},
 				},
 				ServiceTemplateChains: []string{stChainName},
@@ -119,7 +119,7 @@ var _ = Describe("Template Management Controller", func() {
 		am := am.NewAccessManagement(
 			am.WithName(amName),
 			am.WithAccessRules(accessRules),
-			am.WithLabels(kcm.GenericComponentNameLabel, kcm.GenericComponentLabelValueKCM),
+			am.WithLabels(kcmv1.GenericComponentNameLabel, kcmv1.GenericComponentLabelValueKCM),
 		)
 
 		ctChain := tc.NewClusterTemplateChain(tc.WithName(ctChainName), tc.WithNamespace(systemNamespace.Name), tc.ManagedByKCM())
@@ -178,21 +178,21 @@ var _ = Describe("Template Management Controller", func() {
 		})
 
 		AfterEach(func() {
-			for _, chain := range []*kcm.ClusterTemplateChain{ctChain, ctChainToDelete, ctChainUnmanaged} {
+			for _, chain := range []*kcmv1.ClusterTemplateChain{ctChain, ctChainToDelete, ctChainUnmanaged} {
 				for _, ns := range []*corev1.Namespace{systemNamespace, namespace1, namespace2, namespace3} {
 					chain.Namespace = ns.Name
 					err := k8sClient.Delete(ctx, chain)
 					Expect(crclient.IgnoreNotFound(err)).To(Succeed())
 				}
 			}
-			for _, chain := range []*kcm.ServiceTemplateChain{stChain, stChainToDelete, stChainUnmanaged} {
+			for _, chain := range []*kcmv1.ServiceTemplateChain{stChain, stChainToDelete, stChainUnmanaged} {
 				for _, ns := range []*corev1.Namespace{systemNamespace, namespace1, namespace2, namespace3} {
 					chain.Namespace = ns.Name
 					err := k8sClient.Delete(ctx, chain)
 					Expect(crclient.IgnoreNotFound(err)).To(Succeed())
 				}
 			}
-			for _, c := range []*kcm.Credential{cred, credToDelete, credUnmanaged} {
+			for _, c := range []*kcmv1.Credential{cred, credToDelete, credUnmanaged} {
 				for _, ns := range []*corev1.Namespace{systemNamespace, namespace1, namespace2, namespace3} {
 					c.Namespace = ns.Name
 					err := k8sClient.Delete(ctx, c)
@@ -208,15 +208,15 @@ var _ = Describe("Template Management Controller", func() {
 		})
 		It("should successfully reconcile the resource", func() {
 			By("Get unmanaged template chains before the reconciliation to verify it wasn't changed")
-			ctChainUnmanagedBefore := &kcm.ClusterTemplateChain{}
+			ctChainUnmanagedBefore := &kcmv1.ClusterTemplateChain{}
 			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ctChainUnmanaged.Namespace, Name: ctChainUnmanaged.Name}, ctChainUnmanagedBefore)
 			Expect(err).NotTo(HaveOccurred())
 
-			stChainUnmanagedBefore := &kcm.ServiceTemplateChain{}
+			stChainUnmanagedBefore := &kcmv1.ServiceTemplateChain{}
 			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: stChainUnmanaged.Namespace, Name: stChainUnmanaged.Name}, stChainUnmanagedBefore)
 			Expect(err).NotTo(HaveOccurred())
 
-			credUnmanagedBefore := &kcm.Credential{}
+			credUnmanagedBefore := &kcmv1.Credential{}
 			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: credUnmanaged.Namespace, Name: credUnmanaged.Name}, credUnmanagedBefore)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/backup/collect.go
+++ b/internal/controller/backup/collect.go
@@ -25,7 +25,7 @@ import (
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
@@ -42,7 +42,7 @@ func getBackupTemplateSpec(ctx context.Context, cl client.Client) (*velerov1.Bac
 		// fixed ones
 		selector(kcmv1.GenericComponentNameLabel, kcmv1.GenericComponentLabelValueKCM),
 		selector(certmanagerv1.PartOfCertManagerControllerLabelKey, "true"),
-		selector(clusterapiv1beta1.ProviderNameLabel, "cluster-api"),
+		selector(clusterapiv1.ProviderNameLabel, "cluster-api"),
 	}
 
 	clusterTemplates := new(kcmv1.ClusterTemplateList)
@@ -70,7 +70,7 @@ func getBackupTemplateSpec(ctx context.Context, cl client.Client) (*velerov1.Bac
 		// add only enabled providers
 		if len(cldSelectors) > 0 {
 			for _, provider := range cltpl.Status.Providers {
-				orSelectors = append(orSelectors, selector(clusterapiv1beta1.ProviderNameLabel, provider))
+				orSelectors = append(orSelectors, selector(clusterapiv1.ProviderNameLabel, provider))
 			}
 		}
 
@@ -124,7 +124,7 @@ func getClusterDeploymentsSelectors(ctx context.Context, cl client.Client, clust
 	selectors := make([]*metav1.LabelSelector, len(cldeploys.Items)*2)
 	for i, cldeploy := range cldeploys.Items {
 		selectors[i*2] = selector(kcmv1.FluxHelmChartNameKey, cldeploy.Name)
-		selectors[i*2+1] = selector(clusterapiv1beta1.ClusterNameLabel, cldeploy.Name)
+		selectors[i*2+1] = selector(clusterapiv1.ClusterNameLabel, cldeploy.Name)
 	}
 
 	return selectors, nil

--- a/internal/controller/backup/reconcile_env_test.go
+++ b/internal/controller/backup/reconcile_env_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
@@ -423,7 +423,7 @@ func getDefaultVeleroSpec() velerov1.BackupSpec {
 		ExcludedResources:  []string{"clusters.cluster.x-k8s.io"},
 		TTL:                metav1.Duration{Duration: 30 * 24 * time.Hour}, // velero's default, set it for the sake of UX
 		OrLabelSelectors: []*metav1.LabelSelector{
-			selector(clusterapiv1beta1.ProviderNameLabel, "cluster-api"),
+			selector(clusterapiv1.ProviderNameLabel, "cluster-api"),
 			selector(certmanagerv1.PartOfCertManagerControllerLabelKey, "true"),
 			selector(kcmv1.GenericComponentNameLabel, kcmv1.GenericComponentLabelValueKCM),
 		},

--- a/internal/controller/backup/suite_test.go
+++ b/internal/controller/backup/suite_test.go
@@ -59,7 +59,7 @@ func TestControllers(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	ctx, cancel = context.WithCancel(context.TODO())
+	ctx, cancel = context.WithCancel(context.TODO()) //nolint:fatcontext // on purpose
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/internal/controller/ipam/adapter/adapter.go
+++ b/internal/controller/ipam/adapter/adapter.go
@@ -20,24 +20,24 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
 
 const ClusterDeploymentConfigKeyName = "ipPool"
 
 type IPAMAdapter interface {
-	BindAddress(ctx context.Context, config IPAMConfig, c client.Client) (kcm.ClusterIPAMProviderData, error)
+	BindAddress(ctx context.Context, config IPAMConfig, c client.Client) (kcmv1.ClusterIPAMProviderData, error)
 }
 
 type IPAMConfig struct {
-	ClusterIPAMClaim *kcm.ClusterIPAMClaim
+	ClusterIPAMClaim *kcmv1.ClusterIPAMClaim
 }
 
 func Builder(name string) (IPAMAdapter, error) {
 	switch name {
-	case kcm.InClusterProviderName:
+	case kcmv1.InClusterProviderName:
 		return NewInClusterAdapter(), nil
-	case kcm.InfobloxProviderName:
+	case kcmv1.InfobloxProviderName:
 		return NewInfobloxAdapter(), nil
 	default:
 		return nil, fmt.Errorf("unknown provider name '%s'", name)

--- a/internal/controller/ipam/clusteripam_controller_test.go
+++ b/internal/controller/ipam/clusteripam_controller_test.go
@@ -23,21 +23,21 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
 
 var _ = Describe("ClusterIPAM Controller", func() {
-	createIPAMClaim := func(resourceName, namespace string) kcm.ClusterIPAMClaim {
+	createIPAMClaim := func(resourceName, namespace string) kcmv1.ClusterIPAMClaim {
 		By("Creating a new ClusterIPAMClaim resource")
-		ipPoolSpec := kcm.AddressSpaceSpec{}
-		return kcm.ClusterIPAMClaim{
+		ipPoolSpec := kcmv1.AddressSpaceSpec{}
+		return kcmv1.ClusterIPAMClaim{
 			ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: namespace},
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterIPAMClaim",
-				APIVersion: kcm.GroupVersion.String(),
+				APIVersion: kcmv1.GroupVersion.String(),
 			},
-			Spec: kcm.ClusterIPAMClaimSpec{
-				Provider:        kcm.InClusterProviderName,
+			Spec: kcmv1.ClusterIPAMClaimSpec{
+				Provider:        kcmv1.InClusterProviderName,
 				ClusterNetwork:  ipPoolSpec,
 				NodeNetwork:     ipPoolSpec,
 				ExternalNetwork: ipPoolSpec,
@@ -46,27 +46,27 @@ var _ = Describe("ClusterIPAM Controller", func() {
 		}
 	}
 
-	createIPAM := func(resourceName, namespace string) kcm.ClusterIPAM {
+	createIPAM := func(resourceName, namespace string) kcmv1.ClusterIPAM {
 		By("Creating a new ClusterIPAM resource")
-		return kcm.ClusterIPAM{
+		return kcmv1.ClusterIPAM{
 			ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: namespace},
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterIPAM",
-				APIVersion: kcm.GroupVersion.String(),
+				APIVersion: kcmv1.GroupVersion.String(),
 			},
-			Spec: kcm.ClusterIPAMSpec{
-				Provider:            kcm.InClusterProviderName,
+			Spec: kcmv1.ClusterIPAMSpec{
+				Provider:            kcmv1.InClusterProviderName,
 				ClusterIPAMClaimRef: resourceName,
 			},
 		}
 	}
 
-	createCluterDeployment := func(resourceName, namespace string) kcm.ClusterDeployment {
+	createCluterDeployment := func(resourceName, namespace string) kcmv1.ClusterDeployment {
 		By("Creating a new ClusterDeployment resource")
 
-		return kcm.ClusterDeployment{
+		return kcmv1.ClusterDeployment{
 			ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: namespace},
-			Spec: kcm.ClusterDeploymentSpec{
+			Spec: kcmv1.ClusterDeploymentSpec{
 				Template: "test",
 			},
 		}
@@ -75,7 +75,7 @@ var _ = Describe("ClusterIPAM Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource"
 		var namespace corev1.Namespace
-		var clusterIPAMClaim *kcm.ClusterIPAMClaim
+		var clusterIPAMClaim *kcmv1.ClusterIPAMClaim
 
 		BeforeEach(func() {
 			By("Ensuring namespace exists")
@@ -86,19 +86,19 @@ var _ = Describe("ClusterIPAM Controller", func() {
 			DeferCleanup(k8sClient.Delete, &namespace)
 
 			By("Creating the custom resource for ClusterIPAMClaim")
-			clusterIPAMClaim = &kcm.ClusterIPAMClaim{}
+			clusterIPAMClaim = &kcmv1.ClusterIPAMClaim{}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: namespace.Name}, clusterIPAMClaim); errors.IsNotFound(err) {
 				resource := createIPAMClaim(resourceName, namespace.Name)
 				Expect(k8sClient.Create(ctx, &resource)).To(Succeed())
 			}
 
-			clusterIPAM := &kcm.ClusterIPAM{}
+			clusterIPAM := &kcmv1.ClusterIPAM{}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: namespace.Name}, clusterIPAM); errors.IsNotFound(err) {
 				resource := createIPAM(resourceName, namespace.Name)
 				Expect(k8sClient.Create(ctx, &resource)).To(Succeed())
 			}
 
-			clusterDeployment := &kcm.ClusterDeployment{}
+			clusterDeployment := &kcmv1.ClusterDeployment{}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: namespace.Name}, clusterDeployment); errors.IsNotFound(err) {
 				resource := createCluterDeployment(resourceName, namespace.Name)
 				Expect(k8sClient.Create(ctx, &resource)).To(Succeed())
@@ -114,11 +114,11 @@ var _ = Describe("ClusterIPAM Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Fetching the reconciled ClusterIPAM resource")
-			clusterIPAM := &kcm.ClusterIPAM{}
+			clusterIPAM := &kcmv1.ClusterIPAM{}
 			Expect(k8sClient.Get(ctx, namespacedName, clusterIPAM)).To(Succeed())
 
 			By("Verifying the provider")
-			Expect(clusterIPAM.Spec.Provider).To(Equal(kcm.InClusterProviderName))
+			Expect(clusterIPAM.Spec.Provider).To(Equal(kcmv1.InClusterProviderName))
 		})
 	})
 })

--- a/internal/controller/ipam/clusteripamclaim_controller_test.go
+++ b/internal/controller/ipam/clusteripamclaim_controller_test.go
@@ -23,17 +23,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
 
 var _ = Describe("ClusterIPAMClaim Controller", func() {
-	createIPAMClaim := func(resourceName, namespace string) kcm.ClusterIPAMClaim {
+	createIPAMClaim := func(resourceName, namespace string) kcmv1.ClusterIPAMClaim {
 		By("Creating a new ClusterIPAMClaim resource")
-		ipPoolSpec := kcm.AddressSpaceSpec{}
-		return kcm.ClusterIPAMClaim{
+		ipPoolSpec := kcmv1.AddressSpaceSpec{}
+		return kcmv1.ClusterIPAMClaim{
 			ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: namespace},
-			Spec: kcm.ClusterIPAMClaimSpec{
-				Provider:        kcm.InClusterProviderName,
+			Spec: kcmv1.ClusterIPAMClaimSpec{
+				Provider:        kcmv1.InClusterProviderName,
 				ClusterNetwork:  ipPoolSpec,
 				NodeNetwork:     ipPoolSpec,
 				ExternalNetwork: ipPoolSpec,
@@ -44,7 +44,7 @@ var _ = Describe("ClusterIPAMClaim Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource"
 		var namespace corev1.Namespace
-		var clusterIPAMClaim *kcm.ClusterIPAMClaim
+		var clusterIPAMClaim *kcmv1.ClusterIPAMClaim
 
 		BeforeEach(func() {
 			By("Ensuring namespace exists")
@@ -55,7 +55,7 @@ var _ = Describe("ClusterIPAMClaim Controller", func() {
 			DeferCleanup(k8sClient.Delete, &namespace)
 
 			By("Creating the custom resource for ClusterIPAMClaim")
-			clusterIPAMClaim = &kcm.ClusterIPAMClaim{}
+			clusterIPAMClaim = &kcmv1.ClusterIPAMClaim{}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: namespace.Name}, clusterIPAMClaim); errors.IsNotFound(err) {
 				resource := createIPAMClaim(resourceName, namespace.Name)
 				Expect(k8sClient.Create(ctx, &resource)).To(Succeed())
@@ -70,11 +70,11 @@ var _ = Describe("ClusterIPAMClaim Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Fetching the reconciled ClusterIPAM resource")
-			clusterIPAM := &kcm.ClusterIPAM{}
+			clusterIPAM := &kcmv1.ClusterIPAM{}
 			Expect(k8sClient.Get(ctx, namespacedName, clusterIPAM)).To(Succeed())
 
 			By("Verifying the provider")
-			Expect(clusterIPAM.Spec.Provider).To(Equal(kcm.InClusterProviderName))
+			Expect(clusterIPAM.Spec.Provider).To(Equal(kcmv1.InClusterProviderName))
 		})
 	})
 })

--- a/internal/controller/ipam/suite_test.go
+++ b/internal/controller/ipam/suite_test.go
@@ -26,13 +26,13 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	inclusteripamv1alpha2 "sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha2"
 	capioperator "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
-	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 
-	ctx, cancel = context.WithCancel(context.TODO())
+	ctx, cancel = context.WithCancel(context.TODO()) //nolint:fatcontext // on purpose
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "templates", "provider", "kcm", "templates", "crds"),
@@ -100,9 +100,9 @@ var _ = BeforeSuite(func() {
 	Expect(kcmv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(sourcev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(helmcontrollerv2.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(sveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(addoncontrollerv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(capioperator.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(clusterapiv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(clusterapiv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(velerov1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(libsveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(ipamv1.AddToScheme(scheme.Scheme)).To(Succeed())

--- a/internal/controller/management_controller_test.go
+++ b/internal/controller/management_controller_test.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	capioperator "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -412,9 +412,9 @@ var _ = Describe("Management Controller", func() {
 
 			coreProvider.Status.ObservedGeneration = coreProvider.Generation
 			coreProvider.Status.InstalledVersion = utils.PtrTo("v0.0.1")
-			coreProvider.Status.Conditions = clusterv1.Conditions{
+			coreProvider.Status.Conditions = clusterapiv1.Conditions{
 				{
-					Type:               clusterv1.ReadyCondition,
+					Type:               clusterapiv1.ReadyCondition,
 					Status:             corev1.ConditionTrue,
 					LastTransitionTime: metav1.Now(),
 				},
@@ -428,7 +428,7 @@ var _ = Describe("Management Controller", func() {
 					return fmt.Errorf("expected .status.conditions length to be exactly 1, got %d", l)
 				}
 				cond := coreProvider.Status.Conditions[0]
-				if cond.Type != clusterv1.ReadyCondition || cond.Status != corev1.ConditionTrue {
+				if cond.Type != clusterapiv1.ReadyCondition || cond.Status != corev1.ConditionTrue {
 					return fmt.Errorf("unexpected status condition: type %s, status %s", cond.Type, cond.Status)
 				}
 

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -22,7 +22,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"helm.sh/helm/v3/pkg/chart"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
 
 var _ = Describe("MultiClusterService Controller", func() {
@@ -59,10 +59,10 @@ var _ = Describe("MultiClusterService Controller", func() {
 		namespace := &corev1.Namespace{}
 		helmChart := &sourcev1.HelmChart{}
 		helmRepo := &sourcev1.HelmRepository{}
-		serviceTemplate := &kcm.ServiceTemplate{}
-		serviceTemplate2 := &kcm.ServiceTemplate{}
-		multiClusterService := &kcm.MultiClusterService{}
-		clusterProfile := &sveltosv1beta1.ClusterProfile{}
+		serviceTemplate := &kcmv1.ServiceTemplate{}
+		serviceTemplate2 := &kcmv1.ServiceTemplate{}
+		multiClusterService := &kcmv1.MultiClusterService{}
+		clusterProfile := &addoncontrollerv1beta1.ClusterProfile{}
 
 		helmRepositoryRef := types.NamespacedName{Namespace: testSystemNamespace, Name: helmRepoName}
 		helmChartRef := types.NamespacedName{Namespace: testSystemNamespace, Name: helmChartName}
@@ -129,17 +129,17 @@ var _ = Describe("MultiClusterService Controller", func() {
 			By("creating ServiceTemplate1 with chartRef set in .spec")
 			err = k8sClient.Get(ctx, serviceTemplate1Ref, serviceTemplate)
 			if err != nil && apierrors.IsNotFound(err) {
-				serviceTemplate = &kcm.ServiceTemplate{
+				serviceTemplate = &kcmv1.ServiceTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      serviceTemplate1Name,
 						Namespace: testSystemNamespace,
 						Labels: map[string]string{
-							kcm.KCMManagedLabelKey:        "true",
-							kcm.GenericComponentNameLabel: kcm.GenericComponentLabelValueKCM,
+							kcmv1.KCMManagedLabelKey:        "true",
+							kcmv1.GenericComponentNameLabel: kcmv1.GenericComponentLabelValueKCM,
 						},
 					},
-					Spec: kcm.ServiceTemplateSpec{
-						Helm: &kcm.HelmSpec{
+					Spec: kcmv1.ServiceTemplateSpec{
+						Helm: &kcmv1.HelmSpec{
 							ChartRef: &helmcontrollerv2.CrossNamespaceSourceReference{
 								Kind:      "HelmChart",
 								Name:      helmChartName,
@@ -154,14 +154,14 @@ var _ = Describe("MultiClusterService Controller", func() {
 			By("creating ServiceTemplate2 with chartRef set in .status")
 			err = k8sClient.Get(ctx, serviceTemplate2Ref, serviceTemplate2)
 			if err != nil && apierrors.IsNotFound(err) {
-				serviceTemplate2 = &kcm.ServiceTemplate{
+				serviceTemplate2 = &kcmv1.ServiceTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      serviceTemplate2Name,
 						Namespace: testSystemNamespace,
-						Labels:    map[string]string{kcm.GenericComponentNameLabel: kcm.GenericComponentLabelValueKCM},
+						Labels:    map[string]string{kcmv1.GenericComponentNameLabel: kcmv1.GenericComponentLabelValueKCM},
 					},
-					Spec: kcm.ServiceTemplateSpec{
-						Helm: &kcm.HelmSpec{
+					Spec: kcmv1.ServiceTemplateSpec{
+						Helm: &kcmv1.HelmSpec{
 							ChartSpec: &sourcev1.HelmChartSpec{
 								Chart:   helmChartName,
 								Version: helmChartVersion,
@@ -170,14 +170,14 @@ var _ = Describe("MultiClusterService Controller", func() {
 					},
 				}
 				Expect(k8sClient.Create(ctx, serviceTemplate2)).To(Succeed())
-				serviceTemplate2.Status = kcm.ServiceTemplateStatus{
-					TemplateStatusCommon: kcm.TemplateStatusCommon{
+				serviceTemplate2.Status = kcmv1.ServiceTemplateStatus{
+					TemplateStatusCommon: kcmv1.TemplateStatusCommon{
 						ChartRef: &helmcontrollerv2.CrossNamespaceSourceReference{
 							Kind:      "HelmChart",
 							Name:      helmChartName,
 							Namespace: testSystemNamespace,
 						},
-						TemplateValidationStatus: kcm.TemplateValidationStatus{
+						TemplateValidationStatus: kcmv1.TemplateValidationStatus{
 							Valid: true,
 						},
 					},
@@ -204,20 +204,20 @@ var _ = Describe("MultiClusterService Controller", func() {
 			By("creating MultiClusterService")
 			err = k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)
 			if err != nil && apierrors.IsNotFound(err) {
-				multiClusterService = &kcm.MultiClusterService{
+				multiClusterService = &kcmv1.MultiClusterService{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:   multiClusterServiceName,
-						Labels: map[string]string{kcm.GenericComponentNameLabel: kcm.GenericComponentLabelValueKCM},
+						Labels: map[string]string{kcmv1.GenericComponentNameLabel: kcmv1.GenericComponentLabelValueKCM},
 						Finalizers: []string{
 							// Reconcile attempts to add this finalizer and returns immediately
 							// if successful. So adding this finalizer here manually in order
 							// to avoid having to call reconcile multiple times for this test.
-							kcm.MultiClusterServiceFinalizer,
+							kcmv1.MultiClusterServiceFinalizer,
 						},
 					},
-					Spec: kcm.MultiClusterServiceSpec{
-						ServiceSpec: kcm.ServiceSpec{
-							Services: []kcm.Service{
+					Spec: kcmv1.MultiClusterServiceSpec{
+						ServiceSpec: kcmv1.ServiceSpec{
+							Services: []kcmv1.Service{
 								{
 									Template: serviceTemplate1Name,
 									Name:     helmChartReleaseName,
@@ -236,7 +236,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 
 		AfterEach(func() {
 			By("cleaning up")
-			multiClusterServiceResource := &kcm.MultiClusterService{}
+			multiClusterServiceResource := &kcmv1.MultiClusterService{}
 			Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterServiceResource)).NotTo(HaveOccurred())
 
 			reconciler := &MultiClusterServiceReconciler{Client: k8sClient, SystemNamespace: testSystemNamespace}
@@ -246,9 +246,9 @@ var _ = Describe("MultiClusterService Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(k8sClient.Get, 1*time.Minute, 5*time.Second).WithArguments(ctx, multiClusterServiceRef, multiClusterService).Should(HaveOccurred())
 
-			Expect(k8sClient.Get(ctx, clusterProfileRef, &sveltosv1beta1.ClusterProfile{})).To(HaveOccurred())
+			Expect(k8sClient.Get(ctx, clusterProfileRef, &addoncontrollerv1beta1.ClusterProfile{})).To(HaveOccurred())
 
-			serviceTemplateResource := &kcm.ServiceTemplate{}
+			serviceTemplateResource := &kcmv1.ServiceTemplate{}
 			Expect(k8sClient.Get(ctx, serviceTemplate1Ref, serviceTemplateResource)).NotTo(HaveOccurred())
 			Expect(k8sClient.Delete(ctx, serviceTemplateResource)).To(Succeed())
 

--- a/internal/controller/servicetemplate_controller_test.go
+++ b/internal/controller/servicetemplate_controller_test.go
@@ -25,7 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
 
 //nolint:dupl
@@ -34,7 +34,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 		reconciler      ServiceTemplateReconciler
 		namespace       corev1.Namespace
 		secret          corev1.Secret
-		serviceTemplate kcm.ServiceTemplate
+		serviceTemplate kcmv1.ServiceTemplate
 		gitRepository   sourcev1.GitRepository
 		bucket          sourcev1.Bucket
 		ociRepository   sourcev1.OCIRepository
@@ -60,7 +60,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 			})
 
 			By("defining ServiceTemplate metadata", func() {
-				serviceTemplate = kcm.ServiceTemplate{
+				serviceTemplate = kcmv1.ServiceTemplate{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "servicetemplate-",
 						Namespace:    namespace.Name,
@@ -104,47 +104,47 @@ var _ = Describe("ServiceTemplate Controller", func() {
 
 		It("should fail to create invalid service template", func() {
 			By("creating service template with empty spec", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{}
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{}
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template with multiple one-of choices", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Helm:      &kcm.HelmSpec{},
-					Kustomize: &kcm.SourceSpec{},
-					Resources: &kcm.SourceSpec{},
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Helm:      &kcmv1.HelmSpec{},
+					Kustomize: &kcmv1.SourceSpec{},
+					Resources: &kcmv1.SourceSpec{},
 				}
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template with multiple one-of choices: Helm & Kustomize", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Helm:      &kcm.HelmSpec{},
-					Kustomize: &kcm.SourceSpec{},
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Helm:      &kcmv1.HelmSpec{},
+					Kustomize: &kcmv1.SourceSpec{},
 				}
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template with multiple one-of choices: Helm & Resources", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Helm:      &kcm.HelmSpec{},
-					Resources: &kcm.SourceSpec{},
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Helm:      &kcmv1.HelmSpec{},
+					Resources: &kcmv1.SourceSpec{},
 				}
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template with multiple one-of choices: Kustomize & Resources", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{},
-					Resources: &kcm.SourceSpec{},
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{},
+					Resources: &kcmv1.SourceSpec{},
 				}
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template with empty path in Source spec", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{},
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{},
 				}
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template without source defined in Source spec", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path:             ".",
 						LocalSourceRef:   nil,
 						RemoteSourceSpec: nil,
@@ -153,68 +153,68 @@ var _ = Describe("ServiceTemplate Controller", func() {
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template with multiple sources defined in Source spec", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path:             ".",
-						LocalSourceRef:   &kcm.LocalSourceRef{},
-						RemoteSourceSpec: &kcm.RemoteSourceSpec{},
+						LocalSourceRef:   &kcmv1.LocalSourceRef{},
+						RemoteSourceSpec: &kcmv1.RemoteSourceSpec{},
 					},
 				}
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template with unsupported kind in local source in Source spec", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path:           ".",
-						LocalSourceRef: &kcm.LocalSourceRef{Kind: "invalid"},
+						LocalSourceRef: &kcmv1.LocalSourceRef{Kind: "invalid"},
 					},
 				}
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template with multiple remote sources in Source spec", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path: ".",
-						RemoteSourceSpec: &kcm.RemoteSourceSpec{
-							Git:    &kcm.EmbeddedGitRepositorySpec{},
-							Bucket: &kcm.EmbeddedBucketSpec{},
-							OCI:    &kcm.EmbeddedOCIRepositorySpec{},
+						RemoteSourceSpec: &kcmv1.RemoteSourceSpec{
+							Git:    &kcmv1.EmbeddedGitRepositorySpec{},
+							Bucket: &kcmv1.EmbeddedBucketSpec{},
+							OCI:    &kcmv1.EmbeddedOCIRepositorySpec{},
 						},
 					},
 				}
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template with multiple remote sources in Source spec: Git & Bucket", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path: ".",
-						RemoteSourceSpec: &kcm.RemoteSourceSpec{
-							Git:    &kcm.EmbeddedGitRepositorySpec{},
-							Bucket: &kcm.EmbeddedBucketSpec{},
+						RemoteSourceSpec: &kcmv1.RemoteSourceSpec{
+							Git:    &kcmv1.EmbeddedGitRepositorySpec{},
+							Bucket: &kcmv1.EmbeddedBucketSpec{},
 						},
 					},
 				}
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template with multiple remote sources in Source spec: Git & OCI", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path: ".",
-						RemoteSourceSpec: &kcm.RemoteSourceSpec{
-							Git: &kcm.EmbeddedGitRepositorySpec{},
-							OCI: &kcm.EmbeddedOCIRepositorySpec{},
+						RemoteSourceSpec: &kcmv1.RemoteSourceSpec{
+							Git: &kcmv1.EmbeddedGitRepositorySpec{},
+							OCI: &kcmv1.EmbeddedOCIRepositorySpec{},
 						},
 					},
 				}
 				Expect(k8sClient.Create(ctx, &serviceTemplate)).NotTo(Succeed())
 			})
 			By("creating service template with multiple remote sources in Source spec: Bucket & OCI", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path: ".",
-						RemoteSourceSpec: &kcm.RemoteSourceSpec{
-							Bucket: &kcm.EmbeddedBucketSpec{},
-							OCI:    &kcm.EmbeddedOCIRepositorySpec{},
+						RemoteSourceSpec: &kcmv1.RemoteSourceSpec{
+							Bucket: &kcmv1.EmbeddedBucketSpec{},
+							OCI:    &kcmv1.EmbeddedOCIRepositorySpec{},
 						},
 					},
 				}
@@ -224,11 +224,11 @@ var _ = Describe("ServiceTemplate Controller", func() {
 
 		It("should set service template state to invalid if local source is not found", func() {
 			By("creating service template with local source", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path:           ".",
 						DeploymentType: "Remote",
-						LocalSourceRef: &kcm.LocalSourceRef{
+						LocalSourceRef: &kcmv1.LocalSourceRef{
 							Kind: "ConfigMap",
 							Name: "absent-configmap",
 						},
@@ -260,7 +260,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 				Expect(k8sClient.Create(ctx, &bucket)).To(Succeed())
 				DeferCleanup(k8sClient.Delete, &bucket)
 				bucket.Status.Conditions = append(bucket.Status.Conditions, metav1.Condition{
-					Type:               kcm.ReadyCondition,
+					Type:               kcmv1.ReadyCondition,
 					Status:             metav1.ConditionFalse,
 					Reason:             "NotReady",
 					LastTransitionTime: metav1.NewTime(time.Now()),
@@ -269,11 +269,11 @@ var _ = Describe("ServiceTemplate Controller", func() {
 			})
 
 			By("creating service template with bucket source", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path:           ".",
 						DeploymentType: "Remote",
-						LocalSourceRef: &kcm.LocalSourceRef{
+						LocalSourceRef: &kcmv1.LocalSourceRef{
 							Kind: "Bucket",
 							Name: bucket.Name,
 						},
@@ -304,11 +304,11 @@ var _ = Describe("ServiceTemplate Controller", func() {
 			})
 
 			By("creating service template with secret source", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path:           ".",
 						DeploymentType: "Remote",
-						LocalSourceRef: &kcm.LocalSourceRef{
+						LocalSourceRef: &kcmv1.LocalSourceRef{
 							Kind: "Secret",
 							Name: secret.Name,
 						},
@@ -337,7 +337,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 				Expect(k8sClient.Create(ctx, &gitRepository)).To(Succeed())
 				DeferCleanup(k8sClient.Delete, &gitRepository)
 				gitRepository.Status.Conditions = append(gitRepository.Status.Conditions, metav1.Condition{
-					Type:               kcm.ReadyCondition,
+					Type:               kcmv1.ReadyCondition,
 					Status:             metav1.ConditionTrue,
 					Reason:             "Ready",
 					LastTransitionTime: metav1.NewTime(time.Now()),
@@ -346,11 +346,11 @@ var _ = Describe("ServiceTemplate Controller", func() {
 			})
 
 			By("creating service template with git repository source", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path:           ".",
 						DeploymentType: "Remote",
-						LocalSourceRef: &kcm.LocalSourceRef{
+						LocalSourceRef: &kcmv1.LocalSourceRef{
 							Kind: "GitRepository",
 							Name: gitRepository.Name,
 						},
@@ -372,12 +372,12 @@ var _ = Describe("ServiceTemplate Controller", func() {
 
 		It("should reconcile service template with remote source: GitRepository", func() {
 			By("creating service template with remote git repository source", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path:           ".",
 						DeploymentType: "Remote",
-						RemoteSourceSpec: &kcm.RemoteSourceSpec{
-							Git: &kcm.EmbeddedGitRepositorySpec{
+						RemoteSourceSpec: &kcmv1.RemoteSourceSpec{
+							Git: &kcmv1.EmbeddedGitRepositorySpec{
 								GitRepositorySpec: sourcev1.GitRepositorySpec{
 									URL: "https://github.com/valid-git-repository/test.git",
 								},
@@ -406,7 +406,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 			By("updating git repository with ready state", func() {
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&serviceTemplate), &gitRepository)).To(Succeed())
 				gitRepository.Status.Conditions = append(gitRepository.Status.Conditions, metav1.Condition{
-					Type:               kcm.ReadyCondition,
+					Type:               kcmv1.ReadyCondition,
 					Status:             metav1.ConditionTrue,
 					Reason:             "Ready",
 					LastTransitionTime: metav1.NewTime(time.Now()),
@@ -426,12 +426,12 @@ var _ = Describe("ServiceTemplate Controller", func() {
 
 		It("should reconcile service template with remote source: OCIRepository", func() {
 			By("creating service template with remote oci repository source", func() {
-				serviceTemplate.Spec = kcm.ServiceTemplateSpec{
-					Kustomize: &kcm.SourceSpec{
+				serviceTemplate.Spec = kcmv1.ServiceTemplateSpec{
+					Kustomize: &kcmv1.SourceSpec{
 						Path:           ".",
 						DeploymentType: "Remote",
-						RemoteSourceSpec: &kcm.RemoteSourceSpec{
-							OCI: &kcm.EmbeddedOCIRepositorySpec{
+						RemoteSourceSpec: &kcmv1.RemoteSourceSpec{
+							OCI: &kcmv1.EmbeddedOCIRepositorySpec{
 								OCIRepositorySpec: sourcev1.OCIRepositorySpec{
 									URL: "oci://ghcr.io/test/test",
 								},
@@ -460,7 +460,7 @@ var _ = Describe("ServiceTemplate Controller", func() {
 			By("updating oci repository with not ready state", func() {
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&serviceTemplate), &ociRepository)).To(Succeed())
 				ociRepository.Status.Conditions = append(ociRepository.Status.Conditions, metav1.Condition{
-					Type:               kcm.ReadyCondition,
+					Type:               kcmv1.ReadyCondition,
 					Status:             metav1.ConditionFalse,
 					Reason:             "NotReady",
 					LastTransitionTime: metav1.NewTime(time.Now()),

--- a/internal/controller/statemanagementprovider/reconciler_test.go
+++ b/internal/controller/statemanagementprovider/reconciler_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	kcmv1beta1 "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
 
 const (
@@ -183,7 +183,7 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		stateManagementProvider    *kcmv1beta1.StateManagementProvider
+		stateManagementProvider    *kcmv1.StateManagementProvider
 		discoveryResources         []*metav1.APIResourceList
 		existingRBACObjects        []client.Object
 		expectedServiceAccount     *corev1.ServiceAccount
@@ -237,13 +237,13 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 
 	cases := map[string]testCase{
 		"create-rbac-objects": {
-			stateManagementProvider: &kcmv1beta1.StateManagementProvider{
+			stateManagementProvider: &kcmv1.StateManagementProvider{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      stateManagementProviderName,
 					Namespace: systemNamespace,
 				},
-				Spec: kcmv1beta1.StateManagementProviderSpec{
-					Adapter: kcmv1beta1.ResourceReference{
+				Spec: kcmv1.StateManagementProviderSpec{
+					Adapter: kcmv1.ResourceReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       "test",
@@ -305,13 +305,13 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 			},
 		},
 		"update-service-account": {
-			stateManagementProvider: &kcmv1beta1.StateManagementProvider{
+			stateManagementProvider: &kcmv1.StateManagementProvider{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      stateManagementProviderName,
 					Namespace: systemNamespace,
 				},
-				Spec: kcmv1beta1.StateManagementProviderSpec{
-					Adapter: kcmv1beta1.ResourceReference{
+				Spec: kcmv1.StateManagementProviderSpec{
+					Adapter: kcmv1.ResourceReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       "test",
@@ -382,13 +382,13 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 			},
 		},
 		"update-cluster-role": {
-			stateManagementProvider: &kcmv1beta1.StateManagementProvider{
+			stateManagementProvider: &kcmv1.StateManagementProvider{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      stateManagementProviderName,
 					Namespace: systemNamespace,
 				},
-				Spec: kcmv1beta1.StateManagementProviderSpec{
-					Adapter: kcmv1beta1.ResourceReference{
+				Spec: kcmv1.StateManagementProviderSpec{
+					Adapter: kcmv1.ResourceReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       "test",
@@ -469,13 +469,13 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 			},
 		},
 		"update-cluster-role-binding": {
-			stateManagementProvider: &kcmv1beta1.StateManagementProvider{
+			stateManagementProvider: &kcmv1.StateManagementProvider{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      stateManagementProviderName,
 					Namespace: systemNamespace,
 				},
-				Spec: kcmv1beta1.StateManagementProviderSpec{
-					Adapter: kcmv1beta1.ResourceReference{
+				Spec: kcmv1.StateManagementProviderSpec{
+					Adapter: kcmv1.ResourceReference{
 						APIVersion: "apps/v1",
 						Kind:       "Deployment",
 						Name:       "test",
@@ -565,7 +565,7 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 	}
 }
 
-func fakeKubeClient(t *testing.T, smp *kcmv1beta1.StateManagementProvider, objects ...client.Object) client.Client {
+func fakeKubeClient(t *testing.T, smp *kcmv1.StateManagementProvider, objects ...client.Object) client.Client {
 	t.Helper()
 	builder := clientfake.NewClientBuilder().WithScheme(scheme(t)).WithObjects(smp)
 	for _, obj := range objects {
@@ -589,7 +589,7 @@ func scheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(s))
-	utilruntime.Must(kcmv1beta1.AddToScheme(s))
+	utilruntime.Must(kcmv1.AddToScheme(s))
 	return s
 }
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -30,7 +30,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
@@ -40,7 +40,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	capioperator "sigs.k8s.io/cluster-api-operator/api/v1alpha2"
-	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -90,7 +90,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 
-	ctx, cancel = context.WithCancel(context.TODO())
+	ctx, cancel = context.WithCancel(context.TODO()) //nolint:fatcontext // on purpose
 
 	_, mutatingWebhooks, err := loadWebhooks(
 		filepath.Join("..", "..", "templates", "provider", "kcm", "templates", "webhooks.yaml"),
@@ -124,9 +124,9 @@ var _ = BeforeSuite(func() {
 	Expect(kcmv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(sourcev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(helmcontrollerv2.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(sveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(addoncontrollerv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(capioperator.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(clusterapiv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(clusterapiv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(velerov1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(libsveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 	// +kubebuilder:scaffold:scheme

--- a/internal/controller/sveltos/cluster_controller_test.go
+++ b/internal/controller/sveltos/cluster_controller_test.go
@@ -53,7 +53,7 @@ var _ = Describe("SveltosCluster Controller Integration Tests", func() {
 
 		logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-		ctx, cancel = context.WithCancel(context.TODO())
+		ctx, cancel = context.WithCancel(context.TODO()) //nolint:fatcontext // on purpose
 		testEnv = &envtest.Environment{
 			CRDDirectoryPaths: []string{
 				filepath.Join("..", "..", "..", "templates", "provider", "kcm", "templates", "crds"),

--- a/internal/helm/release.go
+++ b/internal/helm/release.go
@@ -18,15 +18,15 @@ import (
 	"context"
 	"time"
 
-	hcv2 "github.com/fluxcd/helm-controller/api/v2"
+	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/pkg/apis/meta"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
 
 const (
@@ -34,11 +34,11 @@ const (
 )
 
 type ReconcileHelmReleaseOpts struct {
-	Values            *apiextensionsv1.JSON
+	Values            *apiextv1.JSON
 	OwnerReference    *metav1.OwnerReference
-	ChartRef          *hcv2.CrossNamespaceSourceReference
+	ChartRef          *helmcontrollerv2.CrossNamespaceSourceReference
 	ReconcileInterval *time.Duration
-	Install           *hcv2.Install
+	Install           *helmcontrollerv2.Install
 	TargetNamespace   string
 	DependsOn         []meta.NamespacedObjectReference
 }
@@ -48,8 +48,8 @@ func ReconcileHelmRelease(ctx context.Context,
 	name string,
 	namespace string,
 	opts ReconcileHelmReleaseOpts,
-) (*hcv2.HelmRelease, controllerutil.OperationResult, error) {
-	hr := &hcv2.HelmRelease{
+) (*helmcontrollerv2.HelmRelease, controllerutil.OperationResult, error) {
+	hr := &helmcontrollerv2.HelmRelease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -60,7 +60,7 @@ func ReconcileHelmRelease(ctx context.Context,
 		if hr.Labels == nil {
 			hr.Labels = make(map[string]string)
 		}
-		hr.Labels[kcm.KCMManagedLabelKey] = kcm.KCMManagedLabelValue
+		hr.Labels[kcmv1.KCMManagedLabelKey] = kcmv1.KCMManagedLabelValue
 
 		if opts.OwnerReference != nil {
 			hr.OwnerReferences = []metav1.OwnerReference{*opts.OwnerReference}
@@ -97,7 +97,7 @@ func ReconcileHelmRelease(ctx context.Context,
 }
 
 func DeleteHelmRelease(ctx context.Context, cl client.Client, name, namespace string) error {
-	err := cl.Delete(ctx, &hcv2.HelmRelease{
+	err := cl.Delete(ctx, &helmcontrollerv2.HelmRelease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/internal/helm/repo.go
+++ b/internal/helm/repo.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
 
 type DefaultRegistryConfig struct {
@@ -77,7 +77,7 @@ func ReconcileHelmRepository(ctx context.Context, cl client.Client, name, namesp
 			helmRepo.Labels = make(map[string]string)
 		}
 
-		helmRepo.Labels[kcm.KCMManagedLabelKey] = kcm.KCMManagedLabelValue
+		helmRepo.Labels[kcmv1.KCMManagedLabelKey] = kcmv1.KCMManagedLabelValue
 		helmRepo.Spec = spec
 		return nil
 	})

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -22,7 +22,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
 
 const (
@@ -36,7 +36,7 @@ const (
 
 var metricTemplateUsage = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
-		Namespace: kcm.CoreKCMName,
+		Namespace: kcmv1.CoreKCMName,
 		Name:      "template_usage",
 		Help:      "Number of templates currently in use",
 	},
@@ -45,7 +45,7 @@ var metricTemplateUsage = prometheus.NewGaugeVec(
 
 var metricTemplateInvalidity = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
-		Namespace: kcm.CoreKCMName,
+		Namespace: kcmv1.CoreKCMName,
 		Name:      "template_invalidity",
 		Help:      "Number of invalid templates",
 	},

--- a/internal/sveltos/profile_test.go
+++ b/internal/sveltos/profile_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	fluxcdmeta "github.com/fluxcd/pkg/apis/meta"
+	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/stretchr/testify/require"
 )
@@ -57,18 +57,18 @@ func Test_nonEmptyRegistryCredentialsConfig(t *testing.T) {
 	}{
 		{tcName: "with insecure registry", repo: &sourcev1.HelmRepository{Spec: sourcev1.HelmRepositorySpec{Insecure: true}}},
 		{tcName: "with secret ref", repo: &sourcev1.HelmRepository{Spec: sourcev1.HelmRepositorySpec{
-			SecretRef: &fluxcdmeta.LocalObjectReference{
+			SecretRef: &fluxmeta.LocalObjectReference{
 				Name: testSecretName,
 			},
 		}}},
 		{tcName: "with insecure registry and secret ref", repo: &sourcev1.HelmRepository{Spec: sourcev1.HelmRepositorySpec{
 			Insecure: true,
-			SecretRef: &fluxcdmeta.LocalObjectReference{
+			SecretRef: &fluxmeta.LocalObjectReference{
 				Name: testSecretName,
 			},
 		}}},
 		{tcName: "with certsecret ref", repo: &sourcev1.HelmRepository{Spec: sourcev1.HelmRepositorySpec{
-			CertSecretRef: &fluxcdmeta.LocalObjectReference{
+			CertSecretRef: &fluxmeta.LocalObjectReference{
 				Name: testCertSecretName,
 			},
 		}}},

--- a/internal/sveltos/status.go
+++ b/internal/sveltos/status.go
@@ -19,18 +19,18 @@ import (
 	"fmt"
 	"strings"
 
-	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	"github.com/K0rdent/kcm/internal/record"
 )
 
 // GetStatusConditions returns a list of conditions from provided ClusterSummary.
-func GetStatusConditions(summary *sveltosv1beta1.ClusterSummary) (conditions []metav1.Condition, err error) {
+func GetStatusConditions(summary *addoncontrollerv1beta1.ClusterSummary) (conditions []metav1.Condition, err error) {
 	if summary == nil {
 		return nil, errors.New("error getting status from ClusterSummary: nil summary provided")
 	}
@@ -72,9 +72,9 @@ func GetStatusConditions(summary *sveltosv1beta1.ClusterSummary) (conditions []m
 func CreateEventFromCondition(object runtime.Object, generation int64, targetCluster client.ObjectKey, condition *metav1.Condition) {
 	if isHelmReleaseReadyConditionType(condition) {
 		if condition.Status == metav1.ConditionTrue {
-			record.Eventf(object, generation, kcm.SveltosHelmReleaseReadyCondition, condition.Message)
+			record.Eventf(object, generation, kcmv1.SveltosHelmReleaseReadyCondition, condition.Message)
 		} else {
-			record.Warnf(object, generation, kcm.SveltosHelmReleaseNotReadyReason, condition.Message)
+			record.Warnf(object, generation, kcmv1.SveltosHelmReleaseNotReadyReason, condition.Message)
 		}
 		return
 	}
@@ -86,9 +86,9 @@ func CreateEventFromCondition(object runtime.Object, generation int64, targetClu
 	// 2. Sveltos feature Helm FailedNonRetriable on target cluster cluster-namespace/cluster-name
 	msg := fmt.Sprintf("Sveltos feature %s %s on target cluster %s", condition.Type, condition.Reason, targetCluster.String())
 	if condition.Status == metav1.ConditionTrue {
-		record.Eventf(object, generation, kcm.SveltosFeatureReadyReason, msg)
+		record.Eventf(object, generation, kcmv1.SveltosFeatureReadyReason, msg)
 	} else {
-		record.Eventf(object, generation, kcm.SveltosFeatureNotReadyReason, msg)
+		record.Eventf(object, generation, kcmv1.SveltosFeatureNotReadyReason, msg)
 	}
 }
 
@@ -99,12 +99,12 @@ func helmReleaseReadyConditionType(releaseNamespace, releaseName string) string 
 		"%s.%s/%s",
 		releaseNamespace,
 		releaseName,
-		kcm.SveltosHelmReleaseReadyCondition,
+		kcmv1.SveltosHelmReleaseReadyCondition,
 	)
 }
 
 func isHelmReleaseReadyConditionType(condition *metav1.Condition) bool {
-	return strings.HasSuffix(condition.Type, kcm.SveltosHelmReleaseReadyCondition)
+	return strings.HasSuffix(condition.Type, kcmv1.SveltosHelmReleaseReadyCondition)
 }
 
 func helmReleaseConditionMessage(releaseNamespace, releaseName, conflictMsg string) string {

--- a/internal/sveltos/status_test.go
+++ b/internal/sveltos/status_test.go
@@ -17,7 +17,7 @@ package sveltos
 import (
 	"testing"
 
-	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,73 +33,73 @@ func TestSetStatusConditions(t *testing.T) {
 		err             error
 		expectCondition metav1.Condition
 		name            string
-		summary         sveltosv1beta1.ClusterSummary
+		summary         addoncontrollerv1beta1.ClusterSummary
 	}{
 		{
 			name: "sveltos featuresummary provisioning",
-			summary: sveltosv1beta1.ClusterSummary{
-				Status: sveltosv1beta1.ClusterSummaryStatus{
-					FeatureSummaries: []sveltosv1beta1.FeatureSummary{
+			summary: addoncontrollerv1beta1.ClusterSummary{
+				Status: addoncontrollerv1beta1.ClusterSummaryStatus{
+					FeatureSummaries: []addoncontrollerv1beta1.FeatureSummary{
 						{
-							FeatureID: sveltosv1beta1.FeatureHelm,
-							Status:    sveltosv1beta1.FeatureStatusProvisioning,
+							FeatureID: addoncontrollerv1beta1.FeatureHelm,
+							Status:    addoncontrollerv1beta1.FeatureStatusProvisioning,
 						},
 					},
 				},
 			},
 			expectCondition: metav1.Condition{
-				Type:   string(sveltosv1beta1.FeatureHelm),
+				Type:   string(addoncontrollerv1beta1.FeatureHelm),
 				Status: metav1.ConditionTrue,
-				Reason: string(sveltosv1beta1.FeatureStatusProvisioning),
+				Reason: string(addoncontrollerv1beta1.FeatureStatusProvisioning),
 			},
 		},
 		{
 			name: "sveltos featuresummary provisioned",
-			summary: sveltosv1beta1.ClusterSummary{
-				Status: sveltosv1beta1.ClusterSummaryStatus{
-					FeatureSummaries: []sveltosv1beta1.FeatureSummary{
+			summary: addoncontrollerv1beta1.ClusterSummary{
+				Status: addoncontrollerv1beta1.ClusterSummaryStatus{
+					FeatureSummaries: []addoncontrollerv1beta1.FeatureSummary{
 						{
-							FeatureID: sveltosv1beta1.FeatureHelm,
-							Status:    sveltosv1beta1.FeatureStatusProvisioned,
+							FeatureID: addoncontrollerv1beta1.FeatureHelm,
+							Status:    addoncontrollerv1beta1.FeatureStatusProvisioned,
 						},
 					},
 				},
 			},
 			expectCondition: metav1.Condition{
-				Type:   string(sveltosv1beta1.FeatureHelm),
+				Type:   string(addoncontrollerv1beta1.FeatureHelm),
 				Status: metav1.ConditionTrue,
-				Reason: string(sveltosv1beta1.FeatureStatusProvisioned),
+				Reason: string(addoncontrollerv1beta1.FeatureStatusProvisioned),
 			},
 		},
 		{
 			name: "sveltos featuresummary failed",
-			summary: sveltosv1beta1.ClusterSummary{
-				Status: sveltosv1beta1.ClusterSummaryStatus{
-					FeatureSummaries: []sveltosv1beta1.FeatureSummary{
+			summary: addoncontrollerv1beta1.ClusterSummary{
+				Status: addoncontrollerv1beta1.ClusterSummaryStatus{
+					FeatureSummaries: []addoncontrollerv1beta1.FeatureSummary{
 						{
-							FeatureID:      sveltosv1beta1.FeatureHelm,
-							Status:         sveltosv1beta1.FeatureStatusFailed,
+							FeatureID:      addoncontrollerv1beta1.FeatureHelm,
+							Status:         addoncontrollerv1beta1.FeatureStatusFailed,
 							FailureMessage: &failureMesg,
 						},
 					},
 				},
 			},
 			expectCondition: metav1.Condition{
-				Type:    string(sveltosv1beta1.FeatureHelm),
+				Type:    string(addoncontrollerv1beta1.FeatureHelm),
 				Status:  metav1.ConditionFalse,
-				Reason:  string(sveltosv1beta1.FeatureStatusFailed),
+				Reason:  string(addoncontrollerv1beta1.FeatureStatusFailed),
 				Message: failureMesg,
 			},
 		},
 		{
 			name: "sveltos helmreleasesummary managing",
-			summary: sveltosv1beta1.ClusterSummary{
-				Status: sveltosv1beta1.ClusterSummaryStatus{
-					HelmReleaseSummaries: []sveltosv1beta1.HelmChartSummary{
+			summary: addoncontrollerv1beta1.ClusterSummary{
+				Status: addoncontrollerv1beta1.ClusterSummaryStatus{
+					HelmReleaseSummaries: []addoncontrollerv1beta1.HelmChartSummary{
 						{
 							ReleaseNamespace: releaseNamespace,
 							ReleaseName:      releaseName,
-							Status:           sveltosv1beta1.HelmChartStatusManaging,
+							Status:           addoncontrollerv1beta1.HelmChartStatusManaging,
 						},
 					},
 				},
@@ -107,19 +107,19 @@ func TestSetStatusConditions(t *testing.T) {
 			expectCondition: metav1.Condition{
 				Type:    helmReleaseReadyConditionType(releaseNamespace, releaseName),
 				Status:  metav1.ConditionTrue,
-				Reason:  string(sveltosv1beta1.HelmChartStatusManaging),
+				Reason:  string(addoncontrollerv1beta1.HelmChartStatusManaging),
 				Message: helmReleaseConditionMessage(releaseNamespace, releaseName, ""),
 			},
 		},
 		{
 			name: "sveltos helmreleasesummary conflict",
-			summary: sveltosv1beta1.ClusterSummary{
-				Status: sveltosv1beta1.ClusterSummaryStatus{
-					HelmReleaseSummaries: []sveltosv1beta1.HelmChartSummary{
+			summary: addoncontrollerv1beta1.ClusterSummary{
+				Status: addoncontrollerv1beta1.ClusterSummaryStatus{
+					HelmReleaseSummaries: []addoncontrollerv1beta1.HelmChartSummary{
 						{
 							ReleaseNamespace: releaseNamespace,
 							ReleaseName:      releaseName,
-							Status:           sveltosv1beta1.HelmChartStatusConflict,
+							Status:           addoncontrollerv1beta1.HelmChartStatusConflict,
 							ConflictMessage:  conflictMsg,
 						},
 					},
@@ -128,7 +128,7 @@ func TestSetStatusConditions(t *testing.T) {
 			expectCondition: metav1.Condition{
 				Type:    helmReleaseReadyConditionType(releaseNamespace, releaseName),
 				Status:  metav1.ConditionFalse,
-				Reason:  string(sveltosv1beta1.HelmChartStatusConflict),
+				Reason:  string(addoncontrollerv1beta1.HelmChartStatusConflict),
 				Message: helmReleaseConditionMessage(releaseNamespace, releaseName, conflictMsg),
 			},
 		},

--- a/internal/utils/conditions/capi.go
+++ b/internal/utils/conditions/capi.go
@@ -22,7 +22,7 @@ import (
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
 
 var _ capiconditions.MergeStrategy = (*clusterConditionCustomMergeStrategy)(nil)
@@ -58,7 +58,7 @@ func getCAPIConditionsSummaryOptions(conditionTypes capiconditions.ForConditionT
 	}
 }
 
-func GetCAPIClusterSummaryCondition(cd *kcm.ClusterDeployment, cluster *clusterapiv1.Cluster) (*metav1.Condition, error) {
+func GetCAPIClusterSummaryCondition(cd *kcmv1.ClusterDeployment, cluster *clusterapiv1.Cluster) (*metav1.Condition, error) {
 	var (
 		capiConditionTypes             capiconditions.ForConditionTypes
 		negativePolarityConditionTypes capiconditions.NegativePolarityConditionTypes
@@ -86,7 +86,7 @@ func GetCAPIClusterSummaryCondition(cd *kcm.ClusterDeployment, cluster *clustera
 
 	capiCondition, err := capiconditions.NewSummaryCondition(
 		cluster,
-		kcm.CAPIClusterSummaryCondition,
+		kcmv1.CAPIClusterSummaryCondition,
 		getCAPIConditionsSummaryOptions(capiConditionTypes, negativePolarityConditionTypes)...,
 	)
 	if err != nil {

--- a/internal/webhook/clusterdeployment_webhook.go
+++ b/internal/webhook/clusterdeployment_webhook.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"slices"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -171,7 +171,7 @@ func (v *ClusterDeploymentValidator) Default(ctx context.Context, obj runtime.Ob
 	}
 
 	clusterDeployment.Spec.DryRun = true
-	clusterDeployment.Spec.Config = &apiextensionsv1.JSON{Raw: template.Status.Config.Raw}
+	clusterDeployment.Spec.Config = &apiextv1.JSON{Raw: template.Status.Config.Raw}
 
 	return nil
 }

--- a/internal/webhook/clusterdeployment_webhook_test.go
+++ b/internal/webhook/clusterdeployment_webhook_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -195,7 +195,7 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 					Services: []kcmv1.Service{
 						{Template: testSvcTemplate1Name},
 					},
-					TemplateResourceRefs: []sveltosv1beta1.TemplateResourceRef{
+					TemplateResourceRefs: []addoncontrollerv1beta1.TemplateResourceRef{
 						{Resource: corev1.ObjectReference{APIVersion: "v1", Kind: "ConfigMap", Name: testConfigMapName, Namespace: otherNamespace}},
 						{Resource: corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Name: testSecretName, Namespace: otherNamespace}},
 					},
@@ -232,7 +232,7 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 					Services: []kcmv1.Service{
 						{
 							Template: testSvcTemplate1Name,
-							ValuesFrom: []sveltosv1beta1.ValueFrom{
+							ValuesFrom: []addoncontrollerv1beta1.ValueFrom{
 								{Kind: "ConfigMap", Name: testConfigMapName, Namespace: otherNamespace},
 								{Kind: "Secret", Name: testSecretName, Namespace: otherNamespace},
 							},
@@ -268,7 +268,7 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 				clusterdeployment.WithClusterTemplate(testTemplateName),
 				clusterdeployment.WithCredential(testCredentialName),
 				clusterdeployment.WithServiceSpec(kcmv1.ServiceSpec{
-					TemplateResourceRefs: []sveltosv1beta1.TemplateResourceRef{
+					TemplateResourceRefs: []addoncontrollerv1beta1.TemplateResourceRef{
 						// Should not fail if namespace is empty
 						{Resource: corev1.ObjectReference{APIVersion: "v1", Kind: "ConfigMap", Name: testConfigMapName}},
 						{Resource: corev1.ObjectReference{APIVersion: "v1", Kind: "Secret", Name: testSecretName}},
@@ -276,7 +276,7 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 					Services: []kcmv1.Service{
 						{
 							Template: testSvcTemplate1Name,
-							ValuesFrom: []sveltosv1beta1.ValueFrom{
+							ValuesFrom: []addoncontrollerv1beta1.ValueFrom{
 								// Should not fail if namespace is empty
 								{Kind: "ConfigMap", Name: testConfigMapName},
 								{Kind: "Secret", Name: testSecretName},

--- a/test/e2e/clusterdeployment/azure/azure.go
+++ b/test/e2e/clusterdeployment/azure/azure.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 
-	kcm "github.com/K0rdent/kcm/api/v1beta1"
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	"github.com/K0rdent/kcm/test/e2e/clusterdeployment"
 	"github.com/K0rdent/kcm/test/e2e/kubeclient"
 )
@@ -53,7 +53,7 @@ func getAzureInfo(ctx context.Context, name string, kc *kubeclient.KubeClient) m
 
 	dc := kc.GetDynamicClient(resourceID, true)
 	list, err := dc.List(ctx, metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{kcm.FluxHelmChartNameKey: name}).String(),
+		LabelSelector: labels.SelectorFromSet(map[string]string{kcmv1.FluxHelmChartNameKey: name}).String(),
 	})
 
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/clusterdeployment/validate_deleted.go
+++ b/test/e2e/clusterdeployment/validate_deleted.go
@@ -174,7 +174,7 @@ func validateObjectsRemoved(kind string, objs []unstructured.Unstructured) error
 		return nil
 	}
 
-	names := make([]string, len(objs))
+	names := make([]string, 0, len(objs))
 	for _, cp := range objs {
 		names = append(names, cp.GetName())
 	}

--- a/test/e2e/upgrade/validator.go
+++ b/test/e2e/upgrade/validator.go
@@ -20,13 +20,13 @@ import (
 	"fmt"
 	"time"
 
-	hcv2 "github.com/fluxcd/helm-controller/api/v2"
+	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
@@ -79,7 +79,7 @@ func (v *ClusterUpgrade) Validate(ctx context.Context) {
 }
 
 func validateHelmRelease(ctx context.Context, mgmtClient, _ crclient.Client, namespace, name, newTemplate string) error {
-	hr := &hcv2.HelmRelease{}
+	hr := &helmcontrollerv2.HelmRelease{}
 	err := mgmtClient.Get(ctx, types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
@@ -108,14 +108,14 @@ func validateHelmRelease(ctx context.Context, mgmtClient, _ crclient.Client, nam
 	if readyCondition.Status != metav1.ConditionTrue {
 		return errors.New("waiting for Ready condition to have status: true")
 	}
-	if readyCondition.Reason != hcv2.UpgradeSucceededReason {
+	if readyCondition.Reason != helmcontrollerv2.UpgradeSucceededReason {
 		return errors.New("waiting for Ready condition to have `UpgradeSucceeded` reason")
 	}
 	return nil
 }
 
 func validateClusterConditions(ctx context.Context, mgmtClient, _ crclient.Client, namespace, name, _ string) error {
-	cluster := &clusterapiv1beta1.Cluster{}
+	cluster := &clusterapiv1.Cluster{}
 	if err := mgmtClient.Get(ctx, types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
@@ -126,9 +126,9 @@ func validateClusterConditions(ctx context.Context, mgmtClient, _ crclient.Clien
 	conditionsToCheck := map[string]struct{}{
 		// TODO: uncomment once https://github.com/k0sproject/k0smotron/issues/911 is fixed
 		// clusterapiv1beta1.ClusterControlPlaneMachinesUpToDateV1Beta2Condition: {},
-		clusterapiv1beta1.ClusterControlPlaneMachinesReadyV1Beta2Condition: {},
-		clusterapiv1beta1.ClusterWorkerMachinesReadyV1Beta2Condition:       {},
-		clusterapiv1beta1.ClusterWorkerMachinesUpToDateV1Beta2Condition:    {},
+		clusterapiv1.ClusterControlPlaneMachinesReadyV1Beta2Condition: {},
+		clusterapiv1.ClusterWorkerMachinesReadyV1Beta2Condition:       {},
+		clusterapiv1.ClusterWorkerMachinesUpToDateV1Beta2Condition:    {},
 	}
 	var errs error
 	for _, c := range cluster.GetV1Beta2Conditions() {

--- a/test/objects/clusterdeployment/clusterdeployment.go
+++ b/test/objects/clusterdeployment/clusterdeployment.go
@@ -15,8 +15,8 @@
 package clusterdeployment
 
 import (
-	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
@@ -69,7 +69,7 @@ func WithClusterTemplate(templateName string) Opt {
 
 func WithConfig(config string) Opt {
 	return func(p *kcmv1.ClusterDeployment) {
-		p.Spec.Config = &apiextensionsv1.JSON{
+		p.Spec.Config = &apiextv1.JSON{
 			Raw: []byte(config),
 		}
 	}
@@ -89,7 +89,7 @@ func WithServiceSpec(serviceSpec kcmv1.ServiceSpec) Opt {
 	}
 }
 
-func WithTemplateResourceRefs(templRefs []sveltosv1beta1.TemplateResourceRef) Opt {
+func WithTemplateResourceRefs(templRefs []addoncontrollerv1beta1.TemplateResourceRef) Opt {
 	return func(p *kcmv1.ClusterDeployment) {
 		p.Spec.ServiceSpec.TemplateResourceRefs = append(p.Spec.ServiceSpec.TemplateResourceRefs, templRefs...)
 	}

--- a/test/objects/template/template.go
+++ b/test/objects/template/template.go
@@ -17,7 +17,7 @@ package template
 import (
 	"fmt"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -174,7 +174,7 @@ func WithProvidersStatus(providers ...string) Opt {
 func WithConfigStatus(config string) Opt {
 	return func(t Template) {
 		status := t.GetCommonStatus()
-		status.Config = &apiextensionsv1.JSON{
+		status.Config = &apiextv1.JSON{
 			Raw: []byte(config),
 		}
 	}

--- a/test/scheme/scheme.go
+++ b/test/scheme/scheme.go
@@ -15,16 +15,16 @@
 package scheme
 
 import (
-	hcv2 "github.com/fluxcd/helm-controller/api/v2"
+	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	sveltosv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
@@ -35,11 +35,11 @@ var (
 	builder = runtime.SchemeBuilder{
 		corev1.AddToScheme,
 		clientgoscheme.AddToScheme,
-		clusterapiv1beta1.AddToScheme,
+		clusterapiv1.AddToScheme,
 		kcmv1.AddToScheme,
 		sourcev1.AddToScheme,
-		hcv2.AddToScheme,
-		sveltosv1beta1.AddToScheme,
+		helmcontrollerv2.AddToScheme,
+		addoncontrollerv1beta1.AddToScheme,
 		kubevirtv1.AddToScheme,
 		cdiv1.AddToScheme,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Rename import to align across all pkgs.

Fix slices errors.

Align structs fields (enable govet on API types).

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:

Closes #1657 
