### PR TITLE
test: Support to run e2e tests on arm64 architecture

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       config: ${{ steps.get_config.outputs.config }}
       public_repo: ${{ steps.get_config.outputs.public_repo }}
+      runner: ${{ steps.get_config.outputs.runner }}
     steps:
       - name: Get Testing Configuration
         id: get_config
@@ -43,7 +44,23 @@ jobs:
             echo "Invalid testing configuration provided"
             exit 1
           fi
-          echo "config=$(echo -n "$config" | base64 -w 0)" >> "$GITHUB_OUTPUT"
+
+          arch=$(echo -n "$config" | yq -r '.architecture // "amd64"')
+          case "$arch" in
+            amd64)
+              echo "runner=ubuntu-latest" >> "$GITHUB_OUTPUT"
+              ;;
+            arm64)
+              echo "runner=ubuntu-24.04-arm" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Error: unsupported architecture '$arch'"
+              echo "Allowed values: 'amd64' or 'arm64'"
+              exit 1
+              ;;
+          esac
+
+          echo "config=$(echo -n "$config" | yq 'del (.architecture) | select(length > 0)' | base64 -w 0)" >> "$GITHUB_OUTPUT"
           if echo "$config" | yq e '... comments=""' | grep -q "hosted"; then
             echo "Hosted cluster deployment was triggered. Using public repository"
             echo "public_repo=true" >> "$GITHUB_OUTPUT"
@@ -136,7 +153,7 @@ jobs:
 
   controller-e2etest:
     name: E2E Controller
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.authorize.outputs.runner || 'ubuntu-latest' }}
     if: ${{ !contains( github.event.pull_request.labels.*.name, 'test e2e') }}
     needs: lint-test
     concurrency:
@@ -173,7 +190,7 @@ jobs:
 
   push-public:
     name: Build and Push Artifacts When Required
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.authorize.outputs.runner || 'ubuntu-latest' }}
     needs:
        - authorize
        - lint-test
@@ -232,7 +249,7 @@ jobs:
 
   provider-cloud-e2etest:
     name: E2E Cloud Providers
-    runs-on: ubuntu-latest
+    runs-on: ${{ needs.authorize.outputs.runner || 'ubuntu-latest' }}
     if: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') }}
     needs:
       - lint-test

--- a/test/e2e/clusterdeployment/aws/aws.go
+++ b/test/e2e/clusterdeployment/aws/aws.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/K0rdent/kcm/test/e2e/clusterdeployment"
+	"github.com/K0rdent/kcm/test/e2e/config"
 	"github.com/K0rdent/kcm/test/e2e/kubeclient"
 )
 
@@ -38,6 +39,19 @@ func CheckEnv() {
 		clusterdeployment.EnvVarAWSAccessKeyID,
 		clusterdeployment.EnvVarAWSSecretAccessKey,
 	})
+}
+
+func PopulateEnvVars(architecture config.Architecture) {
+	GinkgoHelper()
+
+	switch architecture {
+	case config.ArchitectureAmd64:
+		GinkgoT().Setenv(clusterdeployment.EnvVarAWSAMIID, "") // If unset, the default AMI lookup value defined in the template will be used
+		GinkgoT().Setenv(clusterdeployment.EnvVarAWSInstanceType, "t3.small")
+	case config.ArchitectureArm64:
+		GinkgoT().Setenv(clusterdeployment.EnvVarAWSAMIID, "ami-050499786ebf55a6a")
+		GinkgoT().Setenv(clusterdeployment.EnvVarAWSInstanceType, "t4g.small")
+	}
 }
 
 // PopulateHostedTemplateVars populates the environment variables required for

