### PR TITLE
feat: Add openstack-hosted-cp template

### DIFF
--- a/templates/cluster/openstack-hosted-cp/.helmignore
+++ b/templates/cluster/openstack-hosted-cp/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: openstack-hosted-cp
+description: |
+  A KCM template to deploy a k8s cluster on Openstack with control plane components
+  within the management cluster.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v1.32.6+k0s.0"
+annotations:
+  cluster.x-k8s.io/provider: infrastructure-openstack, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/infrastructure-openstack: v1beta1

--- a/templates/cluster/openstack-hosted-cp/templates/_helpers.tpl
+++ b/templates/cluster/openstack-hosted-cp/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{- define "cluster.name" -}}
+    {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "openstackmachinetemplate.name" -}}
+    {{- include "cluster.name" . }}-mt-{{ .Values.image | toString | sha256sum | trunc 8 }}
+{{- end }}
+
+{{- define "k0smotroncontrolplane.name" -}}
+    {{- include "cluster.name" . }}-cp
+{{- end }}
+
+{{- define "k0sworkerconfigtemplate.name" -}}
+    {{- include "cluster.name" . }}-machine-config
+{{- end }}
+
+{{- define "machinedeployment.name" -}}
+    {{- include "cluster.name" . }}-md
+{{- end }}

