### PR TITLE
chore(generation): introduce auto JSON schema generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -640,7 +640,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= release-0.20
 GOLANGCI_LINT_VERSION ?= v2.1.6
 GOLANGCI_LINT_TIMEOUT ?= 1m
-HELM_VERSION ?= v3.17.2
+HELM_VERSION ?= v3.18.3
 KIND_VERSION ?= v0.29.0
 YQ_VERSION ?= v4.45.1
 CLOUDNUKE_VERSION = v0.38.2
@@ -659,12 +659,8 @@ cli-install: controller-gen envtest golangci-lint helm kind yq cloud-nuke azure-
 helm-plugin-schema: HELM_PLUGIN_URL=https://github.com/losisin/helm-values-schema-json.git
 helm-plugin-schema: HELM_SCHEMA_PLUGIN_VERSION=2.1.0
 helm-plugin-schema: helm
-	@output=$$($(HELM) plugin install $(HELM_PLUGIN_URL) --version $(HELM_SCHEMA_PLUGIN_VERSION) 2>&1); \
-	status=$$?; \
-	echo "$$output" | grep -q "plugin already exists" ; \
-	grep_status=$$?; \
-	if [ $$status -ne 0 ] && [ $$grep_status -ne 0 ]; then \
-		echo "$$output" && exit $$status; \
+	@if ! $(HELM) plugin list | grep -qe "schema.*$(HELM_SCHEMA_PLUGIN_VERSION)"; then \
+		$(HELM) plugin install $(HELM_PLUGIN_URL) --version $(HELM_SCHEMA_PLUGIN_VERSION); \
 	fi
 
 .PHONY: controller-gen

--- a/config/dev/adopted-clusterdeployment.yaml
+++ b/config/dev/adopted-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: adopted-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: adopted-cluster-1-0-0
+  template: adopted-cluster-1-0-1
   credential: adopted-cluster-cred
   config:
     clusterLabels: {}

--- a/config/dev/aks-clusterdeployment.yaml
+++ b/config/dev/aks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-aks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-aks-1-0-0
+  template: azure-aks-1-0-1
   credential: azure-aks-credential
   propagateCredentials: false
   config:

--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-6
+  template: aws-standalone-cp-1-0-7
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-4
+  template: azure-standalone-cp-1-0-5
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/docker-clusterdeployment.yaml
+++ b/config/dev/docker-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: docker-hosted-cp-1-0-0
+  template: docker-hosted-cp-1-0-1
   credential: docker-stub-credential
   config:
     clusterLabels: {}

--- a/config/dev/eks-clusterdeployment.yaml
+++ b/config/dev/eks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-eks-1-0-1
+  template: aws-eks-1-0-2
   credential: "aws-cluster-identity-cred"
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-5
+  template: gcp-standalone-cp-1-0-6
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/gke-clusterdeployment.yaml
+++ b/config/dev/gke-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-gke-1-0-1
+  template: gcp-gke-1-0-2
   credential: gcp-credential
   propagateCredentials: false
   config:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-5
+  template: openstack-standalone-cp-1-0-6
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-4
+  template: remote-cluster-1-0-5
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-4
+  template: vsphere-standalone-cp-1-0-5
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/hack/update-release.bash
+++ b/hack/update-release.bash
@@ -38,11 +38,11 @@ for file in $ALL_CHANGED; do
 
   if [[ "$chart_name" == "kcm" ]]; then
     current=$(${YQ} e '.spec.kcm.template' "$RELEASE_FILE")
-    [[ "$current" != "$new_name" ]] && ${YQ} e -i ".spec.kcm.template = \"$new_name\"" "$RELEASE_FILE"
+    [[ "$current" != "$new_name" ]] && ${YQ} e -i ".spec.kcm.template = \"$new_name\"" "$RELEASE_FILE" && \
     echo "Updated spec.kcm.template → $new_name"
   elif [[ "$chart_name" == "cluster-api" ]]; then
     current=$(${YQ} e '.spec.capi.template' "$RELEASE_FILE")
-    [[ "$current" != "$new_name" ]] && ${YQ} e -i ".spec.capi.template = \"$new_name\"" "$RELEASE_FILE"
+    [[ "$current" != "$new_name" ]] && ${YQ} e -i ".spec.capi.template = \"$new_name\"" "$RELEASE_FILE" && \
     echo "Updated spec.capi.template → $new_name"
   else
     index=$(${YQ} e ".spec.providers[] | select(.name == \"$chart_name\") | key" "$RELEASE_FILE")

--- a/templates/cluster/adopted-cluster/Chart.yaml
+++ b/templates/cluster/adopted-cluster/Chart.yaml
@@ -6,6 +6,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 annotations:
   cluster.x-k8s.io/provider: infrastructure-internal

--- a/templates/cluster/adopted-cluster/values.schema.json
+++ b/templates/cluster/adopted-cluster/values.schema.json
@@ -1,27 +1,24 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to adopt an existing k8s cluster.",
+  "description": "A KCM cluster adopted-cluster template",
   "type": "object",
-  "required": [
-    "clusterIdentity"
-  ],
   "properties": {
-    "consecutiveFailureThreshold": {
-      "description": "The number of the failures prior to setting the status condition",
-      "type": "integer",
-      "minimum": 1
+    "clusterAnnotations": {
+      "type": "object"
+    },
+    "clusterIdentity": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
     },
     "clusterLabels": {
-      "type": "object",
-      "description": "Labels to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
+      "type": "object"
     },
-    "clusterAnnotations": {
-      "type": "object",
-      "description": "Annotations to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    }    
+    "consecutiveFailureThreshold": {
+      "type": "integer"
+    }
   }
 }

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-eks/values.schema.json
+++ b/templates/cluster/aws-eks/values.schema.json
@@ -1,32 +1,34 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a K8s managed cluster (EKS) on AWS",
+  "description": "A KCM cluster aws-eks template",
+  "type": "object",
+  "required": [
+    "workersNumber",
+    "region",
+    "clusterIdentity"
+  ],
   "properties": {
     "addons": {
       "description": "The EKS addons to enable with the EKS cluster",
+      "type": "array",
       "items": {
+        "type": "object",
         "properties": {
           "configuration": {
             "description": "Optional configuration of the EKS addon in YAML format",
-            "type": [
-              "string"
-            ]
+            "type": "string"
           },
           "conflictResolution": {
             "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none",
+            "type": "string",
             "enum": [
               "overwrite",
               "none"
-            ],
-            "type": [
-              "string"
             ]
           },
           "name": {
             "description": "The name of the addon",
-            "type": [
-              "string"
-            ]
+            "type": "string"
           },
           "serviceAccountRoleARN": {
             "description": "ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account",
@@ -37,160 +39,113 @@
           },
           "version": {
             "description": "The version of the addon to use",
-            "type": [
-              "string"
-            ]
+            "type": "string"
           }
-        },
-        "type": "object"
-      },
-      "type": [
-        "array"
-      ]
+        }
+      }
     },
     "associateOIDCProvider": {
       "description": "Automatically create an identity provider for the controller for use with IAM roles for service accounts",
-      "type": [
-        "boolean"
-      ]
+      "type": "boolean"
     },
     "clusterAnnotations": {
-      "additionalProperties": true,
       "description": "Annotations to apply to the cluster",
-      "properties": {},
-      "type": [
-        "object"
-      ]
+      "type": "object",
+      "additionalProperties": true
     },
     "clusterIdentity": {
       "description": "A reference to an identity to be used when reconciling the managed control plane",
-      "properties": {
-        "kind": {
-          "description": "Kind of the identity",
-          "type": [
-            "string"
-          ]
-        },
-        "name": {
-          "description": "Name of the identity",
-          "type": [
-            "string"
-          ]
-        }
-      },
+      "type": "object",
       "required": [
         "name",
         "kind"
       ],
-      "type": [
-        "object"
-      ]
+      "properties": {
+        "kind": {
+          "description": "Kind of the identity",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the identity",
+          "type": "string"
+        }
+      }
     },
     "clusterLabels": {
-      "additionalProperties": true,
       "description": "Labels to apply to the cluster",
-      "properties": {},
-      "type": [
-        "object"
-      ]
+      "type": "object",
+      "additionalProperties": true
     },
     "clusterNetwork": {
       "description": "The cluster network configuration",
+      "type": "object",
       "properties": {
         "pods": {
           "description": "The network ranges from which Pod networks are allocated",
+          "type": "object",
           "properties": {
             "cidrBlocks": {
               "description": "A list of CIDR blocks",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": [
-                "array"
-              ]
+              }
             }
-          },
-          "type": [
-            "object"
-          ]
+          }
         },
         "services": {
           "description": "The network ranges from which service VIPs are allocated",
+          "type": "object",
           "properties": {
             "cidrBlocks": {
               "description": "A list of CIDR blocks",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": [
-                "array"
-              ]
+              }
             }
-          },
-          "type": [
-            "object"
-          ]
+          }
         }
-      },
-      "type": [
-        "object"
-      ]
+      }
     },
     "eksClusterName": {
       "description": "The name of the EKS cluster in AWS. If unset, the default name will be created based on the namespace and name of the managed control plane",
-      "type": [
-        "string"
-      ]
+      "type": "string"
     },
     "kubeProxy": {
       "description": "Managed attributes of the kube-proxy daemonset",
+      "type": "object",
       "properties": {
         "disable": {
           "description": "Disable set to true indicates that kube-proxy should be disabled. With EKS clusters kube-proxy is automatically installed into the cluster",
-          "type": [
-            "boolean"
-          ]
+          "type": "boolean"
         }
-      },
-      "type": [
-        "object"
-      ]
+      }
     },
     "kubernetes": {
       "description": "Kubernetes parameters",
-      "properties": {
-        "version": {
-          "description": "Kubernetes version to use",
-          "type": [
-            "string"
-          ]
-        }
-      },
+      "type": "object",
       "required": [
         "version"
       ],
-      "type": [
-        "object"
-      ]
+      "properties": {
+        "version": {
+          "description": "Kubernetes version to use",
+          "type": "string"
+        }
+      }
     },
     "oidcIdentityProviderConfig": {
       "description": "The oidc provider config to be attached with this eks cluster",
-      "properties": {},
-      "type": [
-        "object"
-      ]
+      "type": "object"
     },
     "publicIP": {
       "description": "Specifies whether the instance should get a public IP",
-      "type": [
-        "boolean"
-      ]
+      "type": "boolean"
     },
     "region": {
       "description": "AWS region to deploy the cluster in",
-      "type": [
-        "string"
-      ]
+      "type": "string"
     },
     "sshKeyName": {
       "description": "The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
@@ -201,119 +156,86 @@
     },
     "vpcCni": {
       "description": "The configuration options for the VPC CNI plugin",
+      "type": "object",
       "properties": {
         "disable": {
           "description": "Indicates that the Amazon VPC CNI should be disabled",
-          "type": [
-            "boolean"
-          ]
+          "type": "boolean"
         },
         "env": {
           "description": "A list of environment variables to apply to the aws-node DaemonSet",
-          "type": [
-            "array"
-          ]
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
         }
-      },
-      "type": [
-        "object"
-      ]
+      }
     },
     "worker": {
       "description": "The configuration of the worker machines",
-      "properties": {
-        "amiID": {
-          "description": "The ID of Amazon Machine Image",
-          "type": [
-            "string"
-          ]
-        },
-        "iamInstanceProfile": {
-          "description": "A name of an IAM instance profile to assign to the instance",
-          "type": [
-            "string"
-          ]
-        },
-        "imageLookup": {
-          "description": "AMI lookup parameters",
-          "properties": {
-            "baseOS": {
-              "description": "The name of the base operating system to use for image lookup the AMI is not set",
-              "type": [
-                "string"
-              ]
-            },
-            "format": {
-              "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
-              "type": [
-                "string"
-              ]
-            },
-            "org": {
-              "description": "The AWS Organization ID to use for image lookup if AMI is not set",
-              "type": [
-                "string"
-              ]
-            }
-          },
-          "required": [
-            "format",
-            "org"
-          ],
-          "type": [
-            "object"
-          ]
-        },
-        "instanceType": {
-          "description": "The type of instance to create. Example: m4.xlarge",
-          "type": [
-            "string"
-          ]
-        },
-        "nonRootVolumes": {
-          "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
-          "items": {
-            "type": "object"
-          },
-          "title": "Non-root storage volumes",
-          "type": [
-            "array"
-          ]
-        },
-        "rootVolumeSize": {
-          "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
-          "minimum": 8,
-          "type": [
-            "integer"
-          ]
-        },
-        "uncompressedUserData": {
-          "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
-          "type": [
-            "boolean"
-          ]
-        }
-      },
+      "type": "object",
       "required": [
         "iamInstanceProfile",
         "instanceType"
       ],
-      "type": [
-        "object"
-      ]
+      "properties": {
+        "amiID": {
+          "description": "The ID of Amazon Machine Image",
+          "type": "string"
+        },
+        "iamInstanceProfile": {
+          "description": "A name of an IAM instance profile to assign to the instance",
+          "type": "string"
+        },
+        "imageLookup": {
+          "description": "AMI lookup parameters",
+          "type": "object",
+          "required": [
+            "format",
+            "org"
+          ],
+          "properties": {
+            "baseOS": {
+              "description": "The name of the base operating system to use for image lookup the AMI is not set",
+              "type": "string"
+            },
+            "format": {
+              "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
+              "type": "string"
+            },
+            "org": {
+              "description": "The AWS Organization ID to use for image lookup if AMI is not set",
+              "type": "string"
+            }
+          }
+        },
+        "instanceType": {
+          "description": "The type of instance to create. Example: m4.xlarge",
+          "type": "string"
+        },
+        "nonRootVolumes": {
+          "title": "Non-root storage volumes",
+          "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "rootVolumeSize": {
+          "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
+          "type": "integer",
+          "minimum": 8
+        },
+        "uncompressedUserData": {
+          "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
+          "type": "boolean"
+        }
+      }
     },
     "workersNumber": {
       "description": "The number of the worker machines",
-      "minimum": 1,
-      "type": [
-        "number"
-      ]
+      "type": "number",
+      "minimum": 1
     }
-  },
-  "required": [
-    "workersNumber",
-    "region",
-    "clusterIdentity"
-  ],
-  "type": "object"
+  }
 }

--- a/templates/cluster/aws-eks/values.yaml
+++ b/templates/cluster/aws-eks/values.yaml
@@ -1,7 +1,3 @@
-# Schema generation:
-# $ helm plugin install https://github.com/losisin/helm-values-schema-json.git
-# $ helm schema --draft 2020 --indent 2 --noAdditionalProperties=false --schemaRoot.description='A KCM template to deploy a K8s managed cluster (EKS) on AWS' --input ./templates/cluster/aws-eks/values.yaml --output ./templates/cluster/aws-eks/values.schema.json
-
 # Cluster parameters
 workersNumber: 1 # @schema description: The number of the worker machines; type: number; minimum: 1; required: true
 
@@ -27,7 +23,7 @@ oidcIdentityProviderConfig: {} # @schema description: The oidc provider config t
 
 vpcCni: # @schema description: The configuration options for the VPC CNI plugin; type: object
   disable: false # @schema description: Indicates that the Amazon VPC CNI should be disabled; type: boolean
