### PR TITLE
fix: override velero name

### DIFF
--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   version: 1.1.1
   kcm:
-    template: kcm-1-1-5
+    template: kcm-1-1-6
   capi:
     template: cluster-api-1-0-5
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-1-1-5
+  name: kcm-1-1-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 1.1.5
+      version: 1.1.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.5
+version: 1.1.6
 dependencies:
   - name: flux2
     version: 2.16.0

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -408,6 +408,9 @@
         "enabled": {
           "type": "boolean"
         },
+        "fullnameOverride": {
+          "type": "string"
+        },
         "metrics": {
           "type": "object",
           "properties": {

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -107,6 +107,7 @@ cluster-api-operator:
 
 velero:
   enabled: true
+  fullnameOverride: velero # vmware-tanzu/velero#9023
   # example of enabling a plugin
   # initContainers:
   # - name: velero-plugin-for-aws


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets velero components to fixed `velero` so the restoration would work.

Every cluster that has a version not containing the fix, still has to patch `managements` object manually before the restoration

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
