### PR TITLE
ci: allow e2e tests with mixed config

### DIFF
--- a/.github/actions/check-provider-in-config/action.yml
+++ b/.github/actions/check-provider-in-config/action.yml
@@ -1,22 +1,24 @@
-name: Check Provider in Config
-description: Conditionally skip the job if a provider is missing or present in config
+name: Check Providers in Config
+description: Detect on-prem, cloud, and optional custom provider presence
 
 inputs:
   config:
     description: Base64-encoded config (YAML)
     required: false
   provider:
-    description: Top-level provider key to check for (e.g., 'vsphere')
-    required: true
-  mode:
-    description: "'present' (default) or 'absent' — skip if not present or skip if present, respectively"
+    description: Optional provider name to check for presence
     required: false
-    default: 'present'
 
 outputs:
-  skip:
-    description: Whether the job should be skipped
-    value: ${{ steps.eval.outputs.skip }}
+  provider_present:
+    description: Whether the given provider is present (if provided)
+    value: ${{ steps.eval.outputs.provider_present }}
+  onprem_present:
+    description: Whether any on-prem provider (vsphere/openstack) is present
+    value: ${{ steps.eval.outputs.onprem_present }}
+  cloud_present:
+    description: Whether any cloud provider (not on-prem) is present
+    value: ${{ steps.eval.outputs.cloud_present }}
 
 runs:
   using: "composite"
@@ -25,62 +27,50 @@ runs:
       id: eval
       shell: bash
       run: |
-        echo "Evaluating provider: '${{ inputs.provider }}' with mode: '${{ inputs.mode }}'"
+        echo "provider_present=false" >> "$GITHUB_OUTPUT"
+        echo "onprem_present=false" >> "$GITHUB_OUTPUT"
+        echo "cloud_present=false" >> "$GITHUB_OUTPUT"
 
-        # Handle no config case
         if [ -z "${{ inputs.config }}" ]; then
-          case "${{ inputs.mode }}" in
-            present)
-              if [ "${{ inputs.provider }}" = "vsphere" ]; then
-                echo "No config + 'present' mode + provider is vsphere → skip job"
-                echo "skip=true" >> "$GITHUB_OUTPUT"
-              else
-                echo "No config + 'present' mode + cloud provider → continue"
-                echo "skip=false" >> "$GITHUB_OUTPUT"
-              fi
-              ;;
-            absent)
-              echo "No config + 'absent' mode → assume provider is not present → continue"
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "::error::Invalid mode: '${{ inputs.mode }}'"
-              exit 1
-              ;;
-          esac
+          echo "No config provided — skipping checks"
           exit 0
         fi
 
         echo "${{ inputs.config }}" | base64 -d > config.yaml
 
-        # Check if the key exists regardless of value
-        provider="${{ inputs.provider }}"
-        found=$(grep -E "^${provider}:" config.yaml > /dev/null && echo true || echo false)
+        # Set of on-prem providers (hardcoded)
+        ONPREM_PROVIDERS=("vsphere" "openstack")
 
-        case "${{ inputs.mode }}" in
-          present)
-            if [ "$found" = "true" ]; then
-              echo "Provider '${{ inputs.provider }}' is present — continue"
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-            else
-              echo "Provider '${{ inputs.provider }}' is NOT present — skip"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            fi
-            ;;
-          absent)
-            if [ "$found" = "true" ]; then
-              echo "Provider '${{ inputs.provider }}' is present — skip"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "Provider '${{ inputs.provider }}' is NOT present — continue"
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-            fi
-            ;;
-          *)
-            rm config.yaml
-            echo "::error::Invalid mode: '${{ inputs.mode }}'. Use 'present' or 'absent'."
-            exit 1
-            ;;
-        esac
+        # Initialize flags
+        found_onprem=false
+        found_cloud=false
+
+        # Check for given provider
+        if [ -n "${{ inputs.provider }}" ]; then
+          echo "Checking for provider: '${{ inputs.provider }}'"
+          grep -E "^${{ inputs.provider }}:" config.yaml > /dev/null \
+            && echo "provider_present=true" >> "$GITHUB_OUTPUT" \
+            || echo "provider_present=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        # Loop through top-level keys
+        while IFS= read -r line; do
+          key=$(echo "$line" | cut -d':' -f1 | xargs)
+
+          if [[ -z "$key" ]]; then
+            continue
+          fi
+
+          if [[ " ${ONPREM_PROVIDERS[*]} " =~ " $key " ]]; then
+            echo "Detected on-prem provider: $key"
+            found_onprem=true
+          else
+            echo "Detected cloud provider: $key"
+            found_cloud=true
+          fi
+        done < <(grep '^[a-zA-Z0-9_]\+:' config.yaml)
+
+        echo "onprem_present=$found_onprem" >> "$GITHUB_OUTPUT"
+        echo "cloud_present=$found_cloud" >> "$GITHUB_OUTPUT"
 
         rm config.yaml

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -280,16 +280,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.lint-test.outputs.pr_merge_commit }}
 
-      - name: Check if vsphere-only config (skip cloud)
+      - name: Check cloud providers presence
         id: provider_check
         uses: ./.github/actions/check-provider-in-config
         with:
           config: ${{ needs.authorize.outputs.config }}
-          provider: vsphere
-          mode: absent
 
       - name: Set public registry env variables