-  env: [] # @schema description: A list of environment variables to apply to the aws-node DaemonSet; type: array; type.items: object
+  env: [] # @schema description: A list of environment variables to apply to the aws-node DaemonSet; type: array; item: object
 
 kubeProxy: # @schema description: Managed attributes of the kube-proxy daemonset; type: object
   disable: false # @schema description: Disable set to true indicates that kube-proxy should be disabled. With EKS clusters kube-proxy is automatically installed into the cluster; type: boolean

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/values.schema.json
+++ b/templates/cluster/aws-hosted-cp/values.schema.json
@@ -1,340 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a k8s cluster on AWS with control plane components within the management cluster",
-  "properties": {
-    "amiID": {
-      "description": "The ID of Amazon Machine Image",
-      "type": [
-        "string"
-      ]
-    },
-    "bastion": {
-      "description": "The configuration of the bastion host",
-      "properties": {
-        "allowedCIDRBlocks": {
-          "description": "A list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0)",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array"
-          ]
-        },
-        "ami": {
-          "description": "Uses the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space",
-          "type": [
-            "string"
-          ]
-        },
-        "disableIngressRules": {
-          "description": "Ensures ensure there are no Ingress rules in the bastion host's security group. Requires allowedCIDRBlocks to be empty",
-          "type": [
-            "boolean"
-          ]
-        },
-        "enabled": {
-          "description": "Allows this provider to create a bastion host instance with a public ip to access the VPC private network",
-          "type": [
-            "boolean"
-          ]
-        },
-        "instanceType": {
-          "description": "Use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default",
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "required": [
-        "enabled"
-      ],
-      "type": [
-        "object"
-      ]
-    },
-    "clusterAnnotations": {
-      "additionalProperties": true,
-      "description": "Annotations to apply to the cluster",
-      "properties": {},
-      "type": [
-        "object"
-      ]
-    },
-    "clusterIdentity": {
-      "description": "A reference to an identity to be used when reconciling the managed control plane",
-      "properties": {
-        "kind": {
-          "description": "Kind of the identity",
-          "type": [
-            "string"
-          ]
-        },
-        "name": {
-          "description": "Name of the identity",
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "required": [
-        "name",
-        "kind"
-      ],
-      "type": [
-        "object"
-      ]
-    },
-    "clusterLabels": {
-      "additionalProperties": true,
-      "description": "Labels to apply to the cluster",
-      "properties": {},
-      "type": [
-        "object"
-      ]
-    },
-    "clusterNetwork": {
-      "description": "The cluster network configuration",
-      "properties": {
-        "pods": {
-          "description": "The network ranges from which Pod networks are allocated",
-          "properties": {
-            "cidrBlocks": {
-              "description": "A list of CIDR blocks",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array"
-              ]
-            }
-          },
-          "type": [
-            "object"
-          ]
-        },
-        "services": {
-          "description": "The network ranges from which service VIPs are allocated",
-          "properties": {
-            "cidrBlocks": {
-              "description": "A list of CIDR blocks",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array"
-              ]
-            }
-          },
-          "type": [
-            "object"
-          ]
-        }
-      },
-      "type": [
-        "object"
-      ]
-    },
-    "iamInstanceProfile": {
-      "description": "A name of an IAM instance profile to assign to the instance",
-      "type": [
-        "string"
-      ]
-    },
-    "imageLookup": {
-      "description": "AMI lookup parameters",
-      "properties": {
-        "baseOS": {
-          "description": "The name of the base operating system to use for image lookup the AMI is not set",
-          "type": [
-            "string"
-          ]
-        },
-        "format": {
-          "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
-          "type": [
-            "string"
-          ]
-        },
-        "org": {
-          "description": "The AWS Organization ID to use for image lookup if AMI is not set",
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "required": [
-        "format",
-        "org"
-      ],
-      "type": [
-        "object"
-      ]
-    },
-    "instanceType": {
-      "description": "The type of instance to create. Example: m4.xlarge",
-      "type": [
-        "string"
-      ]
-    },
-    "k0s": {
-      "description": "K0s parameters",
-      "properties": {
-        "api": {
-          "description": "Kubernetes API server parameters",
-          "properties": {
-            "extraArgs": {
-              "additionalProperties": true,
-              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
-              "properties": {},
-              "type": [
-                "object"
-              ]
-            }
-          },
-          "type": [
-            "object"
-          ]
-        },
-        "version": {
-          "description": "K0s version",
-          "type": [
-            "string"
-          ]
-        }
-      },
-      "required": [
-        "version"
-      ],
-      "type": [
-        "object"
-      ]
-    },
-    "k0smotron": {
-      "description": "K0smotron parameters",
-      "properties": {
-        "service": {
-          "description": "The API service configuration",
-          "properties": {
-            "apiPort": {
-              "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
-              "maximum": 65535,
-              "minimum": 1,
-              "type": [
-                "number"
-              ]
-            },
-            "konnectivityPort": {
-              "description": "The konnectivity port. If empty k0smotron will pick it automatically",
-              "maximum": 65535,
-              "minimum": 1,
-              "type": [
-                "number"
-              ]
-            },
-            "type": {
-              "description": "An ingress methods for a service",
-              "enum": [
-                "ClusterIP",
-                "NodePort",
-                "LoadBalancer"
-              ],
-              "type": [
-                "string"
-              ]
-            }
-          },
-          "type": [
-            "object"
-          ]
-        }
-      },
-      "type": [
-        "object"
-      ]
-    },
-    "managementClusterName": {
-      "description": "The name of the management cluster that this template is being deployed on",
-      "type": [
-        "string"
-      ]
-    },
-    "nonRootVolumes": {
-      "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
-      "items": {
-        "type": "object"
-      },
-      "title": "Non-root storage volumes",
-      "type": [
-        "array"
-      ]
-    },
-    "publicIP": {
-      "description": "Specifies whether the instance should get a public IP",
-      "type": [
-        "boolean"
-      ]
-    },
-    "region": {
-      "description": "AWS region to deploy the cluster in",
-      "type": [
-        "string"
-      ]
-    },
-    "rootVolumeSize": {
-      "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
-      "minimum": 8,
-      "type": [
-        "integer"
-      ]
-    },
-    "securityGroupIDs": {
-      "description": "An array of security groups' IDs that should be applied to the instance",
-      "items": {
-        "type": "string"
-      },
-      "type": [
-        "array"
-      ],
-      "uniqueItems": true
-    },
-    "sshKeyName": {
-      "description": "The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "subnets": {
-      "description": "Subnets configuration",
-      "items": {
-        "type": "object"
-      },
-      "minItems": 1,
-      "type": [
-        "array"
-      ],
-      "uniqueItems": true
-    },
-    "uncompressedUserData": {
-      "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
-      "type": [
-        "boolean"
-      ]
-    },
-    "vpcID": {
-      "description": "The VPC ID to deploy the cluster in",
-      "type": [
-        "string"
-      ]
-    },
-    "workersNumber": {
-      "description": "The number of the worker machines",
-      "minimum": 1,
-      "type": [
-        "integer"
-      ]
-    }
-  },
+  "description": "A KCM cluster aws-hosted-cp template",
+  "type": "object",
   "required": [
     "workersNumber",
     "managementClusterName",
@@ -345,5 +12,262 @@
     "instanceType",
     "securityGroupIDs"
   ],
-  "type": "object"
+  "properties": {
+    "amiID": {
+      "description": "The ID of Amazon Machine Image",
+      "type": "string"
+    },
+    "bastion": {
+      "description": "The configuration of the bastion host",
+      "type": "object",
+      "required": [
+        "enabled"
+      ],
+      "properties": {
+        "allowedCIDRBlocks": {
+          "description": "A list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ami": {
+          "description": "Uses the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space",
+          "type": "string"
+        },
+        "disableIngressRules": {
+          "description": "Ensures ensure there are no Ingress rules in the bastion host's security group. Requires allowedCIDRBlocks to be empty",
+          "type": "boolean"
+        },
+        "enabled": {
+          "description": "Allows this provider to create a bastion host instance with a public ip to access the VPC private network",
+          "type": "boolean"
+        },
+        "instanceType": {
+          "description": "Use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default",
+          "type": "string"
+        }
+      }
+    },
+    "clusterAnnotations": {
+      "description": "Annotations to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "clusterIdentity": {
+      "description": "A reference to an identity to be used when reconciling the managed control plane",
+      "type": "object",
+      "required": [
+        "name",
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "description": "Kind of the identity",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the identity",
+          "type": "string"
+        }
+      }
+    },
+    "clusterLabels": {
+      "description": "Labels to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "clusterNetwork": {
+      "description": "The cluster network configuration",
+      "type": "object",
+      "properties": {
+        "pods": {
+          "description": "The network ranges from which Pod networks are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "services": {
+          "description": "The network ranges from which service VIPs are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "iamInstanceProfile": {
+      "description": "A name of an IAM instance profile to assign to the instance",
+      "type": "string"
+    },
+    "imageLookup": {
+      "description": "AMI lookup parameters",
+      "type": "object",
+      "required": [
+        "format",
+        "org"
+      ],
+      "properties": {
+        "baseOS": {
+          "description": "The name of the base operating system to use for image lookup the AMI is not set",
+          "type": "string"
+        },
+        "format": {
+          "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
+          "type": "string"
+        },
+        "org": {
+          "description": "The AWS Organization ID to use for image lookup if AMI is not set",
+          "type": "string"
+        }
+      }
+    },
+    "instanceType": {
+      "description": "The type of instance to create. Example: m4.xlarge",
+      "type": "string"
+    },
+    "k0s": {
+      "description": "K0s parameters",
+      "type": "object",
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "api": {
+          "description": "Kubernetes API server parameters",
+          "type": "object",
+          "properties": {
+            "extraArgs": {
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "version": {
+          "description": "K0s version",
+          "type": "string"
+        }
+      }
+    },
+    "k0smotron": {
+      "description": "K0smotron parameters",
+      "type": "object",
+      "properties": {
+        "service": {
+          "description": "The API service configuration",
+          "type": "object",
+          "properties": {
+            "apiPort": {
+              "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
+            },
+            "konnectivityPort": {
+              "description": "The konnectivity port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
+            },
+            "type": {
+              "description": "An ingress methods for a service",
+              "default": "LoadBalancer",
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "managementClusterName": {
+      "description": "The name of the management cluster that this template is being deployed on",
+      "type": "string"
+    },
+    "nonRootVolumes": {
+      "title": "Non-root storage volumes",
+      "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "publicIP": {
+      "description": "Specifies whether the instance should get a public IP",
+      "type": "boolean"
+    },
+    "region": {
+      "description": "AWS region to deploy the cluster in",
+      "type": "string"
+    },
+    "rootVolumeSize": {
+      "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
+      "type": "integer",
+      "minimum": 8
+    },
+    "securityGroupIDs": {
+      "description": "An array of security groups' IDs that should be applied to the instance",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "sshKeyName": {
+      "description": "The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "subnets": {
+      "description": "Subnets configuration",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "availabilityZone": {
+            "description": "ID defines a unique identifier to reference this resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "ID defines a unique identifier to reference this resource",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "uncompressedUserData": {
+      "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
+      "type": "boolean"
+    },
+    "vpcID": {
+      "description": "The VPC ID to deploy the cluster in",
+      "type": "string"
+    },
+    "workersNumber": {
+      "description": "The number of the worker machines",
+      "type": "integer",
+      "minimum": 1
+    }
+  }
 }

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -1,7 +1,3 @@
-# Schema generation:
-# $ helm plugin install https://github.com/losisin/helm-values-schema-json.git
-# $ helm schema --draft 2020 --indent 2 --noAdditionalProperties=false --schemaRoot.description='A KCM template to deploy a k8s cluster on AWS with control plane components within the management cluster' --input ./templates/cluster/aws-hosted-cp/values.yaml --output ./templates/cluster/aws-hosted-cp/values.schema.json
-
 # Cluster parameters
 workersNumber: 2 # @schema description: The number of the worker machines; minimum: 1; type: integer; required: true
 

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/values.schema.json
+++ b/templates/cluster/aws-standalone-cp/values.schema.json
@@ -1,277 +1,211 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a k0s cluster on AWS with bootstrapped control plane nodes",
+  "description": "A KCM cluster aws-standalone-cp template",
+  "type": "object",
+  "required": [
+    "controlPlaneNumber",
+    "workersNumber",
+    "region",
+    "clusterIdentity"
+  ],
   "properties": {
     "bastion": {
       "description": "The configuration of the bastion host",
-      "properties": {
-        "allowedCIDRBlocks": {
-          "description": "A list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0)",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array"
-          ]
-        },
-        "ami": {
-          "description": "Uses the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space",
-          "type": [
-            "string"
-          ]
-        },
-        "disableIngressRules": {
-          "description": "Ensures ensure there are no Ingress rules in the bastion host's security group. Requires allowedCIDRBlocks to be empty",
-          "type": [
-            "boolean"
-          ]
-        },
-        "enabled": {
-          "description": "Allows this provider to create a bastion host instance with a public ip to access the VPC private network",
-          "type": [
-            "boolean"
-          ]
-        },
-        "instanceType": {
-          "description": "Use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default",
-          "type": [
-            "string"
-          ]
-        }
-      },
+      "type": "object",
       "required": [
         "enabled"
       ],
-      "type": [
-        "object"
-      ]
+      "properties": {
+        "allowedCIDRBlocks": {
+          "description": "A list of CIDR blocks allowed to access the bastion host. They are set as ingress rules for the Bastion host's Security Group (defaults to 0.0.0.0/0)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ami": {
+          "description": "Uses the specified AMI to boot the bastion. If not specified, the AMI will default to one picked out in public space",
+          "type": "string"
+        },
+        "disableIngressRules": {
+          "description": "Ensures ensure there are no Ingress rules in the bastion host's security group. Requires allowedCIDRBlocks to be empty",
+          "type": "boolean"
+        },
+        "enabled": {
+          "description": "Allows this provider to create a bastion host instance with a public ip to access the VPC private network",
+          "type": "boolean"
+        },
+        "instanceType": {
+          "description": "Use the specified instance type for the bastion. If not specified, Cluster API Provider AWS will use t3.micro for all regions except us-east-1, where t2.micro will be the default",
+          "type": "string"
+        }
+      }
     },
     "clusterAnnotations": {
-      "additionalProperties": true,
       "description": "Annotations to apply to the cluster",
-      "properties": {},
-      "type": [
-        "object"
-      ]
+      "type": "object",
+      "additionalProperties": true
     },
     "clusterIdentity": {
       "description": "A reference to an identity to be used when reconciling the managed control plane",
-      "properties": {
-        "kind": {
-          "description": "Kind of the identity",
-          "type": [
-            "string"
-          ]
-        },
-        "name": {
-          "description": "Name of the identity",
-          "type": [
-            "string"
-          ]
-        }
-      },
+      "type": "object",
       "required": [
         "name",
         "kind"
       ],
-      "type": [
-        "object"
-      ]
+      "properties": {
+        "kind": {
+          "description": "Kind of the identity",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the identity",
+          "type": "string"
+        }
+      }
     },
     "clusterLabels": {
-      "additionalProperties": true,
       "description": "Labels to apply to the cluster",
-      "properties": {},
-      "type": [
-        "object"
-      ]
+      "type": "object",
+      "additionalProperties": true
     },
     "clusterNetwork": {
       "description": "The cluster network configuration",
+      "type": "object",
       "properties": {
         "pods": {
           "description": "The network ranges from which Pod networks are allocated",
+          "type": "object",
           "properties": {
             "cidrBlocks": {
               "description": "A list of CIDR blocks",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": [
-                "array"
-              ]
+              }
             }
-          },
-          "type": [
-            "object"
-          ]
+          }
         },
         "services": {
           "description": "The network ranges from which service VIPs are allocated",
+          "type": "object",
           "properties": {
             "cidrBlocks": {
               "description": "A list of CIDR blocks",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": [
-                "array"
-              ]
+              }
             }
-          },
-          "type": [
-            "object"
-          ]
+          }
         }
-      },
-      "type": [
-        "object"
-      ]
+      }
     },
     "controlPlane": {
       "description": "The configuration of the control plane machines",
-      "properties": {
-        "amiID": {
-          "description": "The ID of Amazon Machine Image",
-          "type": [
-            "string"
-          ]
-        },
-        "iamInstanceProfile": {
-          "description": "A name of an IAM instance profile to assign to the instance",
-          "type": [
-            "string"
-          ]
-        },
-        "imageLookup": {
-          "description": "AMI lookup parameters",
-          "properties": {
-            "baseOS": {
-              "description": "The name of the base operating system to use for image lookup the AMI is not set",
-              "type": [
-                "string"
-              ]
-            },
-            "format": {
-              "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
-              "type": [
-                "string"
-              ]
-            },
-            "org": {
-              "description": "The AWS Organization ID to use for image lookup if AMI is not set",
-              "type": [
-                "string"
-              ]
-            }
-          },
-          "required": [
-            "format",
-            "org"
-          ],
-          "type": [
-            "object"
-          ]
-        },
-        "instanceType": {
-          "description": "The type of instance to create. Example: m4.xlarge",
-          "type": [
-            "string"
-          ]
-        },
-        "nonRootVolumes": {
-          "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
-          "items": {
-            "type": "object"
-          },
-          "title": "Non-root storage volumes",
-          "type": [
-            "array"
-          ]
-        },
-        "rootVolumeSize": {
-          "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
-          "minimum": 8,
-          "type": [
-            "integer"
-          ]
-        },
-        "uncompressedUserData": {
-          "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
-          "type": [
-            "boolean"
-          ]
-        }
-      },
+      "type": "object",
       "required": [
         "iamInstanceProfile",
         "instanceType"
       ],
-      "type": [
-        "object"
-      ]
+      "properties": {
+        "amiID": {
+          "description": "The ID of Amazon Machine Image",
+          "type": "string"
+        },
+        "iamInstanceProfile": {
+          "description": "A name of an IAM instance profile to assign to the instance",
+          "type": "string"
+        },
+        "imageLookup": {
+          "description": "AMI lookup parameters",
+          "type": "object",
+          "required": [
+            "format",
+            "org"
+          ],
+          "properties": {
+            "baseOS": {
+              "description": "The name of the base operating system to use for image lookup the AMI is not set",
+              "type": "string"
+            },
+            "format": {
+              "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
+              "type": "string"
+            },
+            "org": {
+              "description": "The AWS Organization ID to use for image lookup if AMI is not set",
+              "type": "string"
+            }
+          }
+        },
+        "instanceType": {
+          "description": "The type of instance to create. Example: m4.xlarge",
+          "type": "string"
+        },
+        "nonRootVolumes": {
+          "title": "Non-root storage volumes",
+          "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "rootVolumeSize": {
+          "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
+          "type": "integer",
+          "minimum": 8
+        },
+        "uncompressedUserData": {
+          "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
+          "type": "boolean"
+        }
+      }
     },
     "controlPlaneNumber": {
       "description": "The number of the control-plane machines",
-      "minimum": 1,
-      "type": [
-        "integer"
-      ]
+      "type": "integer",
+      "minimum": 1
     },
     "k0s": {
-      "additionalProperties": true,
       "description": "K0s parameters",
-      "properties": {
-        "api": {
-          "description": "Kubernetes API server parameters",
-          "properties": {
-            "extraArgs": {
-              "additionalProperties": true,
-              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
-              "properties": {},
-              "type": [
-                "object"
-              ]
-            }
-          },
-          "type": [
-            "object"
-          ]
-        },
-        "files": {
-          "description": "Specifies extra files to be passed to user_data upon creation",
-          "items": {
-            "type": "object"
-          },
-          "type": [
-            "array"
-          ]
-        },
-        "version": {
-          "description": "K0s version",
-          "type": [
-            "string"
-          ]
-        }
-      },
+      "type": "object",
       "required": [
         "version"
       ],
-      "type": [
-        "object"
-      ]
+      "properties": {
+        "api": {
+          "description": "Kubernetes API server parameters",
+          "type": "object",
+          "properties": {
+            "extraArgs": {
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "files": {
+          "description": "Specifies extra files to be passed to user_data upon creation",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "version": {
+          "description": "K0s version",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
     },
     "publicIP": {
       "description": "Specifies whether the instance should get a public IP",
-      "type": [
-        "boolean"
-      ]
+      "type": "boolean"
     },
     "region": {
       "description": "AWS region to deploy the cluster in",
-      "type": [
-        "string"
-      ]
+      "type": "string"
     },
     "sshKeyName": {
       "description": "The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)",
@@ -282,100 +216,69 @@
     },
     "worker": {
       "description": "The configuration of the worker machines",
-      "properties": {
-        "amiID": {
-          "description": "The ID of Amazon Machine Image",
-          "type": [
-            "string"
-          ]
-        },
-        "iamInstanceProfile": {
-          "description": "A name of an IAM instance profile to assign to the instance",
-          "type": [
-            "string"
-          ]
-        },
-        "imageLookup": {
-          "description": "AMI lookup parameters",
-          "properties": {
-            "baseOS": {
-              "description": "The name of the base operating system to use for image lookup the AMI is not set",
-              "type": [
-                "string"
-              ]
-            },
-            "format": {
-              "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
-              "type": [
-                "string"
-              ]
-            },
-            "org": {
-              "description": "The AWS Organization ID to use for image lookup if AMI is not set",
-              "type": [
-                "string"
-              ]
-            }
-          },
-          "required": [
-            "format",
-            "org"
-          ],
-          "type": [
-            "object"
-          ]
-        },
-        "instanceType": {
-          "description": "The type of instance to create. Example: m4.xlarge",
-          "type": [
-            "string"
-          ]
-        },
-        "nonRootVolumes": {
-          "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
-          "items": {
-            "type": "object"
-          },
-          "title": "Non-root storage volumes",
-          "type": [
-            "array"
-          ]
-        },
-        "rootVolumeSize": {
-          "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
-          "minimum": 8,
-          "type": [
-            "integer"
-          ]
-        },
-        "uncompressedUserData": {
-          "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
-          "type": [
-            "boolean"
-          ]
-        }
-      },
+      "type": "object",
       "required": [
         "iamInstanceProfile",
         "instanceType"
       ],
-      "type": [
-        "object"
-      ]
+      "properties": {
+        "amiID": {
+          "description": "The ID of Amazon Machine Image",
+          "type": "string"
+        },
+        "iamInstanceProfile": {
+          "description": "A name of an IAM instance profile to assign to the instance",
+          "type": "string"
+        },
+        "imageLookup": {
+          "description": "AMI lookup parameters",
+          "type": "object",
+          "required": [
+            "format",
+            "org"
+          ],
+          "properties": {
+            "baseOS": {
+              "description": "The name of the base operating system to use for image lookup the AMI is not set",
+              "type": "string"
+            },
+            "format": {
+              "description": "The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set",
+              "type": "string"
+            },
+            "org": {
+              "description": "The AWS Organization ID to use for image lookup if AMI is not set",
+              "type": "string"
+            }
+          }
+        },
+        "instanceType": {
+          "description": "The type of instance to create. Example: m4.xlarge",
+          "type": "string"
+        },
+        "nonRootVolumes": {
+          "title": "Non-root storage volumes",
+          "description": "Configuration options for the non root storage volumes, format: https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2#AWSMachineSpec.NonRootVolumes",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "rootVolumeSize": {
+          "description": "Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater)",
+          "type": "integer",
+          "minimum": 8
+        },
+        "uncompressedUserData": {
+          "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
+          "type": "boolean"
+        }
+      }
     },
     "workersNumber": {
       "description": "The number of the worker machines",
-      "minimum": 1,
-      "type": [
-        "integer"
-      ]
+      "type": "integer",
+      "minimum": 1
     }
-  },
-  "required": [
-    "controlPlaneNumber",
-    "workersNumber",
-    "region",
-    "clusterIdentity"
-  ],
-  "type": "object"
+  }
 }

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -1,7 +1,3 @@
-# Schema generation:
-# $ helm plugin install https://github.com/losisin/helm-values-schema-json.git
-# $ helm schema --draft 2020 --indent 2 --noAdditionalProperties=false --schemaRoot.description='A KCM template to deploy a k0s cluster on AWS with bootstrapped control plane nodes' --input ./templates/cluster/aws-standalone-cp/values.yaml --output ./templates/cluster/aws-standalone-cp/values.schema.json
-
 # Cluster parameters
 controlPlaneNumber: 3 # @schema description: The number of the control-plane machines; minimum: 1; type: integer; required: true
 workersNumber: 2 # @schema description: The number of the worker machines; minimum: 1; type: integer; required: true

--- a/templates/cluster/azure-aks/Chart.yaml
+++ b/templates/cluster/azure-aks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure
   cluster.x-k8s.io/infrastructure-azure: v1beta1

--- a/templates/cluster/azure-aks/values.schema.json
+++ b/templates/cluster/azure-aks/values.schema.json
@@ -1,12 +1,77 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a cluster on AKS.",
+  "description": "A KCM cluster azure-aks template",
   "type": "object",
-  "required": [
-    "clusterIdentity",
-    "location"
-  ],
   "properties": {
+    "apiServerAccessProfile": {
+      "type": "object",
+      "properties": {
+        "authorizedIPRanges": {
+          "type": "array"
+        },
+        "disableRunCommand": {
+          "type": "boolean"
+        },
+        "enablePrivateCluster": {
+          "type": "boolean"
+        },
+        "enablePrivateClusterPublicFQDN": {
+          "type": "boolean"
+        },
+        "privateDNSZone": {
+          "type": "string"
+        }
+      }
+    },
+    "autoUpgradeProfile": {
+      "type": "object",
+      "properties": {
+        "nodeOSUpgradeChannel": {
+          "type": "string"
+        },
+        "upgradeChannel": {
+          "type": "string"
+        }
+      }
+    },
+    "azureMonitorProfile": {
+      "type": "object",
+      "properties": {
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "kubeStateMetrics": {
+              "type": "object",
+              "properties": {
+                "metricAnnotationsAllowList": {
+                  "type": "string"
+                },
+                "metricLabelsAllowlist": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "clusterAnnotations": {
+      "type": "object"
+    },
+    "clusterIdentity": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "clusterLabels": {
+      "type": "object"
+    },
     "clusterNetwork": {
       "type": "object",
       "properties": {
@@ -17,9 +82,7 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
+              }
             }
           }
         },
@@ -30,110 +93,6 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
-            }
-          }
-        }
-      }
-    },
-    "clusterLabels": {
-      "type": "object",
-      "description": "Labels to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },
-    "clusterAnnotations": {
-      "type": "object",
-      "description": "Annotations to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },
-    "clusterIdentity": {
-      "type": "object",
-      "description": "The reference to the secret containing Azure AKS credentials",
-      "required": [
-        "name"
-      ],
-      "properties": {
-        "name": {
-          "description": "The name to the secret containing Azure AKS credentials",
-          "type": "string"
-        }
-      }
-    },
-    "apiServerAccessProfile": {
-      "type": "object",
-      "description": "The access profile for managed cluster API server",
-      "properties": {
-        "authorizedIPRanges": {
-          "description": "IP ranges in CIDR format, e.g. 137.117.106.88⁄29",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "disableRunCommand": {
-          "description": "Whether to disable run command for the cluster or not",
-          "type": "boolean"
-        },
-        "enablePrivateCluster": {
-          "description": "Whether to enable private cluster or not",
-          "type": "boolean"
-        },
-        "enablePrivateClusterPublicFQDN": {
-          "description": "Whether to create additional public FQDN for private cluster or not",
-          "type": "boolean"
-        },
-        "privateDNSZone": {
-          "description": "Private DNS zone. The default is: system",
-          "enum": ["system", "none"],
-          "type": "string"
-        }
-      }
-    },
-    "autoUpgradeProfile": {
-      "type": "object",
-      "description": "Auto upgrade profile for a managed cluster",
-      "properties": {
-        "nodeOSUpgradeChannel": {
-          "description": "Manner in which the OS on your nodes is updated",
-          "enum": ["NodeImage", "None", "Unmanaged"],
-          "type": "string"
-        },
-        "upgradeChannel": {
-          "description": "Upgrade channel",
-          "enum": ["node-image","none","patch","rapid","stable"],
-          "type": "string"
-        }
-      }
-    },
-    "azureMonitorProfile": {
-      "type": "object",
-      "description": "Azure Monitor addon profiles for monitoring the managed cluster",
-      "properties": {
-        "metrics": {
-          "description": "Metrics profile for the Azure Monitor managed service for Prometheus addon",
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "description": "Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring",
-              "type": "boolean"
-            },
-            "kubeStateMetrics": {
-              "description": "Kube State Metrics profile for the Azure Managed Prometheus addon",
-              "type": "object",
-              "properties": {
-                "metricAnnotationsAllowList": {
-                  "description": "Comma-separated list of Kubernetes annotation keys that will be used in the resource’s labels metric (Example: ‘namespaces=[kubernetes.io/team,…],pods=[kubernetes.io/team],…’)",
-                  "type": "string"
-                },
-                "metricLabelsAllowlist": {
-                  "description": "Comma-separated list of additional Kubernetes label keys that will be used in the resource’s labels metric (Example: ‘namespaces=[k8s-label-1,k8s-label-n,…],pods=[app],…’)",
-                  "type": "string"
-                }
               }
             }
           }
@@ -141,76 +100,154 @@
       }
     },
     "dnsServiceIP": {
-      "description": "An IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr",
       "type": "string"
     },
+    "kubernetes": {
+      "type": "object",
+      "properties": {
+        "networkPlugin": {
+          "type": "string"
+        },
+        "networkPolicy": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
     "location": {
-      "description": "Azure location to deploy the cluster in",
       "type": "string"
+    },
+    "machinePools": {
+      "type": "object",
+      "properties": {
+        "system": {
+          "type": "object",
+          "properties": {
+            "autoscaling": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "maxCount": {
+                  "type": "integer"
+                },
+                "minCount": {
+                  "type": "integer"
+                }
+              }
+            },
+            "count": {
+              "type": "integer"
+            },
+            "enableNodePublicIP": {
+              "type": "boolean"
+            },
+            "maxPods": {
+              "type": "integer"
+            },
+            "nodeLabels": {
+              "type": "object"
+            },
+            "nodeTaints": {
+              "type": "array"
+            },
+            "osDiskSizeGB": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            },
+            "vmSize": {
+              "type": "string"
+            }
+          }
+        },
+        "user": {
+          "type": "object",
+          "properties": {
+            "autoscaling": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "maxCount": {
+                  "type": "integer"
+                },
+                "minCount": {
+                  "type": "integer"
+                }
+              }
+            },
+            "count": {
+              "type": "integer"
+            },
+            "enableNodePublicIP": {
+              "type": "boolean"
+            },
+            "maxPods": {
+              "type": "integer"
+            },
+            "nodeLabels": {
+              "type": "object"
+            },
+            "nodeTaints": {
+              "type": "array"
+            },
+            "osDiskSizeGB": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            },
+            "vmSize": {
+              "type": "string"
+            }
+          }
+        }
+      }
     },
     "oidcIssuerProfile": {
       "type": "object",
-      "description": "The OIDC issuer profile of the Managed Cluster",
       "properties": {
         "enabled": {
-          "description": "Whether the OIDC issuer is enabled",
           "type": "boolean"
         }
       }
     },
     "securityProfile": {
       "type": "object",
-      "description": "Security profile for the managed cluster",
       "properties": {
         "azureKeyVaultKms": {
-          "description": "Azure Key Vault key management service settings for the security profile",
           "type": "object",
           "properties": {
             "enabled": {
-              "description": "Whether to enable Azure Key Vault key management service",
               "type": "boolean"
             },
             "keyId": {
-              "description": "Identifier of Azure Key Vault key",
               "type": "string"
             },
             "keyVaultNetworkAccess": {
-              "description": "Network access of key vault. The possible values are Public and Private",
-              "enum": ["Public","Private"],
               "type": "string"
             },
             "keyVaultResourceReference": {
-              "description": "Resource ID of key vault. When keyVaultNetworkAccess is Private, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is Public, leave the field empty",
-              "type": "object",
-              "properties": {
-                "armId": {
-                  "description": "A string of the form /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName} with the resource reference",
-                  "type": "string"
-                }
-              }
+              "type": "object"
             }
           }
         },
         "defender": {
-          "description": "Microsoft Defender settings for the security profile",
           "type": "object",
           "properties": {
             "logAnalyticsWorkspaceResourceReference": {
-              "description": "Resource ID of the Log Analytics workspace to be associated with Microsoft Defender",
-              "type": "object",
-              "properties": {
-                "armId": {
-                  "description": "A string of the form /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName} with the resource reference",
-                  "type": "string"
-                }
-              }
+              "type": "object"
             },
             "securityMonitoring": {
-              "description": "Microsoft Defender threat detection for Cloud settings for the security profile",
               "type": "object",
               "properties": {
                 "enabled": {
-                  "description": "Whether to enable Defender threat detection",
                   "type": "boolean"
                 }
               }
@@ -218,25 +255,20 @@
           }
         },
         "imageCleaner": {
-          "description": "Image Cleaner settings for the security profile",
           "type": "object",
           "properties": {
             "enabled": {
-              "description": "Whether to enable Image Cleaner on AKS cluster",
               "type": "boolean"
             },
             "intervalHours": {
-              "description": "Image Cleaner scanning interval in hours",
               "type": "integer"
             }
           }
         },
         "workloadIdentity": {
-          "description": "Workload identity settings for the security profile",
           "type": "object",
           "properties": {
             "enabled": {
-              "description": "Whether to enable workload identity",
               "type": "boolean"
             }
           }
@@ -244,280 +276,59 @@
       }
     },
     "serviceMeshProfile": {
-      "description": "Service mesh profile for a managed cluster",
       "type": "object",
       "properties": {
-        "mode": {
-          "description": "Mode of the service mesh",
-          "enum": ["Disabled","Istio"],
-          "type": "string"
-        },
         "istio": {
-          "description": "Istio service mesh configuration",
           "type": "object",
           "properties": {
             "certificateAuthority": {
-              "description": "Istio Service Mesh Certificate Authority (CA) configuration",
               "type": "object",
               "properties": {
                 "certChainObjectName": {
-                  "description": "Certificate chain object name in Azure Key Vault",
                   "type": "string"
                 },
                 "certObjectName": {
-                  "description": "Intermediate certificate object name in Azure Key Vault",
                   "type": "string"
                 },
                 "keyObjectName": {
-                  "description": "Intermediate certificate private key object name in Azure Key Vault",
                   "type": "string"
                 },
                 "keyVaultReference": {
-                  "description": "The resource ID of the Key Vault",
-                  "type": "object",
-                  "properties": {
-                    "armId": {
-                      "description": "A string of the form /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName} with the resource reference",
-                      "type": "string"
-                    }
-                  }
+                  "type": "object"
                 },
                 "rootCertObjectName": {
-                  "description": "Root certificate object name in Azure Key Vault",
                   "type": "string"
                 }
               }
             },
             "components": {
-              "description": "Istio components configuration",
               "type": "object",
               "properties": {
                 "egressGateways": {
-                  "description": "Istio egress gateways",
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "description": "Whether to enable the egress gateway",
-                        "type": "boolean"
-                      },
-                      "nodeSelector": {
-                        "description": "NodeSelector for scheduling the egress gateway. Format: map[string]string",
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
+                  "type": "array"
                 },
                 "ingressGateways": {
-                  "description": "Istio ingress gateways",
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "description": "Whether to enable the ingress gateway",
-                        "type": "boolean"
-                      },
-                      "mode": {
-                        "description": "Mode of an ingress gateway. Supported values: Internal, External",
-                        "enum": ["Internal","External"],
-                        "type": "string"
-                      }
-                    }
-                  }
+                  "type": "array"
                 }
               }
             },
             "revisions": {
-              "description": "The list of revisions of the Istio control plane",
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "uniqueItems": true
+              "type": "array"
             }
           }
+        },
+        "mode": {
+          "type": "string"
         }
       }
     },
     "sku": {
-      "description": "The SKU of a Managed Cluster",
       "type": "object",
       "properties": {
         "name": {
-          "description": "The name of a managed cluster SKU",
           "type": "string"
         },
         "tier": {
-          "description": "AKS pricing tier. Default: Free",
-          "enum": ["Free", "Premium", "Standard"],
-          "type": "string"
-        }
-      }
-    },
-    "machinePools": {
-      "description": "The machine pools' configuration",
-      "type": "object",
-      "properties": {
-        "system": {
-          "description": "The configuration of the system machine pool",
-          "type": "object",
-          "required": [
-            "vmSize"
-          ],
-          "properties": {
-            "autoscaling": {
-              "description": "Machine Pool autoscaling options",
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "description": "Whether to enable auto-scaler or not",
-                  "type": "boolean"
-                },
-                "minCount": {
-                  "description": "The minimum number of nodes for auto-scaling",
-                  "type": "integer",
-                  "minimum": 1
-                },
-                "maxCount": {
-                  "description": "The maximum number of nodes for auto-scaling",
-                  "type": "integer"
-                }
-              }
-            },
-            "count": {
-              "description": "Number of VMs to host docker containers",
-              "type": "integer",
-              "minimum": 1
-            },
-            "enableNodePublicIP": {
-              "description": "Whether to enable node public IP or not",
-              "type": "boolean"
-            },
-            "maxPods": {
-              "description": "The maximum number of pods that can run on a node",
-              "type": "integer"
-            },
-            "nodeLabels": {
-              "description": "The node labels to be persisted across all nodes in agent pool",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "nodeTaints": {
-              "description": "The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "osDiskSizeGB": {
-              "description": "The size of OS Disk in GB",
-              "type": "integer"
-            },
-            "type": {
-              "description": "The type of Agent Pool",
-              "enum": ["AvailabilitySet","VirtualMachineScaleSets"],
-              "type": "string"
-            },
-            "vmSize": {
-              "description": "The size of a VM",
-              "type": "string"
-            }
-          }
-        },
-        "user": {
-          "description": "The configuration of the user machine pool",
-          "type": "object",
-          "required": [
-            "vmSize"
-          ],
-          "properties": {
-            "autoscaling": {
-              "description": "Machine Pool autoscaling options",
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "description": "Whether to enable auto-scaler or not",
-                  "type": "boolean"
-                },
-                "minCount": {
-                  "description": "The minimum number of nodes for auto-scaling",
-                  "type": "integer"
-                },
-                "maxCount": {
-                  "description": "The maximum number of nodes for auto-scaling",
-                  "type": "integer"
-                }
-              }
-            },
-            "count": {
-              "description": "Number of VMs to host docker containers",
-              "type": "integer"
-            },
-            "enableNodePublicIP": {
-              "description": "Whether to enable node public IP or not",
-              "type": "boolean"
-            },
-            "maxPods": {
-              "description": "The maximum number of pods that can run on a node",
-              "type": "integer"
-            },
-            "nodeLabels": {
-              "description": "The node labels to be persisted across all nodes in agent pool",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "nodeTaints": {
-              "description": "The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule",
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "osDiskSizeGB": {
-              "description": "The size of OS Disk in GB",
-              "type": "integer"
-            },
-            "type": {
-              "description": "The type of Agent Pool",
-              "enum": ["AvailabilitySet","VirtualMachineScaleSets"],
-              "type": "string"
-            },
-            "vmSize": {
-              "description": "The size of a VM",
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
-    "kubernetes": {
-      "description": "Kubernetes parameters",
-      "type": "object",
-      "required": [
-        "version"
-      ],
-      "properties": {
-        "networkPolicy": {
-          "description": "Network policy used for building the Kubernetes network. Defaults to: azure",
-          "type": "string",
-          "enum": ["azure", "calico", "cilium"]
-        },
-        "networkPlugin": {
-          "description": "Network plugin used for building the Kubernetes network. Defaults to: azure",
-          "type": "string",
-          "enum": ["azure", "kubenet", "none"]
-        },
-        "version":{
-          "description": "Kubernetes version to use",
           "type": "string"
         }
       }

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/values.schema.json
+++ b/templates/cluster/azure-hosted-cp/values.schema.json
@@ -1,27 +1,40 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a K8s cluster on Azure with control plane components within the management cluster.",
+  "description": "A KCM cluster azure-hosted-cp template",
   "type": "object",
-  "required": [
-    "controlPlaneNumber",
-    "workersNumber",
-    "location",
-    "subscriptionID",
-    "clusterIdentity",
-    "resourceGroup",
-    "network",
-    "vmSize"
-  ],
   "properties": {
-    "controlPlaneNumber": {
-      "description": "The number of the control plane pods",
-      "type": "number",
-      "minimum": 1
+    "bastion": {
+      "type": "object",
+      "properties": {
+        "bastionSpec": {
+          "type": "object",
+          "properties": {
+            "azureBastion": {
+              "type": "object"
+            }
+          }
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      }
     },
-    "workersNumber": {
-      "description": "The number of the worker machines",
-      "type": "number",
-      "minimum": 1
+    "clusterAnnotations": {
+      "type": "object"
+    },
+    "clusterIdentity": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        }
+      }
+    },
+    "clusterLabels": {
+      "type": "object"
     },
     "clusterNetwork": {
       "type": "object",
@@ -33,9 +46,7 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
+              }
             }
           }
         },
@@ -46,124 +57,25 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
+              }
             }
           }
         }
       }
     },
-    "clusterLabels": {
-      "type": "object",
-      "description": "Labels to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },
-    "clusterAnnotations": {
-      "type": "object",
-      "description": "Annotations to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },
-    "location": {
-      "description": "Azure location to deploy the cluster in",
-      "type": "string"
-    },
-    "subscriptionID": {
-      "description": "Azure subscription ID which will be used for all resources",
-      "type": "string"
-    },
-    "bastion": {
-      "type": "object",
-      "description": "The configuration of the bastion host",
-      "required": [],
-      "properties": {
-          "enabled": {
-              "type": "boolean"
-          }
-      }
-    },
-    "clusterIdentity": {
-      "type": "object",
-      "description": "AzureClusterIdentity object reference",
-      "required": [
-        "name",
-        "namespace"
-      ],
-      "properties": {
-        "name": {
-	  "description": "AzureClusterIdentity object name",
-          "type": "string"
-        },
-        "namespace": {
-	  "description": "AzureClusterIdentity object namespace",
-          "type": "string"
-        }
-      }
-    },
-    "resourceGroup": {
-      "description": "Existing resource group name for worker nodes",
-      "type": "string"
-    },
-    "network": {
-      "type": "object",
-      "description": "Networking resources reference for worker nodes",
-      "required": [
-        "vnetName",
-        "nodeSubnetName",
-        "routeTableName",
-        "securityGroupName"
-      ],
-      "properties": {
-        "vnetName": {
-	  "description": "Existing vnet name for worker nodes",
-          "type": "string"
-        },
-        "nodeSubnetName": {
-	  "description": "Existing subnet name for worker nodes",
-          "type": "string"
-        },
-        "routeTableName": {
-	  "description": "Existing route table name for worker nodes",
-          "type": "string"
-        },
-        "securityGroupName": {
-	  "description": "Existing security group name for worker nodes",
-          "type": "string"
-        }
-      }
-    },
-    "sshPublicKey": {
-      "description": "SSH public key in base64 format, which will be used on the machine.",
-      "type": "string"
-    },
-    "vmSize": {
-      "description": "The size of instance to create",
-      "type": "string"
-    },
-    "rootVolumeSize": {
-      "description": "The size of the root volume of the instance (GB)",
+    "controlPlaneNumber": {
       "type": "integer"
     },
     "image": {
       "type": "object",
-      "description": "Azure VM image configuration",
       "properties": {
         "marketplace": {
-	  "description": "Azure Marketplace image reference",
           "type": "object",
-          "required": [
-            "publisher",
-            "offer",
-            "sku",
-            "version"
-          ],
           "properties": {
-            "publisher": {
+            "offer": {
               "type": "string"
             },
-            "offer": {
+            "publisher": {
               "type": "string"
             },
             "sku": {
@@ -176,63 +88,78 @@
         }
       }
     },
+    "k0s": {
+      "type": "object",
+      "properties": {
+        "api": {
+          "type": "object",
+          "properties": {
+            "extraArgs": {
+              "type": "object"
+            }
+          }
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
     "k0smotron": {
-      "description": "K0smotron parameters",
       "type": "object",
       "properties": {
         "service": {
-          "description": "The configuration of a K0smotron service",
+          "type": "object",
           "properties": {
-            "type": {
-              "description": "Ingress methods for a k0smotron service",
-              "enum": [
-                "ClusterIP",
-                "NodePort",
-                "LoadBalancer"
-              ],
-              "type": "string"
-            },
             "apiPort": {
-              "description": "The kubernetes API port for a k0smotron service",
-              "type": "number",
-              "minimum": 1,
-              "maximum": 65535
+              "type": "integer"
             },
             "konnectivityPort": {
-              "description": "The konnectivity port",
-              "type": "number",
-              "minimum": 1,
-              "maximum": 65535
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
             }
           }
         }
       }
     },
-    "k0s": {
-      "description": "K0s parameters",
+    "location": {
+      "type": "string"
+    },
+    "network": {
       "type": "object",
-      "required": [
-        "version"
-      ],
       "properties": {
-        "version":{
-          "description": "K0s version to use",
+        "nodeSubnetName": {
           "type": "string"
         },
-        "api": {
-          "description": "Kubernetes api-server parameters",
-          "type": "object",
-          "properties": {
-            "extraArgs": {
-              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          }
+        "routeTableName": {
+          "type": "string"
+        },
+        "securityGroupName": {
+          "type": "string"
+        },
+        "vnetName": {
+          "type": "string"
         }
       }
+    },
+    "resourceGroup": {
+      "type": "string"
+    },
+    "rootVolumeSize": {
+      "type": "integer"
+    },
+    "sshPublicKey": {
+      "type": "string"
+    },
+    "subscriptionID": {
+      "type": "string"
+    },
+    "vmSize": {
+      "type": "string"
+    },
+    "workersNumber": {
+      "type": "integer"
     }
   }
 }

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/values.schema.json
+++ b/templates/cluster/azure-standalone-cp/values.schema.json
@@ -1,24 +1,40 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a k0s cluster on Azure with bootstrapped control plane nodes.",
+  "description": "A KCM cluster azure-standalone-cp template",
   "type": "object",
-  "required": [
-    "controlPlaneNumber",
-    "workersNumber",
-    "location",
-    "subscriptionID",
-    "clusterIdentity"
-  ],
   "properties": {
-    "controlPlaneNumber": {
-      "description": "The number of the control plane machines",
-      "type": "number",
-      "minimum": 1
+    "bastion": {
+      "type": "object",
+      "properties": {
+        "bastionSpec": {
+          "type": "object",
+          "properties": {
+            "azureBastion": {
+              "type": "object"
+            }
+          }
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      }
     },
-    "workersNumber": {
-      "description": "The number of the worker machines",
-      "type": "number",
-      "minimum": 1
+    "clusterAnnotations": {
+      "type": "object"
+    },
+    "clusterIdentity": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        }
+      }
+    },
+    "clusterLabels": {
+      "type": "object"
     },
     "clusterNetwork": {
       "type": "object",
@@ -30,9 +46,7 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
+              }
             }
           }
         },
@@ -43,189 +57,111 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
+              }
             }
           }
-        }
-      }
-    },
-    "clusterLabels": {
-      "type": "object",
-      "description": "Labels to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },    
-    "clusterAnnotations": {
-      "type": "object",
-      "description": "Annotations to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },    
-    "location": {
-      "description": "Azure location to deploy the cluster in",
-      "type": "string"
-    },
-    "subscriptionID": {
-      "description": "Azure subscription ID which will be used for all resources",
-      "type": "string"
-    },
-    "bastion": {
-      "type": "object",
-      "description": "The configuration of the bastion host",
-      "required": [],
-      "properties": {
-        "enabled": {
-          "type": "boolean"
-        }
-      }
-    },
-    "clusterIdentity": {
-      "type": "object",
-      "description": "AzureClusterIdentity object reference",
-      "required": [
-        "name",
-        "namespace"
-      ],
-      "properties": {
-        "name": {
-	  "description": "AzureClusterIdentity object name",
-          "type": "string"
-        },
-        "namespace": {
-	  "description": "AzureClusterIdentity object namespace",
-          "type": "string"
         }
       }
     },
     "controlPlane": {
-      "description": "The configuration of the control plane machines",
       "type": "object",
-      "required": [
-        "vmSize"
-      ],
       "properties": {
-	"sshPublicKey": {
-	  "description": "SSH public key in base64 format, which will be used on the machine.",
-          "type": "string"
-        },
-        "vmSize": {
-          "description": "The size of instance to create",
-          "type": "string"
-        },
-	"rootVolumeSize": {
-	  "description": "The size of the root volume of the instance (GB)",
-          "type": "integer"
-        },
-	"image": {
-	  "type": "object",
-	  "description": "Azure VM image configuration",
-	  "properties": {
-            "marketplace": {
-	      "description": "Azure Marketplace image reference",
-              "type": "object",
-              "required": [
-		"publisher",
-		"offer",
-		"sku",
-		"version"
-              ],
-              "properties": {
-		"publisher": {
-		  "type": "string"
-		},
-		"offer": {
-		  "type": "string"
-		},
-		"sku": {
-		  "type": "string"
-		},
-		"version": {
-		  "type": "string"
-		}
-              }
-            }
-	  }
-	}
-      }
-    },
-    "worker": {
-      "description": "The configuration of the worker machines",
-      "type": "object",
-      "required": [
-        "vmSize"
-      ],
-      "properties": {
-	"sshPublicKey": {
-	  "description": "SSH public key in base64 format, which will be used on the machine.",
-          "type": "string"
-        },
-        "vmSize": {
-          "description": "The size of instance to create",
-          "type": "string"
-        },
-	"rootVolumeSize": {
-	  "description": "The size of the root volume of the instance (GB)",
-          "type": "integer"
-        },
-	"image": {
-	  "type": "object",
-	  "description": "Azure VM image configuration",
-	  "properties": {
-            "marketplace": {
-	      "description": "Azure Marketplace image reference",
-              "type": "object",
-              "required": [
-		"publisher",
-		"offer",
-		"sku",
-		"version"
-              ],
-              "properties": {
-		"publisher": {
-		  "type": "string"
-		},
-		"offer": {
-		  "type": "string"
-		},
-		"sku": {
-		  "type": "string"
-		},
-		"version": {
-		  "type": "string"
-		}
-              }
-            }
-	  }
-	}
-      }
-    },
-    "k0s": {
-      "description": "K0s parameters",
-      "type": "object",
-      "required": [
-        "version"
-      ],
-      "properties": {
-        "version":{
-          "description": "K0s version to use",
-          "type": "string"
-        },
-        "api": {
-          "description": "Kubernetes api-server parameters",
+        "image": {
           "type": "object",
           "properties": {
-            "extraArgs": {
-              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+            "marketplace": {
               "type": "object",
-              "additionalProperties": {
-                "type": "string"
+              "properties": {
+                "offer": {
+                  "type": "string"
+                },
+                "publisher": {
+                  "type": "string"
+                },
+                "sku": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
               }
             }
           }
+        },
+        "rootVolumeSize": {
+          "type": "integer"
+        },
+        "sshPublicKey": {
+          "type": "string"
+        },
+        "vmSize": {
+          "type": "string"
         }
       }
+    },
+    "controlPlaneNumber": {
+      "type": "integer"
+    },
+    "k0s": {
+      "type": "object",
+      "properties": {
+        "api": {
+          "type": "object",
+          "properties": {
+            "extraArgs": {
+              "type": "object"
+            }
+          }
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "location": {
+      "type": "string"
+    },
+    "subscriptionID": {
+      "type": "string"
+    },
+    "worker": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "marketplace": {
+              "type": "object",
+              "properties": {
+                "offer": {
+                  "type": "string"
+                },
+                "publisher": {
+                  "type": "string"
+                },
+                "sku": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "rootVolumeSize": {
+          "type": "integer"
+        },
+        "sshPublicKey": {
+          "type": "string"
+        },
+        "vmSize": {
+          "type": "string"
+        }
+      }
+    },
+    "workersNumber": {
+      "type": "integer"
     }
   }
 }

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/docker-hosted-cp/values.schema.json
+++ b/templates/cluster/docker-hosted-cp/values.schema.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a k0s cluster on Docker with hosted control plane and worker nodes.",
+  "description": "A KCM cluster docker-hosted-cp template",
   "type": "object",
-  "required": ["workersNumber"],
   "properties": {
-    "workersNumber": {
-      "description": "The number of worker nodes",
-      "type": "number",
-      "minimum": 1
+    "clusterAnnotations": {
+      "type": "object"
+    },
+    "clusterLabels": {
+      "type": "object"
     },
     "clusterNetwork": {
       "type": "object",
@@ -19,11 +19,12 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
+              }
             }
           }
+        },
+        "serviceDomain": {
+          "type": "string"
         },
         "services": {
           "type": "object",
@@ -32,58 +33,7 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
-            }
-          }
-        },
-        "serviceDomain": {
-          "type": "string",
-          "description": "The service domain for the cluster"
-        }
-      }
-    },
-    "clusterLabels": {
-      "type": "object",
-      "description": "Labels to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },
-    "clusterAnnotations": {
-      "type": "object",
-      "description": "Annotations to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },
-    "k0smotron": {
-      "type": "object",
-      "description": "K0smotron parameters",
-      "properties": {
-        "service": {
-          "type": "object",
-          "description": "Configuration of a K0smotron service",
-          "properties": {
-            "type": {
-              "type": "string",
-              "description": "Ingress methods for a K0smotron service",
-              "enum": [
-                "ClusterIP",
-                "NodePort",
-                "LoadBalancer"
-              ]
-            },
-            "apiPort": {
-              "type": "number",
-              "description": "The Kubernetes API port for a K0smotron service",
-              "minimum": 1,
-              "maximum": 65535
-            },
-            "konnectivityPort": {
-              "type": "number",
-              "description": "The Konnectivity server port",
-              "minimum": 1,
-              "maximum": 65535
+              }
             }
           }
         }
@@ -91,16 +41,27 @@
     },
     "k0s": {
       "type": "object",
-      "description": "K0s parameters",
-      "required": [
-        "version"
-      ],
       "properties": {
         "version": {
-          "type": "string",
-          "description": "K0s version to use"
+          "type": "string"
         }
       }
+    },
+    "k0smotron": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "workersNumber": {
+      "type": "integer"
     }
   }
 }

--- a/templates/cluster/gcp-gke/Chart.yaml
+++ b/templates/cluster/gcp-gke/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-gke/values.schema.json
+++ b/templates/cluster/gcp-gke/values.schema.json
@@ -1,343 +1,258 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-        "additionalLabels": {
-            "additionalProperties": false,
-            "description": "Additional set of labels to add to all the GCP resources",
-            "patternProperties": {
-                "^[a-zA-Z0-9._-]+$": {
-                    "type": "string"
-                }
-            },
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterAnnotations": {
-            "additionalProperties": true,
-            "description": "Annotations to apply to the cluster",
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterIdentity": {
-            "description": "The GCP Service Account credentials secret reference, auto-populated",
-            "properties": {
-                "name": {
-                    "description": "The GCP Service Account credentials secret name, auto-populated",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "clusterLabels": {
-            "additionalProperties": true,
-            "description": "Labels to apply to the cluster",
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterNetwork": {
-            "description": "The cluster network configuration",
-            "properties": {
-                "pods": {
-                    "description": "The network ranges from which Pod networks are allocated",
-                    "properties": {
-                        "cidrBlocks": {
-                            "description": "A list of CIDR blocks",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "services": {
-                    "description": "The network ranges from which service VIPs are allocated",
-                    "properties": {
-                        "cidrBlocks": {
-                            "description": "A list of CIDR blocks",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "controlPlaneVersion": {
-            "description": "The control plane version of the GKE cluster. If not specified, the default version currently supported by GKE will be used",
-            "type": [
-                "string"
-            ]
-        },
-        "enableAutopilot": {
-            "description": "Indicates whether to enable autopilot for this GKE cluster",
-            "type": [
-                "boolean"
-            ]
-        },
-        "gkeClusterName": {
-            "description": "The name of the GKE cluster. If you don't specify a gkeClusterName then a default name will be created based on the namespace and name of the managed control plane",
-            "type": [
-                "string"
-            ]
-        },
-        "location": {
-            "description": "The location where the GKE cluster will be created. If unspecified, a region will be used, making the cluster regional. Otherwise, specifying a location will create a zonal cluster",
-            "type": [
-                "string"
-            ]
-        },
-        "machines": {
-            "description": "Managed machines' parameters",
-            "properties": {
-                "additionalLabels": {
-                    "additionalProperties": false,
-                    "description": "AdditionalLabels is an optional set of tags to add to GCP resources managed by the GCP provider, in addition to the ones added by default",
-                    "patternProperties": {
-                        "^[a-zA-Z0-9._-]+$": {
-                            "type": "string"
-                        }
-                    },
-                    "properties": {},
-                    "type": [
-                        "object"
-                    ]
-                },
-                "diskSizeGB": {
-                    "description": "The size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB. If unspecified, the default disk size is 100GB",
-                    "minimum": 10,
-                    "type": [
-                        "number"
-                    ]
-                },
-                "diskType": {
-                    "description": "The type of the disk attached to each node",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "imageType": {
-                    "description": "The image type to use for this nodepool",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "instanceType": {
-                    "description": "The name of Compute Engine machine type",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "kubernetesLabels": {
-                    "additionalProperties": true,
-                    "description": "The labels to apply to the nodes of the node pool",
-                    "properties": {},
-                    "type": [
-                        "object"
-                    ]
-                },
-                "kubernetesTaints": {
-                    "additionalProperties": false,
-                    "description": "The taints to apply to the nodes of the node pool",
-                    "type": [
-                        "array"
-                    ]
-                },
-                "localSsdCount": {
-                    "description": "LocalSsdCount is the number of local SSD disks to be attached to the node",
-                    "type": [
-                        "number",
-                        "null"
-                    ]
-                },
-                "machineType": {
-                    "description": "the name of a Google Compute Engine [machine type](https://cloud.google.com/compute/docs/machine-types). If unspecified, the default machine type is `e2-medium`",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "management": {
-                    "description": "The node pool management options",
-                    "properties": {
-                        "autoRepair": {
-                            "description": "AutoRepair specifies whether the node auto-repair is enabled for the node pool. If enabled, the nodes in this node pool will be monitored and, if they fail health checks too many times, an automatic repair action will be triggered",
-                            "type": [
-                                "boolean"
-                            ]
-                        },
-                        "autoUpgrade": {
-                            "description": "AutoUpgrade specifies whether node auto-upgrade is enabled for the node pool. If enabled, node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes",
-                            "type": [
-                                "boolean"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "maxPodsPerNode": {
-                    "description": "The constraint enforced on the max num of pods per node",
-                    "maximum": 256,
-                    "minimum": 8,
-                    "type": [
-                        "number",
-                        "null"
-                    ]
-                },
-                "nodeLocations": {
-                    "description": "The list of zones in which the NodePool's nodes should be located",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array"
-                    ]
-                },
-                "nodePoolName": {
-                    "description": "The name of the GKE node pool corresponding to this MachinePool. If you don't specify a name then a default name will be created based on the namespace and name of the managed machine pool",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "scaling": {
-                    "description": "Scaling specifies scaling for the node pool",
-                    "properties": {
-                        "enableAutoscaling": {
-                            "description": "Is autoscaling enabled for this node pool. If unspecified, the default value is true",
-                            "type": [
-                                "boolean"
-                            ]
-                        },
-                        "locationPolicy": {
-                            "description": "Location policy used when scaling up a nodepool",
-                            "enum": [
-                                "balanced",
-                                "any"
-                            ],
-                            "type": [
-                                "string"
-                            ]
-                        },
-                        "maxCount": {
-                            "description": "The maximum number of nodes in the node pool",
-                            "type": [
-                                "number",
-                                "null"
-                            ]
-                        },
-                        "minCount": {
-                            "description": "The minimum number of nodes in the node pool",
-                            "type": [
-                                "number",
-                                "null"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "masterAuthorizedNetworksConfig": {
-            "description": "Represents configuration options for master authorized networks feature of the GKE cluster. This feature is disabled if this field is not specified",
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "network": {
-            "description": "The GCP network configuration",
-            "properties": {
-                "mtu": {
-                    "description": "Maximum Transmission Unit in bytes",
-                    "maximum": 8896,
-                    "minimum": 1300,
-                    "type": [
-                        "number"
-                    ]
-                },
-                "name": {
-                    "description": "The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": [
-                "object"
-            ]
-        },
-        "project": {
-            "description": "The name of the project to deploy the cluster to",
-            "type": [
-                "string"
-            ]
-        },
-        "region": {
-            "description": "The GCP Region the cluster lives in",
-            "type": [
-                "string"
-            ]
-        },
-        "releaseChannel": {
-            "description": "The release channel of the GKE cluster",
-            "enum": [
-                "rapid",
-                "regular",
-                "stable"
-            ],
-            "type": [
-                "string"
-            ]
-        },
-        "version": {
-            "description": "Version represents the version of the GKE control plane",
-            "type": [
-                "string"
-            ]
-        },
-        "workersNumber": {
-            "description": "The number of the worker nodes. Should be divisible by the number of zones in machines.nodeLocations. If nodeLocations is not specified, must be divisible by the number of zones in this region (default: 3)",
-            "minimum": 1,
-            "type": [
-                "number"
-            ]
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM cluster gcp-gke template",
+  "type": "object",
+  "required": [
+    "project",
+    "region"
+  ],
+  "properties": {
+    "additionalLabels": {
+      "description": "Additional set of labels to add to all the GCP resources",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "type": "string"
         }
+      },
+      "additionalProperties": false
     },
-    "required": [
-        "project",
-        "region"
-    ],
-    "type": "object"
+    "clusterAnnotations": {
+      "description": "Annotations to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "clusterIdentity": {
+      "description": "The GCP Service Account credentials secret reference, auto-populated",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The GCP Service Account credentials secret name, auto-populated",
+          "type": "string"
+        }
+      }
+    },
+    "clusterLabels": {
+      "description": "Labels to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "clusterNetwork": {
+      "description": "The cluster network configuration",
+      "type": "object",
+      "properties": {
+        "pods": {
+          "description": "The network ranges from which Pod networks are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "services": {
+          "description": "The network ranges from which service VIPs are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "controlPlaneVersion": {
+      "description": "The control plane version of the GKE cluster. If not specified, the default version currently supported by GKE will be used",
+      "type": "string"
+    },
+    "enableAutopilot": {
+      "description": "Indicates whether to enable autopilot for this GKE cluster",
+      "type": "boolean"
+    },
+    "gkeClusterName": {
+      "description": "The name of the GKE cluster. If you don't specify a gkeClusterName then a default name will be created based on the namespace and name of the managed control plane",
+      "type": "string"
+    },
+    "location": {
+      "description": "The location where the GKE cluster will be created. If unspecified, a region will be used, making the cluster regional. Otherwise, specifying a location will create a zonal cluster",
+      "type": "string"
+    },
+    "machines": {
+      "description": "Managed machines' parameters",
+      "type": "object",
+      "properties": {
+        "additionalLabels": {
+          "description": "AdditionalLabels is an optional set of tags to add to GCP resources managed by the GCP provider, in addition to the ones added by default",
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9._-]+$": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "diskSizeGB": {
+          "description": "The size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB. If unspecified, the default disk size is 100GB",
+          "type": "number",
+          "minimum": 10
+        },
+        "diskType": {
+          "description": "The type of the disk attached to each node",
+          "type": "string"
+        },
+        "imageType": {
+          "description": "The image type to use for this nodepool",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "The name of Compute Engine machine type",
+          "type": "string"
+        },
+        "kubernetesLabels": {
+          "description": "The labels to apply to the nodes of the node pool",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "kubernetesTaints": {
+          "description": "The taints to apply to the nodes of the node pool",
+          "type": "array",
+          "additionalProperties": false
+        },
+        "localSsdCount": {
+          "description": "LocalSsdCount is the number of local SSD disks to be attached to the node",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "machineType": {
+          "description": "the name of a Google Compute Engine [machine type](https://cloud.google.com/compute/docs/machine-types). If unspecified, the default machine type is `e2-medium`",
+          "type": "string"
+        },
+        "management": {
+          "description": "The node pool management options",
+          "type": "object",
+          "properties": {
+            "autoRepair": {
+              "description": "AutoRepair specifies whether the node auto-repair is enabled for the node pool. If enabled, the nodes in this node pool will be monitored and, if they fail health checks too many times, an automatic repair action will be triggered",
+              "type": "boolean"
+            },
+            "autoUpgrade": {
+              "description": "AutoUpgrade specifies whether node auto-upgrade is enabled for the node pool. If enabled, node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes",
+              "type": "boolean"
+            }
+          }
+        },
+        "maxPodsPerNode": {
+          "description": "The constraint enforced on the max num of pods per node",
+          "type": [
+            "number",
+            "null"
+          ],
+          "maximum": 256,
+          "minimum": 8
+        },
+        "nodeLocations": {
+          "description": "The list of zones in which the NodePool's nodes should be located",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nodePoolName": {
+          "description": "The name of the GKE node pool corresponding to this MachinePool. If you don't specify a name then a default name will be created based on the namespace and name of the managed machine pool",
+          "type": "string"
+        },
+        "scaling": {
+          "description": "Scaling specifies scaling for the node pool",
+          "type": "object",
+          "properties": {
+            "enableAutoscaling": {
+              "description": "Is autoscaling enabled for this node pool. If unspecified, the default value is true",
+              "type": "boolean"
+            },
+            "locationPolicy": {
+              "description": "Location policy used when scaling up a nodepool",
+              "type": "string",
+              "enum": [
+                "balanced",
+                "any"
+              ]
+            },
+            "maxCount": {
+              "description": "The maximum number of nodes in the node pool",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "minCount": {
+              "description": "The minimum number of nodes in the node pool",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "masterAuthorizedNetworksConfig": {
+      "description": "Represents configuration options for master authorized networks feature of the GKE cluster. This feature is disabled if this field is not specified",
+      "type": "object"
+    },
+    "network": {
+      "description": "The GCP network configuration",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "mtu": {
+          "description": "Maximum Transmission Unit in bytes",
+          "type": "number",
+          "maximum": 8896,
+          "minimum": 1300
+        },
+        "name": {
+          "description": "The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP",
+          "type": "string"
+        }
+      }
+    },
+    "project": {
+      "description": "The name of the project to deploy the cluster to",
+      "type": "string"
+    },
+    "region": {
+      "description": "The GCP Region the cluster lives in",
+      "type": "string"
+    },
+    "releaseChannel": {
+      "description": "The release channel of the GKE cluster",
+      "type": "string",
+      "enum": [
+        "rapid",
+        "regular",
+        "stable"
+      ]
+    },
+    "version": {
+      "description": "Version represents the version of the GKE control plane",
+      "type": "string"
+    },
+    "workersNumber": {
+      "description": "The number of the worker nodes. Should be divisible by the number of zones in machines.nodeLocations. If nodeLocations is not specified, must be divisible by the number of zones in this region (default: 3)",
+      "type": "number",
+      "minimum": 1
+    }
+  }
 }

--- a/templates/cluster/gcp-gke/values.yaml
+++ b/templates/cluster/gcp-gke/values.yaml
@@ -1,5 +1,5 @@
 # Cluster parameters
-workersNumber: 3 # @schema description: The number of the worker nodes. Should be divisible by the number of zones in machines.nodeLocations. If nodeLocations is not specified, must be divisible by the number of zones in this region (default: 3); type: number; minimum: 1;
+workersNumber: 3 # @schema description: The number of the worker nodes. Should be divisible by the number of zones in machines.nodeLocations. If nodeLocations is not specified, must be divisible by the number of zones in this region (default: 3); type: number; minimum: 1
 
 clusterIdentity: # @schema description: The GCP Service Account credentials secret reference, auto-populated; type: object
   name: "" # @schema description: The GCP Service Account credentials secret name, auto-populated; type: string

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/values.schema.json
+++ b/templates/cluster/gcp-hosted-cp/values.schema.json
@@ -1,371 +1,264 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-        "additionalLabels": {
-            "additionalProperties": false,
-            "description": "Additional set of labels to add to all the GCP resources",
-            "patternProperties": {
-                "^[a-zA-Z0-9._-]+$": {
-                    "type": "string"
-                }
-            },
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterAnnotations": {
-            "additionalProperties": true,
-            "description": "Annotations to apply to the cluster",
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterIdentity": {
-            "description": "The GCP Service Account credentials secret reference, auto-populated",
-            "properties": {
-                "name": {
-                    "description": "The GCP Service Account credentials secret name, auto-populated",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "clusterLabels": {
-            "additionalProperties": true,
-            "description": "Labels to apply to the cluster",
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterNetwork": {
-            "description": "The cluster network configuration",
-            "properties": {
-                "apiServerPort": {
-                    "description": "The port the API Server should bind to",
-                    "maximum": 65535,
-                    "minimum": 1,
-                    "type": [
-                        "number"
-                    ]
-                },
-                "pods": {
-                    "description": "The network ranges from which Pod networks are allocated",
-                    "properties": {
-                        "cidrBlocks": {
-                            "description": "A list of CIDR blocks",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "services": {
-                    "description": "The network ranges from which service VIPs are allocated",
-                    "properties": {
-                        "cidrBlocks": {
-                            "description": "A list of CIDR blocks",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "controlPlaneNumber": {
-            "description": "The number of the control plane pods",
-            "minimum": 1,
-            "type": [
-                "number"
-            ]
-        },
-        "extensions": {
-            "description": "Defines custom Helm and image repositories to use for pulling k0s extensions",
-            "properties": {
-                "chartRepository": {
-                    "description": "Custom Helm repository",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "imageRepository": {
-                    "description": "Custom images' repository",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "k0s": {
-            "description": "K0s parameters",
-            "properties": {
-                "api": {
-                    "description": "Kubernetes API server parameters",
-                    "properties": {
-                        "extraArgs": {
-                            "additionalProperties": true,
-                            "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
-                            "properties": {},
-                            "type": [
-                                "object"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "version": {
-                    "description": "K0s version",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "k0smotron": {
-            "description": "K0smotron parameters",
-            "properties": {
-                "service": {
-                    "description": "The API service configuration",
-                    "properties": {
-                        "apiPort": {
-                            "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
-                            "maximum": 65535,
-                            "minimum": 1,
-                            "type": [
-                                "number"
-                            ]
-                        },
-                        "konnectivityPort": {
-                            "description": "The konnectivity port. If empty k0smotron will pick it automatically",
-                            "maximum": 65535,
-                            "minimum": 1,
-                            "type": [
-                                "number"
-                            ]
-                        },
-                        "type": {
-                            "description": "An ingress methods for a service",
-                            "enum": [
-                                "ClusterIP",
-                                "NodePort",
-                                "LoadBalancer"
-                            ],
-                            "type": [
-                                "string"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "network": {
-            "description": "The GCP network configuration",
-            "properties": {
-                "mtu": {
-                    "description": "Maximum Transmission Unit in bytes",
-                    "maximum": 8896,
-                    "minimum": 1300,
-                    "type": [
-                        "number"
-                    ]
-                },
-                "name": {
-                    "description": "The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": [
-                "object"
-            ]
-        },
-        "project": {
-            "description": "The name of the project to deploy the cluster to",
-            "type": [
-                "string"
-            ]
-        },
-        "region": {
-            "description": "The GCP Region the cluster lives in",
-            "type": [
-                "string"
-            ]
-        },
-        "worker": {
-            "description": "Worker parameters",
-            "properties": {
-                "additionalLabels": {
-                    "additionalProperties": false,
-                    "description": "Additional set of labels to add to an instance, in addition to the ones added by default by the GCP provider. If both the GCPCluster and the GCPMachine specify the same tag name with different values, the GCPMachine's value takes precedence",
-                    "patternProperties": {
-                        "^[a-zA-Z0-9._-]+$": {
-                            "type": "string"
-                        }
-                    },
-                    "properties": {},
-                    "type": [
-                        "object"
-                    ]
-                },
-                "additionalNetworkTags": {
-                    "description": "A list of network tags that should be applied to the instance. These tags are set in addition to any network tags defined at the cluster level or in the actuator",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array"
-                    ]
-                },
-                "image": {
-                    "description": "The full reference to a valid image to be used for this machine. Takes precedence over imageFamily",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "imageFamily": {
-                    "description": "The full reference to a valid image family to be used for this machine",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "instanceType": {
-                    "description": "The type of instance to create. Example: n1.standard-2",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "ipForwarding": {
-                    "description": "IPForwarding allows this instance to send and receive packets with non-matching destination or source IPs. This is required if you plan to use this instance to forward routes. Defaults to Enabled",
-                    "enum": [
-                        "Enabled",
-                        "Disabled"
-                    ],
-                    "type": [
-                        "string"
-                    ]
-                },
-                "providerID": {
-                    "description": "The unique identifier as specified by the cloud provider",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "publicIP": {
-                    "description": "PublicIP specifies whether the instance should get a public IP. Set this to true if you don't have a NAT instances or Cloud Nat setup",
-                    "type": [
-                        "boolean"
-                    ]
-                },
-                "rootDeviceSize": {
-                    "description": "The size of the root volume in GB",
-                    "minimum": 1,
-                    "type": [
-                        "number"
-                    ]
-                },
-                "rootDeviceType": {
-                    "description": "The type of the root volume",
-                    "enum": [
-                        "pd-standard",
-                        "pd-ssd",
-                        "pd-balanced",
-                        "hyperdisk-balanced"
-                    ],
-                    "type": [
-                        "string"
-                    ]
-                },
-                "rootDiskEncryptionKey": {
-                    "type": "null"
-                },
-                "serviceAccount": {
-                    "description": "The service account email and which scopes to assign to the machine",
-                    "properties": {
-                        "email": {
-                            "description": "Email address of the service account",
-                            "type": [
-                                "string"
-                            ]
-                        },
-                        "scopes": {
-                            "description": "The list of scopes to be made available for this service account",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "subnet": {
-                    "description": "A reference to the subnetwork to use for this instance. If not specified, the first subnetwork retrieved from the Cluster Region and Network is picked",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "required": [
-                "instanceType"
-            ],
-            "type": [
-                "object"
-            ]
-        },
-        "workersNumber": {
-            "description": "The number of the worker nodes",
-            "minimum": 1,
-            "type": [
-                "number"
-            ]
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM cluster gcp-hosted-cp template",
+  "type": "object",
+  "required": [
+    "project",
+    "region"
+  ],
+  "properties": {
+    "additionalLabels": {
+      "description": "Additional set of labels to add to all the GCP resources",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "type": "string"
         }
+      },
+      "additionalProperties": false
     },
-    "required": [
-        "project",
-        "region"
-    ],
-    "type": "object"
+    "clusterAnnotations": {
+      "description": "Annotations to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "clusterIdentity": {
+      "description": "The GCP Service Account credentials secret reference, auto-populated",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The GCP Service Account credentials secret name, auto-populated",
+          "type": "string"
+        }
+      }
+    },
+    "clusterLabels": {
+      "description": "Labels to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "clusterNetwork": {
+      "description": "The cluster network configuration",
+      "type": "object",
+      "properties": {
+        "apiServerPort": {
+          "description": "The port the API Server should bind to",
+          "type": "number",
+          "maximum": 65535,
+          "minimum": 1
+        },
+        "pods": {
+          "description": "The network ranges from which Pod networks are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "services": {
+          "description": "The network ranges from which service VIPs are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "controlPlaneNumber": {
+      "description": "The number of the control plane pods",
+      "type": "number",
+      "minimum": 1
+    },
+    "k0s": {
+      "description": "K0s parameters",
+      "type": "object",
+      "properties": {
+        "api": {
+          "description": "Kubernetes API server parameters",
+          "type": "object",
+          "properties": {
+            "extraArgs": {
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "version": {
+          "description": "K0s version",
+          "type": "string"
+        }
+      }
+    },
+    "k0smotron": {
+      "description": "K0smotron parameters",
+      "type": "object",
+      "properties": {
+        "service": {
+          "description": "The API service configuration",
+          "type": "object",
+          "properties": {
+            "apiPort": {
+              "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
+            },
+            "konnectivityPort": {
+              "description": "The konnectivity port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
+            },
+            "type": {
+              "description": "An ingress methods for a service",
+              "default": "LoadBalancer",
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "network": {
+      "description": "The GCP network configuration",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "mtu": {
+          "description": "Maximum Transmission Unit in bytes",
+          "type": "number",
+          "maximum": 8896,
+          "minimum": 1300
+        },
+        "name": {
+          "description": "The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP",
+          "type": "string"
+        }
+      }
+    },
+    "project": {
+      "description": "The name of the project to deploy the cluster to",
+      "type": "string"
+    },
+    "region": {
+      "description": "The GCP Region the cluster lives in",
+      "type": "string"
+    },
+    "worker": {
+      "description": "Worker parameters",
+      "type": "object",
+      "required": [
+        "instanceType"
+      ],
+      "properties": {
+        "additionalLabels": {
+          "description": "Additional set of labels to add to an instance, in addition to the ones added by default by the GCP provider. If both the GCPCluster and the GCPMachine specify the same tag name with different values, the GCPMachine's value takes precedence",
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9._-]+$": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "additionalNetworkTags": {
+          "description": "A list of network tags that should be applied to the instance. These tags are set in addition to any network tags defined at the cluster level or in the actuator",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "image": {
+          "description": "The full reference to a valid image to be used for this machine. Takes precedence over imageFamily",
+          "type": "string"
+        },
+        "imageFamily": {
+          "description": "The full reference to a valid image family to be used for this machine",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "The type of instance to create. Example: n1.standard-2",
+          "type": "string"
+        },
+        "ipForwarding": {
+          "description": "IPForwarding allows this instance to send and receive packets with non-matching destination or source IPs. This is required if you plan to use this instance to forward routes. Defaults to Enabled",
+          "type": "string",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ]
+        },
+        "providerID": {
+          "description": "The unique identifier as specified by the cloud provider",
+          "type": "string"
+        },
+        "publicIP": {
+          "description": "PublicIP specifies whether the instance should get a public IP. Set this to true if you don't have a NAT instances or Cloud Nat setup",
+          "type": "boolean"
+        },
+        "rootDeviceSize": {
+          "description": "The size of the root volume in GB",
+          "type": "number",
+          "minimum": 1
+        },
+        "rootDeviceType": {
+          "description": "The type of the root volume",
+          "type": "string",
+          "enum": [
+            "pd-standard",
+            "pd-ssd",
+            "pd-balanced",
+            "hyperdisk-balanced"
+          ]
+        },
+        "rootDiskEncryptionKey": {
+          "type": "null"
+        },
+        "serviceAccount": {
+          "description": "The service account email and which scopes to assign to the machine",
+          "type": "object",
+          "properties": {
+            "email": {
+              "description": "Email address of the service account",
+              "type": "string"
+            },
+            "scopes": {
+              "description": "The list of scopes to be made available for this service account",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "subnet": {
+          "description": "A reference to the subnetwork to use for this instance. If not specified, the first subnetwork retrieved from the Cluster Region and Network is picked",
+          "type": "string"
+        }
+      }
+    },
+    "workersNumber": {
+      "description": "The number of the worker nodes",
+      "type": "number",
+      "minimum": 1
+    }
+  }
 }

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -36,7 +36,7 @@ worker: # @schema description: Worker parameters; type: object
   publicIP: true # @schema description: PublicIP specifies whether the instance should get a public IP. Set this to true if you don't have a NAT instances or Cloud Nat setup; type: boolean
   additionalNetworkTags: [] # @schema description: A list of network tags that should be applied to the instance. These tags are set in addition to any network tags defined at the cluster level or in the actuator; type: array; item: string
   rootDeviceSize: 30 # @schema description: The size of the root volume in GB; type: number; minimum: 1
-  rootDeviceType: pd-standard # @schema description: The type of the root volume; type: string; enum: pd-standard,pd-ssd,pd-balanced,hyperdisk-balanced;
+  rootDeviceType: pd-standard # @schema description: The type of the root volume; type: string; enum: pd-standard,pd-ssd,pd-balanced,hyperdisk-balanced
   rootDiskEncryptionKey:
   serviceAccount: # @schema description: The service account email and which scopes to assign to the machine; type: object
     email: "default" # @schema description: Email address of the service account; type: string
@@ -54,5 +54,5 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
   version: v1.32.5+k0s.1 # @schema description: K0s version; type: string
-  api: # @schema description: Kubernetes API server parameters; type: object; additionalProperties: object
+  api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/values.schema.json
+++ b/templates/cluster/gcp-standalone-cp/values.schema.json
@@ -1,449 +1,320 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-        "additionalLabels": {
-            "additionalProperties": false,
-            "description": "Additional set of labels to add to all the GCP resources",
-            "patternProperties": {
-                "^[a-zA-Z0-9._-]+$": {
-                    "type": "string"
-                }
-            },
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterAnnotations": {
-            "additionalProperties": true,
-            "description": "Annotations to apply to the cluster",
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterIdentity": {
-            "description": "The GCP Service Account credentials secret reference, auto-populated",
-            "properties": {
-                "name": {
-                    "description": "The GCP Service Account credentials secret name, auto-populated",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "clusterLabels": {
-            "additionalProperties": true,
-            "description": "Labels to apply to the cluster",
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterNetwork": {
-            "description": "The cluster network configuration",
-            "properties": {
-                "apiServerPort": {
-                    "description": "The port the API Server should bind to",
-                    "maximum": 65535,
-                    "minimum": 1,
-                    "type": [
-                        "number"
-                    ]
-                },
-                "pods": {
-                    "description": "The network ranges from which Pod networks are allocated",
-                    "properties": {
-                        "cidrBlocks": {
-                            "description": "A list of CIDR blocks",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "services": {
-                    "description": "The network ranges from which service VIPs are allocated",
-                    "properties": {
-                        "cidrBlocks": {
-                            "description": "A list of CIDR blocks",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "controlPlane": {
-            "description": "Control plane parameters",
-            "properties": {
-                "additionalLabels": {
-                    "additionalProperties": false,
-                    "description": "Additional set of labels to add to an instance, in addition to the ones added by default by the GCP provider. If both the GCPCluster and the GCPMachine specify the same tag name with different values, the GCPMachine's value takes precedence",
-                    "patternProperties": {
-                        "^[a-zA-Z0-9._-]+$": {
-                            "type": "string"
-                        }
-                    },
-                    "properties": {},
-                    "type": [
-                        "object"
-                    ]
-                },
-                "additionalNetworkTags": {
-                    "description": "A list of network tags that should be applied to the instance. These tags are set in addition to any network tags defined at the cluster level or in the actuator",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array"
-                    ]
-                },
-                "image": {
-                    "description": "The full reference to a valid image to be used for this machine. Takes precedence over imageFamily",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "imageFamily": {
-                    "description": "The full reference to a valid image family to be used for this machine",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "instanceType": {
-                    "description": "The type of instance to create. Example: n1.standard-2",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "ipForwarding": {
-                    "description": "IPForwarding allows this instance to send and receive packets with non-matching destination or source IPs. This is required if you plan to use this instance to forward routes. Defaults to Enabled",
-                    "enum": [
-                        "Enabled",
-                        "Disabled"
-                    ],
-                    "type": [
-                        "string"
-                    ]
-                },
-                "providerID": {
-                    "description": "The unique identifier as specified by the cloud provider",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "publicIP": {
-                    "description": "PublicIP specifies whether the instance should get a public IP. Set this to true if you don't have a NAT instances or Cloud Nat setup",
-                    "type": [
-                        "boolean"
-                    ]
-                },
-                "rootDeviceSize": {
-                    "description": "The size of the root volume in GB",
-                    "minimum": 1,
-                    "type": [
-                        "number"
-                    ]
-                },
-                "rootDeviceType": {
-                    "description": "The type of the root volume",
-                    "enum": [
-                        "pd-standard",
-                        "pd-ssd",
-                        "pd-balanced",
-                        "hyperdisk-balanced"
-                    ],
-                    "type": [
-                        "string"
-                    ]
-                },
-                "serviceAccount": {
-                    "description": "The service account email and which scopes to assign to the machine",
-                    "properties": {
-                        "email": {
-                            "description": "Email address of the service account",
-                            "type": [
-                                "string"
-                            ]
-                        },
-                        "scopes": {
-                            "description": "The list of scopes to be made available for this service account",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "subnet": {
-                    "description": "A reference to the subnetwork to use for this instance. If not specified, the first subnetwork retrieved from the Cluster Region and Network is picked",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "required": [
-                "instanceType"
-            ],
-            "type": [
-                "object"
-            ]
-        },
-        "controlPlaneNumber": {
-            "description": "The number of the control plane nodes",
-            "minimum": 1,
-            "type": [
-                "number"
-            ]
-        },
-        "extensions": {
-            "description": "Defines custom Helm and image repositories to use for pulling k0s extensions",
-            "properties": {
-                "chartRepository": {
-                    "description": "Custom Helm repository",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "imageRepository": {
-                    "description": "Custom images' repository",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "k0s": {
-            "description": "K0s parameters",
-            "properties": {
-                "api": {
-                    "description": "Kubernetes API server parameters",
-                    "properties": {
-                        "extraArgs": {
-                            "additionalProperties": true,
-                            "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
-                            "properties": {},
-                            "type": [
-                                "object"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "version": {
-                    "description": "K0s version",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "network": {
-            "description": "The GCP network configuration",
-            "properties": {
-                "mtu": {
-                    "description": "Maximum Transmission Unit in bytes",
-                    "maximum": 8896,
-                    "minimum": 1300,
-                    "type": [
-                        "number"
-                    ]
-                },
-                "name": {
-                    "description": "The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "required": [
-                "name"
-            ],
-            "type": [
-                "object"
-            ]
-        },
-        "project": {
-            "description": "The name of the project to deploy the cluster to",
-            "type": [
-                "string"
-            ]
-        },
-        "region": {
-            "description": "The GCP Region the cluster lives in",
-            "type": [
-                "string"
-            ]
-        },
-        "worker": {
-            "description": "Worker parameters",
-            "properties": {
-                "additionalLabels": {
-                    "additionalProperties": false,
-                    "description": "Additional set of labels to add to an instance, in addition to the ones added by default by the GCP provider. If both the GCPCluster and the GCPMachine specify the same tag name with different values, the GCPMachine's value takes precedence",
-                    "patternProperties": {
-                        "^[a-zA-Z0-9._-]+$": {
-                            "type": "string"
-                        }
-                    },
-                    "properties": {},
-                    "type": [
-                        "object"
-                    ]
-                },
-                "additionalNetworkTags": {
-                    "description": "A list of network tags that should be applied to the instance. These tags are set in addition to any network tags defined at the cluster level or in the actuator",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": [
-                        "array"
-                    ]
-                },
-                "image": {
-                    "description": "The full reference to a valid image to be used for this machine. Takes precedence over imageFamily",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "imageFamily": {
-                    "description": "The full reference to a valid image family to be used for this machine",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "instanceType": {
-                    "description": "The type of instance to create. Example: n1.standard-2",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "ipForwarding": {
-                    "description": "IPForwarding allows this instance to send and receive packets with non-matching destination or source IPs. This is required if you plan to use this instance to forward routes. Defaults to Enabled",
-                    "enum": [
-                        "Enabled",
-                        "Disabled"
-                    ],
-                    "type": [
-                        "string"
-                    ]
-                },
-                "providerID": {
-                    "description": "The unique identifier as specified by the cloud provider",
-                    "type": [
-                        "string"
-                    ]
-                },
-                "publicIP": {
-                    "description": "PublicIP specifies whether the instance should get a public IP. Set this to true if you don't have a NAT instances or Cloud Nat setup",
-                    "type": [
-                        "boolean"
-                    ]
-                },
-                "rootDeviceSize": {
-                    "description": "The size of the root volume in GB",
-                    "minimum": 1,
-                    "type": [
-                        "number"
-                    ]
-                },
-                "rootDeviceType": {
-                    "description": "The type of the root volume",
-                    "enum": [
-                        "pd-standard",
-                        "pd-ssd",
-                        "pd-balanced",
-                        "hyperdisk-balanced"
-                    ],
-                    "type": [
-                        "string"
-                    ]
-                },
-                "rootDiskEncryptionKey": {
-                    "type": "null"
-                },
-                "serviceAccount": {
-                    "description": "The service account email and which scopes to assign to the machine",
-                    "properties": {
-                        "email": {
-                            "description": "Email address of the service account",
-                            "type": [
-                                "string"
-                            ]
-                        },
-                        "scopes": {
-                            "description": "The list of scopes to be made available for this service account",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "subnet": {
-                    "description": "A reference to the subnetwork to use for this instance. If not specified, the first subnetwork retrieved from the Cluster Region and Network is picked",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "required": [
-                "instanceType"
-            ],
-            "type": [
-                "object"
-            ]
-        },
-        "workersNumber": {
-            "description": "The number of the worker nodes",
-            "minimum": 1,
-            "type": [
-                "number"
-            ]
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM cluster gcp-standalone-cp template",
+  "type": "object",
+  "required": [
+    "project",
+    "region"
+  ],
+  "properties": {
+    "additionalLabels": {
+      "description": "Additional set of labels to add to all the GCP resources",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "type": "string"
         }
+      },
+      "additionalProperties": false
     },
-    "required": [
-        "project",
-        "region"
-    ],
-    "type": "object"
+    "clusterAnnotations": {
+      "description": "Annotations to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "clusterIdentity": {
+      "description": "The GCP Service Account credentials secret reference, auto-populated",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The GCP Service Account credentials secret name, auto-populated",
+          "type": "string"
+        }
+      }
+    },
+    "clusterLabels": {
+      "description": "Labels to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "clusterNetwork": {
+      "description": "The cluster network configuration",
+      "type": "object",
+      "properties": {
+        "apiServerPort": {
+          "description": "The port the API Server should bind to",
+          "type": "number",
+          "maximum": 65535,
+          "minimum": 1
+        },
+        "pods": {
+          "description": "The network ranges from which Pod networks are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "services": {
+          "description": "The network ranges from which service VIPs are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "controlPlane": {
+      "description": "Control plane parameters",
+      "type": "object",
+      "required": [
+        "instanceType"
+      ],
+      "properties": {
+        "additionalLabels": {
+          "description": "Additional set of labels to add to an instance, in addition to the ones added by default by the GCP provider. If both the GCPCluster and the GCPMachine specify the same tag name with different values, the GCPMachine's value takes precedence",
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9._-]+$": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "additionalNetworkTags": {
+          "description": "A list of network tags that should be applied to the instance. These tags are set in addition to any network tags defined at the cluster level or in the actuator",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "image": {
+          "description": "The full reference to a valid image to be used for this machine. Takes precedence over imageFamily",
+          "type": "string"
+        },
+        "imageFamily": {
+          "description": "The full reference to a valid image family to be used for this machine",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "The type of instance to create. Example: n1.standard-2",
+          "type": "string"
+        },
+        "ipForwarding": {
+          "description": "IPForwarding allows this instance to send and receive packets with non-matching destination or source IPs. This is required if you plan to use this instance to forward routes. Defaults to Enabled",
+          "type": "string",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ]
+        },
+        "providerID": {
+          "description": "The unique identifier as specified by the cloud provider",
+          "type": "string"
+        },
+        "publicIP": {
+          "description": "PublicIP specifies whether the instance should get a public IP. Set this to true if you don't have a NAT instances or Cloud Nat setup",
+          "type": "boolean"
+        },
+        "rootDeviceSize": {
+          "description": "The size of the root volume in GB",
+          "type": "number",
+          "minimum": 1
+        },
+        "rootDeviceType": {
+          "description": "The type of the root volume",
+          "type": "string",
+          "enum": [
+            "pd-standard",
+            "pd-ssd",
+            "pd-balanced",
+            "hyperdisk-balanced"
+          ]
+        },
+        "serviceAccount": {
+          "description": "The service account email and which scopes to assign to the machine",
+          "type": "object",
+          "properties": {
+            "email": {
+              "description": "Email address of the service account",
+              "type": "string"
+            },
+            "scopes": {
+              "description": "The list of scopes to be made available for this service account",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "subnet": {
+          "description": "A reference to the subnetwork to use for this instance. If not specified, the first subnetwork retrieved from the Cluster Region and Network is picked",
+          "type": "string"
+        }
+      }
+    },
+    "controlPlaneNumber": {
+      "description": "The number of the control plane nodes",
+      "type": "number",
+      "minimum": 1
+    },
+    "k0s": {
+      "description": "K0s parameters",
+      "type": "object",
+      "properties": {
+        "api": {
+          "description": "Kubernetes API server parameters",
+          "type": "object",
+          "properties": {
+            "extraArgs": {
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "version": {
+          "description": "K0s version",
+          "type": "string"
+        }
+      }
+    },
+    "network": {
+      "description": "The GCP network configuration",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "mtu": {
+          "description": "Maximum Transmission Unit in bytes",
+          "type": "number",
+          "maximum": 8896,
+          "minimum": 1300
+        },
+        "name": {
+          "description": "The name of an existing GCP network or a new network that will be created by Cluster API Provider GCP",
+          "type": "string"
+        }
+      }
+    },
+    "project": {
+      "description": "The name of the project to deploy the cluster to",
+      "type": "string"
+    },
+    "region": {
+      "description": "The GCP Region the cluster lives in",
+      "type": "string"
+    },
+    "worker": {
+      "description": "Worker parameters",
+      "type": "object",
+      "required": [
+        "instanceType"
+      ],
+      "properties": {
+        "additionalLabels": {
+          "description": "Additional set of labels to add to an instance, in addition to the ones added by default by the GCP provider. If both the GCPCluster and the GCPMachine specify the same tag name with different values, the GCPMachine's value takes precedence",
+          "type": "object",
+          "patternProperties": {
+            "^[a-zA-Z0-9._-]+$": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "additionalNetworkTags": {
+          "description": "A list of network tags that should be applied to the instance. These tags are set in addition to any network tags defined at the cluster level or in the actuator",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "image": {
+          "description": "The full reference to a valid image to be used for this machine. Takes precedence over imageFamily",
+          "type": "string"
+        },
+        "imageFamily": {
+          "description": "The full reference to a valid image family to be used for this machine",
+          "type": "string"
+        },
+        "instanceType": {
+          "description": "The type of instance to create. Example: n1.standard-2",
+          "type": "string"
+        },
+        "ipForwarding": {
+          "description": "IPForwarding allows this instance to send and receive packets with non-matching destination or source IPs. This is required if you plan to use this instance to forward routes. Defaults to Enabled",
+          "type": "string",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ]
+        },
+        "providerID": {
+          "description": "The unique identifier as specified by the cloud provider",
+          "type": "string"
+        },
+        "publicIP": {
+          "description": "PublicIP specifies whether the instance should get a public IP. Set this to true if you don't have a NAT instances or Cloud Nat setup",
+          "type": "boolean"
+        },
+        "rootDeviceSize": {
+          "description": "The size of the root volume in GB",
+          "type": "number",
+          "minimum": 1
+        },
+        "rootDeviceType": {
+          "description": "The type of the root volume",
+          "type": "string",
+          "enum": [
+            "pd-standard",
+            "pd-ssd",
+            "pd-balanced",
+            "hyperdisk-balanced"
+          ]
+        },
+        "rootDiskEncryptionKey": {
+          "type": "null"
+        },
+        "serviceAccount": {
+          "description": "The service account email and which scopes to assign to the machine",
+          "type": "object",
+          "properties": {
+            "email": {
+              "description": "Email address of the service account",
+              "type": "string"
+            },
+            "scopes": {
+              "description": "The list of scopes to be made available for this service account",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "subnet": {
+          "description": "A reference to the subnetwork to use for this instance. If not specified, the first subnetwork retrieved from the Cluster Region and Network is picked",
+          "type": "string"
+        }
+      }
+    },
+    "workersNumber": {
+      "description": "The number of the worker nodes",
+      "type": "number",
+      "minimum": 1
+    }
+  }
 }

--- a/templates/cluster/gcp-standalone-cp/values.yaml
+++ b/templates/cluster/gcp-standalone-cp/values.yaml
@@ -36,7 +36,7 @@ controlPlane: # @schema description: Control plane parameters; type: object
   publicIP: true # @schema description: PublicIP specifies whether the instance should get a public IP. Set this to true if you don't have a NAT instances or Cloud Nat setup; type: boolean
   additionalNetworkTags: [] # @schema description: A list of network tags that should be applied to the instance. These tags are set in addition to any network tags defined at the cluster level or in the actuator; type: array; item: string
   rootDeviceSize: 30 # @schema description: The size of the root volume in GB; type: number; minimum: 1
-  rootDeviceType: pd-standard # @schema description: The type of the root volume; type: string; enum: pd-standard,pd-ssd,pd-balanced,hyperdisk-balanced;
+  rootDeviceType: pd-standard # @schema description: The type of the root volume; type: string; enum: pd-standard,pd-ssd,pd-balanced,hyperdisk-balanced
   serviceAccount: # @schema description: The service account email and which scopes to assign to the machine; type: object
     email: "default" # @schema description: Email address of the service account; type: string
     scopes: # @schema description: The list of scopes to be made available for this service account; type: array; item: string
@@ -53,7 +53,7 @@ worker: # @schema description: Worker parameters; type: object
   publicIP: true # @schema description: PublicIP specifies whether the instance should get a public IP. Set this to true if you don't have a NAT instances or Cloud Nat setup; type: boolean
   additionalNetworkTags: [] # @schema description: A list of network tags that should be applied to the instance. These tags are set in addition to any network tags defined at the cluster level or in the actuator; type: array; item: string
   rootDeviceSize: 30 # @schema description: The size of the root volume in GB; type: number; minimum: 1
-  rootDeviceType: pd-standard # @schema description: The type of the root volume; type: string; enum: pd-standard,pd-ssd,pd-balanced,hyperdisk-balanced;
+  rootDeviceType: pd-standard # @schema description: The type of the root volume; type: string; enum: pd-standard,pd-ssd,pd-balanced,hyperdisk-balanced
   rootDiskEncryptionKey:
   serviceAccount: # @schema description: The service account email and which scopes to assign to the machine; type: object
     email: "default" # @schema description: Email address of the service account; type: string
@@ -64,5 +64,5 @@ worker: # @schema description: Worker parameters; type: object
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
   version: v1.32.5+k0s.1 # @schema description: K0s version; type: string
-  api: # @schema description: Kubernetes API server parameters; type: object; additionalProperties: object
+  api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -1,32 +1,34 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a k0s cluster on OpenStack with bootstrapped control plane nodes",
+  "description": "A KCM cluster openstack-standalone-cp template",
+  "type": "object",
+  "required": [
+    "controlPlaneNumber",
+    "workersNumber",
+    "identityRef"
+  ],
   "properties": {
     "apiServerLoadBalancer": {
       "description": "Configuration for external load balancer for API server",
+      "type": "object",
       "properties": {
         "enabled": {
           "description": "Enable/disable external load balancer for the API server",
-          "type": [
-            "boolean"
-          ]
+          "type": "boolean"
         }
-      },
-      "type": [
-        "object"
-      ]
+      }
     },
     "bastion": {
       "description": "Configuration of the bastion host",
+      "type": "object",
       "properties": {
         "enabled": {
           "description": "Enable bastion server for SSH access",
-          "type": [
-            "boolean"
-          ]
+          "type": "boolean"
         },
         "spec": {
           "description": "Bastion host spec",
+          "type": "object",
           "properties": {
             "flavor": {
               "description": "Flavor of the bastion server",
@@ -37,34 +39,26 @@
             },
             "image": {
               "description": "Bastion host image configuration",
+              "type": "object",
               "properties": {
                 "filter": {
                   "description": "Filter describes a query for an image. If specified, the combination of name and tags must return a single matching image or an error will be raised",
+                  "type": "object",
                   "properties": {
                     "name": {
                       "description": "Name of the image",
-                      "type": [
-                        "string"
-                      ]
+                      "type": "string"
                     },
                     "tags": {
                       "description": "The tags associated with the desired image",
+                      "type": "array",
                       "items": {
                         "type": "string"
-                      },
-                      "type": [
-                        "array"
-                      ]
+                      }
                     }
-                  },
-                  "type": [
-                    "object"
-                  ]
+                  }
                 }
-              },
-              "type": [
-                "object"
-              ]
+              }
             },
             "providerID": {
               "description": "Provider ID of the bastion server",
@@ -75,141 +69,108 @@
             },
             "sshKeyName": {
               "description": "SSH public key for accessing the bastion",
-              "type": [
-                "string"
-              ]
+              "type": "string"
             }
-          },
-          "type": [
-            "object"
-          ]
+          }
         }
-      },
-      "type": [
-        "object"
-      ]
+      }
     },
     "ccmRegional": {
       "description": "Allow OpenStack CCM to set ProviderID with region name",
-      "type": [
-        "boolean"
-      ]
+      "type": "boolean"
     },
     "clusterAnnotations": {
-      "additionalProperties": true,
       "description": "Annotations to apply to the cluster",
-      "properties": {},
-      "type": [
-        "object"
-      ]
+      "type": "object",
+      "additionalProperties": true
     },
     "clusterLabels": {
-      "additionalProperties": true,
       "description": "Labels to apply to the cluster",
-      "properties": {},
-      "type": [
-        "object"
-      ]
+      "type": "object",
+      "additionalProperties": true
     },
     "clusterNetwork": {
       "description": "The cluster network configuration",
+      "type": "object",
       "properties": {
         "pods": {
           "description": "The network ranges from which Pod networks are allocated",
+          "type": "object",
           "properties": {
             "cidrBlocks": {
               "description": "A list of CIDR blocks",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": [
-                "array"
-              ]
+              }
             }
-          },
-          "type": [
-            "object"
-          ]
+          }
         },
         "serviceDomain": {
           "type": "string"
         },
         "services": {
           "description": "The network ranges from which service VIPs are allocated",
+          "type": "object",
           "properties": {
             "cidrBlocks": {
               "description": "A list of CIDR blocks",
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": [
-                "array"
-              ]
+              }
             }
-          },
-          "type": [
-            "object"
-          ]
+          }
         }
-      },
-      "type": [
-        "object"
-      ]
+      }
     },
     "controlPlane": {
       "description": "Configuration of the control plane instances",
+      "type": "object",
+      "required": [
+        "flavor"
+      ],
       "properties": {
         "additionalBlockDevices": {
           "description": "AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance",
-          "type": [
-            "array"
-          ]
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
         },
         "flavor": {
           "description": "OpenStack flavor for instance size",
-          "type": [
-            "string"
-          ]
+          "type": "string"
         },
         "image": {
           "description": "Image configuration",
+          "type": "object",
           "properties": {
             "filter": {
               "description": "Filter describes a query for an image. If specified, the combination of name and tags must return a single matching image or an error will be raised",
+              "type": "object",
               "properties": {
                 "name": {
                   "description": "Name of the image",
-                  "type": [
-                    "string"
-                  ]
+                  "type": "string"
                 },
                 "tags": {
                   "description": "The tags associated with the desired image",
+                  "type": "array",
                   "items": {
                     "type": "string"
-                  },
-                  "type": [
-                    "array"
-                  ]
+                  }
                 }
-              },
-              "type": [
-                "object"
-              ]
+              }
             }
-          },
-          "type": [
-            "object"
-          ]
+          }
         },
         "portOpts": {
           "description": "Ports to be attached to the server instance",
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": [
-            "array"
-          ]
+          }
         },
         "providerID": {
           "description": "Unique ID for the instance provider",
@@ -220,82 +181,58 @@
         },
         "rootVolume": {
           "description": "The volume metadata to boot from",
-          "properties": {},
-          "type": [
-            "object"
-          ]
+          "type": "object"
         },
         "securityGroups": {
           "description": "Security groups to be assigned to the instance",
+          "type": "array",
           "items": {
+            "type": "object",
             "properties": {
               "filter": {
+                "type": "object",
                 "properties": {
                   "description": {
                     "description": "Description for filtering",
-                    "type": [
-                      "string"
-                    ]
+                    "type": "string"
                   },
                   "name": {
                     "description": "Name of the security group to filter by",
-                    "type": [
-                      "string"
-                    ]
+                    "type": "string"
                   },
                   "projectID": {
                     "description": "Optional: project ID for filtering",
-                    "type": [
-                      "string"
-                    ]
+                    "type": "string"
                   }
-                },
-                "type": "object"
+                }
               }
-            },
-            "type": "object"
-          },
-          "type": [
-            "array"
-          ]
+            }
+          }
         },
         "sshKeyName": {
           "description": "SSH public key for accessing nodes",
-          "type": [
-            "string"
-          ]
+          "type": "string"
         }
-      },
-      "required": [
-        "flavor"
-      ],
-      "type": [
-        "object"
-      ]
+      }
     },
     "controlPlaneNumber": {
       "description": "The number of the control-plane machines",
-      "minimum": 1,
-      "type": [
-        "integer"
-      ]
+      "type": "integer",
+      "minimum": 1
     },
     "externalNetwork": {
       "description": "External network configuration for the cluster",
+      "type": "object",
       "properties": {
         "filter": {
           "description": "Filter specifies a filter to select an OpenStack network",
+          "type": "object",
           "properties": {
             "name": {
               "description": "Name of the external network",
-              "type": [
-                "string"
-              ]
+              "type": "string"
             }
-          },
-          "type": [
-            "object"
-          ]
+          }
         },
         "id": {
           "description": "ID of the external network",
@@ -304,176 +241,142 @@
             "null"
           ]
         }
-      },
-      "type": [
-        "object"
-      ]
+      }
     },
     "identityRef": {
       "description": "OpenStack cluster identity object reference",
-      "properties": {
-        "caCert": {
-          "description": "Reference to the secret with the content of a custom CA",
-          "properties": {
-            "path": {
-              "description": "The path where the secret with a custom CA will be mounted",
-              "type": [
-                "string"
-              ]
-            },
-            "secretName": {
-              "description": "The name of the secret with a custom CA in kube-system namespace",
-              "type": [
-                "string"
-              ]
-            }
-          },
-          "type": [
-            "object"
-          ]
-        },
-        "cloudName": {
-          "description": "Name of the entry in the clouds.yaml file to use",
-          "type": [
-            "string"
-          ]
-        },
-        "name": {
-          "description": "Name of the identity",
-          "type": [
-            "string"
-          ]
-        },
-        "region": {
-          "description": "OpenStack region",
-          "type": [
-            "string"
-          ]
-        }
-      },
+      "type": "object",
       "required": [
         "name",
         "cloudName",
         "region"
       ],
-      "type": [
-        "object"
-      ]
+      "properties": {
+        "caCert": {
+          "description": "Reference to the secret with the content of a custom CA",
+          "type": "object",
+          "properties": {
+            "path": {
+              "description": "The directory where the secret with a custom CA will be mounted",
+              "type": "string"
+            },
+            "secretName": {
+              "description": "The name of the secret with a custom CA in kube-system namespace",
+              "type": "string"
+            }
+          }
+        },
+        "cloudName": {
+          "description": "Name of the entry in the clouds.yaml file to use",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the identity",
+          "type": "string"
+        },
+        "region": {
+          "description": "OpenStack region",
+          "type": "string"
+        }
+      }
     },
     "k0s": {
-      "additionalProperties": true,
       "description": "K0s parameters",
-      "properties": {
-        "api": {
-          "description": "Kubernetes API server parameters",
-          "properties": {
-            "extraArgs": {
-              "additionalProperties": true,
-              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
-              "properties": {},
-              "type": [
-                "object"
-              ]
-            }
-          },
-          "type": [
-            "object"
-          ]
-        },
-        "version": {
-          "description": "K0s version",
-          "type": [
-            "string"
-          ]
-        }
-      },
+      "type": "object",
       "required": [
         "version"
       ],
-      "type": [
-        "object"
-      ]
+      "properties": {
+        "api": {
+          "description": "Kubernetes API server parameters",
+          "type": "object",
+          "properties": {
+            "extraArgs": {
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "version": {
+          "description": "K0s version",
+          "type": "string"
+        }
+      }
     },
     "managedSecurityGroups": {
       "description": "Defines whether OpenStack security groups are managed by the provider or specific rules are provided",
-      "properties": {
-        "allowAllInClusterTraffic": {
-          "description": "Allow all traffic within the cluster security groups",
-          "type": [
-            "boolean"
-          ]
-        }
-      },
+      "type": "object",
       "required": [
         "allowAllInClusterTraffic"
       ],
-      "type": [
-        "object"
-      ]
+      "properties": {
+        "allowAllInClusterTraffic": {
+          "description": "Allow all traffic within the cluster security groups",
+          "type": "boolean"
+        }
+      }
     },
     "managedSubnets": {
       "description": "Subnets managed by OpenStack for the cluster",
+      "type": "array",
       "items": {
-        "type": "object"
-      },
-      "type": [
-        "array"
-      ]
+        "type": "object",
+        "properties": {
+          "cidr": {
+            "description": "CIDR block for the subnet",
+            "type": "string"
+          }
+        }
+      }
     },
     "worker": {
       "description": "Configuration of the worker instances",
+      "type": "object",
+      "required": [
+        "flavor"
+      ],
       "properties": {
         "additionalBlockDevices": {
           "description": "AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance",
-          "type": [
-            "array"
-          ]
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
         },
         "flavor": {
           "description": "OpenStack flavor for instance size",
-          "type": [
-            "string"
-          ]
+          "type": "string"
         },
         "image": {
           "description": "Image configuration",
+          "type": "object",
           "properties": {
             "filter": {
               "description": "Filter describes a query for an image. If specified, the combination of name and tags must return a single matching image or an error will be raised",
+              "type": "object",
               "properties": {
                 "name": {
                   "description": "Name of the image",
-                  "type": [
-                    "string"
-                  ]
+                  "type": "string"
                 },
                 "tags": {
                   "description": "The tags associated with the desired image",
+                  "type": "array",
                   "items": {
                     "type": "string"
-                  },
-                  "type": [
-                    "array"
-                  ]
+                  }
                 }
-              },
-              "type": [
-                "object"
-              ]
+              }
             }
-          },
-          "type": [
-            "object"
-          ]
+          }
         },
         "portOpts": {
           "description": "Ports to be attached to the server instance",
+          "type": "array",
           "items": {
             "type": "string"
-          },
-          "type": [
-            "array"
-          ]
+          }
         },
         "providerID": {
           "description": "Unique ID for the instance provider",
@@ -484,71 +387,44 @@
         },
         "rootVolume": {
           "description": "The volume metadata to boot from",
-          "properties": {},
-          "type": [
-            "object"
-          ]
+          "type": "object"
         },
         "securityGroups": {
           "description": "Security groups to be assigned to the instance",
+          "type": "array",
           "items": {
+            "type": "object",
             "properties": {
               "filter": {
+                "type": "object",
                 "properties": {
                   "description": {
                     "description": "Description for filtering",
-                    "type": [
-                      "string"
-                    ]
+                    "type": "string"
                   },
                   "name": {
                     "description": "Name of the security group to filter by",
-                    "type": [
-                      "string"
-                    ]
+                    "type": "string"
                   },
                   "projectID": {
                     "description": "Optional: project ID for filtering",
-                    "type": [
-                      "string"
-                    ]
+                    "type": "string"
                   }
-                },
-                "type": "object"
+                }
               }
-            },
-            "type": "object"
-          },
-          "type": [
-            "array"
-          ]
+            }
+          }
         },
         "sshKeyName": {
           "description": "SSH public key for accessing nodes",
-          "type": [
-            "string"
-          ]
+          "type": "string"
         }
-      },
-      "required": [
-        "flavor"
-      ],
-      "type": [
-        "object"
-      ]
+      }
     },
     "workersNumber": {
       "description": "The number of the worker machines",
-      "minimum": 1,
-      "type": [
-        "integer"
-      ]
+      "type": "integer",
+      "minimum": 1
     }
-  },
-  "required": [
-    "controlPlaneNumber",
-    "workersNumber",
-    "identityRef"
-  ],
-  "type": "object"
+  }
 }

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -1,7 +1,3 @@
-# Schema generation:
-# $ helm plugin install https://github.com/losisin/helm-values-schema-json.git
-# $ helm schema --draft 2020 --indent 2 --noAdditionalProperties=false --schemaRoot.description='A KCM template to deploy a k0s cluster on OpenStack with bootstrapped control plane nodes' --input ./templates/cluster/openstack-standalone-cp/values.yaml --output ./templates/cluster/openstack-standalone-cp/values.schema.json
-
 # Cluster parameters
 controlPlaneNumber: 3 # @schema description: The number of the control-plane machines; minimum: 1; type: integer; required: true
 workersNumber: 2 # @schema description: The number of the worker machines; minimum: 1; type: integer; required: true
@@ -63,8 +59,8 @@ controlPlane: # @schema description: Configuration of the control plane instance
       tags: [] # @schema description: The tags associated with the desired image; type: array; item: string
   portOpts: [] # @schema description: Ports to be attached to the server instance; type: array; item: string
   rootVolume: {} # @schema description: The volume metadata to boot from; type: object
-  additionalBlockDevices: [] # @schema description: AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance; type: array; items: object
-  securityGroups: # @schema description: Security groups to be assigned to the instance; type: array; items: object
+  additionalBlockDevices: [] # @schema description: AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance; type: array; item: object
+  securityGroups: # @schema description: Security groups to be assigned to the instance; type: array; item: object
     - filter:
         name: "default" # @schema description: Name of the security group to filter by; type: string
         description: "" # @schema description: Description for filtering; type: string
@@ -80,8 +76,8 @@ worker: # @schema description: Configuration of the worker instances; type: obje
       tags: [] # @schema description: The tags associated with the desired image; type: array; item: string
   portOpts: [] # @schema description: Ports to be attached to the server instance; type: array; item: string
   rootVolume: {} # @schema description: The volume metadata to boot from; type: object
-  additionalBlockDevices: [] # @schema description: AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance; type: array; items: object
-  securityGroups: # @schema description: Security groups to be assigned to the instance; type: array; items: object
+  additionalBlockDevices: [] # @schema description: AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance; type: array; item: object
+  securityGroups: # @schema description: Security groups to be assigned to the instance; type: array; item: object
     - filter:
         name: "default" # @schema description: Name of the security group to filter by; type: string
         description: "" # @schema description: Description for filtering; type: string

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/values.schema.json
+++ b/templates/cluster/remote-cluster/values.schema.json
@@ -1,322 +1,245 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-        "clusterAnnotations": {
-            "additionalProperties": true,
-            "description": "Annotations to apply to the cluster",
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterIdentity": {
-            "description": "The SSH key secret reference, auto-populated",
-            "properties": {
-                "name": {
-                    "description": "The SSH key secret name, auto-populated",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "clusterLabels": {
-            "additionalProperties": true,
-            "description": "Labels to apply to the cluster",
-            "properties": {},
-            "type": [
-                "object"
-            ]
-        },
-        "clusterNetwork": {
-            "description": "The cluster network configuration",
-            "properties": {
-                "pods": {
-                    "description": "The network ranges from which Pod networks are allocated",
-                    "properties": {
-                        "cidrBlocks": {
-                            "description": "A list of CIDR blocks",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "services": {
-                    "description": "The network ranges from which service VIPs are allocated",
-                    "properties": {
-                        "cidrBlocks": {
-                            "description": "A list of CIDR blocks",
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": [
-                                "array"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "controlPlaneNumber": {
-            "description": "The number of the control plane pods",
-            "minimum": 1,
-            "type": [
-                "number"
-            ]
-        },
-        "k0s": {
-            "description": "K0s parameters",
-            "properties": {
-                "api": {
-                    "description": "Kubernetes API server parameters",
-                    "properties": {
-                        "extraArgs": {
-                            "additionalProperties": true,
-                            "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
-                            "properties": {},
-                            "type": [
-                                "object"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "extensions": {
-                    "description": "K0s extensions configuration",
-                    "properties": {
-                        "helm": {
-                            "description": "K0s helm repositories and charts configuration",
-                            "properties": {
-                                "charts": {
-                                    "description": "The list of helm charts to deploy during cluster bootstrap",
-                                    "items": {
-                                        "type": "object"
-                                    },
-                                    "type": [
-                                        "array"
-                                    ]
-                                },
-                                "repositories": {
-                                    "description": "The list of Helm repositories for deploying charts during cluster bootstrap",
-                                    "items": {
-                                        "type": "object"
-                                    },
-                                    "type": [
-                                        "array"
-                                    ]
-                                }
-                            },
-                            "type": [
-                                "object"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "network": {
-                    "description": "K0s network configuration",
-                    "properties": {},
-                    "type": [
-                        "object"
-                    ]
-                },
-                "version": {
-                    "description": "K0s version",
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "k0smotron": {
-            "description": "K0smotron parameters",
-            "properties": {
-                "controllerPlaneFlags": {
-                    "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
-                    "type": [
-                        "array"
-                    ]
-                },
-                "persistence": {
-                    "description": "The persistence configuration",
-                    "properties": {
-                        "type": {
-                            "description": "The persistence type",
-                            "type": [
-                                "string"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                },
-                "service": {
-                    "description": "The API service configuration",
-                    "properties": {
-                        "apiPort": {
-                            "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
-                            "maximum": 65535,
-                            "minimum": 1,
-                            "type": [
-                                "number"
-                            ]
-                        },
-                        "konnectivityPort": {
-                            "description": "The konnectivity port. If empty k0smotron will pick it automatically",
-                            "maximum": 65535,
-                            "minimum": 1,
-                            "type": [
-                                "number"
-                            ]
-                        },
-                        "type": {
-                            "description": "An ingress methods for a service",
-                            "enum": [
-                                "ClusterIP",
-                                "NodePort",
-                                "LoadBalancer"
-                            ],
-                            "type": [
-                                "string"
-                            ]
-                        }
-                    },
-                    "type": [
-                        "object"
-                    ]
-                }
-            },
-            "type": [
-                "object"
-            ]
-        },
-        "machines": {
-            "description": "The list of remote machines configurations",
-            "items": {
-                "properties": {
-                    "address": {
-                        "description": "The IP address of the remote machine",
-                        "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$",
-                        "type": [
-                            "string"
-                        ]
-                    },
-                    "k0s": {
-                        "description": "k0s worker configuration options",
-                        "properties": {
-                            "args": {
-                                "description": "Extra arguments to be passed to k0s worker, see: https://docs.k0sproject.io/stable/worker-node-config/",
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": [
-                                    "array"
-                                ]
-                            }
-                        },
-                        "type": [
-                            "object"
-                        ]
-                    },
-                    "port": {
-                        "default": 22,
-                        "description": "The SSH port of the remote machine",
-                        "maximum": 65535,
-                        "minimum": 1,
-                        "type": [
-                            "number"
-                        ]
-                    },
-                    "provisionJob": {
-                        "description": "The kubernetes Job to use to provision the machine",
-                        "properties": {
-                            "jobSpecTemplate": {
-                                "description": "The job template to use to provision the machine, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplate",
-                                "properties": {
-                                    "metadata": {
-                                        "description": "Standard object's metadata of the jobs created from this template, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatemetadata",
-                                        "properties": {},
-                                        "type": [
-                                            "object"
-                                        ]
-                                    },
-                                    "spec": {
-                                        "description": "Specification of the desired behavior of the job, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatespec",
-                                        "properties": {},
-                                        "type": [
-                                            "object"
-                                        ]
-                                    }
-                                },
-                                "type": [
-                                    "object"
-                                ]
-                            },
-                            "scpCommand": {
-                                "description": "The scp command",
-                                "type": [
-                                    "string"
-                                ]
-                            },
-                            "sshCommand": {
-                                "description": "The ssh command",
-                                "type": [
-                                    "string"
-                                ]
-                            }
-                        },
-                        "type": [
-                            "object"
-                        ]
-                    },
-                    "useSudo": {
-                        "default": false,
-                        "description": "Determines whether to use sudo for k0s cluster bootstrap commands",
-                        "type": [
-                            "boolean"
-                        ]
-                    },
-                    "user": {
-                        "description": "The user to use when connecting to the remote machine",
-                        "type": [
-                            "string"
-                        ]
-                    }
-                },
-                "required": [
-                    "address"
-                ],
-                "type": "object"
-            },
-            "minItems": 1,
-            "type": [
-                "array"
-            ]
-        }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM cluster remote-cluster template",
+  "type": "object",
+  "properties": {
+    "clusterAnnotations": {
+      "description": "Annotations to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
     },
-    "type": "object"
+    "clusterIdentity": {
+      "description": "The SSH key secret reference, auto-populated",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The SSH key secret name, auto-populated",
+          "type": "string"
+        }
+      }
+    },
+    "clusterLabels": {
+      "description": "Labels to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "clusterNetwork": {
+      "description": "The cluster network configuration",
+      "type": "object",
+      "properties": {
+        "pods": {
+          "description": "The network ranges from which Pod networks are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "services": {
+          "description": "The network ranges from which service VIPs are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "controlPlaneNumber": {
+      "description": "The number of the control plane pods",
+      "type": "number",
+      "minimum": 1
+    },
+    "k0s": {
+      "description": "K0s parameters",
+      "type": "object",
+      "properties": {
+        "api": {
+          "description": "Kubernetes API server parameters",
+          "type": "object",
+          "properties": {
+            "extraArgs": {
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "extensions": {
+          "description": "K0s extensions configuration",
+          "type": "object",
+          "properties": {
+            "helm": {
+              "description": "K0s helm repositories and charts configuration",
+              "type": "object",
+              "properties": {
+                "charts": {
+                  "description": "The list of helm charts to deploy during cluster bootstrap",
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                },
+                "repositories": {
+                  "description": "The list of Helm repositories for deploying charts during cluster bootstrap",
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "network": {
+          "description": "K0s network configuration",
+          "type": "object"
+        },
+        "version": {
+          "description": "K0s version",
+          "type": "string"
+        }
+      }
+    },
+    "k0smotron": {
+      "description": "K0smotron parameters",
+      "type": "object",
+      "properties": {
+        "controllerPlaneFlags": {
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "persistence": {
+          "description": "The persistence configuration",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "The persistence type",
+              "default": "EmptyDir",
+              "type": "string"
+            }
+          }
+        },
+        "service": {
+          "description": "The API service configuration",
+          "type": "object",
+          "properties": {
+            "apiPort": {
+              "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
+            },
+            "konnectivityPort": {
+              "description": "The konnectivity port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
+            },
+            "type": {
+              "description": "An ingress methods for a service",
+              "default": "ClusterIP",
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "machines": {
+      "description": "The list of remote machines configurations",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "address"
+        ],
+        "properties": {
+          "address": {
+            "description": "The IP address of the remote machine",
+            "type": "string",
+            "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$"
+          },
+          "k0s": {
+            "description": "k0s worker configuration options",
+            "type": "object",
+            "properties": {
+              "args": {
+                "description": "Extra arguments to be passed to k0s worker, see: https://docs.k0sproject.io/stable/worker-node-config/",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "port": {
+            "description": "The SSH port of the remote machine",
+            "default": 22,
+            "type": "number",
+            "maximum": 65535,
+            "minimum": 1
+          },
+          "provisionJob": {
+            "description": "The kubernetes Job to use to provision the machine",
+            "type": "object",
+            "properties": {
+              "jobSpecTemplate": {
+                "description": "The job template to use to provision the machine, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplate",
+                "type": "object",
+                "properties": {
+                  "metadata": {
+                    "description": "Standard object's metadata of the jobs created from this template, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatemetadata",
+                    "type": "object"
+                  },
+                  "spec": {
+                    "description": "Specification of the desired behavior of the job, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatespec",
+                    "type": "object"
+                  }
+                }
+              },
+              "scpCommand": {
+                "description": "The scp command",
+                "default": "scp",
+                "type": "string"
+              },
+              "sshCommand": {
+                "description": "The ssh command",
+                "default": "ssh",
+                "type": "string"
+              }
+            }
+          },
+          "useSudo": {
+            "description": "Determines whether to use sudo for k0s cluster bootstrap commands",
+            "default": false,
+            "type": "boolean"
+          },
+          "user": {
+            "description": "The user to use when connecting to the remote machine",
+            "default": "root",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
 }

--- a/templates/cluster/remote-cluster/values.yaml
+++ b/templates/cluster/remote-cluster/values.yaml
@@ -17,7 +17,7 @@ clusterNetwork: # @schema description: The cluster network configuration; type: 
 
 
 # Machines' parameters
-machines: # @schema description: The list of remote machines configurations; type: array; type.items: object; minItems: 1
+machines: # @schema description: The list of remote machines configurations; type: array; item: object; minItems: 1
   - address: "0.0.0.0" # @schema description: The IP address of the remote machine; type: string; pattern:^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$; required: true
     port: 22 # @schema description: The SSH port of the remote machine; type: number; minimum: 1; maximum: 65535; default: 22
     user: "root" # @schema description: The user to use when connecting to the remote machine; type: string; default: root
@@ -33,7 +33,7 @@ machines: # @schema description: The list of remote machines configurations; typ
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; items.type: string
+  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string
   persistence: # @schema description: The persistence configuration; type: object
     type: EmptyDir # @schema description: The persistence type; type: string; default: EmptyDir
   service: # @schema description: The API service configuration; type: object
@@ -44,7 +44,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
   version: v1.32.5+k0s.1 # @schema description: K0s version; type: string
-  api: # @schema description: Kubernetes API server parameters; type: object; additionalProperties: object
+  api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: {} # @schema description: K0s network configuration; type: object
   extensions: # @schema description: K0s extensions configuration; type: object

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -1,30 +1,21 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a k0s cluster on VSphere with bootstrapped control plane nodes.",
+  "description": "A KCM cluster vsphere-hosted-cp template",
   "type": "object",
-  "required": [
-    "controlPlaneNumber",
-    "workersNumber",
-    "vsphere",
-    "controlPlaneEndpointIP",
-    "clusterIdentity",
-    "ssh",
-    "rootVolumeSize",
-    "cpus",
-    "memory",
-    "vmTemplate",
-    "network"
-  ],
   "properties": {
-    "controlPlaneNumber": {
-      "description": "The number of the control plane machines",
-      "type": "number",
-      "minimum": 1
+    "clusterAnnotations": {
+      "type": "object"
     },
-    "workersNumber": {
-      "description": "The number of the worker machines",
-      "type": "number",
-      "minimum": 1
+    "clusterIdentity": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "clusterLabels": {
+      "type": "object"
     },
     "clusterNetwork": {
       "type": "object",
@@ -36,9 +27,7 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
+              }
             }
           }
         },
@@ -49,130 +38,104 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
+              }
             }
           }
         }
       }
     },
-    "clusterLabels": {
-      "type": "object",
-      "description": "Labels to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
+    "controlPlaneEndpointIP": {
+      "type": "string"
     },
-    "clusterAnnotations": {
-      "type": "object",
-      "description": "Annotations to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
+    "controlPlaneNumber": {
+      "type": "integer"
     },
-    "clusterIdentity": {
+    "cpus": {
+      "type": "integer"
+    },
+    "k0s": {
       "type": "object",
-      "description": "VSphereClusterIdentity object reference",
-      "required": [
-        "name"
-      ],
       "properties": {
-        "name": {
-	  "description": "VSphereClusterIdentity object name",
+        "api": {
+          "type": "object",
+          "properties": {
+            "extraArgs": {
+              "type": "object"
+            }
+          }
+        },
+        "version": {
           "type": "string"
         }
       }
     },
+    "k0smotron": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "type": "object",
+          "properties": {
+            "apiPort": {
+              "type": "integer"
+            },
+            "konnectivityPort": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "memory": {
+      "type": "integer"
+    },
+    "network": {
+      "type": "string"
+    },
+    "rootVolumeSize": {
+      "type": "integer"
+    },
+    "ssh": {
+      "type": "object",
+      "properties": {
+        "publicKey": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        }
+      }
+    },
+    "vmTemplate": {
+      "type": "string"
+    },
     "vsphere": {
       "type": "object",
-      "description": "Data about vSphere instance where cluster will be deployed.",
-      "required": [
-        "server",
-        "thumbprint",
-        "datacenter",
-        "datastore",
-        "resourcePool",
-        "folder"
-      ],
       "properties": {
-        "server": {
-          "type": "string"
-        },
-        "thumbprint": {
-          "type": "string"
-        },
         "datacenter": {
           "type": "string"
         },
         "datastore": {
           "type": "string"
         },
+        "folder": {
+          "type": "string"
+        },
         "resourcePool": {
           "type": "string"
         },
-        "folder": {
-          "type": "string"
-        }
-      }
-    },
-    "controlPlaneEndpointIP": {
-      "description": "Virtual IP address which will be used for K8s API endpoint",
-      "type": "string"
-    },
-    "ssh": {
-      "type": "object",
-      "required": [
-	"user",
-	"publicKey"
-      ],
-      "properties": {
-	"user": {
-	  "type": "string"
-	},
-	"publicKey": {
-	  "type": "string"
-	}
-      }
-    },
-    "rootVolumeSize": {
-      "type": "integer"
-    },
-    "cpus": {
-      "type": "integer"
-    },
-    "memory": {
-      "type": "integer"
-    },
-    "vmTemplate": {
-      "type": "string"
-    },
-    "network": {
-      "type": "string"
-    },
-    "k0s": {
-      "description": "K0s parameters",
-      "type": "object",
-      "required": [
-        "version"
-      ],
-      "properties": {
-        "version":{
-          "description": "K0s version to use",
+        "server": {
           "type": "string"
         },
-        "api": {
-          "description": "Kubernetes api-server parameters",
-          "type": "object",
-          "properties": {
-            "extraArgs": {
-              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          }
+        "thumbprint": {
+          "type": "string"
         }
       }
+    },
+    "workersNumber": {
+      "type": "integer"
     }
   }
 }

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/values.schema.json
+++ b/templates/cluster/vsphere-standalone-cp/values.schema.json
@@ -81,25 +81,6 @@
     "controlPlaneNumber": {
       "type": "integer"
     },
-    "ipPool": {
-      "type": "object",
-      "properties": {
-        "data": {
-          "type": "object",
-          "properties": {
-            "apiGroup": {
-              "type": "string"
-            },
-            "kind": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
     "ipamEnabled": {
       "type": "boolean"
     },
@@ -118,6 +99,9 @@
           "type": "string"
         }
       }
+    },
+    "nameservers": {
+      "type": "array"
     },
     "vsphere": {
       "type": "object",
@@ -142,15 +126,7 @@
         }
       }
     },
-    "controlPlaneEndpointIP": {
-      "description": "Virtual IP address which will be used for K8s API endpoint",
-      "type": "string"
-    },
-    "nameservers": {
-      "description": "Nameservers to be used for DNS resolution",
-      "type": "array"
-    },
-    "controlPlane": {
+    "worker": {
       "type": "object",
       "properties": {
         "cpus": {

--- a/templates/cluster/vsphere-standalone-cp/values.schema.json
+++ b/templates/cluster/vsphere-standalone-cp/values.schema.json
@@ -1,24 +1,21 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A KCM template to deploy a k0s cluster on VSphere with bootstrapped control plane nodes.",
+  "description": "A KCM cluster vsphere-standalone-cp template",
   "type": "object",
-  "required": [
-    "controlPlaneNumber",
-    "workersNumber",
-    "vsphere",
-    "controlPlaneEndpointIP",
-    "clusterIdentity"
-  ],
   "properties": {
-    "controlPlaneNumber": {
-      "description": "The number of the control plane machines",
-      "type": "number",
-      "minimum": 1
+    "clusterAnnotations": {
+      "type": "object"
     },
-    "workersNumber": {
-      "description": "The number of the worker machines",
-      "type": "number",
-      "minimum": 1
+    "clusterIdentity": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "clusterLabels": {
+      "type": "object"
     },
     "clusterNetwork": {
       "type": "object",
@@ -30,9 +27,7 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
+              }
             }
           }
         },
@@ -43,67 +38,106 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
+              }
             }
           }
         }
       }
     },
-    "clusterLabels": {
+    "controlPlane": {
       "type": "object",
-      "description": "Labels to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },
-    "clusterAnnotations": {
-      "type": "object",
-      "description": "Annotations to apply to the cluster",
-      "required": [],
-      "additionalProperties": true
-    },
-    "clusterIdentity": {
-      "type": "object",
-      "description": "VSphereClusterIdentity object reference",
-      "required": [
-        "name"
-      ],
       "properties": {
-        "name": {
-	  "description": "VSphereClusterIdentity object name",
+        "cpus": {
+          "type": "integer"
+        },
+        "memory": {
+          "type": "integer"
+        },
+        "network": {
+          "type": "string"
+        },
+        "rootVolumeSize": {
+          "type": "integer"
+        },
+        "ssh": {
+          "type": "object",
+          "properties": {
+            "publicKey": {
+              "type": "string"
+            },
+            "user": {
+              "type": "string"
+            }
+          }
+        },
+        "vmTemplate": {
+          "type": "string"
+        }
+      }
+    },
+    "controlPlaneEndpointIP": {
+      "type": "string"
+    },
+    "controlPlaneNumber": {
+      "type": "integer"
+    },
+    "ipPool": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "apiGroup": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "ipamEnabled": {
+      "type": "boolean"
+    },
+    "k0s": {
+      "type": "object",
+      "properties": {
+        "api": {
+          "type": "object",
+          "properties": {
+            "extraArgs": {
+              "type": "object"
+            }
+          }
+        },
+        "version": {
           "type": "string"
         }
       }
     },
     "vsphere": {
       "type": "object",
-      "description": "Data about vSphere instance where cluster will be deployed.",
-      "required": [
-        "server",
-        "thumbprint",
-        "datacenter",
-        "datastore",
-        "resourcePool",
-        "folder"
-      ],
       "properties": {
-        "server": {
-          "type": "string"
-        },
-        "thumbprint": {
-          "type": "string"
-        },
         "datacenter": {
           "type": "string"
         },
         "datastore": {
           "type": "string"
         },
+        "folder": {
+          "type": "string"
+        },
         "resourcePool": {
           "type": "string"
         },
-        "folder": {
+        "server": {
+          "type": "string"
+        },
+        "thumbprint": {
           "type": "string"
         }
       }
@@ -118,117 +152,37 @@
     },
     "controlPlane": {
       "type": "object",
-      "description": "The configuration of the control plane machines",
-      "required": [
-        "ssh",
-        "rootVolumeSize",
-        "cpus",
-        "memory",
-        "vmTemplate",
-        "network"
-      ],
       "properties": {
-        "ssh": {
-          "type": "object",
-          "required": [
-            "user",
-            "publicKey"
-          ],
-          "properties": {
-            "user": {
-              "type": "string"
-            },
-            "publicKey": {
-              "type": "string"
-            }
-          }
-        },
-        "rootVolumeSize": {
-          "type": "integer"
-        },
         "cpus": {
           "type": "integer"
         },
         "memory": {
           "type": "integer"
         },
-        "vmTemplate": {
-          "type": "string"
-        },
         "network": {
           "type": "string"
-        }
-      }
-    },
-    "worker": {
-      "type": "object",
-      "description": "The configuration of the worker machines",
-      "required": [
-        "ssh",
-        "rootVolumeSize",
-        "cpus",
-        "memory",
-        "vmTemplate",
-        "network"
-      ],
-      "properties": {
-        "ssh": {
-          "type": "object",
-          "required": [
-            "user",
-            "publicKey"
-          ],
-          "properties": {
-            "user": {
-              "type": "string"
-            },
-            "publicKey": {
-              "type": "string"
-            }
-          }
         },
         "rootVolumeSize": {
           "type": "integer"
         },
-        "cpus": {
-          "type": "integer"
-        },
-        "memory": {
-          "type": "integer"
+        "ssh": {
+          "type": "object",
+          "properties": {
+            "publicKey": {
+              "type": "string"
+            },
+            "user": {
+              "type": "string"
+            }
+          }
         },
         "vmTemplate": {
-          "type": "string"
-        },
-        "network": {
           "type": "string"
         }
       }
     },
-    "k0s": {
-      "description": "K0s parameters",
-      "type": "object",
-      "required": [
-        "version"
-      ],
-      "properties": {
-        "version":{
-          "description": "K0s version to use",
-          "type": "string"
-        },
-        "api": {
-          "description": "Kubernetes api-server parameters",
-          "type": "object",
-          "properties": {
-            "extraArgs": {
-              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      }
+    "workersNumber": {
+      "type": "integer"
     }
   }
 }

--- a/templates/provider/cluster-api-provider-aws/Chart.yaml
+++ b/templates/provider/cluster-api-provider-aws/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-aws/values.schema.json
+++ b/templates/provider/cluster-api-provider-aws/values.schema.json
@@ -1,7 +1,16 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM provider cluster-api-provider-aws template",
   "type": "object",
   "properties": {
+    "config": {
+      "type": "object",
+      "properties": {
+        "AWS_B64ENCODED_CREDENTIALS": {
+          "type": "string"
+        }
+      }
+    },
     "configSecret": {
       "type": "object",
       "properties": {
@@ -16,11 +25,8 @@
         }
       }
     },
-    "config": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
+    "manager": {
+      "type": "object"
     }
   }
 }

--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-azure/values.schema.json
+++ b/templates/provider/cluster-api-provider-azure/values.schema.json
@@ -1,7 +1,11 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM provider cluster-api-provider-azure template",
   "type": "object",
   "properties": {
+    "config": {
+      "type": "object"
+    },
     "configSecret": {
       "type": "object",
       "properties": {
@@ -16,11 +20,8 @@
         }
       }
     },
-    "config": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
+    "manager": {
+      "type": "object"
     }
   }
 }

--- a/templates/provider/cluster-api-provider-docker/Chart.yaml
+++ b/templates/provider/cluster-api-provider-docker/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-docker/values.schema.json
+++ b/templates/provider/cluster-api-provider-docker/values.schema.json
@@ -1,38 +1,27 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Schema for configuration secret settings used in the OpenStack deployment.",
+  "description": "A KCM provider cluster-api-provider-docker template",
   "type": "object",
-  "required": [
-    "configSecret"
-  ],
   "properties": {
+    "config": {
+      "type": "object"
+    },
     "configSecret": {
       "type": "object",
-      "description": "Settings for the OpenStack configuration secret.",
-      "required": [
-        "create",
-        "name"
-      ],
       "properties": {
         "create": {
-          "type": "boolean",
-          "description": "Indicates whether a new secret should be created."
+          "type": "boolean"
         },
         "name": {
-          "type": "string",
-          "description": "The name of the OpenStack configuration secret."
+          "type": "string"
         },
         "namespace": {
-          "type": "string",
-          "description": "The namespace where the OpenStack configuration secret will be created or referenced."
+          "type": "string"
         }
       }
     },
-    "config": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
+    "manager": {
+      "type": "object"
     }
   }
 }

--- a/templates/provider/cluster-api-provider-gcp/Chart.yaml
+++ b/templates/provider/cluster-api-provider-gcp/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-gcp/values.schema.json
+++ b/templates/provider/cluster-api-provider-gcp/values.schema.json
@@ -1,7 +1,16 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM provider cluster-api-provider-gcp template",
   "type": "object",
   "properties": {
+    "config": {
+      "type": "object",
+      "properties": {
+        "GCP_B64ENCODED_CREDENTIALS": {
+          "type": "string"
+        }
+      }
+    },
     "configSecret": {
       "type": "object",
       "properties": {
@@ -16,11 +25,8 @@
         }
       }
     },
-    "config": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
+    "manager": {
+      "type": "object"
     }
   }
 }

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/values.schema.json
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/values.schema.json
@@ -1,7 +1,11 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM provider cluster-api-provider-k0sproject-k0smotron template",
   "type": "object",
   "properties": {
+    "config": {
+      "type": "object"
+    },
     "configSecret": {
       "type": "object",
       "properties": {
@@ -14,12 +18,6 @@
         "namespace": {
           "type": "string"
         }
-      }
-    },
-    "config": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
       }
     }
   }

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/values.schema.json
+++ b/templates/provider/cluster-api-provider-openstack/values.schema.json
@@ -1,38 +1,27 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Schema for configuration secret settings used in the OpenStack deployment.",
+  "description": "A KCM provider cluster-api-provider-openstack template",
   "type": "object",
-  "required": [
-    "configSecret"
-  ],
   "properties": {
+    "config": {
+      "type": "object"
+    },
     "configSecret": {
       "type": "object",
-      "description": "Settings for the OpenStack configuration secret.",
-      "required": [
-        "create",
-        "name"
-      ],
       "properties": {
         "create": {
-          "type": "boolean",
-          "description": "Indicates whether a new secret should be created."
+          "type": "boolean"
         },
         "name": {
-          "type": "string",
-          "description": "The name of the OpenStack configuration secret."
+          "type": "string"
         },
         "namespace": {
-          "type": "string",
-          "description": "The namespace where the OpenStack configuration secret will be created or referenced."
+          "type": "string"
         }
       }
     },
-    "config": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
+    "manager": {
+      "type": "object"
     }
   }
 }

--- a/templates/provider/cluster-api-provider-vsphere/Chart.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-vsphere/values.schema.json
+++ b/templates/provider/cluster-api-provider-vsphere/values.schema.json
@@ -1,7 +1,61 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM provider cluster-api-provider-vsphere template",
   "type": "object",
   "properties": {
+    "config": {
+      "type": "object",
+      "properties": {
+        "CONTROL_PLANE_ENDPOINT_IP": {
+          "type": "string"
+        },
+        "CPI_IMAGE_K8S_VERSION": {
+          "type": "string"
+        },
+        "EXP_CLUSTER_RESOURCE_SET": {
+          "type": "string"
+        },
+        "KUBERNETES_VERSION": {
+          "type": "string"
+        },
+        "VSPHERE_DATACENTER": {
+          "type": "string"
+        },
+        "VSPHERE_DATASTORE": {
+          "type": "string"
+        },
+        "VSPHERE_FOLDER": {
+          "type": "string"
+        },
+        "VSPHERE_NETWORK": {
+          "type": "string"
+        },
+        "VSPHERE_PASSWORD": {
+          "type": "string"
+        },
+        "VSPHERE_RESOURCE_POOL": {
+          "type": "string"
+        },
+        "VSPHERE_SERVER": {
+          "type": "string"
+        },
+        "VSPHERE_SSH_AUTHORIZED_KEY": {
+          "type": "string"
+        },
+        "VSPHERE_STORAGE_POLICY": {
+          "type": "string"
+        },
+        "VSPHERE_TEMPLATE": {
+          "type": "string"
+        },
+        "VSPHERE_TLS_THUMBPRINT": {
+          "type": "string"
+        },
+        "VSPHERE_USERNAME": {
+          "type": "string"
+        }
+      }
+    },
     "configSecret": {
       "type": "object",
       "properties": {
@@ -16,11 +70,8 @@
         }
       }
     },
-    "config": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
+    "manager": {
+      "type": "object"
     }
   }
 }

--- a/templates/provider/cluster-api/Chart.yaml
+++ b/templates/provider/cluster-api/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api/values.schema.json
+++ b/templates/provider/cluster-api/values.schema.json
@@ -1,7 +1,11 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM provider cluster-api template",
   "type": "object",
   "properties": {
+    "config": {
+      "type": "object"
+    },
     "configSecret": {
       "type": "object",
       "properties": {
@@ -16,11 +20,8 @@
         }
       }
     },
-    "config": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "string"
-      }
+    "manager": {
+      "type": "object"
     }
   }
 }

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -7,12 +7,12 @@ metadata:
 spec:
   version: 1.0.0
   kcm:
-    template: kcm-1-0-3
+    template: kcm-1-0-4
   capi:
-    template: cluster-api-1-0-3
+    template: cluster-api-1-0-4
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
-      template: cluster-api-provider-k0sproject-k0smotron-1-0-3
+      template: cluster-api-provider-k0sproject-k0smotron-1-0-4
     - name: cluster-api-provider-azure
       template: cluster-api-provider-azure-1-0-3
     - name: cluster-api-provider-vsphere

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -14,17 +14,17 @@ spec:
     - name: cluster-api-provider-k0sproject-k0smotron
       template: cluster-api-provider-k0sproject-k0smotron-1-0-3
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-1-0-2
+      template: cluster-api-provider-azure-1-0-3
     - name: cluster-api-provider-vsphere
-      template: cluster-api-provider-vsphere-1-0-1
+      template: cluster-api-provider-vsphere-1-0-2
     - name: cluster-api-provider-aws
-      template: cluster-api-provider-aws-1-0-2
+      template: cluster-api-provider-aws-1-0-3
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-1-0-2
+      template: cluster-api-provider-openstack-1-0-3
     - name: cluster-api-provider-docker
-      template: cluster-api-provider-docker-1-0-1
+      template: cluster-api-provider-docker-1-0-2
     - name: cluster-api-provider-gcp
-      template: cluster-api-provider-gcp-1-0-2
+      template: cluster-api-provider-gcp-1-0-3
     - name: cluster-api-provider-ipam
       template: cluster-api-provider-ipam-1-0-2
     - name: cluster-api-provider-infoblox

--- a/templates/provider/kcm-templates/files/templates/adopted-cluster-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/adopted-cluster-1-0-1.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-gke-1-0-1
+  name: adopted-cluster-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-gke
+      chart: adopted-cluster
       version: 1.0.1
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/aws-eks-1-0-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-1-0-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-aks-1-0-0
+  name: aws-eks-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-aks
-      version: 1.0.0
+      chart: aws-eks
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-5
+  name: aws-hosted-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.5
+      chart: aws-hosted-cp
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-7.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-7.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-6
+  name: aws-standalone-cp-1-0-7
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: aws-standalone-cp
-      version: 1.0.6
+      version: 1.0.7
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-aks-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-aks-1-0-1.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-eks-1-0-1
+  name: azure-aks-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-eks
+      chart: azure-aks
       version: 1.0.1
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-5.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-5.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-5
+  name: azure-hosted-cp-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
+      chart: azure-hosted-cp
       version: 1.0.5
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-5.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-5.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-4
+  name: azure-standalone-cp-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.4
+      chart: azure-standalone-cp
+      version: 1.0.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-aws-1-0-2
+  name: cluster-api-provider-aws-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-aws
-      version: 1.0.2
+      version: 1.0.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-1-0-2
+  name: cluster-api-provider-azure-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-azure
-      version: 1.0.2
+      version: 1.0.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-docker-1-0-1
+  name: cluster-api-provider-docker-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-docker
-      version: 1.0.1
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-gcp-1-0-2
+  name: cluster-api-provider-gcp-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-gcp
-      version: 1.0.2
+      version: 1.0.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-k0sproject-k0smotron-1-0-3
+  name: cluster-api-provider-k0sproject-k0smotron-1-0-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-k0sproject-k0smotron
-      version: 1.0.3
+      version: 1.0.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-1-0-2
+  name: cluster-api-provider-openstack-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 1.0.2
+      version: 1.0.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-vsphere-1-0-1
+  name: cluster-api-provider-vsphere-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-vsphere
-      version: 1.0.1
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-1-0-3
+  name: cluster-api-1-0-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api
-      version: 1.0.3
+      version: 1.0.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: docker-hosted-cp-1-0-0
+  name: docker-hosted-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: docker-hosted-cp
-      version: 1.0.0
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: adopted-cluster-1-0-0
+  name: gcp-gke-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: adopted-cluster
-      version: 1.0.0
+      chart: gcp-gke
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-4
+  name: gcp-hosted-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.4
+      chart: gcp-hosted-cp
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-5
+  name: gcp-standalone-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.5
+      chart: gcp-standalone-cp
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-1-0-3
+  name: kcm-1-0-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 1.0.3
+      version: 1.0.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-4
+  name: openstack-standalone-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.4
+      chart: openstack-standalone-cp
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-5.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-5.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-4
+  name: remote-cluster-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.4
+      chart: remote-cluster
+      version: 1.0.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-5.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-5.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-4
+  name: vsphere-hosted-cp-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.4
+      chart: vsphere-hosted-cp
+      version: 1.0.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-5.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-5.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-5
+  name: vsphere-standalone-cp-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
+      chart: vsphere-standalone-cp
       version: 1.0.5
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/values.schema.json
+++ b/templates/provider/kcm-templates/values.schema.json
@@ -1,4 +1,10 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "type": "object"
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM provider kcm-templates template",
+  "type": "object",
+  "properties": {
+    "createRelease": {
+      "type": "boolean"
+    }
+  }
 }

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 dependencies:
   - name: flux2
     version: 2.16.0

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Helm Chart to deploy KCM manager controller and its related components",
+  "description": "A KCM provider kcm template",
+  "type": "object",
   "properties": {
     "admissionWebhook": {
+      "type": "object",
       "properties": {
         "certDir": {
           "type": "string"
@@ -10,12 +12,13 @@
         "port": {
           "type": "integer"
         }
-      },
-      "type": "object"
+      }
     },
     "cert-manager": {
+      "type": "object",
       "properties": {
         "crds": {
+          "type": "object",
           "properties": {
             "enabled": {
               "type": "boolean"
@@ -23,25 +26,27 @@
             "keep": {
               "type": "boolean"
             }
-          },
-          "type": "object"
+          }
         },
         "enabled": {
           "type": "boolean"
         }
-      },
-      "type": "object"
+      }
     },
     "cluster-api-operator": {
+      "type": "object",
       "properties": {
         "enabled": {
           "type": "boolean"
         },
         "resources": {
+          "type": "object",
           "properties": {
             "manager": {
+              "type": "object",
               "properties": {
                 "limits": {
+                  "type": "object",
                   "properties": {
                     "cpu": {
                       "type": "string"
@@ -49,10 +54,10 @@
                     "memory": {
                       "type": "string"
                     }
-                  },
-                  "type": "object"
+                  }
                 },
                 "requests": {
+                  "type": "object",
                   "properties": {
                     "cpu": {
                       "type": "string"
@@ -60,45 +65,39 @@
                     "memory": {
                       "type": "string"
                     }
-                  },
-                  "type": "object"
+                  }
                 }
-              },
-              "type": "object"
+              }
             }
-          },
-          "type": "object"
+          }
         }
-      },
-      "type": "object"
+      }
     },
     "containerSecurityContext": {
+      "type": "object",
       "properties": {
         "allowPrivilegeEscalation": {
           "type": "boolean"
         },
         "capabilities": {
+          "type": "object",
           "properties": {
             "drop": {
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
             }
-          },
-          "type": "object"
+          }
         }
-      },
-      "type": "object"
+      }
     },
     "controller": {
+      "type": "object",
       "properties": {
         "affinity": {
           "description": "Affinity rules for pod scheduling",
-          "properties": {},
-          "type": [
-            "object"
-          ]
+          "type": "object"
         },
         "createAccessManagement": {
           "type": "boolean"
@@ -113,23 +112,19 @@
           "type": "boolean"
         },
         "debug": {
+          "type": "object",
           "properties": {
             "pprofBindAddress": {
-              "description": "The TCP address that the controller should bind to for serving pprof, '0' or empty value disables pprof",
-              "pattern": "(?:^0?$)|(?:^(?:[\\w.-]+(?:\\.?[\\w\\.-]+)+)?:(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$)",
               "title": "Set pprof binding address",
-              "type": [
-                "string"
-              ]
+              "description": "The TCP address that the controller should bind to for serving pprof, '0' or empty value disables pprof",
+              "type": "string",
+              "pattern": "(?:^0?$)|(?:^(?:[\\w.-]+(?:\\.?[\\w\\.-]+)+)?:(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$)"
             }
-          },
-          "type": "object"
+          }
         },
         "enableSveltosExpiredCtrl": {
           "description": "Enables SveltosCluster controller, updating stuck (expired) sveltos management cluster kubeconfig tokens",
-          "type": [
-            "boolean"
-          ]
+          "type": "boolean"
         },
         "enableTelemetry": {
           "type": "boolean"
@@ -145,52 +140,45 @@
         },
         "k0sURLCertSecret": {
           "description": "Name of a Secret containing K0s Download URL Root CA with ca.crt key",
-          "type": [
-            "string"
-          ]
+          "type": "string"
         },
         "logger": {
+          "title": "Logger Settings",
           "description": "Global controllers logger settings",
+          "type": "object",
           "properties": {
             "devel": {
               "description": "Development defaults(encoder=console,logLevel=debug,stackTraceLevel=warn) Production defaults(encoder=json,logLevel=info,stackTraceLevel=error)",
-              "type": [
-                "boolean"
-              ]
+              "type": "boolean"
             },
             "encoder": {
+              "type": "string",
               "enum": [
                 "json",
                 "console",
                 ""
-              ],
-              "type": [
-                "string"
               ]
             },
             "log-level": {
+              "type": "string",
               "enum": [
                 "info",
                 "debug",
                 "error",
                 ""
-              ],
-              "type": [
-                "string"
               ]
             },
             "stacktrace-level": {
+              "type": "string",
               "enum": [
                 "info",
                 "error",
                 "panic",
                 ""
-              ],
-              "type": [
-                "string"
               ]
             },
             "time-encoding": {
+              "type": "string",
               "enum": [
                 "epoch",
                 "millis",
@@ -199,138 +187,120 @@
                 "rfc3339",
                 "rfc3339nano",
                 ""
-              ],
-              "type": [
-                "string"
               ]
             }
-          },
-          "title": "Logger Settings",
-          "type": [
-            "object"
-          ]
+          }
         },
         "nodeSelector": {
           "description": "Node selector to constrain the pod to run on specific nodes",
-          "properties": {},
-          "type": [
-            "object"
-          ]
+          "type": "object"
         },
         "registryCertSecret": {
           "description": "Name of a Secret containing Registry Root CA with ca.crt key",
-          "type": [
-            "string"
-          ]
+          "type": "string"
         },
         "registryCredsSecret": {
           "description": "Name of a Secret containing Registry Credentials (Auth) Data",
-          "type": [
-            "string"
-          ]
+          "type": "string"
         },
         "templatesRepoURL": {
           "type": "string"
         },
         "tolerations": {
           "description": "Tolerations to allow the pod to schedule on tainted nodes",
-          "type": [
-            "array"
-          ]
+          "type": "array"
         },
         "validateClusterUpgradePath": {
           "description": "Specifies whether the ClusterDeployment upgrade path should be validated",
-          "type": [
-            "boolean"
-          ]
+          "type": "boolean"
         }
-      },
-      "type": "object"
+      }
     },
     "flux2": {
+      "type": "object",
       "properties": {
         "enabled": {
           "type": "boolean"
         },
         "helmController": {
+          "type": "object",
           "properties": {
             "container": {
+              "type": "object",
               "properties": {
                 "additionalArgs": {
+                  "type": "array",
                   "items": {
                     "type": "string"
-                  },
-                  "type": "array"
+                  }
                 }
-              },
-              "type": "object"
+              }
             }
-          },
-          "type": "object"
+          }
         },
         "imageAutomationController": {
+          "type": "object",
           "properties": {
             "create": {
               "type": "boolean"
             }
-          },
-          "type": "object"
+          }
         },
         "imageReflectionController": {
+          "type": "object",
           "properties": {
             "create": {
               "type": "boolean"
             }
-          },
-          "type": "object"
+          }
         },
         "kustomizeController": {
+          "type": "object",
           "properties": {
             "create": {
               "type": "boolean"
             }
-          },
-          "type": "object"
+          }
         },
         "notificationController": {
+          "type": "object",
           "properties": {
             "create": {
               "type": "boolean"
             }
-          },
-          "type": "object"
+          }
         },
         "policies": {
+          "type": "object",
           "properties": {
             "create": {
               "type": "boolean"
             }
-          },
-          "type": "object"
+          }
         },
         "sourceController": {
+          "type": "object",
           "properties": {
             "container": {
+              "type": "object",
               "properties": {
                 "additionalArgs": {
+                  "type": "array",
                   "items": {
                     "type": "string"
-                  },
-                  "type": "array"
+                  }
                 }
-              },
-              "type": "object"
+              }
             }
-          },
-          "type": "object"
+          }
         }
-      },
-      "type": "object"
+      }
     },
     "fullnameOverride": {
       "type": "string"
     },
     "image": {
+      "type": "object",
       "properties": {
         "pullPolicy": {
           "type": "string"
@@ -341,16 +311,18 @@
         "tag": {
           "type": "string"
         }
-      },
-      "type": "object"
+      }
     },
     "kubernetesClusterDomain": {
       "type": "string"
     },
     "metricsService": {
+      "type": "object",
       "properties": {
         "ports": {
+          "type": "array",
           "items": {
+            "type": "object",
             "properties": {
               "name": {
                 "type": "string"
@@ -364,16 +336,13 @@
               "targetPort": {
                 "type": "integer"
               }
-            },
-            "type": "object"
-          },
-          "type": "array"
+            }
+          }
         },
         "type": {
           "type": "string"
         }
-      },
-      "type": "object"
+      }
     },
     "nameOverride": {
       "type": "string"
@@ -382,8 +351,10 @@
       "type": "integer"
     },
     "resources": {
+      "type": "object",
       "properties": {
         "limits": {
+          "type": "object",
           "properties": {
             "cpu": {
               "type": "string"
@@ -391,10 +362,10 @@
             "memory": {
               "type": "string"
             }
-          },
-          "type": "object"
+          }
         },
         "requests": {
+          "type": "object",
           "properties": {
             "cpu": {
               "type": "string"
@@ -402,22 +373,20 @@
             "memory": {
               "type": "string"
             }
-          },
-          "type": "object"
+          }
         }
-      },
-      "type": "object"
+      }
     },
     "serviceAccount": {
+      "type": "object",
       "properties": {
         "annotations": {
-          "properties": {},
           "type": "object"
         }
-      },
-      "type": "object"
+      }
     },
     "velero": {
+      "type": "object",
       "properties": {
         "backupsEnabled": {
           "type": "boolean"
@@ -426,12 +395,12 @@
           "type": "boolean"
         },
         "credentials": {
+          "type": "object",
           "properties": {
             "useSecret": {
               "type": "boolean"
             }
-          },
-          "type": "object"
+          }
         },
         "deployNodeAgent": {
           "type": "boolean"
@@ -440,12 +409,12 @@
           "type": "boolean"
         },
         "metrics": {
+          "type": "object",
           "properties": {
             "enabled": {
               "type": "boolean"
             }
-          },
-          "type": "object"
+          }
         },
         "snapshotsEnabled": {
           "type": "boolean"
@@ -453,9 +422,7 @@
         "upgradeCRDs": {
           "type": "boolean"
         }
-      },
-      "type": "object"
+      }
     }
-  },
-  "type": "object"
+  }
 }

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -1,7 +1,3 @@
-# Schema generation:
-# $ helm plugin install https://github.com/losisin/helm-values-schema-json.git
-# $ helm schema --draft 2020 --indent 2 --noAdditionalProperties=false --schemaRoot.description='Helm Chart to deploy KCM manager controller and its related components' --input ./templates/provider/kcm/values.yaml --output ./templates/provider/kcm/values.schema.json
-
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduce a fixed version of the `schema` plugin, migrate to `v2` of the plugin, and introduce auto-generation of JSON schema via the `generate-all` recipe.

Fixes schema errors in the following templates:
- aws-eks
- gcp-gke
- gcp-hosted-cp
- gcp-standalone-cp
- openstack-standalone-cp
- remote-cluster

Regenerate all of the related files.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #1674 
