### PR TITLE
ci: amend templates scripts

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -122,11 +122,22 @@ jobs:
         run: GOLANGCI_LINT_TIMEOUT=10m make lint
 
       - name: Verify all generated pieces are up-to-date
-        run: make generate-all && git add -N . && git diff --exit-code
+        env:
+          BASE_COMMIT: "origin/${{ github.event.pull_request.base.ref }}"
+        shell: bash
+        run: |
+          make generate-all
+          git add -N .
+          if ! git diff --exit-code; then
+            echo "::error::Generated files are out of date. Please run 'make generate-all'."
+            git diff --name-only
+            exit 1
+          fi
 
       - name: Unit tests
-        run: |
-          make test
+        env:
+          BASE_COMMIT: "origin/${{ github.event.pull_request.base.ref }}"
+        run: make test
 
       - name: Get outputs
         id: vars
@@ -174,8 +185,7 @@ jobs:
           GINKGO_LABEL_FILTER: 'controller'
           CLUSTER_DEPLOYMENT_PREFIX: ${{ needs.lint-test.outputs.clusterprefix }}
           VERSION: ${{ needs.lint-test.outputs.version }}
-        run: |
-          make test-e2e
+        run: make test-e2e
 
       - name: Archive test results
         uses: actions/upload-artifact@v4
@@ -319,8 +329,8 @@ jobs:
           GINKGO_LABEL_FILTER: 'provider:cloud'
           CLUSTER_DEPLOYMENT_PREFIX: ${{ needs.lint-test.outputs.clusterprefix }}
           VERSION: ${{ needs.lint-test.outputs.version }}
-        run: |
-          make test-e2e
+        run: make test-e2e
+
       - name: Archive test results
         uses: actions/upload-artifact@v4
         if: always()
@@ -398,8 +408,7 @@ jobs:
           GINKGO_LABEL_FILTER: 'provider:onprem'
           CLUSTER_DEPLOYMENT_PREFIX: ${{ needs.lint-test.outputs.clusterprefix }}
           VERSION: ${{ needs.lint-test.outputs.version }}
-        run: |
-          make test-e2e
+        run: make test-e2e
 
       - name: Archive test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/post-merge-push.yaml
+++ b/.github/workflows/post-merge-push.yaml
@@ -17,7 +17,17 @@ jobs:
           fetch-depth: 0
 
       - name: Verify all generated pieces are up-to-date
-        run: make generate-all && git add -N . && git diff --exit-code
+        shell: bash
+        env:
+          BASE_COMMIT: "origin/${{ github.event.pull_request.base.ref }}"
+        run: |
+          make generate-all
+          git add -N .
+          if ! git diff --exit-code; then
+            echo "::error::Generated files are out of date. Please run 'make generate-all'."
+            git diff --name-only
+            exit 1
+          fi
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3

--- a/Makefile
+++ b/Makefile
@@ -102,15 +102,15 @@ templates-generate:
 
 .PHONY: bump-chart-version
 bump-chart-version: yq
-	@$(SHELL) hack/chart-version.bash
+	@YQ=$(YQ) $(SHELL) hack/chart-version.bash
 
 .PHONY: update-release
 update-release: yq
-	@$(SHELL) hack/update-release.bash
+	@YQ=$(YQ) $(SHELL) hack/update-release.bash
 
 .PHONY: update-dev-confs
 update-dev-confs: yq
-	@$(SHELL) hack/update-dev-configs.bash
+	@YQ=$(YQ) $(SHELL) hack/update-dev-configs.bash
 
 .PHONY: capo-orc-fetch
 capo-orc-fetch: CAPO_DIR := $(PROVIDER_TEMPLATES_DIR)/cluster-api-provider-openstack

--- a/hack/update-dev-configs.bash
+++ b/hack/update-dev-configs.bash
@@ -18,31 +18,32 @@ set -eu
 
 TEMPLATE_DIR=${TEMPLATE_DIR:-templates/provider/kcm-templates/files/templates}
 CONFIG_DEV_DIR=${CONFIG_DEV_DIR:-config/dev}
+BASE_COMMIT=${BASE_COMMIT:-origin/main}
+HEAD_COMMIT=${HEAD_COMMIT:-HEAD}
 
-# Get tracked + untracked changed files
-TRACKED_CHANGED=$(git diff --name-only HEAD -- "$TEMPLATE_DIR")
+COMMITTED_CHANGED=$(git diff --name-only "$BASE_COMMIT"...$HEAD_COMMIT -- "$TEMPLATE_DIR")
+TRACKED_CHANGED=$(git diff --name-only -- "$TEMPLATE_DIR")
 UNTRACKED_CHANGED=$(git ls-files --others --exclude-standard "$TEMPLATE_DIR")
-ALL_CHANGED=$(echo -e "$TRACKED_CHANGED\n$UNTRACKED_CHANGED" | sort -u | grep -E '\.ya?ml$' || true)
+ALL_CHANGED=$(echo -e "$COMMITTED_CHANGED\n$TRACKED_CHANGED\n$UNTRACKED_CHANGED" \
+  | sort -u | grep -E '\.ya?ml$' || true)
 
 for file in $ALL_CHANGED; do
-  # Skip deleted/missing files
   [[ -f "$file" ]] || continue
 
-  # Only process ClusterTemplate kind
-  kind=$(yq e '.kind' "$file")
+  kind=$(${YQ} e '.kind' "$file")
   [[ "$kind" != "ClusterTemplate" ]] && continue
 
-  template_name=$(yq e '.metadata.name' "$file")
-  template_type=$(yq e '.spec.helm.chartSpec.chart' "$file")
+  template_name=$(${YQ} e '.metadata.name' "$file")
+  template_type=$(${YQ} e '.spec.helm.chartSpec.chart' "$file")
 
   for deployment in "$CONFIG_DEV_DIR"/*-clusterdeployment.yaml; do
-    [[ ! -f "$deployment" ]] && continue
+    [[ -f "$deployment" ]] || continue
 
-    current_template=$(yq e '.spec.template' "$deployment")
+    current_template=$(${YQ} e '.spec.template' "$deployment")
 
     if [[ "$current_template" == *"$template_type"* && "$current_template" != "$template_name" ]]; then
       echo "Updating $deployment: $current_template → $template_name"
-      yq e -i ".spec.template = \"$template_name\"" "$deployment"
+      ${YQ} e -i ".spec.template = \"$template_name\"" "$deployment"
     fi
   done
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
Use make's yq in the scripts.

Generate templates based not only on the dirty state but rather on base commit.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Mend of #1574 