### PR TITLE
fix: allow dns and ipv6 in remote tpl

### DIFF
--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-8
+  template: remote-cluster-1-0-9
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/values.schema.json
+++ b/templates/cluster/remote-cluster/values.schema.json
@@ -185,9 +185,13 @@
         ],
         "properties": {
           "address": {
-            "description": "The IP address of the remote machine",
-            "type": "string",
-            "pattern": "^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$"
+            "description": "Address is the IP address or DNS name of the remote machine",
+            "examples": [
+              "10.130.0.237",
+              "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+              "hostname"
+            ],
+            "type": "string"
           },
           "k0s": {
             "description": "k0s worker configuration options",

--- a/templates/cluster/remote-cluster/values.yaml
+++ b/templates/cluster/remote-cluster/values.yaml
@@ -18,7 +18,7 @@ clusterNetwork: # @schema description: The cluster network configuration; type: 
 
 # Machines' parameters
 machines: # @schema description: The list of remote machines configurations; type: array; item: object; minItems: 1
-  - address: "0.0.0.0" # @schema description: The IP address of the remote machine; type: string; pattern:^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$; required: true
+  - address: "0.0.0.0" # @schema description: Address is the IP address or DNS name of the remote machine; type: string; required: true; examples: [10.130.0.237, 2001:0db8:85a3:0000:0000:8a2e:0370:7334, hostname]
     port: 22 # @schema description: The SSH port of the remote machine; type: number; minimum: 1; maximum: 65535; default: 22
     user: "root" # @schema description: The user to use when connecting to the remote machine; type: string; default: root
     useSudo: false # @schema description: Determines whether to use sudo for k0s cluster bootstrap commands; type: boolean; default: false

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-9.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-9.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-8
+  name: remote-cluster-1-0-9
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: remote-cluster
-      version: 1.0.8
+      version: 1.0.9
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes validation of the machine address in the remote-cluster template.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #1746 
