### PR TITLE
fix: Bump version of GKE cluster to v1.32.6

### DIFF
--- a/config/dev/gke-clusterdeployment.yaml
+++ b/config/dev/gke-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-gke-1-0-3
+  template: gcp-gke-1-0-4
   credential: gcp-credential
   propagateCredentials: false
   config:

--- a/templates/cluster/gcp-gke/Chart.yaml
+++ b/templates/cluster/gcp-gke/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-gke/values.yaml
+++ b/templates/cluster/gcp-gke/values.yaml
@@ -52,4 +52,4 @@ machines: # @schema description: Managed machines' parameters; type: object
     autoUpgrade: true # @schema description: AutoUpgrade specifies whether node auto-upgrade is enabled for the node pool. If enabled, node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes; type: boolean
     autoRepair: false # @schema description: AutoRepair specifies whether the node auto-repair is enabled for the node pool. If enabled, the nodes in this node pool will be monitored and, if they fail health checks too many times, an automatic repair action will be triggered; type: boolean
 
-version: 1.32.4-gke.1415000 # @schema description: Version represents the version of the GKE control plane. See: https://cloud.google.com/kubernetes-engine/docs/release-notes; type: string
+version: 1.32.6-gke.1096000 # @schema description: Version represents the version of the GKE control plane. See: https://cloud.google.com/kubernetes-engine/docs/release-notes; type: string

--- a/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-4.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-4.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-gke-1-0-3
+  name: gcp-gke-1-0-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-gke
-      version: 1.0.3
+      version: 1.0.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**: Update GKE version to v1.32.6

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_: Fixes #1796
