### PR TITLE
Fix: Catch errors not found errors and remind users to label the template

### DIFF
--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -359,6 +359,11 @@ func fillStatusWithProviders(template templateCommon, helmChart *chart.Chart) er
 func (r *TemplateReconciler) updateStatus(ctx context.Context, template templateCommon, validationError string) error {
 	status := template.GetCommonStatus()
 	status.ObservedGeneration = template.GetGeneration()
+
+	if validationError != "" && strings.Contains(validationError, "failed to get source:") && strings.Contains(validationError, "not found") {
+		validationError += ". Please ensure that the referenced object has been properly labeled with the required KCM labels. https://docs.k0rdent.io/latest/admin/services/admin-service-templates/#creating-helm-based-servicetemplate"
+	}
+
 	status.ValidationError = validationError
 	status.Valid = validationError == ""
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Customer ran into an issue while creating a service template but did not know about the required `k0rdent.mirantis.com/managed: "true"` label. This PR captures the "Not found" and makes a note to tell the user to add a label. This makes the issue easier to diagnose for users.
