### PR TITLE
style: add ready print column for releases

### DIFF
--- a/api/v1beta1/release_types.go
+++ b/api/v1beta1/release_types.go
@@ -99,6 +99,8 @@ func (in *Release) GetConditions() *[]metav1.Condition {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`,description="Denotes Release is ready to be used",priority=0
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time elapsed since object creation",priority=0
 
 // Release is the Schema for the releases API
 type Release struct {

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   version: 1.1.1
   kcm:
-    template: kcm-1-1-4
+    template: kcm-1-1-5
   capi:
     template: cluster-api-1-0-4
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-1-1-4
+  name: kcm-1-1-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 1.1.4
+      version: 1.1.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.4
+version: 1.1.5
 dependencies:
   - name: flux2
     version: 2.16.0

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_releases.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_releases.yaml
@@ -159,7 +159,16 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Denotes Release is ready to be used
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Time elapsed since object creation
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Release is the Schema for the releases API


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `ready` print columt with priority 0 to the output of the `releases` resource

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #1773