### PR TITLE
fix: removed unneeded regex restricting dns names and ipv6 addresses

### DIFF
--- a/templates/cluster/remote-cluster/values.schema.json
+++ b/templates/cluster/remote-cluster/values.schema.json
@@ -186,8 +186,7 @@
         "properties": {
           "address": {
             "description": "The IP address of the remote machine",
-            "type": "string",
-            "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$"
+            "type": "string"
           },
           "k0s": {
             "description": "k0s worker configuration options",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes a regex that checks for a valid ipv4 address

The reason to remove this is the downstream k0smotron remote controller supports ipv6 and dns names - this regex restricts these use cases so it has been removed.

More details and discussion on internal slack channel.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
#1746
