### PR TITLE
fix: services deployed & clusters matched in MCS kubectl output

### DIFF
--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -313,18 +313,18 @@ func (r *MultiClusterServiceReconciler) setClustersServicesReadinessConditions(c
 		return fmt.Errorf("failed to construct selector from MultiClusterService %s selector: %w", client.ObjectKeyFromObject(mcs), err)
 	}
 
-	clusters := &metav1.PartialObjectMetadataList{}
-	clusters.SetGroupVersionKind(schema.GroupVersionKind{
+	capiClusters := &metav1.PartialObjectMetadataList{}
+	capiClusters.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "cluster.x-k8s.io",
 		Version: "v1beta1",
 		Kind:    "Cluster",
 	})
-	if err := r.Client.List(ctx, clusters, client.MatchingLabelsSelector{Selector: sel}); err != nil {
+	if err := r.Client.List(ctx, capiClusters, client.MatchingLabelsSelector{Selector: sel}); err != nil {
 		return fmt.Errorf("failed to list partial Clusters: %w", err)
 	}
 
 	ready := 0
-	for _, cluster := range clusters.Items {
+	for _, cluster := range capiClusters.Items {
 		key := client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}
 		cld := new(kcmv1.ClusterDeployment)
 		if err := r.Client.Get(ctx, key, cld); err != nil {
@@ -337,7 +337,31 @@ func (r *MultiClusterServiceReconciler) setClustersServicesReadinessConditions(c
 		}
 	}
 
-	desiredClusters, desiredServices := len(clusters.Items), len(clusters.Items)*len(mcs.Spec.ServiceSpec.Services)
+	// There is also SveltosCluster type to consider.
+	sveltosClusters := &metav1.PartialObjectMetadataList{}
+	sveltosClusters.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "lib.projectsveltos.io",
+		Version: "v1beta1",
+		Kind:    "SveltosCluster",
+	})
+	if err := r.Client.List(ctx, sveltosClusters, client.MatchingLabelsSelector{Selector: sel}); err != nil {
+		return fmt.Errorf("failed to list partial SveltosClusters: %w", err)
+	}
+
+	for _, cluster := range sveltosClusters.Items {
+		key := client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}
+		sc := libsveltosv1beta1.SveltosCluster{}
+		if err := r.Client.Get(ctx, key, &sc); err != nil {
+			return fmt.Errorf("failed to get SveltosCluster %s: %w", key.String(), err)
+		}
+
+		if sc.Status.Ready {
+			ready++
+		}
+	}
+
+	desiredClusters := len(capiClusters.Items) + len(sveltosClusters.Items)
+	desiredServices := desiredClusters * len(mcs.Spec.ServiceSpec.Services)
 	c := metav1.Condition{
 		Type:    kcmv1.ClusterInReadyStateCondition,
 		Status:  metav1.ConditionTrue,

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -28,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -312,19 +313,32 @@ func (r *MultiClusterServiceReconciler) setClustersServicesReadinessConditions(c
 		return fmt.Errorf("failed to construct selector from MultiClusterService %s selector: %w", client.ObjectKeyFromObject(mcs), err)
 	}
 
-	capiClusters := &kcmv1.ClusterDeploymentList{}
+	// Fetch matching CAPI clusters/
+	capiClusters := &metav1.PartialObjectMetadataList{}
+	capiClusters.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "cluster.x-k8s.io",
+		Version: "v1beta1",
+		Kind:    "Cluster",
+	})
 	if err := r.Client.List(ctx, capiClusters, client.MatchingLabelsSelector{Selector: sel}); err != nil {
-		return fmt.Errorf("failed to list CAPI Clusters: %w", err)
+		return fmt.Errorf("failed to list partial Clusters: %w", err)
 	}
 
 	ready := 0
 	for _, cluster := range capiClusters.Items {
-		rc := apimeta.FindStatusCondition(cluster.Status.Conditions, kcmv1.ReadyCondition)
+		key := client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}
+		cld := new(kcmv1.ClusterDeployment)
+		if err := r.Client.Get(ctx, key, cld); err != nil {
+			return fmt.Errorf("failed to get ClusterDeployment %s: %w", key.String(), err)
+		}
+
+		rc := apimeta.FindStatusCondition(cld.Status.Conditions, kcmv1.ReadyCondition)
 		if rc != nil && rc.Status == metav1.ConditionTrue {
 			ready++
 		}
 	}
 
