### PR TITLE
feat(templates): k0s cp/worker flags

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-7
+  template: aws-standalone-cp-1-0-8
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-5
+  template: azure-standalone-cp-1-0-6
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/docker-clusterdeployment.yaml
+++ b/config/dev/docker-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: docker-hosted-cp-1-0-1
+  template: docker-hosted-cp-1-0-2
   credential: docker-stub-credential
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-6
+  template: gcp-standalone-cp-1-0-7
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-6
+  template: openstack-standalone-cp-1-0-7
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-5
+  template: remote-cluster-1-0-6
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-5
+  template: vsphere-standalone-cp-1-0-6
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -27,8 +27,11 @@ spec:
   {{- end }}
   {{- end }}
   controllerPlaneFlags:
-  - "--enable-cloud-provider=true"
-  - "--debug=true"
+    - --enable-cloud-provider=true
+    - --debug=true
+    {{- range $arg := .Values.k0smotron.controllerPlaneFlags }}
+    - {{ toYaml $arg }}
+    {{- end }}
   k0sConfig:
     apiVersion: k0s.k0sproject.io/v1beta1
     kind: ClusterConfig

--- a/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -29,3 +29,6 @@ spec:
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
+      {{- range $arg := .Values.k0s.workerArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}

--- a/templates/cluster/aws-hosted-cp/values.schema.json
+++ b/templates/cluster/aws-hosted-cp/values.schema.json
@@ -160,6 +160,14 @@
         "version": {
           "description": "K0s version",
           "type": "string"
+        },
+        "workerArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -167,6 +175,14 @@
       "description": "K0smotron parameters",
       "type": "object",
       "properties": {
+        "controllerPlaneFlags": {
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "service": {
           "description": "The API service configuration",
           "type": "object",

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -47,6 +47,7 @@ nonRootVolumes: [] # @schema title: Non-root storage volumes; description: Confi
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
+  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
@@ -55,5 +56,6 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
   version: v1.32.5+k0s.1 # @schema description: K0s version; type: string; required: true
+  workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -15,6 +15,9 @@ spec:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
       - --disable-components=konnectivity-server
+      {{- range $arg := .Values.k0s.cpArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}
     {{- $auth := .Values.k0s.auth }}
     {{- $files := .Values.k0s.files }}
     {{- if or (and $auth $auth.enabled) $files $global.registryCertSecret $global.k0sURLCertSecret }}

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -29,3 +29,6 @@ spec:
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
+      {{- range $arg := .Values.k0s.workerArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}

--- a/templates/cluster/aws-standalone-cp/values.schema.json
+++ b/templates/cluster/aws-standalone-cp/values.schema.json
@@ -185,6 +185,14 @@
             }
           }
         },
+        "cpArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "files": {
           "description": "Specifies extra files to be passed to user_data upon creation",
           "type": "array",
@@ -195,6 +203,14 @@
         "version": {
           "description": "K0s version",
           "type": "string"
+        },
+        "workerArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": true

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -56,6 +56,8 @@ worker: # @schema description: The configuration of the worker machines; type: o
 # # NOTE: .k0s additional properties are to support prior .k0s.auth implementation
 k0s: # @schema description: K0s parameters; type: object; additionalProperties: true
   version: v1.32.5+k0s.1 # @schema description: K0s version; type: string; required: true
+  cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
+  workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   files: [] # @schema description: Specifies extra files to be passed to user_data upon creation; type: array; item: object

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -26,8 +26,11 @@ spec:
   {{- end }}
   {{- end }}
   controllerPlaneFlags:
-  - "--enable-cloud-provider=true"
-  - "--debug=true"
+    - --enable-cloud-provider=true
+    - --debug=true
+    {{- range $arg := .Values.k0smotron.controllerPlaneFlags }}
+    - {{ toYaml $arg }}
+    {{- end }}
   k0sConfig:
     apiVersion: k0s.k0sproject.io/v1beta1
     kind: ClusterConfig

--- a/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -29,3 +29,6 @@ spec:
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
+      {{- range $arg := .Values.k0s.workerArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}

--- a/templates/cluster/azure-hosted-cp/values.schema.json
+++ b/templates/cluster/azure-hosted-cp/values.schema.json
@@ -89,35 +89,71 @@
       }
     },
     "k0s": {
+      "description": "K0s parameters",
       "type": "object",
       "properties": {
         "api": {
+          "description": "Kubernetes API server parameters",
           "type": "object",
           "properties": {
             "extraArgs": {
-              "type": "object"
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "type": "object",
+              "additionalProperties": true
             }
           }
         },
         "version": {
+          "description": "K0s version",
           "type": "string"
+        },
+        "workerArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
     "k0smotron": {
+      "description": "K0smotron parameters",
       "type": "object",
       "properties": {
+        "controllerPlaneFlags": {
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "service": {
+          "description": "The API service configuration",
           "type": "object",
           "properties": {
             "apiPort": {
-              "type": "integer"
+              "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
             },
             "konnectivityPort": {
-              "type": "integer"
+              "description": "The konnectivity port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
             },
             "type": {
-              "type": "string"
+              "description": "An ingress methods for a service",
+              "default": "LoadBalancer",
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
             }
           }
         }

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -42,14 +42,16 @@ image:
     version: "130.3.20240717"
 
 # K0smotron parameters
-k0smotron:
-  service:
-    type: LoadBalancer
-    apiPort: 6443
-    konnectivityPort: 8132
+k0smotron: # @schema description: K0smotron parameters; type: object
+  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  service: # @schema description: The API service configuration; type: object
+    type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
+    apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
+    konnectivityPort: 8132 # @schema description: The konnectivity port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
 
 # K0s parameters
-k0s:
-  version: v1.32.5+k0s.1
-  api:
-    extraArgs: {}
+k0s: # @schema description: K0s parameters; type: object
+  version: v1.32.5+k0s.1 # @schema description: K0s version; type: string
+  workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
+  api: # @schema description: Kubernetes API server parameters; type: object
+    extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -31,6 +31,9 @@ spec:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
       - --disable-components=konnectivity-server
+      {{- range $arg := .Values.k0s.cpArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: ClusterConfig

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -29,3 +29,6 @@ spec:
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
+      {{- range $arg := .Values.k0s.workerArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}

--- a/templates/cluster/azure-standalone-cp/values.schema.json
+++ b/templates/cluster/azure-standalone-cp/values.schema.json
@@ -103,18 +103,39 @@
       "type": "integer"
     },
     "k0s": {
+      "description": "K0s parameters",
       "type": "object",
       "properties": {
         "api": {
+          "description": "Kubernetes API server parameters",
           "type": "object",
           "properties": {
             "extraArgs": {
-              "type": "object"
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "type": "object",
+              "additionalProperties": true
             }
           }
         },
+        "cpArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "version": {
+          "description": "K0s version",
           "type": "string"
+        },
+        "workerArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/templates/cluster/azure-standalone-cp/values.yaml
+++ b/templates/cluster/azure-standalone-cp/values.yaml
@@ -47,7 +47,9 @@ worker:
       version: "130.3.20240717"
 
 # K0s parameters
-k0s:
-  version: v1.32.5+k0s.1
-  api:
-    extraArgs: {}
+k0s: # @schema description: K0s parameters; type: object
+  version: v1.32.5+k0s.1 # @schema description: K0s version; type: string
+  cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
+  workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
+  api: # @schema description: Kubernetes API server parameters; type: object
+    extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/docker-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/docker-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -10,4 +10,6 @@ spec:
   service:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-
+  {{- with .Values.k0smotron.controllerPlaneFlags }}
+  controllerPlaneFlags: {{ toYaml . | nindent 4 }}
+  {{- end }}

--- a/templates/cluster/docker-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/docker-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -6,3 +6,6 @@ spec:
   template:
     spec:
       version: {{ .Values.k0s.version }}
+      {{- with .Values.k0s.workerArgs }}
+      args: {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/templates/cluster/docker-hosted-cp/values.schema.json
+++ b/templates/cluster/docker-hosted-cp/values.schema.json
@@ -40,21 +40,48 @@
       }
     },
     "k0s": {
+      "description": "K0s parameters",
       "type": "object",
       "properties": {
         "version": {
+          "description": "K0s version",
           "type": "string"
+        },
+        "workerArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
     "k0smotron": {
+      "description": "K0smotron parameters",
       "type": "object",
       "properties": {
+        "controllerPlaneFlags": {
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "service": {
+          "description": "The API service configuration",
           "type": "object",
           "properties": {
             "type": {
-              "type": "string"
+              "description": "An ingress methods for a service",
+              "default": "NodePort",
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
             }
           }
         }

--- a/templates/cluster/docker-hosted-cp/values.yaml
+++ b/templates/cluster/docker-hosted-cp/values.yaml
@@ -13,10 +13,13 @@ clusterNetwork:
   serviceDomain: "cluster.local"
 
 # K0smotron parameters
-k0smotron:
-  service:
-    type: NodePort
+k0smotron: # @schema description: K0smotron parameters; type: object
+  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  service: # @schema description: The API service configuration; type: object
+    type: NodePort # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: NodePort
 
-k0s:
+# K0s parameters
+k0s: # @schema description: K0s parameters; type: object
   # NOTE: Update with caution – see: PR https://github.com/k0rdent/kcm/pull/1057#issuecomment-2668629616
-  version: v1.32.1+k0s.0
+  version: v1.32.1+k0s.0 # @schema description: K0s version; type: string
+  workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -26,8 +26,11 @@ spec:
   {{- end }}
   {{- end }}
   controllerPlaneFlags:
-  - "--enable-cloud-provider=true"
-  - "--debug=true"
+    - --enable-cloud-provider=true
+    - --debug=true
+    {{- range $arg := .Values.k0smotron.controllerPlaneFlags }}
+    - {{ toYaml $arg }}
+    {{- end }}
   k0sConfig:
     apiVersion: k0s.k0sproject.io/v1beta1
     kind: ClusterConfig

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -29,3 +29,6 @@ spec:
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
+      {{- range $arg := .Values.k0s.workerArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}

--- a/templates/cluster/gcp-hosted-cp/values.schema.json
+++ b/templates/cluster/gcp-hosted-cp/values.schema.json
@@ -98,6 +98,14 @@
         "version": {
           "description": "K0s version",
           "type": "string"
+        },
+        "workerArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -105,6 +113,14 @@
       "description": "K0smotron parameters",
       "type": "object",
       "properties": {
+        "controllerPlaneFlags": {
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "service": {
           "description": "The API service configuration",
           "type": "object",

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -46,6 +46,7 @@ worker: # @schema description: Worker parameters; type: object
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
+  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
@@ -54,5 +55,6 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
   version: v1.32.5+k0s.1 # @schema description: K0s version; type: string
+  workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -31,6 +31,9 @@ spec:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
       - --disable-components=konnectivity-server
+      {{- range $arg := .Values.k0s.cpArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: ClusterConfig

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -29,3 +29,6 @@ spec:
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
+      {{- range $arg := .Values.k0s.workerArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}

--- a/templates/cluster/gcp-standalone-cp/values.schema.json
+++ b/templates/cluster/gcp-standalone-cp/values.schema.json
@@ -185,9 +185,25 @@
             }
           }
         },
+        "cpArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "version": {
           "description": "K0s version",
           "type": "string"
+        },
+        "workerArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/templates/cluster/gcp-standalone-cp/values.yaml
+++ b/templates/cluster/gcp-standalone-cp/values.yaml
@@ -64,5 +64,7 @@ worker: # @schema description: Worker parameters; type: object
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
   version: v1.32.5+k0s.1 # @schema description: K0s version; type: string
+  cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
+  workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -31,6 +31,9 @@ spec:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
       - --disable-components=konnectivity-server
+      {{- range $arg := .Values.k0s.cpArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: ClusterConfig

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -25,7 +25,10 @@ spec:
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}
+      version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external"
-      version: {{ .Values.k0s.version }}
+      {{- range $arg := .Values.k0s.workerArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -298,9 +298,25 @@
             }
           }
         },
+        "cpArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "version": {
           "description": "K0s version",
           "type": "string"
+        },
+        "workerArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -86,6 +86,8 @@ worker: # @schema description: Configuration of the worker instances; type: obje
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
   version: v1.32.5+k0s.1 # @schema description: K0s version; type: string; required: true
+  cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
+  workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
 

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/values.schema.json
+++ b/templates/cluster/remote-cluster/values.schema.json
@@ -118,6 +118,7 @@
         "controllerPlaneFlags": {
           "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
+          "uniqueItems": true,
           "items": {
             "type": "string"
           }
@@ -183,8 +184,9 @@
             "type": "object",
             "properties": {
               "args": {
-                "description": "Extra arguments to be passed to k0s worker, see: https://docs.k0sproject.io/stable/worker-node-config/",
+                "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
                 "type": "array",
+                "uniqueItems": true,
                 "items": {
                   "type": "string"
                 }

--- a/templates/cluster/remote-cluster/values.yaml
+++ b/templates/cluster/remote-cluster/values.yaml
@@ -29,11 +29,11 @@ machines: # @schema description: The list of remote machines configurations; typ
         metadata: {} # @schema description: Standard object's metadata of the jobs created from this template, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatemetadata; type: object
         spec: {} # @schema description: Specification of the desired behavior of the job, see: https://docs.k0smotron.io/stable/resource-reference/#remotemachinespecprovisionjobjobspectemplatespec; type: object
     k0s: # @schema description: k0s worker configuration options; type: object
-      args: [] # @schema description: Extra arguments to be passed to k0s worker, see: https://docs.k0sproject.io/stable/worker-node-config/; type: array; item: string
+      args: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string
+  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   persistence: # @schema description: The persistence configuration; type: object
     type: EmptyDir # @schema description: The persistence type; type: string; default: EmptyDir
   service: # @schema description: The API service configuration; type: object

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -26,8 +26,11 @@ spec:
   {{- end }}
   {{- end }}
   controllerPlaneFlags:
-  - "--enable-cloud-provider=true"
-  - "--debug=true"
+    - --enable-cloud-provider=true
+    - --debug=true
+    {{- range $arg := .Values.k0smotron.controllerPlaneFlags }}
+    - {{ toYaml $arg }}
+    {{- end }}
   k0sConfig:
     apiVersion: k0s.k0sproject.io/v1beta1
     kind: ClusterConfig

--- a/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -32,4 +32,7 @@ spec:
         {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
         - "sudo update-ca-certificates"
         {{- end }}
+      {{- with .Values.k0s.workerArgs }}
+      args: {{ toYaml . | nindent 8 }}
+      {{- end }}
 

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -54,35 +54,71 @@
       "type": "integer"
     },
     "k0s": {
+      "description": "K0s parameters",
       "type": "object",
       "properties": {
         "api": {
+          "description": "Kubernetes API server parameters",
           "type": "object",
           "properties": {
             "extraArgs": {
-              "type": "object"
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "type": "object",
+              "additionalProperties": true
             }
           }
         },
         "version": {
+          "description": "K0s version",
           "type": "string"
+        },
+        "workerArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
     "k0smotron": {
+      "description": "K0smotron parameters",
       "type": "object",
       "properties": {
+        "controllerPlaneFlags": {
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "service": {
+          "description": "The API service configuration",
           "type": "object",
           "properties": {
             "apiPort": {
-              "type": "integer"
+              "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
             },
             "konnectivityPort": {
-              "type": "integer"
+              "description": "The konnectivity port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
             },
             "type": {
-              "type": "string"
+              "description": "An ingress methods for a service",
+              "default": "LoadBalancer",
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
             }
           }
         }

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -36,14 +36,16 @@ vmTemplate: ""
 network: ""
 
 # K0smotron parameters
-k0smotron:
-  service:
-    type: LoadBalancer
-    apiPort: 6443
-    konnectivityPort: 8132
+k0smotron: # @schema description: K0smotron parameters; type: object
+  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  service: # @schema description: The API service configuration; type: object
+    type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
+    apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
+    konnectivityPort: 8132 # @schema description: The konnectivity port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
 
 # K0s parameters
-k0s:
-  version: v1.32.5+k0s.1
-  api:
-    extraArgs: {}
+k0s: # @schema description: K0s parameters; type: object
+  version: v1.32.5+k0s.1 # @schema description: K0s version; type: string
+  workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
+  api: # @schema description: Kubernetes API server parameters; type: object
+    extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -36,6 +36,9 @@ spec:
     args:
       - --enable-worker
       - --disable-components=konnectivity-server
+      {{- range $arg := .Values.k0s.cpArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}
     k0s:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: ClusterConfig

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -10,6 +10,9 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-amd64"
       {{- end }}
       version: {{ .Values.k0s.version }}
+      {{- with .Values.k0s.workerArgs }}
+      args: {{ toYaml . | nindent 8 }}
+      {{- end }}
       files:
         - path: /home/{{ .Values.worker.ssh.user }}/.ssh/authorized_keys
           permissions: "0600"

--- a/templates/cluster/vsphere-standalone-cp/values.schema.json
+++ b/templates/cluster/vsphere-standalone-cp/values.schema.json
@@ -85,18 +85,39 @@
       "type": "boolean"
     },
     "k0s": {
+      "description": "K0s parameters",
       "type": "object",
       "properties": {
         "api": {
+          "description": "Kubernetes API server parameters",
           "type": "object",
           "properties": {
             "extraArgs": {
-              "type": "object"
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "type": "object",
+              "additionalProperties": true
             }
           }
         },
+        "cpArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "version": {
+          "description": "K0s version",
           "type": "string"
+        },
+        "workerArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/templates/cluster/vsphere-standalone-cp/values.yaml
+++ b/templates/cluster/vsphere-standalone-cp/values.yaml
@@ -50,7 +50,10 @@ worker:
   network: ""
 
 # K0s parameters
-k0s:
-  version: v1.32.5+k0s.1
-  api:
-    extraArgs: {}
+k0s: # @schema description: K0s parameters; type: object
+  version: v1.32.5+k0s.1 # @schema description: K0s version; type: string
+  cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
+  workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
+  api: # @schema description: Kubernetes API server parameters; type: object
+    extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-7.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-7.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-6
+  name: aws-hosted-cp-1-0-7
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.6
+      chart: aws-hosted-cp
+      version: 1.0.7
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-8.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-8.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-5
+  name: aws-standalone-cp-1-0-8
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.5
+      chart: aws-standalone-cp
+      version: 1.0.8
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-5
+  name: azure-hosted-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.5
+      chart: azure-hosted-cp
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-5
+  name: azure-standalone-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: azure-standalone-cp
-      version: 1.0.5
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-6
+  name: docker-hosted-cp-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.6
+      chart: docker-hosted-cp
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-7.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-7.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: docker-hosted-cp-1-0-1
+  name: gcp-hosted-cp-1-0-7
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: docker-hosted-cp
-      version: 1.0.1
+      chart: gcp-hosted-cp
+      version: 1.0.7
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-7.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-7.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-7
+  name: gcp-standalone-cp-1-0-7
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
+      chart: gcp-standalone-cp
       version: 1.0.7
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-7.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-7.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-5
+  name: openstack-standalone-cp-1-0-7
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.5
+      chart: openstack-standalone-cp
+      version: 1.0.7
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-6.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-6
+  name: remote-cluster-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
+      chart: remote-cluster
       version: 1.0.6
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-5
+  name: vsphere-hosted-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: vsphere-hosted-cp
-      version: 1.0.5
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-6.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-6
+  name: vsphere-standalone-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
+      chart: vsphere-standalone-cp
       version: 1.0.6
       interval: 10m0s
       sourceRef:


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces ability to set k0smotron controller plane flags, k0s cp and worker extra args

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #1641 
