### PR TITLE
fix: Credential secret parameter in openstack templates

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-11
+  template: openstack-standalone-cp-1-0-12
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/openstackcluster.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/openstackcluster.yaml
@@ -15,12 +15,10 @@ spec:
   externalNetwork:
     {{- toYaml .Values.externalNetwork | nindent 4 }}
   {{- end }}
-  {{- if .Values.identityRef }}
   identityRef:
-    name: {{ .Values.identityRef.name }}
+    name: {{ .Values.clusterIdentity.name }}
     cloudName: {{ .Values.identityRef.cloudName | default "openstack" }}
     region: {{ .Values.identityRef.region | default "RegionOne" }}
-  {{- end }}
   {{- if .Values.managedSecurityGroups }}
   managedSecurityGroups:
     {{- toYaml .Values.managedSecurityGroups | nindent 4 }}

--- a/templates/cluster/openstack-hosted-cp/values.schema.json
+++ b/templates/cluster/openstack-hosted-cp/values.schema.json
@@ -4,6 +4,7 @@
   "type": "object",
   "required": [
     "workersNumber",
+    "clusterIdentity",
     "identityRef",
     "flavor",
     "ports"
@@ -82,6 +83,19 @@
       "type": "object",
       "additionalProperties": true
     },
+    "clusterIdentity": {
+      "description": "The OpenStack credentials secret reference, auto-populated",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of the secret with OpenStack credentials",
+          "type": "string"
+        }
+      }
+    },
     "clusterLabels": {
       "description": "Labels to apply to the cluster",
       "type": "object",
@@ -153,7 +167,6 @@
       "description": "OpenStack cluster identity object reference",
       "type": "object",
       "required": [
-        "name",
         "cloudName",
         "region"
       ],
@@ -174,10 +187,6 @@
         },
         "cloudName": {
           "description": "Name of the entry in the clouds.yaml file to use",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name of the identity",
           "type": "string"
         },
         "region": {

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -15,8 +15,10 @@ clusterAnnotations: {} # @schema description: Annotations to apply to the cluste
 
 ccmRegional: true # @schema description: Allow OpenStack CCM to set ProviderID with region name; type: boolean
 
+clusterIdentity: # @schema description: The OpenStack credentials secret reference, auto-populated; type: object; required: true
+  name: "" # @schema description: Name of the secret with OpenStack credentials; type: string; required: true
+
 identityRef: # @schema description: OpenStack cluster identity object reference; type: object; required: true
-  name: "" # @schema description: Name of the identity; type: string; required: true
   cloudName: "" # @schema description: Name of the entry in the clouds.yaml file to use; type: string; required: true
   region: "" # @schema description: OpenStack region; type: string; required: true
   caCert: # @schema description: Reference to the secret with the content of a custom CA; type: object

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/openstackcluster.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackcluster.yaml
@@ -18,12 +18,10 @@ spec:
   externalNetwork:
     {{- toYaml .Values.externalNetwork | nindent 4 }}
   {{- end }}
-  {{- if .Values.identityRef }}
   identityRef:
-    name: {{ .Values.identityRef.name }}
+    name: {{ .Values.clusterIdentity.name }}
     cloudName: {{ .Values.identityRef.cloudName | default "openstack" }}
     region: {{ .Values.identityRef.region | default "RegionOne" }}
-  {{- end }}
   managedSecurityGroups:
     {{- toYaml .Values.managedSecurityGroups | nindent 4 }}
   {{- if .Values.managedSubnets }}

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -5,6 +5,7 @@
   "required": [
     "controlPlaneNumber",
     "workersNumber",
+    "clusterIdentity",
     "identityRef"
   ],
   "properties": {
@@ -90,6 +91,19 @@
       "description": "Annotations to apply to the cluster",
       "type": "object",
       "additionalProperties": true
+    },
+    "clusterIdentity": {
+      "description": "The OpenStack credentials secret reference, auto-populated",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "description": "Name of the secret with OpenStack credentials",
+          "type": "string"
+        }
+      }
     },
     "clusterLabels": {
       "description": "Labels to apply to the cluster",
@@ -254,7 +268,6 @@
       "description": "OpenStack cluster identity object reference",
       "type": "object",
       "required": [
-        "name",
         "cloudName",
         "region"
       ],
@@ -275,10 +288,6 @@
         },
         "cloudName": {
           "description": "Name of the entry in the clouds.yaml file to use",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name of the identity",
           "type": "string"
         },
         "region": {

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -18,8 +18,10 @@ ccmCanViewAllProjects: false # @schema description: Specify if OS creds being us
 ccmEnableUniqueClusterName: false #@ schema description: Specify whether CCM should be seeded with a unique cluster.name. Set to false for backward compatibility
 ccmRegional: true # @schema description: Allow OpenStack CCM to set ProviderID with region name; type: boolean
 
+clusterIdentity: # @schema description: The OpenStack credentials secret reference, auto-populated; type: object; required: true
+  name: "" # @schema description: Name of the secret with OpenStack credentials; type: string; required: true
+
 identityRef: # @schema description: OpenStack cluster identity object reference; type: object; required: true
-  name: "" # @schema description: Name of the identity; type: string; required: true
   cloudName: "" # @schema description: Name of the entry in the clouds.yaml file to use; type: string; required: true
   region: "" # @schema description: OpenStack region; type: string; required: true
   caCert: # @schema description: Reference to the secret with the content of a custom CA; type: object

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-11
+  name: openstack-hosted-cp-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.11
+      chart: openstack-hosted-cp
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-12.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-12.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-1
+  name: openstack-standalone-cp-1-0-12
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.1
+      chart: openstack-standalone-cp
+      version: 1.0.12
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**: This PR updates the credential secret parameter name in the OpenStack templates to follow the Credential approach.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_: Fixes #1793