+	// Fetch matching Sveltos clusters.
 	sveltosClusters := &libsveltosv1beta1.SveltosClusterList{}
 	if err := r.Client.List(ctx, sveltosClusters, client.MatchingLabelsSelector{Selector: sel}); err != nil {
 		return fmt.Errorf("failed to list SveltosClusters: %w", err)

--- a/internal/sveltos/status_test.go
+++ b/internal/sveltos/status_test.go
@@ -92,7 +92,7 @@ func TestSetStatusConditions(t *testing.T) {
 			},
 		},
 		{
-			name: "sveltos helmreleasesummary managing",
+			name: "sveltos helmreleasesummary managing but not deployed yet",
 			summary: addoncontrollerv1beta1.ClusterSummary{
 				Status: addoncontrollerv1beta1.ClusterSummaryStatus{
 					HelmReleaseSummaries: []addoncontrollerv1beta1.HelmChartSummary{
@@ -100,6 +100,27 @@ func TestSetStatusConditions(t *testing.T) {
 							ReleaseNamespace: releaseNamespace,
 							ReleaseName:      releaseName,
 							Status:           addoncontrollerv1beta1.HelmChartStatusManaging,
+						},
+					},
+				},
+			},
+			expectCondition: metav1.Condition{
+				Type:    helmReleaseReadyConditionType(releaseNamespace, releaseName),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(addoncontrollerv1beta1.HelmChartStatusManaging),
+				Message: helmReleaseConditionMessage(releaseNamespace, releaseName, ""),
+			},
+		},
+		{
+			name: "sveltos helmreleasesummary managing and successfully deployed",
+			summary: addoncontrollerv1beta1.ClusterSummary{
+				Status: addoncontrollerv1beta1.ClusterSummaryStatus{
+					HelmReleaseSummaries: []addoncontrollerv1beta1.HelmChartSummary{
+						{
+							ReleaseNamespace: releaseNamespace,
+							ReleaseName:      releaseName,
+							Status:           addoncontrollerv1beta1.HelmChartStatusManaging,
+							ValuesHash:       []byte("somehash"),
 						},
 					},
 				},


### PR DESCRIPTION
# Description

Fix the `kubectl get mcs` output to:

1. Also consider SveltosCluster type alongside CAPI clusters.
2. Fix the bug where if a service errors out, the output still shows it to be deployed. E.g., if the spec has 1 service and that fails, the output still shows 1/1 services. This PR fixes this to show 0/1 services in the output.

# Verification

Created the following service templates (with helm repositories):
```yaml
apiVersion: source.toolkit.fluxcd.io/v1
kind: HelmRepository
metadata:
  name: k0rdent-catalog
  namespace: kcm-system
  labels:
    k0rdent.mirantis.com/managed: "true"
spec:
  insecure: true
  interval: 10m0s
  provider: generic
  type: oci
  url: oci://ghcr.io/k0rdent/catalog/charts
---
apiVersion: source.toolkit.fluxcd.io/v1
kind: HelmRepository
metadata:
  name: nginx-upstream
  namespace: kcm-system
  labels:
    k0rdent.mirantis.com/managed: "true"
spec:
  interval: 10m0s
  url: https://kubernetes.github.io/ingress-nginx
---
apiVersion: k0rdent.mirantis.com/v1beta1
kind: ServiceTemplate
metadata:
  annotations:
    helm.sh/resource-policy: keep
  name: ingress-nginx-4-12-0
  namespace: kcm-system
spec:
  helm:
    chartSpec:
      chart: ingress-nginx
      sourceRef:
        kind: HelmRepository
        name: nginx-upstream
      version: 4.12.0
---
apiVersion: k0rdent.mirantis.com/v1beta1
kind: ServiceTemplate
metadata:
  annotations:
    helm.sh/resource-policy: keep
  name: ingress-nginx-4-11-5
  namespace: kcm-system
spec:
  helm:
    chartSpec:
      chart: ingress-nginx
      sourceRef:
        kind: HelmRepository
        name: k0rdent-catalog
      version: 4.11.5
---
apiVersion: k0rdent.mirantis.com/v1beta1
kind: ServiceTemplate
metadata:
  name: kyverno-3-2-6
  annotations:
    helm.sh/resource-policy: keep
spec:
  helm:
    chartSpec:
      chart: kyverno
      version: 3.2.6
      interval: 10m0s
      sourceRef:
        kind: HelmRepository
        name: k0rdent-catalog
```
```sh
➜  ~ kubectl -n kcm-system get servicetemplate
NAME                   VALID
ingress-nginx-4-11-5   true
ingress-nginx-4-12-0   true
kyverno-3-2-6          true
```

Now created an MCS with the following spec targeting the management cluster itself:
```yaml
apiVersion: k0rdent.mirantis.com/v1beta1
kind: MultiClusterService
metadata:
  name: mgmt
spec:
  clusterSelector:
    matchLabels:
      k0rdent.mirantis.com/management-cluster: "true"
      sveltos-agent: present
  serviceSpec:
    priority: 1000
    services:
      - template: ingress-nginx-4-11-5
        name: ingress-nginx
        namespace: ingress-nginx
      - template: kyverno-3-2-6
        name: kyverno
        namespace: kyverno
    reload: false
```

Now deleted the MCS and recreated with the following spec to induce the `no cached repo found` error:
```sh
apiVersion: k0rdent.mirantis.com/v1beta1
kind: MultiClusterService
. . .
  serviceSpec:
    priority: 1000
    services:
      - template: ingress-nginx-4-12-0
        name: ingress-nginx
        namespace: ingress-nginx
      - template: kyverno-3-2-6
        name: kyverno
        namespace: kyverno
. . .
```

We can see that the `no cached repo found` error exists in the status:
```sh
➜  util git:(main) ✗ kubectl get mcs mgmt -o yaml
apiVersion: k0rdent.mirantis.com/v1beta1
kind: MultiClusterService
metadata:
  . . .
spec:
  . . .
status:
  . . .
  services:
  - clusterName: mgmt
    clusterNamespace: mgmt
    conditions:
    - lastTransitionTime: "2025-07-23T15:44:16Z"
      message: 'no cached repo found. (try ''helm repo update''): open /home/nonroot/.cache/helm/repository/ingress-nginx-index.yaml:
        no such file or directory'
      reason: Provisioning
      status: "False"
      type: Helm
    - lastTransitionTime: "2025-07-23T15:44:16Z"
      message: Release ingress-nginx/ingress-nginx
      reason: Managing
      status: "False"
      type: ingress-nginx.ingress-nginx/SveltosHelmReleaseReady
    - lastTransitionTime: "2025-07-23T15:44:16Z"
      message: Release kyverno/kyverno
      reason: Managing
      status: "False"
      type: kyverno.kyverno/SveltosHelmReleaseReady
  servicesUpgradePaths:
  - name: ingress-nginx
    namespace: ingress-nginx
    template: ingress-nginx-4-12-0
  - name: kyverno
    namespace: kyverno
    template: kyverno-3-2-6
```
✅ So now we can verify that `kubectl get` output shows 0/2 services deployed and 1/1 cluster ready:
```sh
➜  ~ kubectl get mcs mgmt                     
NAME   SERVICES   CLUSTERS   AGE
mgmt   0/2        1/1        7m43s
```
Now let's set `continueOnError=True`, so that kyverno can be installed:
```sh
apiVersion: k0rdent.mirantis.com/v1beta1
kind: MultiClusterService
. . .
  serviceSpec:
    priority: 1000
    continueOnError: true
    services:
      - template: ingress-nginx-4-12-0
        name: ingress-nginx
        namespace: ingress-nginx
      - template: kyverno-3-2-6
        name: kyverno
        namespace: kyverno
. . .
```
We can see from the status that kyverno has been successfully deployed while ingress-nginx still shows the error:
```sh
apiVersion: k0rdent.mirantis.com/v1beta1
kind: MultiClusterService
metadata:
  . . .
spec:
  . . .
status:
  . . .
  services:
  - clusterName: mgmt
    clusterNamespace: mgmt
    conditions:
    - lastTransitionTime: "2025-07-23T15:51:41Z"
      message: |
        chart: ingress-nginx/ingress-nginx, release: ingress-nginx, uninstall: Release not loaded: ingress-nginx: release: not found
      reason: Provisioning
      status: "False"
      type: Helm
    - lastTransitionTime: "2025-07-23T15:51:41Z"
      message: Release ingress-nginx/ingress-nginx
      reason: Managing
      status: "False"
      type: ingress-nginx.ingress-nginx/SveltosHelmReleaseReady
    - lastTransitionTime: "2025-07-23T15:51:41Z"
      message: Release kyverno/kyverno
      reason: Managing
      status: "True"
      type: kyverno.kyverno/SveltosHelmReleaseReady
 . . .
```
✅ So now we should expect `kubectl get` to show 1/2 services installed and 1/1 clusters ready, which is the case:
```sh
➜  ~ kubectl get mcs mgmt 
NAME   SERVICES   CLUSTERS   AGE
mgmt   1/2        1/1        34s
```
