### PR TITLE
ci(merge): cache earlier

### DIFF
--- a/.github/workflows/post-merge-push.yaml
+++ b/.github/workflows/post-merge-push.yaml
@@ -16,6 +16,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Verify all generated pieces are up-to-date
         shell: bash
         run: |
@@ -36,16 +46,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Get version
         id: version


### PR DESCRIPTION
**What this PR does / why we need it**:
Use cache before any steps on merge

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
