### PR TITLE
test: update gke and vsphere test tpls

### DIFF
--- a/test/e2e/clusterdeployment/constants.go
+++ b/test/e2e/clusterdeployment/constants.go
@@ -56,6 +56,8 @@ const (
 
 	// GCP
 	EnvVarGCPEncodedCredentials = "GCP_B64ENCODED_CREDENTIALS"
+	EnvVarGCPProject            = "GCP_PROJECT"
+	EnvVarGCPRegion             = "GCP_REGION"
 
 	// Adopted
 	EnvVarAdoptedKubeconfigData = "KUBECONFIG_DATA"

--- a/test/e2e/clusterdeployment/gcp/env.go
+++ b/test/e2e/clusterdeployment/gcp/env.go
@@ -19,5 +19,7 @@ import "github.com/K0rdent/kcm/test/e2e/clusterdeployment"
 func CheckEnv() {
 	clusterdeployment.ValidateDeploymentVars([]string{
 		clusterdeployment.EnvVarGCPEncodedCredentials,
+		clusterdeployment.EnvVarGCPProject,
+		clusterdeployment.EnvVarGCPRegion,
 	})
 }

--- a/test/e2e/clusterdeployment/resources/gcp-gke.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/gcp-gke.yaml.tpl
@@ -13,7 +13,7 @@ spec:
     region: ${GCP_REGION}
     network:
       name: ${CLUSTER_DEPLOYMENT_NAME}
-    releaseChannel: stable
+    releaseChannel: regular
     machines:
       nodeLocations:
       - ${GCP_REGION}-a

--- a/test/e2e/clusterdeployment/resources/vsphere-standalone-cp.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/vsphere-standalone-cp.yaml.tpl
@@ -35,7 +35,7 @@ spec:
         user: ubuntu
         publicKey: "${VSPHERE_SSH_KEY}"
       rootVolumeSize: 50
-      cpus: 4
-      memory: 4096
+      cpus: 8
+      memory: 8192
       vmTemplate: "${VSPHERE_VM_TEMPLATE}"
       network: "${VSPHERE_NETWORK}"


### PR DESCRIPTION
    Adds new GKE constants to validate.
    Changes GKE default channel to release, which is default as in the
    template.
    Changes worker resources of vsphere-standalone cld to 8CPU/8192MEM