-        if: ${{ steps.provider_check.outputs.skip != 'true' && env.PUBLIC_REPO == 'true' }}
+        if: ${{ steps.provider_check.outputs.cloud_present == 'true' && env.PUBLIC_REPO == 'true' }}
         run: |
           echo "REGISTRY_REPO=oci://ghcr.io/k0rdent/kcm/charts-ci" >> $GITHUB_ENV
           echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.lint-test.outputs.version }}" >> $GITHUB_ENV
@@ -302,7 +300,7 @@ jobs:
           provider: remote
 
       - name: Check disk space and cleanup if too low
-        if: ${{ steps.provider_check.outputs.skip != 'true' && steps.remote_provider_check.outputs.skip != 'true' }}
+        if: ${{ steps.provider_check.outputs.cloud_present == 'true' && steps.remote_provider_check.outputs.provider_present == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -330,22 +328,22 @@ jobs:
           fi
 
       - name: Setup kubectl
-        if: steps.provider_check.outputs.skip != 'true'
+        if: steps.provider_check.outputs.cloud_present == 'true'
         uses: azure/setup-kubectl@v4
 
       - name: Setup Go and Cache
-        if: steps.provider_check.outputs.skip != 'true'
+        if: steps.provider_check.outputs.cloud_present == 'true'
         uses: ./.github/actions/setup-go-cache
 
       - name: Load testing configuration
-        if: ${{ steps.provider_check.outputs.skip != 'true' && needs.authorize.outputs.config != '' }}
+        if: ${{ steps.provider_check.outputs.cloud_present == 'true' && needs.authorize.outputs.config != '' }}
         run: |
           echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
           echo "Testing configuration was overwritten:"
           cat test/e2e/config/config.yaml
 
       - name: Run E2E tests
-        if: steps.provider_check.outputs.skip != 'true'
+        if: steps.provider_check.outputs.cloud_present == 'true'
         env:
           GINKGO_LABEL_FILTER: 'provider:cloud'
           CLUSTER_DEPLOYMENT_PREFIX: ${{ needs.lint-test.outputs.clusterprefix }}
@@ -354,7 +352,7 @@ jobs:
 
       - name: Archive test results
         uses: actions/upload-artifact@v4
-        if: ${{ steps.provider_check.outputs.skip != 'true' && always() }}
+        if: ${{ steps.provider_check.outputs.cloud_present == 'true' && always() }}
         with:
           name: support-bundles
           path: /home/runner/work/kcm/kcm/support-bundle-*"
@@ -393,12 +391,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.lint-test.outputs.pr_merge_commit }}
 
-      - name: Check vsphere presence
+      - name: Check on-prem providers presence
         id: provider_check
         uses: ./.github/actions/check-provider-in-config
         with:
           config: ${{ needs.authorize.outputs.config }}
-          provider: vsphere
 
       - name: Set public registry env variables
         if: ${{ env.PUBLIC_REPO == 'true' }}
@@ -407,25 +404,25 @@ jobs:
           echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.lint-test.outputs.version }}" >> $GITHUB_ENV
 
       - name: Setup Go and Cache
-        if: steps.provider_check.outputs.skip != 'true'
+        if: steps.provider_check.outputs.onprem_present == 'true'
         # we do not want to use cache on the self-hosted runner
         env:
           USE_CACHE: false
         uses: ./.github/actions/setup-go-cache
 
       - name: Setup kubectl
-        if: steps.provider_check.outputs.skip != 'true'
+        if: steps.provider_check.outputs.onprem_present == 'true'
         uses: azure/setup-kubectl@v4
 
       - name: Load testing configuration
-        if: ${{ steps.provider_check.outputs.skip != 'true' && needs.authorize.outputs.config != '' }}
+        if: ${{ steps.provider_check.outputs.onprem_present == 'true' && needs.authorize.outputs.config != '' }}
         run: |
           echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
           echo "Testing configuration was overwritten:"
           cat test/e2e/config/config.yaml
 
       - name: Run E2E tests
-        if: steps.provider_check.outputs.skip != 'true'
+        if: steps.provider_check.outputs.onprem_present == 'true'
         env:
           GINKGO_LABEL_FILTER: 'provider:onprem'
           CLUSTER_DEPLOYMENT_PREFIX: ${{ needs.lint-test.outputs.clusterprefix }}
@@ -434,7 +431,7 @@ jobs:
 
       - name: Archive test results
         uses: actions/upload-artifact@v4
-        if: ${{ steps.provider_check.outputs.skip != 'true' && always() }}
+        if: ${{ steps.provider_check.outputs.onprem_present == 'true' && always() }}
         with:
           name: support-bundles
           path: "/home/gh-runner/actions-runner/_work/kcm/kcm/support-bundle-*"
@@ -442,7 +439,7 @@ jobs:
           overwrite: true
 
       - name: Cleanup go build and mod cache
-        if: steps.provider_check.outputs.skip != 'true'
+        if: steps.provider_check.outputs.onprem_present == 'true'
         run: go clean -modcache -cache
 
   cleanup:


### PR DESCRIPTION
**What this PR does / why we need it**:

Generalize check provider action to allow mixed configurations with both cloud and on-prem providers.

Added a list of on-prem providers for the generalized approach.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
