### PR TITLE
chore: Deprecate and remove install.yaml generation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,6 @@ project_name: kcm
 before:
   hooks:
     - make tidy
-    - sh -c "if [ \"${SKIP_SCM_RELEASE}\" != "true" ]; then make kcm-dist-release && mv ./dist/install.yaml ./install.yaml.out && rmdir ./dist/; fi"
 
 git:
   # Default: '-version:refname'
@@ -165,8 +164,6 @@ release:
     **Full Changelog**: https://github.com/k0rdent/kcm/compare/{{ .PreviousTag }}...{{ .Tag }}
 
   extra_files:
-    - glob: ./install.yaml.out
-      name_template: install.yaml
     - glob: ./templates/provider/kcm-templates/files/release.yaml
 
   # Upload metadata.json and artifacts.json to the release as well.

--- a/Makefile
+++ b/Makefile
@@ -85,16 +85,6 @@ set-kcm-repo: yq
 .PHONY: kcm-chart-release
 kcm-chart-release: set-kcm-version templates-generate ## Generate kcm helm chart
 
-.PHONY: kcm-dist-release
-kcm-dist-release: helm yq
-	@mkdir -p dist
-	@printf "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: $(NAMESPACE)\n" > dist/install.yaml
-	$(HELM) template -n $(NAMESPACE) kcm $(PROVIDER_TEMPLATES_DIR)/kcm >> dist/install.yaml
-	$(YQ) eval -i '.metadata.namespace = "kcm-system"' dist/install.yaml
-	$(YQ) eval -i '.metadata.annotations."meta.helm.sh/release-name" = "kcm"' dist/install.yaml
-	$(YQ) eval -i '.metadata.annotations."meta.helm.sh/release-namespace" = "kcm-system"' dist/install.yaml
-	$(YQ) eval -i '.metadata.labels."app.kubernetes.io/managed-by" = "Helm"' dist/install.yaml
-
 # TODO: combine all of the bash/sh files into a single one
 .PHONY: templates-generate
 templates-generate:


### PR DESCRIPTION
**What this PR does / why we need it**: Deprecate and remove install.yaml generation

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_: Fixes #1790

