### PR TITLE
feat: expose services.policyRef in CD and MCS spec 

### DIFF
--- a/api/v1beta1/multiclusterservice_types.go
+++ b/api/v1beta1/multiclusterservice_types.go
@@ -117,6 +117,15 @@ type ServiceSpec struct {
 	// TemplateResourceRefs is a list of resources to collect from the management cluster,
 	// the values from which can be used in templates.
 	TemplateResourceRefs []addoncontrollerv1beta1.TemplateResourceRef `json:"templateResourceRefs,omitempty"`
+
+	// +listType=atomic
+
+	// PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
+	// that need to be deployed in the target clusters.
+	// The values contained in those resources can be static or leverage Go templates for dynamic customization.
+	// When expressed as templates, the values are filled in using information from
+	// resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+	PolicyRefs []addoncontrollerv1beta1.PolicyRef `json:"policyRefs,omitempty"`
 	// DriftIgnore specifies resources to ignore for drift detection.
 	DriftIgnore []libsveltosv1beta1.PatchSelector `json:"driftIgnore,omitempty"`
 	// DriftExclusions specifies specific configurations of resources to ignore for drift detection.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1852,6 +1852,11 @@ func (in *ServiceSpec) DeepCopyInto(out *ServiceSpec) {
 		*out = make([]apiv1beta1.TemplateResourceRef, len(*in))
 		copy(*out, *in)
 	}
+	if in.PolicyRefs != nil {
+		in, out := &in.PolicyRefs, &out.PolicyRefs
+		*out = make([]apiv1beta1.PolicyRef, len(*in))
+		copy(*out, *in)
+	}
 	if in.DriftIgnore != nil {
 		in, out := &in.DriftIgnore, &out.DriftIgnore
 		*out = make([]libsveltosapiv1beta1.PatchSelector, len(*in))

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -209,6 +209,8 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 		return ctrl.Result{}, err
 	}
 