--- a/test/e2e/clusterdeployment/azure/azure.go
+++ b/test/e2e/clusterdeployment/azure/azure.go
@@ -31,6 +31,7 @@ import (
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	"github.com/K0rdent/kcm/internal/utils/pointer"
 	"github.com/K0rdent/kcm/test/e2e/clusterdeployment"
+	"github.com/K0rdent/kcm/test/e2e/config"
 	"github.com/K0rdent/kcm/test/e2e/kubeclient"
 )
 
@@ -41,6 +42,22 @@ func CheckEnv() {
 		clusterdeployment.EnvVarAzureTenantID,
 		clusterdeployment.EnvVarAzureSubscription,
 	})
+}
+
+func PopulateEnvVars(architecture config.Architecture) {
+	GinkgoHelper()
+
+	GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageGallery, "aksazurelinux-f7c7cda5-1c9a-4bdc-a222-9614c968580b")
+	switch architecture {
+	case config.ArchitectureAmd64:
+		GinkgoT().Setenv(clusterdeployment.EnvVarAzureVMSize, "Standard_A4_v2")
+		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageName, "V2")
+		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageVersion, "202409.23.0")
+	case config.ArchitectureArm64:
+		GinkgoT().Setenv(clusterdeployment.EnvVarAzureVMSize, "Standard_D4pls_v6")
+		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageName, "V2gen2arm64")
+		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageVersion, "202501.05.0")
+	}
 }
 
 func getAzureInfo(ctx context.Context, name string, kc *kubeclient.KubeClient) map[string]any {

--- a/test/e2e/clusterdeployment/constants.go
+++ b/test/e2e/clusterdeployment/constants.go
@@ -31,6 +31,7 @@ const (
 	EnvVarAWSVPCID           = "AWS_VPC_ID"
 	EnvVarAWSSubnets         = "AWS_SUBNETS"
 	EnvVarAWSInstanceType    = "AWS_INSTANCE_TYPE"
+	EnvVarAWSAMIID           = "AWS_AMI_ID"
 	EnvVarAWSSecurityGroupID = "AWS_SG_ID"
 
 	// VSphere
@@ -53,11 +54,18 @@ const (
 	EnvVarAzureClientID     = "AZURE_CLIENT_ID"
 	EnvVarAzureTenantID     = "AZURE_TENANT_ID"
 	EnvVarAzureSubscription = "AZURE_SUBSCRIPTION_ID"
+	EnvVarAzureVMSize       = "AZURE_VM_SIZE"
+	EnvVarAzureImageGallery = "AZURE_IMAGE_GALLERY"
+	EnvVarAzureImageName    = "AZURE_IMAGE_NAME"
+	EnvVarAzureImageVersion = "AZURE_IMAGE_VERSION"
 
 	// GCP
 	EnvVarGCPEncodedCredentials = "GCP_B64ENCODED_CREDENTIALS"
 	EnvVarGCPProject            = "GCP_PROJECT"
 	EnvVarGCPRegion             = "GCP_REGION"
+	EnvVarGCPInstanceType       = "GCP_INSTANCE_TYPE"
+	EnvVarGCPImage              = "GCP_IMAGE"
+	EnvVarGCPRootDeviceType     = "GCP_ROOT_DEVICE_TYPE"
 
 	// Adopted
 	EnvVarAdoptedKubeconfigData = "KUBECONFIG_DATA"

--- a/test/e2e/clusterdeployment/gcp/env.go
+++ b/test/e2e/clusterdeployment/gcp/env.go
@@ -14,7 +14,12 @@
 
 package gcp
 
-import "github.com/K0rdent/kcm/test/e2e/clusterdeployment"
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/K0rdent/kcm/test/e2e/clusterdeployment"
+	"github.com/K0rdent/kcm/test/e2e/config"
+)
 
 func CheckEnv() {
 	clusterdeployment.ValidateDeploymentVars([]string{
@@ -22,4 +27,19 @@ func CheckEnv() {
 		clusterdeployment.EnvVarGCPProject,
 		clusterdeployment.EnvVarGCPRegion,
 	})
+}
+
+func PopulateEnvVars(architecture config.Architecture) {
+	GinkgoHelper()
+
+	switch architecture {
+	case config.ArchitectureAmd64:
+		GinkgoT().Setenv(clusterdeployment.EnvVarGCPInstanceType, "n1-standard-2")
+		GinkgoT().Setenv(clusterdeployment.EnvVarGCPImage, "projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20250213")
+		GinkgoT().Setenv(clusterdeployment.EnvVarGCPRootDeviceType, "pd-standard")
+	case config.ArchitectureArm64:
+		GinkgoT().Setenv(clusterdeployment.EnvVarGCPInstanceType, "c4a-standard-2")
+		GinkgoT().Setenv(clusterdeployment.EnvVarGCPImage, "projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-arm64-v20250712")
+		GinkgoT().Setenv(clusterdeployment.EnvVarGCPRootDeviceType, "hyperdisk-balanced")
+	}
 }

--- a/test/e2e/clusterdeployment/resources/aws-eks.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/aws-eks.yaml.tpl
@@ -12,4 +12,5 @@ spec:
     workersNumber: ${WORKERS_NUMBER:=1}
     publicIP: ${AWS_PUBLIC_IP:=true}
     worker:
+      amiID: ${AMI_ID}
       instanceType: ${AWS_INSTANCE_TYPE:=t3.small}

--- a/test/e2e/clusterdeployment/resources/aws-hosted-cp.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/aws-hosted-cp.yaml.tpl
@@ -11,6 +11,7 @@ spec:
     region: ${AWS_REGION}
     subnets:
 ${AWS_SUBNETS}
+    amiID: ${AWS_AMI_ID}
     instanceType: ${AWS_INSTANCE_TYPE:=t3.medium}
     securityGroupIDs:
       - ${AWS_SG_ID}

--- a/test/e2e/clusterdeployment/resources/aws-standalone-cp.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/aws-standalone-cp.yaml.tpl
@@ -12,11 +12,13 @@ spec:
     controlPlaneNumber: ${CONTROL_PLANE_NUMBER:=1}
     workersNumber: ${WORKERS_NUMBER:=1}
     controlPlane:
+      amiID: ${AWS_AMI_ID}
       instanceType: ${AWS_INSTANCE_TYPE:=t3.small}
-      rootVolumeSize: 30
+      rootVolumeSize: 40
     worker:
+      amiID: ${AWS_AMI_ID}
       instanceType: ${AWS_INSTANCE_TYPE:=t3.small}
-      rootVolumeSize: 30
+      rootVolumeSize: 40
   serviceSpec:
     services:
       - template: ingress-nginx-4-12-1

--- a/test/e2e/clusterdeployment/resources/azure-aks.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/azure-aks.yaml.tpl
@@ -13,7 +13,7 @@ spec:
     machinePools:
       system:
         count: 1
-        vmSize: Standard_A4_v2
+        vmSize: ${AZURE_VM_SIZE:=Standard_A4_v2}
       user:
         count: 1
-        vmSize: Standard_A4_v2
+        vmSize: ${AZURE_VM_SIZE:=Standard_A4_v2}

--- a/test/e2e/clusterdeployment/resources/azure-hosted-cp.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/azure-hosted-cp.yaml.tpl
@@ -9,7 +9,13 @@ spec:
   config:
     location: "${AZURE_REGION}"
     subscriptionID: "${AZURE_SUBSCRIPTION_ID}"
-    vmSize: Standard_A4_v2
+    vmSize: ${AZURE_VM_SIZE:=Standard_A4_v2}
+    rootVolumeSize: 50
+    image:
+      computeGallery:
+        gallery: ${AZURE_IMAGE_GALLERY}
+        name: ${AZURE_IMAGE_NAME}
+        version: ${AZURE_IMAGE_VERSION}
     resourceGroup: "${AZURE_RESOURCE_GROUP}"
     network:
       vnetName: "${AZURE_VM_NET_NAME}"

--- a/test/e2e/clusterdeployment/resources/azure-standalone-cp.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/azure-standalone-cp.yaml.tpl
@@ -12,9 +12,21 @@ spec:
     location: "${AZURE_REGION}"
     subscriptionID: "${AZURE_SUBSCRIPTION_ID}"
     controlPlane:
-      vmSize: Standard_A4_v2
+      vmSize: ${AZURE_VM_SIZE:=Standard_A4_v2}
+      rootVolumeSize: 50
+      image:
+        computeGallery:
+          gallery: ${AZURE_IMAGE_GALLERY}
+          name: ${AZURE_IMAGE_NAME}
+          version: ${AZURE_IMAGE_VERSION}
     worker:
-      vmSize: Standard_A4_v2
+      vmSize: ${AZURE_VM_SIZE:=Standard_A4_v2}
+      rootVolumeSize: 50
+      image:
+        computeGallery:
+          gallery: ${AZURE_IMAGE_GALLERY}
+          name: ${AZURE_IMAGE_NAME}
+          version: ${AZURE_IMAGE_VERSION}
     tenantID: "${AZURE_TENANT_ID}"
     clientID: "${AZURE_CLIENT_ID}"
     clientSecret: "${AZURE_CLIENT_SECRET}"

--- a/test/e2e/clusterdeployment/resources/gcp-gke.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/gcp-gke.yaml.tpl
@@ -15,5 +15,6 @@ spec:
       name: ${CLUSTER_DEPLOYMENT_NAME}
     releaseChannel: regular
     machines:
+      machineType: ${GCP_INSTANCE_TYPE:=n1-standard-2}
       nodeLocations:
       - ${GCP_REGION}-a

--- a/test/e2e/clusterdeployment/resources/gcp-hosted-cp.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/gcp-hosted-cp.yaml.tpl
@@ -13,7 +13,8 @@ spec:
       name: default
     controlPlaneNumber: 1
     worker:
-      instanceType: n1-standard-2
-      image: projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20250213
+      instanceType: ${GCP_INSTANCE_TYPE:=n1-standard-2}
+      image: ${GCP_IMAGE:=projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20250213}
+      rootDeviceType: ${GCP_ROOT_DEVICE_TYPE:=pd-standard}
       publicIP: true
     workersNumber: 1

--- a/test/e2e/clusterdeployment/resources/gcp-standalone-cp.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/gcp-standalone-cp.yaml.tpl
@@ -12,12 +12,14 @@ spec:
     network:
       name: default
     controlPlane:
-      instanceType: n1-standard-2
-      image: projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20250213
+      instanceType: ${GCP_INSTANCE_TYPE:=n1-standard-2}
+      image: ${GCP_IMAGE:=projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20250213}
+      rootDeviceType: ${GCP_ROOT_DEVICE_TYPE:=pd-standard}
       publicIP: true
     controlPlaneNumber: 1
     worker:
-      instanceType: n1-standard-2
-      image: projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20250213
+      instanceType: ${GCP_INSTANCE_TYPE:=n1-standard-2}
+      image: ${GCP_IMAGE:=projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20250213}
+      rootDeviceType: ${GCP_ROOT_DEVICE_TYPE:=pd-standard}
       publicIP: true
     workersNumber: 1

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -66,8 +66,36 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	By("validating that all K0rdent management components are ready")
 	kc := kubeclient.NewFromLocal(internalutils.DefaultSystemNamespace)
+
+	// TODO: remove after https://github.com/k0rdent/kcm/issues/1575 is fixed
+	By("applying workaround to disable infoblox provider")
+	mgmt := &kcmv1.Management{}
+	Eventually(func() error {
+		return kc.CrClient.Get(context.Background(), crclient.ObjectKey{Name: kcmv1.ManagementName}, mgmt)
+	}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+	capiInfobloxProviderName := "cluster-api-provider-infoblox"
+	Eventually(func() error {
+		patch := crclient.MergeFrom(mgmt.DeepCopy())
+		mgmt.Spec.Providers = slices.DeleteFunc(mgmt.Spec.Providers, func(provider kcmv1.Provider) bool {
+			return provider.Name == capiInfobloxProviderName
+		})
+		if err := kc.CrClient.Patch(context.Background(), mgmt, patch); err != nil {
+			return err
+		}
+		if err := kc.CrClient.Get(context.Background(), crclient.ObjectKey{Name: kcmv1.ManagementName}, mgmt); err != nil {
+			return err
+		}
+		if !slices.ContainsFunc(mgmt.Spec.Providers, func(provider kcmv1.Provider) bool {
+			return provider.Name == capiInfobloxProviderName
+		}) {
+			return nil
+		}
+		return fmt.Errorf("%s provider is still present in Management spec", capiInfobloxProviderName)
+	}).WithTimeout(10 * time.Minute).WithPolling(20 * time.Second).Should(Succeed())
+
+	By("validating that all K0rdent management components are ready")
 	Eventually(func() error {
 		err = verifyManagementReadiness(kc)
 		if err != nil {

--- a/test/e2e/provider_adopted_test.go
+++ b/test/e2e/provider_adopted_test.go
@@ -27,6 +27,7 @@ import (
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	internalutils "github.com/K0rdent/kcm/internal/utils"
 	"github.com/K0rdent/kcm/test/e2e/clusterdeployment"
+	"github.com/K0rdent/kcm/test/e2e/clusterdeployment/aws"
 	"github.com/K0rdent/kcm/test/e2e/config"
 	"github.com/K0rdent/kcm/test/e2e/credential"
 	"github.com/K0rdent/kcm/test/e2e/flux"
@@ -129,6 +130,14 @@ var _ = Describe("Adopted Cluster Templates", Label("provider:cloud", "provider:
 			awsTemplates := templates.FindLatestTemplatesWithType(clusterTemplates, templates.TemplateAWSStandaloneCP, 1)
 			Expect(awsTemplates).NotTo(BeEmpty())
 			clusterTemplate := awsTemplates[0]
+
+			// Supported architectures for AWS deployment: amd64, arm64
+			Expect(testingConfig.Architecture).To(SatisfyAny(
+				Equal(config.ArchitectureAmd64),
+				Equal(config.ArchitectureArm64)),
+				fmt.Sprintf("architecture should be either %s or %s", config.ArchitectureAmd64, config.ArchitectureArm64),
+			)
+			aws.PopulateEnvVars(testingConfig.Architecture)
 
 			templateBy(templates.TemplateAWSStandaloneCP, fmt.Sprintf("creating a ClusterDeployment %s with template %s", clusterName, clusterTemplate))
 			sd := clusterdeployment.Generate(templates.TemplateAWSStandaloneCP, clusterName, clusterTemplate)

--- a/test/e2e/provider_aws_test.go
+++ b/test/e2e/provider_aws_test.go
@@ -140,6 +140,15 @@ var _ = Describe("AWS Templates", Label("provider:cloud", "provider:aws"), Order
 				Equal(templates.TemplateAWSStandaloneCP)),
 				fmt.Sprintf("template type should be either %s or %s", templates.TemplateAWSEKS, templates.TemplateAWSStandaloneCP))
 
+			// Supported architectures for AWS standalone deployment: amd64, arm64
+			Expect(testingConfig.Architecture).To(SatisfyAny(
+				Equal(config.ArchitectureAmd64),
+				Equal(config.ArchitectureArm64)),
+				fmt.Sprintf("architecture should be either %s or %s", config.ArchitectureAmd64, config.ArchitectureArm64),
+			)
+
+			aws.PopulateEnvVars(testingConfig.Architecture)
+
 			templateBy(sdTemplateType, fmt.Sprintf("creating a ClusterDeployment %s with template %s", sdName, sdTemplate))
 
 			sd := clusterdeployment.Generate(sdTemplateType, sdName, sdTemplate)
@@ -279,6 +288,15 @@ var _ = Describe("AWS Templates", Label("provider:cloud", "provider:aws"), Order
 
 				// Ensure AWS credentials are set in the standalone cluster.
 				credential.Apply(kubeCfgPath, "aws")
+
+				// Supported architectures for AWS hosted deployment: amd64, arm64
+				Expect(testingConfig.Hosted.Architecture).To(SatisfyAny(
+					Equal(config.ArchitectureAmd64),
+					Equal(config.ArchitectureArm64)),
+					fmt.Sprintf("architecture should be either %s or %s", config.ArchitectureAmd64, config.ArchitectureArm64),
+				)
+
+				aws.PopulateEnvVars(testingConfig.Hosted.Architecture)
 
 				// Populate the environment variables required for the hosted cluster.
 				aws.PopulateHostedTemplateVars(context.Background(), kc, sdName)

--- a/test/e2e/provider_azure_test.go
+++ b/test/e2e/provider_azure_test.go
@@ -109,6 +109,14 @@ var _ = Context("Azure Templates", Label("provider:cloud", "provider:azure"), Or
 			sdTemplate := testingConfig.Template
 			sdTemplateType := templates.GetType(sdTemplate)
 
+			// Supported architectures for Azure standalone deployment: amd64, arm64
+			Expect(testingConfig.Architecture).To(SatisfyAny(
+				Equal(config.ArchitectureAmd64),
+				Equal(config.ArchitectureArm64)),
+				fmt.Sprintf("architecture should be either %s or %s", config.ArchitectureAmd64, config.ArchitectureArm64),
+			)
+			azure.PopulateEnvVars(testingConfig.Architecture)
+
 			templateBy(sdTemplateType, fmt.Sprintf("creating a ClusterDeployment %s with template %s", sdName, sdTemplate))
 
 			sd := clusterdeployment.Generate(templates.TemplateAzureStandaloneCP, sdName, sdTemplate)
@@ -197,6 +205,14 @@ var _ = Context("Azure Templates", Label("provider:cloud", "provider:azure"), Or
 
 				By("Create default storage class for azure-disk CSI driver")
 				azure.CreateDefaultStorageClass(standaloneClient)
+
+				// Supported architectures for Azure hosted deployment: amd64, arm64
+				Expect(testingConfig.Hosted.Architecture).To(SatisfyAny(
+					Equal(config.ArchitectureAmd64),
+					Equal(config.ArchitectureArm64)),
+					fmt.Sprintf("architecture should be either %s or %s", config.ArchitectureAmd64, config.ArchitectureArm64),
+				)
+				azure.PopulateEnvVars(testingConfig.Architecture)
 
 				hdName = clusterdeployment.GenerateClusterName(fmt.Sprintf("azure-hosted-%d", i))
 				hdTemplate := testingConfig.Hosted.Template

--- a/test/e2e/provider_gcp_test.go
+++ b/test/e2e/provider_gcp_test.go
@@ -103,6 +103,14 @@ var _ = Context("GCP Templates", Label("provider:cloud", "provider:gcp"), Ordere
 				Equal(templates.TemplateGCPGKE)),
 				fmt.Sprintf("template type should be either %s or %s", templates.TemplateGCPGKE, templates.TemplateGCPStandaloneCP))
 
+			// Supported architectures for GCP standalone deployment: amd64, arm64
+			Expect(testingConfig.Architecture).To(SatisfyAny(
+				Equal(config.ArchitectureAmd64),
+				Equal(config.ArchitectureArm64)),
+				fmt.Sprintf("architecture should be either %s or %s", config.ArchitectureAmd64, config.ArchitectureArm64),
+			)
+			gcp.PopulateEnvVars(testingConfig.Architecture)
+
 			templateBy(sdTemplateType, fmt.Sprintf("creating a ClusterDeployment %s with template %s", sdName, sdTemplate))
 
 			sd := clusterdeployment.Generate(sdTemplateType, sdName, sdTemplate)
@@ -182,6 +190,14 @@ var _ = Context("GCP Templates", Label("provider:cloud", "provider:gcp"), Ordere
 					}
 					return nil
 				}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+				// Supported architectures for GCP hosted deployment: amd64, arm64
+				Expect(testingConfig.Hosted.Architecture).To(SatisfyAny(
+					Equal(config.ArchitectureAmd64),
+					Equal(config.ArchitectureArm64)),
+					fmt.Sprintf("architecture should be either %s or %s", config.ArchitectureAmd64, config.ArchitectureArm64),
+				)
+				gcp.PopulateEnvVars(testingConfig.Architecture)
 
 				By("Ensuring GCP credentials are set")
 				credential.Apply(kubeCfgPath, "gcp")

--- a/test/e2e/provider_remote_test.go
+++ b/test/e2e/provider_remote_test.go
@@ -109,6 +109,11 @@ var _ = Describe("Remote Cluster Templates", Label("provider:cloud", "provider:r
 			clusterName := clusterdeployment.GenerateClusterName(fmt.Sprintf("remote-%d", i))
 			clusterTemplate := testingConfig.Template
 
+			// Supported architectures for remote deployment: amd64
+			Expect(testingConfig.Architecture).To(Equal(config.ArchitectureAmd64),
+				fmt.Sprintf("expected architecture %s", config.ArchitectureAmd64),
+			)
+
 			By("Preparing Virtual Machines using KubeVirt")
 			ports, err := remote.PrepareVMs(context.Background(), kc.CrClient, internalutils.DefaultSystemNamespace, clusterName, publicKey, 2)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/provider_vsphere_test.go
+++ b/test/e2e/provider_vsphere_test.go
@@ -108,6 +108,11 @@ var _ = Context("vSphere Templates", Label("provider:onprem", "provider:vsphere"
 				Expect(vsphere.SetControlPlaneEndpointEnv()).NotTo(HaveOccurred())
 			}
 
+			// Supported architecture for Vsphere standalone deployment: amd64
+			Expect(testingConfig.Architecture).To(Equal(config.ArchitectureAmd64),
+				fmt.Sprintf("expected architecture %s", config.ArchitectureAmd64),
+			)
+
 			templateBy(templates.TemplateVSphereStandaloneCP, fmt.Sprintf("Creating a ClusterDeployment %s with template %s", sdName, sdTemplate))
 			sd := clusterdeployment.Generate(templates.TemplateVSphereStandaloneCP, sdName, sdTemplate)
 
@@ -182,6 +187,11 @@ var _ = Context("vSphere Templates", Label("provider:onprem", "provider:vsphere"
 
 					return nil
 				}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+				// Supported architecture for Vsphere hosted deployment: amd64
+				Expect(testingConfig.Hosted.Architecture).To(Equal(config.ArchitectureAmd64),
+					fmt.Sprintf("expected architecture %s", config.ArchitectureAmd64),
+				)
 
 				By("Providing cluster identity and credentials in the standalone cluster")
 				credential.Apply(kubeCfgPath, "vsphere")


### PR DESCRIPTION
**What this PR does / why we need it**: 

This PR introduces the following changes:

1. Adds support for testing K0rdent on ubuntu arm64.
2. Enables testing of cluster deployment on arm64 across the following providers: aws, eks, azure, aks, gcp, gke.
3. Temporarily removes Infoblox from the list of deployed providers in e2e tests, pending resolution of #1575
4. Cleans up a redundant workaround previously used for AWS EKS testing.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_: Fixes #1576
