### PR TITLE
fix: azure-csi remove oss path from repository

### DIFF
--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-10
+  template: azure-standalone-cp-1-0-11
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -102,6 +102,18 @@ spec:
                 {{- if $global.registry }}
                 image:
                   baseRepo: {{ $global.registry }}
+                  azuredisk:
+                    repository: /kubernetes-csi/azuredisk-csi
+                  csiProvisioner:
+                    repository: /kubernetes-csi/csi-provisioner
+                  csiAttacher:
+                    repository: /kubernetes-csi/csi-attacher
+                  csiResizer:
+                    repository: /kubernetes-csi/csi-resizer
+                  livenessProbe:
+                    repository: /kubernetes-csi/livenessprobe
+                  nodeDriverRegistrar:
+                    repository: /kubernetes-csi/csi-node-driver-registrar
                 {{- end }}
                 controller:
                   cloudConfigSecretName: azure-cloud-provider

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -100,6 +100,18 @@ spec:
                   {{- if $global.registry }}
                   image:
                     baseRepo: {{ $global.registry }}
+                    azuredisk:
+                      repository: /kubernetes-csi/azuredisk-csi
+                    csiProvisioner:
+                      repository: /kubernetes-csi/csi-provisioner
+                    csiAttacher:
+                      repository: /kubernetes-csi/csi-attacher
+                    csiResizer:
+                      repository: /kubernetes-csi/csi-resizer
+                    livenessProbe:
+                      repository: /kubernetes-csi/livenessprobe
+                    nodeDriverRegistrar:
+                      repository: /kubernetes-csi/csi-node-driver-registrar
                   {{- end }}
                   controller:
                     cloudConfigSecretName: azure-cloud-provider

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-11.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-11.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-10
+  name: azure-hosted-cp-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.10
+      chart: azure-hosted-cp
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-11.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-11.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-10
+  name: azure-standalone-cp-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.10
+      chart: azure-standalone-cp
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
More consistent images path for azure-csi images

When using custom registry image paths in that registry will be only one subpath deep and not more. By default images are under additional `/oss` subpath which breaks this rule.