### PR TITLE
feat: add releases to user-facing rbac (#1748)

### DIFF
--- a/templates/provider/kcm/templates/rbac/user-facing/management-editor.yaml
+++ b/templates/provider/kcm/templates/rbac/user-facing/management-editor.yaml
@@ -14,6 +14,7 @@ rules:
       - k0rdent.mirantis.com
     resources:
       - providertemplates
+      - releases
     verbs: {{ include "rbac.viewerVerbs" . | nindent 6 }}
       - create
       - delete

--- a/templates/provider/kcm/templates/rbac/user-facing/management-viewer.yaml
+++ b/templates/provider/kcm/templates/rbac/user-facing/management-viewer.yaml
@@ -10,4 +10,5 @@ rules:
     resources:
       - management
       - providertemplates
+      - releases
     verbs: {{ include "rbac.viewerVerbs" . | nindent 6 }}


### PR DESCRIPTION
This PR https://github.com/k0rdent/kcm/pull/1748 is currently missing from the `v1.2.0-release` and `main` branches. It’s being added to the `v1.2.0-release` branch to keep things in sync. The `v1.2.0-release` branch will be merged into `main` once the release is complete.