### PR TITLE
fix: change logic for registry credentials for CA certs

### DIFF
--- a/internal/sveltos/profile.go
+++ b/internal/sveltos/profile.go
@@ -242,7 +242,7 @@ func helmChartFromSpecOrRef(
 			// See: https://projectsveltos.github.io/sveltos/addons/helm_charts/.
 			return fmt.Sprintf("%s/%s", chartName, chartName)
 		}()
-		if repo.Spec.Insecure || repo.Spec.SecretRef != nil {
+		if repo.Spec.Insecure || repo.Spec.SecretRef != nil || repo.Spec.CertSecretRef != nil {
 			registryCredentialsConfig = generateRegistryCredentialsConfig(namespace, repo.Spec.Insecure, repo.Spec.SecretRef, repo.Spec.CertSecretRef)
 		}
 	case sourcev1.GitRepositoryKind:


### PR DESCRIPTION
Simple change to ensure that we provide the ca certificate for a registry when it's supplied without any client auth certificate. Fixes #1701 
