### PR TITLE
fix: KCM controller RBAC for configmaps

### DIFF
--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -199,6 +199,7 @@ rules:
   - ""
   resources:
   - namespaces
+  - configmaps
   verbs: {{ include "rbac.viewerVerbs" . | nindent 4 }}
 - apiGroups:
   - k0rdent.mirantis.com


### PR DESCRIPTION
**What this PR does / why we need it**:
grants RO access to configmaps to KCM controller

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #1710 
