### PR TITLE
feat: Make image configuration more flexible for Azure templates

### DIFF
--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-8
+  template: azure-standalone-cp-1-0-9
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/azuremachinetemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/azuremachinetemplate.yaml
@@ -15,6 +15,14 @@ spec:
       {{- if not (quote .Values.image | empty) }}
       {{- with .Values.image }}
       image:
-        {{- toYaml . | nindent 8 }}
+        {{- if .id }}
+        id: {{ .id }}
+        {{- else if .computeGallery }}
+        computeGallery:
+          {{- toYaml .computeGallery | nindent 10 }}
+        {{- else if .marketplace }}
+        marketplace:
+          {{- toYaml .marketplace | nindent 10 }}
+        {{- end }}
       {{- end }}
       {{- end }}

--- a/templates/cluster/azure-hosted-cp/values.schema.json
+++ b/templates/cluster/azure-hosted-cp/values.schema.json
@@ -69,6 +69,12 @@
     "image": {
       "type": "object",
       "properties": {
+        "computeGallery": {
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
         "marketplace": {
           "type": "object",
           "properties": {

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -35,6 +35,8 @@ sshPublicKey: ""
 vmSize: ""
 rootVolumeSize: 30
 image:
+  id: ""
+  computeGallery: {}
   marketplace:
     publisher: "cncf-upstream"
     offer: "capi"

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-controlplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-controlplane.yaml
@@ -15,6 +15,14 @@ spec:
       {{- if not (quote .Values.controlPlane.image | empty) }}
       {{- with .Values.controlPlane.image }}
       image:
-        {{- toYaml . | nindent 8 }}
+        {{- if .id }}
+        id: {{ .id }}
+        {{- else if .computeGallery }}
+        computeGallery:
+          {{- toYaml .computeGallery | nindent 10 }}
+        {{- else if .marketplace }}
+        marketplace:
+          {{- toYaml .marketplace | nindent 10 }}
+        {{- end }}
       {{- end }}
       {{- end }}

--- a/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-worker.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-worker.yaml
@@ -15,6 +15,14 @@ spec:
       {{- if not (quote .Values.worker.image | empty) }}
       {{- with .Values.worker.image }}
       image:
-        {{- toYaml . | nindent 8 }}
+        {{- if .id }}
+        id: {{ .id }}
+        {{- else if .computeGallery }}
+        computeGallery:
+          {{- toYaml .computeGallery | nindent 10 }}
+        {{- else if .marketplace }}
+        marketplace:
+          {{- toYaml .marketplace | nindent 10 }}
+        {{- end }}
       {{- end }}
       {{- end }}

--- a/templates/cluster/azure-standalone-cp/values.schema.json
+++ b/templates/cluster/azure-standalone-cp/values.schema.json
@@ -69,6 +69,12 @@
         "image": {
           "type": "object",
           "properties": {
+            "computeGallery": {
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
             "marketplace": {
               "type": "object",
               "properties": {
@@ -161,6 +167,12 @@
         "image": {
           "type": "object",
           "properties": {
+            "computeGallery": {
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
             "marketplace": {
               "type": "object",
               "properties": {

--- a/templates/cluster/azure-standalone-cp/values.yaml
+++ b/templates/cluster/azure-standalone-cp/values.yaml
@@ -29,6 +29,8 @@ controlPlane:
   vmSize: ""
   rootVolumeSize: 30
   image:
+    id: ""
+    computeGallery: {}
     marketplace:
       publisher: "cncf-upstream"
       offer: "capi"
@@ -40,6 +42,8 @@ worker:
   vmSize: ""
   rootVolumeSize: 30
   image:
+    id: ""
+    computeGallery: {}
     marketplace:
       publisher: "cncf-upstream"
       offer: "capi"

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-9.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-9.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-8
+  name: azure-hosted-cp-1-0-9
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.8
+      chart: azure-hosted-cp
+      version: 1.0.9
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-9.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-9.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-8
+  name: azure-standalone-cp-1-0-9
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.8
+      chart: azure-standalone-cp
+      version: 1.0.9
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Azure templates to support specifying images using either the `id` or `computeGallery` configuration options. `image.marketplace` is still kept as a default but if either `id` or `computeGallery` is specified, this value will be used. (priority: `id` > `computeGallery` > `marketplace`).

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_: Fixes #1767
