### PR TITLE
fix: allow configuration of the default HelmRelease timeout

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -114,6 +115,7 @@ func main() {
 		pprofBindAddress              string
 		leaderElectionNamespace       string
 		enableSveltosCtrl             bool
+		defaultHelmTimeout            time.Duration
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -150,6 +152,7 @@ func main() {
 		"Webhook cert dir, only used when webhook-port is specified.")
 	flag.StringVar(&pprofBindAddress, "pprof-bind-address", "", "The TCP address that the controller should bind to for serving pprof, \"0\" or empty value disables pprof")
 	flag.BoolVar(&enableSveltosCtrl, "enable-sveltos-expire-ctrl", false, "Enable SveltosCluster stuck (expired) tokens controller")
+	flag.DurationVar(&defaultHelmTimeout, "default-helm-timeout", 0, "Specifies the timeout duration for Helm install or upgrade operations. If unset, Flux’s default value will be used")
 
 	opts := zap.Options{
 		Development: true,
@@ -298,6 +301,7 @@ func main() {
 		GlobalK0sURL:           globalK0sURL,
 		K0sURLCertSecretName:   k0sURLCertSecretName,
 		RegistryCertSecretName: registryCertSecretName,
+		DefaultHelmTimeout:     defaultHelmTimeout,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Management")
 		os.Exit(1)
@@ -342,6 +346,7 @@ func main() {
 			CertSecretName:        registryCertSecretName,
 			Insecure:              insecureRegistry,
 		},
+		DefaultHelmTimeout: defaultHelmTimeout,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Release")
 		os.Exit(1)

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -92,6 +92,7 @@ type ClusterDeploymentReconciler struct {
 	K0sURLCertSecretName   string // Name of a Secret with K0s Download URL Root CA with ca.crt key
 	RegistryCertSecretName string // Name of a Secret with Registry Root CA with ca.crt key
 
+	DefaultHelmTimeout time.Duration
 	defaultRequeueTime time.Duration
 
 	IsDisabledValidationWH bool // is webhook disabled set via the controller flags
@@ -319,6 +320,7 @@ func (r *ClusterDeploymentReconciler) updateCluster(ctx context.Context, cd *kcm
 			UID:        cd.UID,
 		},
 		ChartRef: clusterTpl.Status.ChartRef,
+		Timeout:  r.DefaultHelmTimeout,
 	}
 	if clusterTpl.Spec.Helm.ChartSpec != nil {
 		hrReconcileOpts.ReconcileInterval = &clusterTpl.Spec.Helm.ChartSpec.Interval.Duration

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -73,6 +73,7 @@ type ManagementReconciler struct {
 	K0sURLCertSecretName   string // Name of a Secret with K0s Download URL Root CA with ca.crt key; to be passed to the ClusterDeploymentReconciler
 	RegistryCertSecretName string // Name of a Secret with Registry Root CA with ca.crt key; used by ManagementReconciler and ClusterDeploymentReconciler
 
+	DefaultHelmTimeout time.Duration
 	defaultRequeueTime time.Duration
 
 	CreateAccessManagement bool
@@ -251,6 +252,7 @@ func (r *ManagementReconciler) reconcileManagementComponents(ctx context.Context
 			DependsOn:       component.dependsOn,
 			TargetNamespace: component.targetNamespace,
 			Install:         component.installSettings,
+			Timeout:         r.DefaultHelmTimeout,
 		}
 		if template.Spec.Helm.ChartSpec != nil {
 			hrReconcileOpts.ReconcileInterval = &template.Spec.Helm.ChartSpec.Interval.Duration
@@ -376,6 +378,7 @@ func (r *ManagementReconciler) startDependentControllers(ctx context.Context, ma
 		GlobalK0sURL:           r.GlobalK0sURL,
 		K0sURLCertSecretName:   r.K0sURLCertSecretName,
 		RegistryCertSecretName: r.RegistryCertSecretName,
+		DefaultHelmTimeout:     r.DefaultHelmTimeout,
 	}).SetupWithManager(r.Manager); err != nil {
 		return false, fmt.Errorf("failed to setup controller for ClusterDeployment: %w", err)
 	}

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -65,6 +65,8 @@ type ReleaseReconciler struct {
 
 	DefaultRegistryConfig helm.DefaultRegistryConfig
 
+	DefaultHelmTimeout time.Duration
+
 	CreateManagement bool
 	CreateRelease    bool
 	CreateTemplates  bool
@@ -364,6 +366,7 @@ func (r *ReleaseReconciler) reconcileKCMTemplates(ctx context.Context, releaseNa
 			Namespace: helmChart.Namespace,
 		},
 		OwnerReference: ownerRef,
+		Timeout:        r.DefaultHelmTimeout,
 	}
 
 	if initialInstall {

--- a/internal/helm/release.go
+++ b/internal/helm/release.go
@@ -41,6 +41,7 @@ type ReconcileHelmReleaseOpts struct {
 	Install           *helmcontrollerv2.Install
 	TargetNamespace   string
 	DependsOn         []meta.NamespacedObjectReference
+	Timeout           time.Duration
 }
 
 func ReconcileHelmRelease(ctx context.Context,
@@ -83,6 +84,9 @@ func ReconcileHelmRelease(ctx context.Context,
 		}
 		if opts.TargetNamespace != "" {
 			hr.Spec.TargetNamespace = opts.TargetNamespace
+		}
+		if opts.Timeout != 0 {
+			hr.Spec.Timeout = &metav1.Duration{Duration: opts.Timeout}
 		}
 		if opts.Install != nil {
 			hr.Spec.Install = opts.Install

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   version: 1.2.0
   kcm:
-    template: kcm-1-2-1
+    template: kcm-1-2-2
   capi:
     template: cluster-api-1-0-5
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-1-2-1
+  name: kcm-1-2-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 1.2.1
+      version: 1.2.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 dependencies:
   - name: flux2
     version: 2.16.0

--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
         {{- if .Values.controller.enableSveltosExpiredCtrl }}
         - --enable-sveltos-expire-ctrl={{ .Values.controller.enableSveltosExpiredCtrl }}
         {{- end }}
+        {{- if .Values.controller.defaultHelmTimeout }}
+        - --default-helm-timeout={{ .Values.controller.defaultHelmTimeout }}
+        {{- end }}
         command:
         - /manager
         env:

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -122,6 +122,10 @@
             }
           }
         },
+        "defaultHelmTimeout": {
+          "description": "Specifies the timeout duration for Helm install or upgrade operations. If unset, Flux’s default value will be used",
+          "type": "string"
+        },
         "enableSveltosExpiredCtrl": {
           "description": "Enables SveltosCluster controller, updating stuck (expired) sveltos management cluster kubeconfig tokens",
           "type": "boolean"

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -24,6 +24,7 @@ controller:
   tolerations: [] # @schema type: array; description: Tolerations to allow the pod to schedule on tainted nodes
   validateClusterUpgradePath: true # @schema type: boolean; description: Specifies whether the ClusterDeployment upgrade path should be validated
   enableSveltosExpiredCtrl: false # @schema type: boolean; description: Enables SveltosCluster controller, updating stuck (expired) sveltos management cluster kubeconfig tokens
+  defaultHelmTimeout: "" # @schema type: string; description: Specifies the timeout duration for Helm install or upgrade operations. If unset, Flux’s default value will be used
   logger: # @schema title: Logger Settings; description: Global controllers logger settings; type: object
     devel: false # @schema type: boolean; description: Development defaults(encoder=console,logLevel=debug,stackTraceLevel=warn) Production defaults(encoder=json,logLevel=info,stackTraceLevel=error)
     encoder: "" # @schema enum:[json, console, ""] ; type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows the configuration of the default timeout for HelmReleases. If not specified, the default Flux's value will be used (5 minutes).


**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #1643