### PR TITLE
revert: Refactor registry configuration for k0s images (#1777)

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-11
+  template: aws-standalone-cp-1-0-12
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-11
+  template: azure-standalone-cp-1-0-12
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-11
+  template: gcp-standalone-cp-1-0-12
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-12
+  template: openstack-standalone-cp-1-0-13
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-10
+  template: remote-cluster-1-0-11
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-10
+  template: vsphere-standalone-cp-1-0-11
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -49,7 +49,21 @@ spec:
           mode: ipip
       {{- if $global.registry }}
       images:
-        repository: "{{ $global.registry }}"
+        metricsserver:
+          image: "{{ $global.registry }}/metrics-server/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry }}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry }}/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry }}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -67,7 +67,21 @@ spec:
             mode: ipip
         {{- if $global.registry }}
         images:
-          repository: "{{ $global.registry }}"
+          metricsserver:
+            image: "{{ $global.registry }}/metrics-server/metrics-server"
+          kubeproxy:
+            image: "{{ $global.registry }}/k0sproject/kube-proxy"
+          coredns:
+            image: "{{ $global.registry }}/k0sproject/coredns"
+          pause:
+            image: "{{ $global.registry }}/pause"
+          calico:
+            cni:
+              image: "{{ $global.registry }}/k0sproject/calico-cni"
+            node:
+              image: "{{ $global.registry }}/k0sproject/calico-node"
+            kubecontrollers:
+              image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
         {{- end }}
         extensions:
           helm:

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -48,7 +48,21 @@ spec:
           mode: vxlan
       {{- if $global.registry }}
       images:
-        repository: "{{ $global.registry }}"
+        metricsserver:
+          image: "{{ $global.registry }}/metrics-server/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry }}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry }}/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry }}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -52,7 +52,21 @@ spec:
             mode: vxlan
         {{- if $global.registry }}
         images:
-          repository: "{{ $global.registry }}"
+          metricsserver:
+            image: "{{ $global.registry }}/metrics-server/metrics-server"
+          kubeproxy:
+            image: "{{ $global.registry }}/k0sproject/kube-proxy"
+          coredns:
+            image: "{{ $global.registry }}/k0sproject/coredns"
+          pause:
+            image: "{{ $global.registry }}/pause"
+          calico:
+            cni:
+              image: "{{ $global.registry }}/k0sproject/calico-cni"
+            node:
+              image: "{{ $global.registry }}/k0sproject/calico-node"
+            kubecontrollers:
+              image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
         {{- end }}
         extensions:
           helm:

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -48,7 +48,21 @@ spec:
           mode: vxlan
       {{- if $global.registry }}
       images:
-        repository: "{{ $global.registry }}"
+        metricsserver:
+          image: "{{ $global.registry }}/metrics-server/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry }}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry }}/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry }}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -52,7 +52,21 @@ spec:
             mode: ipip
         {{- if $global.registry }}
         images:
-          repository: "{{ $global.registry }}"
+          metricsserver:
+            image: "{{ $global.registry }}/metrics-server/metrics-server"
+          kubeproxy:
+            image: "{{ $global.registry }}/k0sproject/kube-proxy"
+          coredns:
+            image: "{{ $global.registry }}/k0sproject/coredns"
+          pause:
+            image: "{{ $global.registry }}/pause"
+          calico:
+            cni:
+              image: "{{ $global.registry }}/k0sproject/calico-cni"
+            node:
+              image: "{{ $global.registry }}/k0sproject/calico-node"
+            kubecontrollers:
+              image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
         {{- end }}
         extensions:
           helm:

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -48,7 +48,23 @@ spec:
           mode: vxlan
       {{- if $global.registry }}
       images:
-        repository: "{{ $global.registry }}"
+        konnectivity:
+          image: "{{ $global.registry }}/k0sproject/apiserver-network-proxy-agent"
+        metricsserver:
+          image: "{{ $global.registry }}/metrics-server/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry }}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry }}/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry }}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -52,7 +52,21 @@ spec:
             mode: vxlan
         {{- if $global.registry }}
         images:
-          repository: "{{ $global.registry }}"
+          metricsserver:
+            image: "{{ $global.registry }}/metrics-server/metrics-server"
+          kubeproxy:
+            image: "{{ $global.registry }}/k0sproject/kube-proxy"
+          coredns:
+            image: "{{ $global.registry }}/k0sproject/coredns"
+          pause:
+            image: "{{ $global.registry }}/pause"
+          calico:
+            cni:
+              image: "{{ $global.registry }}/k0sproject/calico-cni"
+            node:
+              image: "{{ $global.registry }}/k0sproject/calico-node"
+            kubecontrollers:
+              image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
         {{- end }}
         extensions:
           helm:

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
@@ -46,7 +46,21 @@ spec:
       {{- end }}
       {{- if $global.registry }}
       images:
-        repository: {{ $global.registry }}
+        metricsserver:
+          image: "{{ $global.registry }}/metrics-server/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry }}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry }}/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry }}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.9
+version: 1.0.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -48,7 +48,21 @@ spec:
           mode: vxlan
       {{- if $global.registry }}
       images:
-        repository: "{{ $global.registry }}"
+        metricsserver:
+          image: "{{ $global.registry }}/metrics-server/metrics-server"
+        kubeproxy:
+          image: "{{ $global.registry }}/k0sproject/kube-proxy"
+        coredns:
+          image: "{{ $global.registry }}/k0sproject/coredns"
+        pause:
+          image: "{{ $global.registry }}/pause"
+        calico:
+          cni:
+            image: "{{ $global.registry }}/k0sproject/calico-cni"
+          node:
+            image: "{{ $global.registry }}/k0sproject/calico-node"
+          kubecontrollers:
+            image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
       {{- end }}
       extensions:
         helm:

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -59,7 +59,21 @@ spec:
             mode: vxlan
         {{- if $global.registry }}
         images:
-          repository: "{{ $global.registry }}"
+          metricsserver:
+            image: "{{ $global.registry }}/metrics-server/metrics-server"
+          kubeproxy:
+            image: "{{ $global.registry }}/k0sproject/kube-proxy"
+          coredns:
+            image: "{{ $global.registry }}/k0sproject/coredns"
+          pause:
+            image: "{{ $global.registry }}/pause"
+          calico:
+            cni:
+              image: "{{ $global.registry }}/k0sproject/calico-cni"
+            node:
+              image: "{{ $global.registry }}/k0sproject/calico-node"
+            kubecontrollers:
+              image: "{{ $global.registry }}/k0sproject/calico-kube-controllers"
         {{- end }}
         extensions:
           helm:

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-11.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-11.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-10
+  name: aws-hosted-cp-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.10
+      chart: aws-hosted-cp
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-12.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-12.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-2
+  name: aws-standalone-cp-1-0-12
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.2
+      chart: aws-standalone-cp
+      version: 1.0.12
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-12.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-12.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-11
+  name: azure-hosted-cp-1-0-12
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: azure-hosted-cp
-      version: 1.0.11
+      version: 1.0.12
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-12.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-12.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-11
+  name: azure-standalone-cp-1-0-12
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.11
+      chart: azure-standalone-cp
+      version: 1.0.12
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-12.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-12.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-9
+  name: gcp-hosted-cp-1-0-12
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.9
+      chart: gcp-hosted-cp
+      version: 1.0.12
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-12.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-12.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-10
+  name: gcp-standalone-cp-1-0-12
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.10
+      chart: gcp-standalone-cp
+      version: 1.0.12
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-3.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-3.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-11
+  name: openstack-hosted-cp-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.11
+      chart: openstack-hosted-cp
+      version: 1.0.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-13.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-13.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-11
+  name: openstack-standalone-cp-1-0-13
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.11
+      chart: openstack-standalone-cp
+      version: 1.0.13
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-11.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-11.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-10
+  name: remote-cluster-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.10
+      chart: remote-cluster
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-10.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-10.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-11
+  name: vsphere-hosted-cp-1-0-10
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.11
+      chart: vsphere-hosted-cp
+      version: 1.0.10
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-11.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-11.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-12
+  name: vsphere-standalone-cp-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.12
+      chart: vsphere-standalone-cp
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
This reverts commit 42fb2847d0913f348c0adbd6948864a2059e9347.

**What this PR does / why we need it**: This PR causes regression when the registry contains a subpath.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Related issue: #1769 
