### PR TITLE
fix: gcp csi driver node values

### DIFF
--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-10
+  template: gcp-standalone-cp-1-0-11
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -108,6 +108,14 @@ spec:
                   linux:
                     enabled: true
                     kubeletPath: /var/lib/k0s/kubelet
+                    {{- if $global.registry }}
+                    registrar:
+                      image:
+                        repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
+                    driver:
+                      image:
+                        repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+                    {{- end }}
                   windows:
                     enabled: false
                 defaultStorageClass:
@@ -126,12 +134,6 @@ spec:
                   snapshotter:
                     image:
                       repository: {{ $global.registry }}/sig-storage/csi-snapshotter
-                  driver:
-                    image:
-                      repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-                node:
-                  registrar:
-                    repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
                   driver:
                     image:
                       repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -108,6 +108,14 @@ spec:
                     linux:
                       enabled: true
                       kubeletPath: /var/lib/k0s/kubelet
+                      {{- if $global.registry }}
+                      registrar:
+                        image:
+                          repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
+                      driver:
+                        image:
+                          repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+                      {{- end }}
                     windows:
                       enabled: false
                   defaultStorageClass:
@@ -126,12 +134,6 @@ spec:
                     snapshotter:
                       image:
                         repository: {{ $global.registry }}/sig-storage/csi-snapshotter
-                    driver:
-                      image:
-                        repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-                  node:
-                    registrar:
-                      repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
                     driver:
                       image:
                         repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-11.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-11.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-10
+  name: gcp-hosted-cp-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.10
+      chart: gcp-hosted-cp
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-11.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-11.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-10
+  name: gcp-standalone-cp-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.10
+      chart: gcp-standalone-cp
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Fixes shadowing of node values when using global.registry

The main issue is that `kubeletPath` gets default value, because values has 2 declarations of `node` and last one has higher precedence.
