### PR TITLE
chore: Bump kubernetes to v1.32.6 in aws eks template

### DIFF
--- a/config/dev/eks-clusterdeployment.yaml
+++ b/config/dev/eks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-eks-1-0-2
+  template: aws-eks-1-0-3
   credential: "aws-cluster-identity-cred"
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-eks/values.yaml
+++ b/templates/cluster/aws-eks/values.yaml
@@ -56,4 +56,4 @@ addons: # @schema description: The EKS addons to enable with the EKS cluster; ty
 
 # Kubernetes version
 kubernetes: # @schema description: Kubernetes parameters; type: object
-  version: v1.30.4 # @schema description: Kubernetes version to use; type: string; required: true
+  version: v1.32.6 # @schema description: Kubernetes version to use; type: string; required: true

--- a/templates/provider/kcm-templates/files/templates/aws-eks-1-0-3.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-1-0-3.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-eks-1-0-2
+  name: aws-eks-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: aws-eks
-      version: 1.0.2
+      version: 1.0.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**: Kubernetes version bump for `aws-aks` template

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_: Fixes #1785
