### PR TITLE
ci(merge): remove redundant base

### DIFF
--- a/.github/workflows/post-merge-push.yaml
+++ b/.github/workflows/post-merge-push.yaml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Verify all generated pieces are up-to-date
         shell: bash
-        env:
-          BASE_COMMIT: "origin/${{ github.event.pull_request.base.ref }}"
         run: |
           make generate-all
           git add -N .


### PR DESCRIPTION
**What this PR does / why we need it**:
On merge there is no PR context nor need to change base commit for generation
**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
