### PR TITLE
chore(tidy): cleanup some deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,12 +15,12 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
-	github.com/opencontainers/go-digest v1.0.1-0.20231025023718-d50d2fec9c98
+	github.com/opencontainers/go-digest v1.0.1-0.20250116041648-1e56c6daea3b
 	github.com/projectsveltos/addon-controller v0.54.0
 	github.com/projectsveltos/libsveltos v0.54.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/segmentio/analytics-go v3.1.0+incompatible
+	github.com/segmentio/analytics-go/v3 v3.3.0
 	github.com/stretchr/testify v1.10.0
 	github.com/telekom/cluster-api-ipam-provider-infoblox v0.1.0-alpha.8
 	github.com/vmware-tanzu/velero v1.16.1
@@ -34,7 +34,6 @@ require (
 	k8s.io/apimachinery v0.33.2
 	k8s.io/client-go v0.33.2
 	k8s.io/kubectl v0.33.2
-	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979
 	kubevirt.io/api v1.5.2
 	kubevirt.io/containerized-data-importer-api v1.62.0
 	sigs.k8s.io/cluster-api v1.10.3
@@ -160,7 +159,6 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
-	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.opentelemetry.io/otel v1.34.0 // indirect
@@ -191,6 +189,7 @@ require (
 	k8s.io/component-base v0.33.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
+	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/gateway-api v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
 github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
-github.com/opencontainers/go-digest v1.0.1-0.20231025023718-d50d2fec9c98 h1:H55sU3giNgBkIvmAo0vI/AAFwVTwfWsf6MN3+9H6U8o=
-github.com/opencontainers/go-digest v1.0.1-0.20231025023718-d50d2fec9c98/go.mod h1:RqnyioA3pIEZMkSbOIcrw32YSgETfn/VrLuEikEdPNU=
+github.com/opencontainers/go-digest v1.0.1-0.20250116041648-1e56c6daea3b h1:0XWQwEHfTQ7zrjFjaOnKrU8z9UVdv1A4uGU39phmwNI=
+github.com/opencontainers/go-digest v1.0.1-0.20250116041648-1e56c6daea3b/go.mod h1:RqnyioA3pIEZMkSbOIcrw32YSgETfn/VrLuEikEdPNU=
 github.com/opencontainers/go-digest/blake3 v0.0.0-20250116041648-1e56c6daea3b h1:nAiL9bmUK4IzFrKoVMRykv0iYGdoit5vpbPaVCZ+fI4=
 github.com/opencontainers/go-digest/blake3 v0.0.0-20250116041648-1e56c6daea3b/go.mod h1:kqQaIc6bZstKgnGpL7GD5dWoLKbA6mH1Y9ULjGImBnM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -443,8 +443,8 @@ github.com/rubenv/sql-migrate v1.8.0 h1:dXnYiJk9k3wetp7GfQbKJcPHjVJL6YK19tKj8t2N
 github.com/rubenv/sql-migrate v1.8.0/go.mod h1:F2bGFBwCU+pnmbtNYDeKvSuvL6lBVtXDXUUv5t+u1qw=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/segmentio/analytics-go v3.1.0+incompatible h1:IyiOfUgQFVHvsykKKbdI7ZsH374uv3/DfZUo9+G0Z80=
-github.com/segmentio/analytics-go v3.1.0+incompatible/go.mod h1:C7CYBtQWk4vRk2RyLu0qOcbHJ18E3F1HV2C/8JvKN48=
+github.com/segmentio/analytics-go/v3 v3.3.0 h1:8VOMaVGBW03pdBrj1CMFfY9o/rnjJC+1wyQHlVxjw5o=
+github.com/segmentio/analytics-go/v3 v3.3.0/go.mod h1:p8owAF8X+5o27jmvUognuXxdtqvSGtD0ZrfY2kcS9bE=
 github.com/segmentio/backo-go v1.1.0 h1:cJIfHQUdmLsd8t9IXqf5J8SdrOMn9vMa7cIvOavHAhc=
 github.com/segmentio/backo-go v1.1.0/go.mod h1:ckenwdf+v/qbyhVdNPWHnqh2YdJBED1O9cidYyM5J18=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
@@ -495,8 +495,6 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
-github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c h1:3lbZUMbMiGUW/LMkfsEABsc5zNT9+b1CvsJx47JzJ8g=
-github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -56,6 +56,7 @@ import (
 	"github.com/K0rdent/kcm/internal/helm"
 	"github.com/K0rdent/kcm/internal/record"
 	"github.com/K0rdent/kcm/internal/utils"
+	"github.com/K0rdent/kcm/internal/utils/pointer"
 	"github.com/K0rdent/kcm/internal/utils/ratelimit"
 	"github.com/K0rdent/kcm/internal/utils/validation"
 )
@@ -817,7 +818,7 @@ func (r *ManagementReconciler) getWrappedComponents(ctx context.Context, mgmt *k
 		installSettings: &helmcontrollerv2.Install{
 			Remediation: &helmcontrollerv2.InstallRemediation{
 				Retries:              1,
-				RemediateLastFailure: utils.PtrTo(true),
+				RemediateLastFailure: pointer.To(true),
 			},
 		},
 		helmReleaseName: kcmv1.CoreCAPIName,

--- a/internal/controller/management_controller_test.go
+++ b/internal/controller/management_controller_test.go
@@ -36,6 +36,7 @@ import (
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	"github.com/K0rdent/kcm/internal/utils"
+	"github.com/K0rdent/kcm/internal/utils/pointer"
 )
 
 var _ = Describe("Management Controller", func() {
@@ -411,7 +412,7 @@ var _ = Describe("Management Controller", func() {
 			Expect(k8sClient.Create(ctx, coreProvider)).To(Succeed())
 
 			coreProvider.Status.ObservedGeneration = coreProvider.Generation
-			coreProvider.Status.InstalledVersion = utils.PtrTo("v0.0.1")
+			coreProvider.Status.InstalledVersion = pointer.To("v0.0.1")
 			coreProvider.Status.Conditions = clusterapiv1.Conditions{
 				{
 					Type:               clusterapiv1.ReadyCondition,

--- a/internal/controller/statemanagementprovider/reconciler_test.go
+++ b/internal/controller/statemanagementprovider/reconciler_test.go
@@ -33,11 +33,11 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+	"github.com/K0rdent/kcm/internal/utils/pointer"
 )
 
 const (
@@ -337,7 +337,7 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 						Name:      stateManagementProviderName + serviceAccountSuffix,
 						Namespace: systemNamespace,
 					},
-					AutomountServiceAccountToken: ptr.To(true),
+					AutomountServiceAccountToken: pointer.To(true),
 				},
 			},
 			expectedServiceAccount: &corev1.ServiceAccount{

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -15,7 +15,7 @@
 package telemetry
 
 import (
-	"github.com/segmentio/analytics-go"
+	"github.com/segmentio/analytics-go/v3"
 )
 
 var (

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -15,7 +15,7 @@
 package telemetry
 
 import (
-	"github.com/segmentio/analytics-go"
+	"github.com/segmentio/analytics-go/v3"
 
 	"github.com/K0rdent/kcm/internal/build"
 )

--- a/internal/utils/pointer/ptr.go
+++ b/internal/utils/pointer/ptr.go
@@ -1,4 +1,4 @@
-// Copyright 2024
+// Copyright 2025
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+// Package pointer provides generic functions to work with pointers.
+package pointer
 
-func PtrTo[T any](v T) *T {
+// To returns a pointer to the given value.
+func To[T any](v T) *T {
 	return &v
+}
+
+// Deref returns dereference of the given value if not nil, otherwise the given default.
+func Deref[T any](v *T, def T) T {
+	if v != nil {
+		return *v
+	}
+	return def
 }

--- a/test/e2e/clusterdeployment/azure/azure.go
+++ b/test/e2e/clusterdeployment/azure/azure.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+	"github.com/K0rdent/kcm/internal/utils/pointer"
 	"github.com/K0rdent/kcm/test/e2e/clusterdeployment"
 	"github.com/K0rdent/kcm/test/e2e/kubeclient"
 )
@@ -119,9 +119,9 @@ func CreateDefaultStorageClass(kc *kubeclient.KubeClient) {
 			},
 		},
 		Provisioner:          "disk.csi.azure.com",
-		ReclaimPolicy:        ptr.To(corev1.PersistentVolumeReclaimDelete),
-		VolumeBindingMode:    ptr.To(storagev1.VolumeBindingWaitForFirstConsumer),
-		AllowVolumeExpansion: ptr.To(true),
+		ReclaimPolicy:        pointer.To(corev1.PersistentVolumeReclaimDelete),
+		VolumeBindingMode:    pointer.To(storagev1.VolumeBindingWaitForFirstConsumer),
+		AllowVolumeExpansion: pointer.To(true),
 		Parameters: map[string]string{
 			"skuName": "StandardSSD_LRS",
 		},

--- a/test/e2e/kubevirt/vm.go
+++ b/test/e2e/kubevirt/vm.go
@@ -27,7 +27,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/K0rdent/kcm/internal/utils"
+	"github.com/K0rdent/kcm/internal/utils/pointer"
 	"github.com/K0rdent/kcm/test/e2e/logs"
 )
 
@@ -107,7 +107,7 @@ func getDefaultVirtualMachineSpec(namespace, name, publicSSHKey string) kubevirt
 								corev1.ResourceStorage: defaultStorageRequest,
 							},
 						},
-						StorageClassName: utils.PtrTo("standard"),
+						StorageClassName: pointer.To("standard"),
 					},
 					Source: &cdiv1.DataVolumeSource{
 						HTTP: &cdiv1.DataVolumeSourceHTTP{
@@ -162,7 +162,7 @@ func getDefaultDevices() kubevirtv1.Devices {
 				DiskDevice: kubevirtv1.DiskDevice{
 					CDRom: &kubevirtv1.CDRomTarget{
 						Bus:      kubevirtv1.DiskBusSATA, // no arm support
-						ReadOnly: utils.PtrTo(true),
+						ReadOnly: pointer.To(true),
 					},
 				},
 				Name: "cloudinitdisk",


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleans `k8s.io/utils/ptr` as a dep. Bumps `go-digest` module, along with migrating to a proper `segmentio/analytics-go` version.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