+	policyRefs = append(policyRefs, mcs.Spec.ServiceSpec.PolicyRefs...)
+
 	if _, err = sveltos.ReconcileClusterProfile(ctx, r.Client, mcs.Name,
 		sveltos.ReconcileProfileOpts{
 			OwnerReference: &metav1.OwnerReference{

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   version: 1.2.0
   kcm:
-    template: kcm-1-2-2
+    template: kcm-1-2-3
   capi:
     template: cluster-api-1-0-5
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-1-2-2
+  name: kcm-1-2-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 1.2.2
+      version: 1.2.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2
+version: 1.2.3
 dependencies:
   - name: flux2
     version: 2.16.0

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
@@ -862,6 +862,69 @@ spec:
                           type: string
                       type: object
                     type: array
+                  policyRefs:
+                    description: |-
+                      PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
+                      that need to be deployed in the target clusters.
+                      The values contained in those resources can be static or leverage Go templates for dynamic customization.
+                      When expressed as templates, the values are filled in using information from
+                      resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+                    items:
+                      properties:
+                        deploymentType:
+                          default: Remote
+                          description: |-
+                            DeploymentType indicates whether resources need to be deployed
+                            into the management cluster (local) or the managed cluster (remote)
+                          enum:
+                          - Local
+                          - Remote
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the resource. Supported kinds are:
+                            - ConfigMap/Secret
+                            - flux GitRepository;OCIRepository;Bucket
+                          enum:
+                          - GitRepository
+                          - OCIRepository
+                          - Bucket
+                          - ConfigMap
+                          - Secret
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referenced resource.
+                            Name can be expressed as a template and instantiate using any cluster field.
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referenced resource.
+                            For ClusterProfile namespace can be left empty. In such a case, namespace will
+                            be implicit set to cluster's namespace.
+                            For Profile namespace must be left empty. Profile namespace will be used.
+                            Namespace can be expressed as a template and instantiate using any cluster field.
+                          type: string
+                        optional:
+                          default: false
+                          description: |-
+                            Optional indicates that the referenced resource is not mandatory.
+                            If set to true and the resource is not found, the error will be ignored,
+                            and Sveltos will continue processing other PolicyRefs.
+                          type: boolean
+                        path:
+                          description: |-
+                            Path to the directory containing the YAML files.
+                            Defaults to 'None', which translates to the root path of the SourceRef.
+                            Used only for GitRepository;OCIRepository;Bucket
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
                   priority:
                     default: 100
                     description: |-

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -776,6 +776,69 @@ spec:
                           type: string
                       type: object
                     type: array
+                  policyRefs:
+                    description: |-
+                      PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
+                      that need to be deployed in the target clusters.
+                      The values contained in those resources can be static or leverage Go templates for dynamic customization.
+                      When expressed as templates, the values are filled in using information from
+                      resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+                    items:
+                      properties:
+                        deploymentType:
+                          default: Remote
+                          description: |-
+                            DeploymentType indicates whether resources need to be deployed
+                            into the management cluster (local) or the managed cluster (remote)
+                          enum:
+                          - Local
+                          - Remote
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the resource. Supported kinds are:
+                            - ConfigMap/Secret
+                            - flux GitRepository;OCIRepository;Bucket
+                          enum:
+                          - GitRepository
+                          - OCIRepository
+                          - Bucket
+                          - ConfigMap
+                          - Secret
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referenced resource.
+                            Name can be expressed as a template and instantiate using any cluster field.
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referenced resource.
+                            For ClusterProfile namespace can be left empty. In such a case, namespace will
+                            be implicit set to cluster's namespace.
+                            For Profile namespace must be left empty. Profile namespace will be used.
+                            Namespace can be expressed as a template and instantiate using any cluster field.
+                          type: string
+                        optional:
+                          default: false
+                          description: |-
+                            Optional indicates that the referenced resource is not mandatory.
+                            If set to true and the resource is not found, the error will be ignored,
+                            and Sveltos will continue processing other PolicyRefs.
+                          type: boolean
+                        path:
+                          description: |-
+                            Path to the directory containing the YAML files.
+                            Defaults to 'None', which translates to the root path of the SourceRef.
+                            Used only for GitRepository;OCIRepository;Bucket
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
                   priority:
                     default: 100
                     description: |-


### PR DESCRIPTION
# Description

Exposing `services.policyRef` field in CD and MCS spec in order to support features like propagating secrets from k0rdent management cluster to target cluster. See https://github.com/k0rdent/catalog/pull/503.

# Verifying secret is propagated

I have the following secret:
```sh
➜  ~ kubectl -n kcm-system get secret secret-dockercfg 
NAME               TYPE                      DATA   AGE
secret-dockercfg   kubernetes.io/dockercfg   1      27h
```

And I want to propagate it to the following target cluster in "myns" namespace:
```sh
➜  ~ kubectl -n kcm-system get cluster --show-labels 
NAME         CLUSTERCLASS   PHASE         AGE   VERSION   LABELS
wali-dev-1                  Provisioned   28h             app.kubernetes.io/managed-by=Helm,helm.toolkit.fluxcd.io/name=wali-dev-1,helm.toolkit.fluxcd.io/namespace=kcm-system,k0rdent.mirantis.com/component=kcm,sveltos-agent=present
```

So I use the following values:
```yaml
propagate:
  secrets:
    - name: secret-dockercfg
      namespace: kcm-system
      targetNamespace: myns
clusterSelector:
  matchLabels:
    k0rdent.mirantis.com/component=kcm
```
to install the [`propagate-secrets`](https://github.com/k0rdent/catalog/pull/503) helm chart on k0rdent management cluster:
```sh
➜  ~ helm -n kcm-system install mgmt propagate-secrets 
NAME: mgmt
LAST DEPLOYED: Mon Jul  7 22:20:57 2025
NAMESPACE: kcm-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Release mgmt successfully installed.

A MultiClusterService named mgmt-propagate-secrets-mcs has been installed. 
It references the provided secrets in .Values.propagate.secrets in its .spec.servicesSpec.services.templateResourceRefs field.
```

Wait for the MCS to be reconciled:
```sh
➜  util git:(main) ✗ kubectl get mcs mgmt-propagate-secrets-mcs -o yaml
apiVersion: k0rdent.mirantis.com/v1beta1
kind: MultiClusterService
metadata:
  annotations:
    meta.helm.sh/release-name: mgmt
    meta.helm.sh/release-namespace: kcm-system
  creationTimestamp: "2025-07-08T02:20:58Z"
  finalizers:
  - k0rdent.mirantis.com/multicluster-service
  generation: 1
  labels:
    app.kubernetes.io/instance: mgmt
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: propagate-secrets
    app.kubernetes.io/version: 1.0.0
    helm.sh/chart: propagate-secrets-1.0.0
    k0rdent.mirantis.com/component: kcm
  name: mgmt-propagate-secrets-mcs
  resourceVersion: "40024"
  uid: be8e1cde-03ae-4114-a483-a01760d02ac4
spec:
  clusterSelector:
    matchLabels:
      k0rdent.mirantis.com/component: kcm
  serviceSpec:
    continueOnError: false
    policyRefs:
    - deploymentType: Remote
      kind: Secret
      name: mgmt-secret-dockercfg-policy
      namespace: kcm-system
      optional: false
    priority: 100
    stopOnConflict: false
    syncMode: Continuous
    templateResourceRefs:
    - identifier: mgmt-secret-dockercfg-id
      optional: false
      resource:
        apiVersion: v1
        kind: Secret
        name: secret-dockercfg
        namespace: kcm-system
status:
  conditions:
  - lastTransitionTime: "2025-07-08T02:21:08Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: SveltosClusterProfileReady
  - lastTransitionTime: "2025-07-08T02:21:08Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: FetchServicesStatusSuccess
  - lastTransitionTime: "2025-07-08T02:21:08Z"
    message: ""
    reason: Succeeded
    status: "True"
    type: ServicesReferencesValidation
  - lastTransitionTime: "2025-07-08T02:21:08Z"
    message: 1/1
    reason: Succeeded
    status: "True"
    type: ClusterInReadyState
  - lastTransitionTime: "2025-07-08T02:21:08Z"
    message: 0/0
    reason: Succeeded
    status: "True"
    type: ServicesInReadyState
  observedGeneration: 1
```

I can verify that the secret has been created on the target cluster:
```sh
➜  ~ KUBECONFIG=wali-dev-1-kubeconfig kubectl -n myns get secret
NAME               TYPE                      DATA   AGE
secret-dockercfg   kubernetes.io/dockercfg   1      79s
```

# Verifying any change to secret is also propagated
Currently the value in the `secrets-dockercfg` that has been propagated to the target cluster is:
```sh
➜  ~ KUBECONFIG=wali-dev-1-kubeconfig kubectl -n myns get secret secret-dockercfg -o jsonpath='{.data.\.dockercfg}' | base64 --decode
{"auths":{"https://example/v1/":{"auth":"opensesame"}}}%  
```

If I change the value of the original secret in k0rdent management cluster:
```sh
➜  ~ kubectl -n kcm-system get secret secret-dockercfg -o yaml
apiVersion: v1
data:
  .dockercfg: eyJhdXRocyI6eyJodHRwczovL2V4YW1wbGUvdjEvIjp7ImF1dGgiOiJvcGVuc2VzYW1lIn19fQ==
kind: Secret
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{".dockercfg":"eyJhdXRocyI6eyJodHRwczovL2V4YW1wbGUvdjEvIjp7ImF1dGgiOiJvcGVuc2VzYW1lIn19fQ==\n"},"kind":"Secret","metadata":{"annotations":{},"name":"secret-dockercfg","namespace":"kcm-system"},"type":"kubernetes.io/dockercfg"}
  creationTimestamp: "2025-07-08T01:32:40Z"
  name: secret-dockercfg
  namespace: kcm-system
  resourceVersion: "102656"
  uid: bfc9f5f7-f991-4a60-b5e1-6dd138f3ce7f
type: kubernetes.io/dockercfg
```

I can see that the new value gets propagated to the target cluster:
```sh
➜  ~ KUBECONFIG=wali-dev-1-kubeconfig kubectl -n myns get secret secret-dockercfg -o jsonpath='{.data.\.dockercfg}'      
eyJhdXRocyI6eyJodHRwczovL2V4YW1wbGUvdjEvIjp7ImF1dGgiOiJvcGVuc2VzYW1lMiJ9fX0=%                                             ➜  ~ 
➜  ~ KUBECONFIG=wali-dev-1-kubeconfig kubectl -n myns get secret secret-dockercfg -o jsonpath='{.data.\.dockercfg}' | base64 --decode
{"auths":{"https://example/v1/":{"auth":"opensesame2"}}}% 
```