### PR TITLE
test: remove amiID from the eks e2e template

### DIFF
--- a/test/e2e/clusterdeployment/resources/aws-eks.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/aws-eks.yaml.tpl
@@ -12,5 +12,4 @@ spec:
     workersNumber: ${WORKERS_NUMBER:=1}
     publicIP: ${AWS_PUBLIC_IP:=true}
     worker:
-      amiID: ${AMI_ID}
       instanceType: ${AWS_INSTANCE_TYPE:=t3.small}


### PR DESCRIPTION
**What this PR does / why we need it**:
When the ami ID is not specified, CAPA will auto-select the correct AMI based on the instance Type and Kubernetes version.
The previous AMI was incorrect when deploying the arm64 architecture.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Related issue #1820