--- a/templates/cluster/openstack-hosted-cp/templates/cluster.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/cluster.yaml
@@ -1,0 +1,23 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: {{ include "cluster.name" . }}
+  {{- if .Values.clusterLabels }}
+  labels: {{- toYaml .Values.clusterLabels | nindent 4}}
+  {{- end }}
+  {{- if .Values.clusterAnnotations }}
+  annotations: {{- toYaml .Values.clusterAnnotations | nindent 4}}
+  {{- end }}
+spec:
+  {{- with .Values.clusterNetwork }}
+  clusterNetwork:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: K0smotronControlPlane
+    name: {{ include "k0smotroncontrolplane.name" .  }}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: OpenStackCluster
+    name: {{ include "cluster.name" . }}

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,0 +1,197 @@
+{{- $global := .Values.global | default dict }}
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: K0smotronControlPlane
+metadata:
+  name: {{ include "k0smotroncontrolplane.name" . }}
+spec:
+  replicas: {{ .Values.controlPlaneNumber }}
+  version: {{ .Values.k0s.version | replace "+" "-" }}
+  {{- with .Values.k0smotron.service }}
+  service:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if $global.registry }}
+  image: {{ $global.registry }}/k0sproject/k0s
+  etcd:
+    image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+  {{- if $global.registryCertSecret }}
+  mounts:
+    - path: /usr/local/share/ca-certificates/registry
+      secret:
+        defaultMode: 420
+        items:
+          - key: ca.crt
+            path: ca.crt
+        secretName: {{ $global.registryCertSecret }}
+  {{- end }}
+  {{- end }}
+  controllerPlaneFlags:
+    - --enable-cloud-provider=true
+    - --debug=true
+    {{- range $arg := .Values.k0smotron.controllerPlaneFlags }}
+    - {{ toYaml $arg }}
+    {{- end }}
+  k0sConfig:
+    apiVersion: k0s.k0sproject.io/v1beta1
+    kind: ClusterConfig
+    metadata:
+      name: k0s
+    spec:
+      {{- with .Values.k0s.api.extraArgs }}
+      api:
+        extraArgs:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+      network:
+        provider: calico
+        calico:
+          mode: vxlan
+      {{- if $global.registry }}
+      images:
+        konnectivity:
+          image: "{{ $global.registry }}/k0sproject/apiserver-network-proxy-agent"
+        metricsserver:
+          image: "{{ $global.registry }}/metrics-server/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry }}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry }}/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry }}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
+      {{- end }}
+      extensions:
+        helm:
+          repositories:
+          {{- if not $global.registry }}
+            - name: openstack
+              url: https://kubernetes.github.io/cloud-provider-openstack/
+          {{- else }}
+            - name: global-registry
+              url: oci://{{ $global.registry }}
+              {{- if $global.registryCertSecret }}
+              caFile: /usr/local/share/ca-certificates/registry/ca.crt
+              {{- end }}
+          {{- end }}
+          charts:
+            - name: openstack-ccm
+              {{- if $global.registry }}
+              chartname: oci://{{ $global.registry }}/charts/openstack-cloud-controller-manager
+              {{- else }}
+              chartname: openstack/openstack-cloud-controller-manager
+              {{- end }}
+              version: 2.31.1
+              order: 1
+              namespace: kube-system
+              values: |
+                {{- if $global.registry }}
+                image:
+                  repository: {{ $global.registry }}/provider-os/openstack-cloud-controller-manager
+                {{- end }}
+                secret:
+                  enabled: true
+                  name: openstack-cloud-config
+                  create: false
+                nodeSelector: null
+                tolerations:
+                  - key: node.cloudprovider.kubernetes.io/uninitialized
+                    value: "true"
+                    effect: NoSchedule
+                  - key: node-role.kubernetes.io/control-plane
+                    effect: NoSchedule
+                  - key: node-role.kubernetes.io/master
+                    effect: NoSchedule   
+                extraEnv:
+                  - name: OS_CCM_REGIONAL
+                    value: {{ .Values.ccmRegional | quote }}
+                extraVolumes:
+                  - name: flexvolume-dir
+                    hostPath:
+                      path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+                  - name: k8s-certs
+                    hostPath:
+                      path: /etc/kubernetes/pki
+                  {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
+                  - name: cloud-ca-cert
+                    secret:
+                      secretName: {{ .Values.identityRef.caCert.secretName }}
+                  {{- end }}
+                extraVolumeMounts:
+                  - name: flexvolume-dir
+                    mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+                    readOnly: true
+                  - name: k8s-certs
+                    mountPath: /etc/kubernetes/pki
+                    readOnly: true
+                  {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
+                  - name: cloud-ca-cert
+                    mountPath: {{ .Values.identityRef.caCert.path }}
+                  {{- end }}
+            - name: openstack-csi
+              {{- if $global.registry }}
+              chartname: oci://{{ $global.registry }}/charts/openstack-cinder-csi
+              {{- else }}
+              chartname: openstack/openstack-cinder-csi
+              {{- end }}
+              version: 2.31.2
+              order: 2
+              namespace: kube-system
+              values: |
+                storageClass:
+                  enabled: true
+                  delete:
+                    isDefault: true
+                    allowVolumeExpansion: true
+                  retain:
+                    isDefault: false
+                    allowVolumeExpansion: false
+                secret:
+                  enabled: true
+                  name: openstack-cloud-config
+                  create: false
+                csi:
+                  {{- if $global.registry }}
+                  attacher:
+                    image:
+                      repository: {{ $global.registry }}/sig-storage/csi-attacher
+                  provisioner:
+                    image:
+                      repository: {{ $global.registry }}/sig-storage/csi-provisioner
+                  snapshotter:
+                    image:
+                      repository: {{ $global.registry }}/sig-storage/csi-snapshotter
+                  resizer:
+                    image:
+                      repository: {{ $global.registry }}/sig-storage/csi-resizer
+                  livenessprobe:
+                    image:
+                      repository: {{ $global.registry }}/sig-storage/livenessprobe
+                  nodeDriverRegistrar:
+                    image:
+                      repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
+                  {{- end }}
+                  plugin:
+                    {{- if $global.registry }}
+                    image:
+                      repository: {{ $global.registry }}/provider-os/cinder-csi-plugin
+                    {{- end }}
+                    nodePlugin:
+                      kubeletDir: /var/lib/k0s/kubelet
+                    {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
+                    volumes:
+                    - name: cloud-ca-cert
+                      secret:
+                        secretName: {{ .Values.identityRef.caCert.secretName }}
+                    volumeMounts:
+                    - name: cloud-config
+                      mountPath: /etc/kubernetes
+                      readOnly: true
+                    - name: cloud-ca-cert
+                      mountPath: {{ .Values.identityRef.caCert.path }}
+                   {{- end }}

--- a/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,0 +1,35 @@
+{{- $global := .Values.global | default dict }}
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: K0sWorkerConfigTemplate
+metadata:
+  name: {{ include "k0sworkerconfigtemplate.name" . }}
+spec:
+  template:
+    spec:
+      {{- if $global.k0sURL }}
+      downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
+      {{- end }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      files:
+        {{- range $path, $secret := $certs }}
+        {{- if $secret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $secret }}
+              key: ca.crt
+          permissions: "0664"
+          path: /usr/local/share/ca-certificates/{{ $path }}
+        {{- end }}
+        {{- end }}
+      preStartCommands:
+      - "sudo update-ca-certificates"
+      {{- end }}
+      version: {{ .Values.k0s.version }}
+      args:
+      - --enable-cloud-provider
+      - --kubelet-extra-args="--cloud-provider=external"
+      - --debug=true
+      {{- range $arg := .Values.k0s.workerArgs }}
+      - {{ toYaml $arg }}
+      {{- end }}

--- a/templates/cluster/openstack-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/machinedeployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: {{ include "machinedeployment.name" . }}
+spec:
+  clusterName: {{ include "cluster.name" . }}
+  replicas: {{ .Values.workersNumber }}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
+    spec:
+      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version "" }}
+      clusterName: {{ include "cluster.name" . }}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: K0sWorkerConfigTemplate
+          name: {{ include "k0sworkerconfigtemplate.name" . }}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: OpenStackMachineTemplate
+        name: {{ include "openstackmachinetemplate.name" . }}

--- a/templates/cluster/openstack-hosted-cp/templates/openstackcluster.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/openstackcluster.yaml
@@ -1,0 +1,39 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackCluster
+metadata:
+  name: {{ include "cluster.name" . }}
+spec:
+  disableAPIServerFloatingIP: true
+  {{- if .Values.bastion.enabled }}
+  bastion:
+  {{- with .Values.bastion.spec }}
+    spec:
+      {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.externalNetwork }}
+  externalNetwork:
+    {{- toYaml .Values.externalNetwork | nindent 4 }}
+  {{- end }}
+  {{- if .Values.identityRef }}
+  identityRef:
+    name: {{ .Values.identityRef.name }}
+    cloudName: {{ .Values.identityRef.cloudName | default "openstack" }}
+    region: {{ .Values.identityRef.region | default "RegionOne" }}
+  {{- end }}
+  {{- if .Values.managedSecurityGroups }}
+  managedSecurityGroups:
+    {{- toYaml .Values.managedSecurityGroups | nindent 4 }}
+  {{- end }}
+  {{- if .Values.network }}
+  network:
+    {{- toYaml .Values.network | nindent 4 }}
+  {{- end }}
+  {{- if .Values.subnets }}
+  subnets:
+    {{- toYaml .Values.subnets | nindent 4 }}
+  {{- end }}
+  {{- if .Values.router }}
+  router:
+    {{- toYaml .Values.router | nindent 4 }}
+  {{- end }}

--- a/templates/cluster/openstack-hosted-cp/templates/openstackmachinetemplate.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/openstackmachinetemplate.yaml
@@ -1,0 +1,41 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: {{ include "openstackmachinetemplate.name" . }}
+spec:
+  template:
+    spec:
+      flavor: {{ .Values.flavor }}
+      identityRef:
+        name: {{ .Values.identityRef.name }}
+        region: {{ .Values.identityRef.region }}
+        cloudName: {{ .Values.identityRef.cloudName}}
+      image:
+        filter:
+          name: {{ .Values.image.filter.name }}
+          {{- if .Values.image.filter.tags }}
+          tags:
+            {{- range $tag := .Values.image.filter.tags }}
+            - {{ $tag }}
+            {{- end }}
+          {{- end }}
+      {{- if .Values.ports }}
+      ports:
+        {{ .Values.ports | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.rootVolume }}
+      rootVolume:
+        {{ .Values.rootVolume | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if gt (len .Values.additionalBlockDevices) 0 }}
+      additionalBlockDevices:
+        {{ .Values.additionalBlockDevices | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if gt (len .Values.securityGroups) 0 }}
+      securityGroups:
+        {{ .Values.securityGroups | toYaml | nindent 8 }}
+      {{- end }}
+      {{- $sshKey := .Values.sshKeyName | default .Values.sshPublicKey }}
+      {{- if $sshKey }}
+      sshKeyName: {{ $sshKey }}
+      {{- end }}

--- a/templates/cluster/openstack-hosted-cp/values.schema.json
+++ b/templates/cluster/openstack-hosted-cp/values.schema.json
@@ -1,0 +1,414 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM cluster openstack-hosted-cp template",
+  "type": "object",
+  "required": [
+    "workersNumber",
+    "identityRef",
+    "flavor",
+    "ports"
+  ],
+  "properties": {
+    "additionalBlockDevices": {
+      "description": "AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "bastion": {
+      "description": "Configuration of the bastion host",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable bastion server for SSH access",
+          "type": "boolean"
+        },
+        "spec": {
+          "description": "Bastion host spec",
+          "type": "object",
+          "properties": {
+            "flavor": {
+              "description": "Flavor of the bastion server",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "image": {
+              "description": "Bastion host image configuration",
+              "type": "object",
+              "properties": {
+                "filter": {
+                  "description": "Filter describes a query for an image. If specified, the combination of name and tags must return a single matching image or an error will be raised",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the image",
+                      "type": "string"
+                    },
+                    "tags": {
+                      "description": "The tags associated with the desired image",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "providerID": {
+              "description": "Provider ID of the bastion server",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sshKeyName": {
+              "description": "SSH public key for accessing the bastion",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "ccmRegional": {
+      "description": "Allow OpenStack CCM to set ProviderID with region name",
+      "type": "boolean"
+    },
+    "clusterAnnotations": {
+      "description": "Annotations to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "clusterLabels": {
+      "description": "Labels to apply to the cluster",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "clusterNetwork": {
+      "description": "The cluster network configuration",
+      "type": "object",
+      "properties": {
+        "pods": {
+          "description": "The network ranges from which Pod networks are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "serviceDomain": {
+          "type": "string"
+        },
+        "services": {
+          "description": "The network ranges from which service VIPs are allocated",
+          "type": "object",
+          "properties": {
+            "cidrBlocks": {
+              "description": "A list of CIDR blocks",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "externalNetwork": {
+      "description": "External network configuration for the cluster",
+      "type": "object",
+      "properties": {
+        "filter": {
+          "description": "Filter specifies a filter to select an OpenStack network",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "Name of the external network",
+              "type": "string"
+            }
+          }
+        },
+        "id": {
+          "description": "ID of the external network",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "flavor": {
+      "description": "OpenStack flavor for instance size",
+      "type": "string"
+    },
+    "identityRef": {
+      "description": "OpenStack cluster identity object reference",
+      "type": "object",
+      "required": [
+        "name",
+        "cloudName",
+        "region"
+      ],
+      "properties": {
+        "caCert": {
+          "description": "Reference to the secret with the content of a custom CA",
+          "type": "object",
+          "properties": {
+            "path": {
+              "description": "The directory where the secret with a custom CA will be mounted",
+              "type": "string"
+            },
+            "secretName": {
+              "description": "The name of the secret with a custom CA in kube-system namespace",
+              "type": "string"
+            }
+          }
+        },
+        "cloudName": {
+          "description": "Name of the entry in the clouds.yaml file to use",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the identity",
+          "type": "string"
+        },
+        "region": {
+          "description": "OpenStack region",
+          "type": "string"
+        }
+      }
+    },
+    "image": {
+      "description": "Image configuration",
+      "type": "object",
+      "properties": {
+        "filter": {
+          "description": "Filter describes a query for an image. If specified, the combination of name and tags must return a single matching image or an error will be raised",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "Name of the image",
+              "type": "string"
+            },
+            "tags": {
+              "description": "The tags associated with the desired image",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "k0s": {
+      "description": "K0s parameters",
+      "type": "object",
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "api": {
+          "description": "Kubernetes API server parameters",
+          "type": "object",
+          "properties": {
+            "extraArgs": {
+              "description": "Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process",
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "arch": {
+          "description": "K0s Download URL Arch",
+          "default": "amd64",
+          "type": "string",
+          "enum": [
+            "amd64",
+            "arm64",
+            "arm"
+          ]
+        },
+        "version": {
+          "description": "K0s version",
+          "type": "string"
+        },
+        "workerArgs": {
+          "description": "Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "k0smotron": {
+      "description": "K0smotron parameters",
+      "type": "object",
+      "properties": {
+        "controllerPlaneFlags": {
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "service": {
+          "description": "The API service configuration",
+          "type": "object",
+          "properties": {
+            "apiPort": {
+              "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
+            },
+            "konnectivityPort": {
+              "description": "The konnectivity port. If empty k0smotron will pick it automatically",
+              "type": "number",
+              "maximum": 65535,
+              "minimum": 1
+            },
+            "type": {
+              "description": "An ingress methods for a service",
+              "default": "LoadBalancer",
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "managedSecurityGroups": {
+      "description": "Defines whether OpenStack security groups are managed by the provider or specific rules are provided",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "network": {
+      "description": "The reference to OpenStack network",
+      "type": "object",
+      "required": [
+        "filter"
+      ],
+      "properties": {
+        "filter": {
+          "description": "Represents basic information about the associated OpenStack Network",
+          "type": "object"
+        }
+      }
+    },
+    "ports": {
+      "description": "Ports to be attached to the server instance",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "network": {
+            "description": "Network is a query for an OpenStack network that the port will be discovered on",
+            "type": "object",
+            "required": [
+              "filter"
+            ],
+            "properties": {
+              "filter": {
+                "description": "Specifies a filter to select an OpenStack network",
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "providerID": {
+      "description": "Unique ID for the instance provider",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "rootVolume": {
+      "description": "The volume metadata to boot from",
+      "type": "object"
+    },
+    "router": {
+      "description": "The reference to OpenStack router",
+      "type": "object",
+      "required": [
+        "filter"
+      ],
+      "properties": {
+        "filter": {
+          "description": "Specifies a query to select an OpenStack router",
+          "type": "object"
+        }
+      }
+    },
+    "securityGroups": {
+      "description": "Security groups to be assigned to the instance",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "description": "Description for filtering",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the security group to filter by",
+                "type": "string"
+              },
+              "projectID": {
+                "description": "Optional: project ID for filtering",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "sshKeyName": {
+      "description": "SSH public key for accessing nodes",
+      "type": "string"
+    },
+    "subnets": {
+      "description": "The reference to OpenStack subnet",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "filter"
+        ],
+        "properties": {
+          "filter": {
+            "description": "Represents basic information about the associated OpenStack Neutron Subnet",
+            "type": "object"
+          }
+        }
+      }
+    },
+    "workersNumber": {
+      "description": "The number of the worker machines",
+      "type": "integer",
+      "minimum": 1
+    }
+  }
+}

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -1,0 +1,86 @@
+# Cluster parameters
+workersNumber: 2 # @schema description: The number of the worker machines; minimum: 1; type: integer; required: true
+
+clusterNetwork:  # @schema description: The cluster network configuration; type: object
+  pods: # @schema description: The network ranges from which Pod networks are allocated; type: object
+    cidrBlocks: # @schema description: A list of CIDR blocks; type: array; item: string
+    - "10.244.0.0/16"
+  services: # @schema description: The network ranges from which service VIPs are allocated; type: object
+    cidrBlocks: # @schema description: A list of CIDR blocks; type: array; item: string
+    - "10.96.0.0/12"
+  serviceDomain: "cluster.local"
+
+clusterLabels: {} # @schema description: Labels to apply to the cluster; type: object; additionalProperties: true
+clusterAnnotations: {} # @schema description: Annotations to apply to the cluster; type: object; additionalProperties: true
+
+ccmRegional: true # @schema description: Allow OpenStack CCM to set ProviderID with region name; type: boolean
+
+identityRef: # @schema description: OpenStack cluster identity object reference; type: object; required: true
+  name: "" # @schema description: Name of the identity; type: string; required: true
+  cloudName: "" # @schema description: Name of the entry in the clouds.yaml file to use; type: string; required: true
+  region: "" # @schema description: OpenStack region; type: string; required: true
+  caCert: # @schema description: Reference to the secret with the content of a custom CA; type: object
+    secretName: "" # @schema description: The name of the secret with a custom CA in kube-system namespace; type: string
+    path: /etc/cacert # @schema description: The directory where the secret with a custom CA will be mounted; type: string
+
+bastion: # @schema description: Configuration of the bastion host; type: object
+  enabled: false # @schema description: Enable bastion server for SSH access; type: boolean
+  spec: # @schema description: Bastion host spec; type: object
+    sshKeyName: "" # @schema description: SSH public key for accessing the bastion; type: string
+    providerID: "" # @schema description: Provider ID of the bastion server; type: [string, null]
+    flavor: "" # @schema description: Flavor of the bastion server; type: [string, null]
+    image: # @schema description: Bastion host image configuration; type: object
+      filter: # @schema description: Filter describes a query for an image. If specified, the combination of name and tags must return a single matching image or an error will be raised; type: object
+        name: "" # @schema description: Name of the image; type: string
+        tags: [] # @schema description: The tags associated with the desired image; type: array; item: string
+
+managedSecurityGroups: null # @schema description: Defines whether OpenStack security groups are managed by the provider or specific rules are provided; type: [object, null]
+
+externalNetwork: # @schema description: External network configuration for the cluster; type: object
+  id: # @schema description: ID of the external network; type: [string, null]
+  filter: # @schema description: Filter specifies a filter to select an OpenStack network; type: object
+    name: "" # @schema description: Name of the external network; type: string
+
+# OpenStack cluster parameters
+router: # @schema description: The reference to OpenStack router; type: object
+  filter: {} # @schema description: Specifies a query to select an OpenStack router; type: object; required: true
+subnets: # @schema description: The reference to OpenStack subnet; type: array; item: object
+  - filter: {} # @schema description: Represents basic information about the associated OpenStack Neutron Subnet; type: object; required: true
+network: # @schema description: The reference to OpenStack network; type: object
+  filter: {} # @schema description: Represents basic information about the associated OpenStack Network; type: object; required: true
+
+# OpenStack worker machine parameters
+sshKeyName: "" # @schema description: SSH public key for accessing nodes; type: string
+providerID: "" # @schema description: Unique ID for the instance provider; type: [string, null]
+flavor: "" # @schema description: OpenStack flavor for instance size; type: string; required: true
+image: # @schema description: Image configuration; type: object
+  filter: # @schema description: Filter describes a query for an image. If specified, the combination of name and tags must return a single matching image or an error will be raised; type: object
+    name: "" # @schema description: Name of the image; type: string
+    tags: [] # @schema description: The tags associated with the desired image; type: array; item: string
+rootVolume: {} # @schema description: The volume metadata to boot from; type: object
+additionalBlockDevices: [] # @schema description: AdditionalBlockDevices is a list of specifications for additional block devices to attach to the server instance; type: array; item: object
+ports: # @schema description: Ports to be attached to the server instance; type: array; item: object; required: true
+  - network: # @schema description: Network is a query for an OpenStack network that the port will be discovered on; type: object
+      filter: {} # @schema description: Specifies a filter to select an OpenStack network; type: object; required: true
+
+securityGroups: # @schema description: Security groups to be assigned to the instance; type: array; item: object
+  - filter:
+      name: "default" # @schema description: Name of the security group to filter by; type: string
+      description: "" # @schema description: Description for filtering; type: string
+      projectID: "" # @schema description: Optional: project ID for filtering; type: string
+
+# K0smotron parameters
+k0smotron: # @schema description: K0smotron parameters; type: object
+  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  service: # @schema description: The API service configuration; type: object
+    type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
+    apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
+    konnectivityPort: 8132 # @schema description: The konnectivity port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
+
+# K0s parameters
+k0s: # @schema description: K0s parameters; type: object
+  version: v1.32.6+k0s.0 # @schema description: K0s version; type: string; required: true
+  arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
+  workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
+  api: # @schema description: Kubernetes API server parameters; type: object
+    extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-0.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-0.yaml
@@ -1,0 +1,15 @@
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ClusterTemplate
+metadata:
+  name: openstack-hosted-cp-1-0-0
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  helm:
+    chartSpec:
+      chart: openstack-hosted-cp
+      version: 1.0.0
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: kcm-templates


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new template for hosted OpenStack cluster deployment.

The deployment requires to provide existing network, subnet and router.

Example of the ClusterDeployment configuration:
```
apiVersion: k0rdent.mirantis.com/v1beta1
kind: ClusterDeployment
metadata:
  name: ekaz-hosted
  namespace: kcm-system
spec:
  template: openstack-hosted-cp-1-1-1
  credential: openstack-cluster-identity-cred
  config:
    clusterLabels: {}
    clusterAnnotations: {}
    workersNumber: 2

    sshKeyName: ekaz-new
    flavor: kaas.small
    image:
      filter:
        name: ubuntu-20.04
    externalNetwork:
      filter:
        name: "public"
    authURL: https://keystone.ic-eu.ssl.mirantis.net/
    identityRef:
      name: "openstack-cloud-config"
      cloudName: "openstack"
      region: RegionOne

    network:
      filter:
        name: k8s-clusterapi-cluster-kcm-system-openstack-ekaz
    router:
      filter:
        name: k8s-clusterapi-cluster-kcm-system-openstack-ekaz
    subnets:
    - filter:
        name: k8s-clusterapi-cluster-kcm-system-openstack-ekaz
    ports:
    - network:
        filter:
          name: k8s-clusterapi-cluster-kcm-system-openstack-ekaz
```
