### PR TITLE
ci(arm): skip build in e2e tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -217,7 +217,7 @@ jobs:
           IMAGE_NAME: controller-ci
           VERSION: ${{ needs.lint-test.outputs.version }}
           SKIP_SCM_RELEASE: true
-          # SKIP_ARM: true
+          SKIP_ARM: true
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -236,7 +236,6 @@ dockers:
       - --platform=linux/arm/v7
 
 docker_manifests:
-  # NOTE: https://github.com/orgs/goreleaser/discussions/5822 ; https://github.com/goreleaser/goreleaser/issues/5824
   - name_template: "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Env.VERSION }}"
     image_templates:
       - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}:{{ .Env.VERSION }}-amd64"


### PR DESCRIPTION
**What this PR does / why we need it**:

A [new goreleaser](https://github.com/goreleaser/goreleaser/releases/tag/v2.11.0) version has the required fix to conditional skip images. We do not test arm64/arm at the moment, so that reduces package amout pressure

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
