### PR TITLE
ci(artifacts): fix conflict in support bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,7 @@ test-apply: kind-deploy
 dev-destroy: kind-undeploy registry-undeploy ## Destroy the development environment by deleting the kind cluster and local registry.
 
 .PHONY: support-bundle
-support-bundle: SUPPORT_BUNDLE_OUTPUT=$(CURDIR)/support-bundle-$(shell date +"%Y-%m-%dT%H_%M_%S")
+support-bundle: SUPPORT_BUNDLE_OUTPUT=$(CURDIR)/support-bundle-$(shell date +"%Y-%m-%dT%H_%M_%S_%N")
 support-bundle: envsubst support-bundle-cli
 	@NAMESPACE=$(NAMESPACE) $(ENVSUBST) -no-unset -i config/support-bundle.yaml | $(SUPPORT_BUNDLE_CLI) -o $(SUPPORT_BUNDLE_OUTPUT) --debug -
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures unique names of support bundle archives on CI
**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #1636 