### PR TITLE
feat: Pass registry CA cert to hosted CP components

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,9 +132,8 @@ func main() {
 	flag.StringVar(&registryCredentialsSecretName, "registry-creds-secret", "",
 		"Name of a Secret containing authentication credentials for the registry.")
 	flag.StringVar(&registryCertSecretName, "registry-cert-secret-name", "",
-		"Name of a Secret containing a CA certificate (`ca.crt`) required for connecting to the registry endpoint. "+
-			"The Secret may also include a client certificate (`tls.crt`) and key (`tls.key`) for mutual TLS.")
-	flag.StringVar(&k0sURLCertSecretName, "k0s-url-cert-secret-name", "", "Name of a Secret containing root CA certificate (`ca.crt`) for the k0s download URL")
+		"Name of a Secret containing root CA certificate (`ca.crt`) for connecting to the registry endpoint.")
+	flag.StringVar(&k0sURLCertSecretName, "k0s-url-cert-secret-name", "", "Name of a Secret containing root CA certificate (`ca.crt`) for the k0s download URL.")
 	flag.BoolVar(&insecureRegistry, "insecure-registry", false, "Allow connecting to an HTTP registry.")
 	flag.BoolVar(&createManagement, "create-management", true, "Create a Management object with default configuration upon initial installation.")
 	flag.BoolVar(&createAccessManagement, "create-access-management", true,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,8 +132,9 @@ func main() {
 	flag.StringVar(&registryCredentialsSecretName, "registry-creds-secret", "",
 		"Name of a Secret containing authentication credentials for the registry.")
 	flag.StringVar(&registryCertSecretName, "registry-cert-secret-name", "",
-		"Name of a Secret containing a client certificate (`tls.crt`) and private key (`tls.key`) and/or a CA certificate (`ca.crt`) for the registry endpoint")
-	flag.StringVar(&k0sURLCertSecretName, "k0s-url-cert-secret-name", "", "Name of a Secret containing a client certificate (`tls.crt`) and private key (`tls.key`) and (optionally) a CA certificate (`ca.crt`) for the k0s download URL")
+		"Name of a Secret containing a CA certificate (`ca.crt`) required for connecting to the registry endpoint. "+
+			"The Secret may also include a client certificate (`tls.crt`) and key (`tls.key`) for mutual TLS.")
+	flag.StringVar(&k0sURLCertSecretName, "k0s-url-cert-secret-name", "", "Name of a Secret containing root CA certificate (`ca.crt`) for the k0s download URL")
 	flag.BoolVar(&insecureRegistry, "insecure-registry", false, "Allow connecting to an HTTP registry.")
 	flag.BoolVar(&createManagement, "create-management", true, "Create a Management object with default configuration upon initial installation.")
 	flag.BoolVar(&createAccessManagement, "create-access-management", true,

--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-4
+  template: aws-standalone-cp-1-0-5
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-2
+  template: azure-standalone-cp-1-0-3
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-3
+  template: gcp-standalone-cp-1-0-4
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-3
+  template: openstack-standalone-cp-1-0-4
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-2
+  template: remote-cluster-1-0-3
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-2
+  template: vsphere-standalone-cp-1-0-3
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -88,8 +88,8 @@ type ClusterDeploymentReconciler struct {
 	SystemNamespace        string
 	GlobalRegistry         string
 	GlobalK0sURL           string
-	K0sURLCertSecretName   string // Name of a Secret with K0s Download URL TLS Data
-	RegistryCertSecretName string // Name of a Secret with Registry TLS Data
+	K0sURLCertSecretName   string // Name of a Secret with K0s Download URL Root CA with ca.crt key
+	RegistryCertSecretName string // Name of a Secret with Registry Root CA with ca.crt key and mTLS data: client cert (tls.crt) and key (tls.key)
 
 	defaultRequeueTime time.Duration
 

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -89,7 +89,7 @@ type ClusterDeploymentReconciler struct {
 	GlobalRegistry         string
 	GlobalK0sURL           string
 	K0sURLCertSecretName   string // Name of a Secret with K0s Download URL Root CA with ca.crt key
-	RegistryCertSecretName string // Name of a Secret with Registry Root CA with ca.crt key and mTLS data: client cert (tls.crt) and key (tls.key)
+	RegistryCertSecretName string // Name of a Secret with Registry Root CA with ca.crt key
 
 	defaultRequeueTime time.Duration
 

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -70,8 +70,8 @@ type ManagementReconciler struct {
 	SystemNamespace        string
 	GlobalRegistry         string
 	GlobalK0sURL           string
-	K0sURLCertSecretName   string // Name of a Secret with K0s Download URL TLS Data; to be passed to the ClusterDeploymentReconciler
-	RegistryCertSecretName string // Name of a Secret with Registry TLS Data; used by ManagementReconciler and ClusterDeploymentReconciler
+	K0sURLCertSecretName   string // Name of a Secret with K0s Download URL Root CA with ca.crt key; to be passed to the ClusterDeploymentReconciler
+	RegistryCertSecretName string // Name of a Secret with Registry Root CA with ca.crt key and mTLS data: client cert (tls.crt) and key (tls.key); used by ManagementReconciler and ClusterDeploymentReconciler
 
 	defaultRequeueTime time.Duration
 
@@ -887,7 +887,7 @@ func processCAPIOperatorCertVolumeMounts(capiOperatorValues map[string]any, regi
 			"secretName":  registryCertSecret,
 			"items": []any{
 				map[string]any{
-					"key":  "tls.crt",
+					"key":  "ca.crt",
 					"path": "registry-ca.pem",
 				},
 			},

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -71,7 +71,7 @@ type ManagementReconciler struct {
 	GlobalRegistry         string
 	GlobalK0sURL           string
 	K0sURLCertSecretName   string // Name of a Secret with K0s Download URL Root CA with ca.crt key; to be passed to the ClusterDeploymentReconciler
-	RegistryCertSecretName string // Name of a Secret with Registry Root CA with ca.crt key and mTLS data: client cert (tls.crt) and key (tls.key); used by ManagementReconciler and ClusterDeploymentReconciler
+	RegistryCertSecretName string // Name of a Secret with Registry Root CA with ca.crt key; used by ManagementReconciler and ClusterDeploymentReconciler
 
 	defaultRequeueTime time.Duration
 

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -15,6 +15,16 @@ spec:
   image: {{ $global.registry }}/k0s
   etcd:
     image: "{{ $global.registry }}/etcd:v3.5.13"
+  {{- if $global.registryCertSecret }}
+  mounts:
+    - path: /usr/local/share/ca-certificates/registry
+      secret:
+        defaultMode: 420
+        items:
+          - key: ca.crt
+            path: ca.crt
+        secretName: {{ $global.registryCertSecret }}
+  {{- end }}
   {{- end }}
   controllerPlaneFlags:
   - "--enable-cloud-provider=true"
@@ -54,12 +64,18 @@ spec:
       {{- end }}
       extensions:
         helm:
-          {{- if not $global.registry }}
           repositories:
+          {{- if not $global.registry }}
             - name: mirantis
               url: https://charts.mirantis.com
             - name: aws-ebs-csi-driver
               url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+          {{- else }}
+            - name: global-registry
+              url: oci://{{ $global.registry }}
+              {{- if $global.registryCertSecret }}
+              caFile: /usr/local/share/ca-certificates/registry/ca.crt
+              {{- end }}
           {{- end }}
           charts:
           - name: aws-cloud-controller-manager

--- a/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -17,7 +17,7 @@ spec:
         - contentFrom:
             secretRef:
               name: {{ $secret }}
-              key: tls.crt
+              key: ca.crt
           permissions: "0664"
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -34,7 +34,7 @@ spec:
     - contentFrom:
         secretRef:
           name: {{ $secret }}
-          key: tls.crt
+          key: ca.crt
       permissions: "0664"
       path: /usr/local/share/ca-certificates/{{ $path }}
     {{- end }}

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -17,7 +17,7 @@ spec:
         - contentFrom:
             secretRef:
               name: {{ $secret }}
-              key: tls.crt
+              key: ca.crt
           permissions: "0664"
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -14,6 +14,16 @@ spec:
   image: {{ $global.registry }}/k0s
   etcd:
     image: "{{ $global.registry }}/etcd:v3.5.13"
+  {{- if $global.registryCertSecret }}
+  mounts:
+    - path: /usr/local/share/ca-certificates/registry
+      secret:
+        defaultMode: 420
+        items:
+          - key: ca.crt
+            path: ca.crt
+        secretName: {{ $global.registryCertSecret }}
+  {{- end }}
   {{- end }}
   controllerPlaneFlags:
   - "--enable-cloud-provider=true"
@@ -53,12 +63,18 @@ spec:
       {{- end }}
       extensions:
         helm:
-          {{- if not $global.registry }}
           repositories:
+          {{- if not $global.registry }}
             - name: mirantis
               url: https://charts.mirantis.com
             - name: azuredisk-csi-driver
               url: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
+          {{- else }}
+            - name: global-registry
+              url: oci://{{ $global.registry }}
+              {{- if $global.registryCertSecret }}
+              caFile: /usr/local/share/ca-certificates/registry/ca.crt
+              {{- end }}
           {{- end }}
           charts:
             - name: cloud-provider-azure

--- a/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -17,7 +17,7 @@ spec:
         - contentFrom:
             secretRef:
               name: {{ $secret }}
-              key: tls.crt
+              key: ca.crt
           permissions: "0664"
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -18,7 +18,7 @@ spec:
       - contentFrom:
           secretRef:
             name: {{ $secret }}
-            key: tls.crt
+            key: ca.crt
         permissions: "0664"
         path: /usr/local/share/ca-certificates/{{ $path }}
       {{- end }}

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -17,7 +17,7 @@ spec:
         - contentFrom:
             secretRef:
               name: {{ $secret }}
-              key: tls.crt
+              key: ca.crt
           permissions: "0664"
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -14,6 +14,16 @@ spec:
   image: {{ $global.registry }}/k0s
   etcd:
     image: "{{ $global.registry }}/etcd:v3.5.13"
+  {{- if $global.registryCertSecret }}
+  mounts:
+    - path: /usr/local/share/ca-certificates/registry
+      secret:
+        defaultMode: 420
+        items:
+          - key: ca.crt
+            path: ca.crt
+        secretName: {{ $global.registryCertSecret }}
+  {{- end }}
   {{- end }}
   controllerPlaneFlags:
   - "--enable-cloud-provider=true"
@@ -53,10 +63,16 @@ spec:
       {{- end }}
       extensions:
         helm:
-          {{- if not $global.registry }}
           repositories:
+          {{- if not $global.registry }}
             - name: mirantis
               url: https://charts.mirantis.com
+          {{- else }}
+            - name: global-registry
+              url: oci://{{ $global.registry }}
+              {{- if $global.registryCertSecret }}
+              caFile: /usr/local/share/ca-certificates/registry/ca.crt
+              {{- end }}
           {{- end }}
           charts:
             - name: gcp-cloud-controller-manager

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -17,7 +17,7 @@ spec:
         - contentFrom:
             secretRef:
               name: {{ $secret }}
-              key: tls.crt
+              key: ca.crt
           permissions: "0664"
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -18,7 +18,7 @@ spec:
       - contentFrom:
           secretRef:
             name: {{ $secret }}
-            key: tls.crt
+            key: ca.crt
         permissions: "0664"
         path: /usr/local/share/ca-certificates/{{ $path }}
       {{- end }}

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -17,7 +17,7 @@ spec:
         - contentFrom:
             secretRef:
               name: {{ $secret }}
-              key: tls.crt
+              key: ca.crt
           permissions: "0664"
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -18,7 +18,7 @@ spec:
       - contentFrom:
           secretRef:
             name: {{ $secret }}
-            key: tls.crt
+            key: ca.crt
         permissions: "0664"
         path: /usr/local/share/ca-certificates/{{ $path }}
       {{- end }}

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -17,7 +17,7 @@ spec:
         - contentFrom:
             secretRef:
               name: {{ $secret }}
-              key: tls.crt
+              key: ca.crt
           permissions: "0664"
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
@@ -18,6 +18,16 @@ spec:
   image: {{ $global.registry }}/k0s
   etcd:
     image: "{{ $global.registry }}/etcd:v3.5.13"
+  {{- if $global.registryCertSecret }}
+  mounts:
+    - path: /usr/local/share/ca-certificates/registry
+      secret:
+        defaultMode: 420
+        items:
+          - key: ca.crt
+            path: ca.crt
+        secretName: {{ $global.registryCertSecret }}
+  {{- end }}
   {{- end }}
   k0sConfig:
     apiVersion: k0s.k0sproject.io/v1beta1

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -37,7 +37,7 @@ spec:
     - contentFrom:
         secretRef:
           name: {{ $secret }}
-          key: tls.crt
+          key: ca.crt
       permissions: "0664"
       path: /usr/local/share/ca-certificates/{{ $path }}
     {{- end }}

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -14,6 +14,16 @@ spec:
   image: {{ $global.registry }}/k0s
   etcd:
     image: "{{ $global.registry }}/etcd:v3.5.13"
+  {{- if $global.registryCertSecret }}
+  mounts:
+    - path: /usr/local/share/ca-certificates/registry
+      secret:
+        defaultMode: 420
+        items:
+          - key: ca.crt
+            path: ca.crt
+        secretName: {{ $global.registryCertSecret }}
+  {{- end }}
   {{- end }}
   controllerPlaneFlags:
   - "--enable-cloud-provider=true"
@@ -53,12 +63,18 @@ spec:
       {{- end }}
       extensions:
         helm:
-          {{- if not $global.registry }}
           repositories:
+          {{- if not $global.registry }}
             - name: vsphere-cpi
               url: https://kubernetes.github.io/cloud-provider-vsphere
             - name: mirantis
               url: https://charts.mirantis.com
+          {{- else }}
+            - name: global-registry
+              url: oci://{{ $global.registry }}
+              {{- if $global.registryCertSecret }}
+              caFile: /usr/local/share/ca-certificates/registry/ca.crt
+              {{- end }}
           {{- end }}
           charts:
           - name: vsphere-cpi

--- a/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -21,7 +21,7 @@ spec:
         - contentFrom:
             secretRef:
               name: {{ $secret }}
-              key: tls.crt
+              key: ca.crt
           permissions: "0664"
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -21,7 +21,7 @@ spec:
       - contentFrom:
           secretRef:
             name: {{ $secret }}
-            key: tls.crt
+            key: ca.crt
         permissions: "0664"
         path: /usr/local/share/ca-certificates/{{ $path }}
       {{- end }}

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -21,7 +21,7 @@ spec:
         - contentFrom:
             secretRef:
               name: {{ $secret }}
-              key: tls.crt
+              key: ca.crt
           permissions: "0664"
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-4.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-4.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-2
+  name: aws-hosted-cp-1-0-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.2
+      chart: aws-hosted-cp
+      version: 1.0.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-5.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-5.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-2
+  name: aws-standalone-cp-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.2
+      chart: aws-standalone-cp
+      version: 1.0.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-3.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-3.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-3
+  name: azure-hosted-cp-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
+      chart: azure-hosted-cp
       version: 1.0.3
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-3.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-3.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-3
+  name: azure-standalone-cp-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
+      chart: azure-standalone-cp
       version: 1.0.3
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-4.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-4.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-4
+  name: gcp-hosted-cp-1-0-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
+      chart: gcp-hosted-cp
       version: 1.0.4
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-4.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-4.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-2
+  name: gcp-standalone-cp-1-0-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.2
+      chart: gcp-standalone-cp
+      version: 1.0.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-4.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-4.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-2
+  name: openstack-standalone-cp-1-0-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.2
+      chart: openstack-standalone-cp
+      version: 1.0.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-3.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-3.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-3
+  name: remote-cluster-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
+      chart: remote-cluster
       version: 1.0.3
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-3.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-3.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-3
+  name: vsphere-hosted-cp-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
+      chart: vsphere-hosted-cp
       version: 1.0.3
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-3.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-3.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1alpha1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-2
+  name: vsphere-standalone-cp-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.2
+      chart: vsphere-standalone-cp
+      version: 1.0.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -218,7 +218,7 @@
           ]
         },
         "registryCertSecret": {
-          "description": "Name of a Secret containing Registry Root CA with ca.crt key and mTLS data: client cert (tls.crt) and key (tls.key)",
+          "description": "Name of a Secret containing Registry Root CA with ca.crt key",
           "type": [
             "string"
           ]

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -144,7 +144,7 @@
           "type": "boolean"
         },
         "k0sURLCertSecret": {
-          "description": "Name of a Secret containing K0s Download URL TLS Data",
+          "description": "Name of a Secret containing K0s Download URL Root CA with ca.crt key",
           "type": [
             "string"
           ]
@@ -218,7 +218,7 @@
           ]
         },
         "registryCertSecret": {
-          "description": "Name of a Secret containing Registry TLS Data",
+          "description": "Name of a Secret containing Registry Root CA with ca.crt key and mTLS data: client cert (tls.crt) and key (tls.key)",
           "type": [
             "string"
           ]

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -16,7 +16,7 @@ controller:
   globalK0sURL: ""
   k0sURLCertSecret: "" # @schema type: string; description: Name of a Secret containing K0s Download URL Root CA with ca.crt key
   registryCredsSecret: "" # @schema type: string; description: Name of a Secret containing Registry Credentials (Auth) Data
-  registryCertSecret: "" # @schema type: string; description: Name of a Secret containing Registry Root CA with ca.crt key and mTLS data: client cert (tls.crt) and key (tls.key)
+  registryCertSecret: "" # @schema type: string; description: Name of a Secret containing Registry Root CA with ca.crt key
   insecureRegistry: false
   createManagement: true
   createAccessManagement: true

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -14,9 +14,9 @@ controller:
   templatesRepoURL: "oci://ghcr.io/k0rdent/kcm/charts"
   globalRegistry: ""
   globalK0sURL: ""
-  k0sURLCertSecret: "" # @schema type: string; description: Name of a Secret containing K0s Download URL TLS Data
+  k0sURLCertSecret: "" # @schema type: string; description: Name of a Secret containing K0s Download URL Root CA with ca.crt key
   registryCredsSecret: "" # @schema type: string; description: Name of a Secret containing Registry Credentials (Auth) Data
-  registryCertSecret: "" # @schema type: string; description: Name of a Secret containing Registry TLS Data
+  registryCertSecret: "" # @schema type: string; description: Name of a Secret containing Registry Root CA with ca.crt key and mTLS data: client cert (tls.crt) and key (tls.key)
   insecureRegistry: false
   createManagement: true
   createAccessManagement: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for passing a registry CA certificate when fetching Helm extensions for hosted control plane components. It requires a version of k0s that includes the fix for https://github.com/k0sproject/k0s/issues/5877.

Note: Even if the registry CA certificate is passed and mounted, it will not take effect until a k0s version with the required fix is used.

Also contains the fix to mount the `ca.crt` secret data instead of `tls.crt`.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_: 
Fixes #1612

