### PR TITLE
fix: Mount CA secret to flux before installing kcm-templates

### DIFF
--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -947,26 +947,25 @@ func processFluxCertVolumeMounts(fluxValues map[string]any, registryCertSecret s
 	}
 
 	registryCertMount := getRegistryCertVolumeMountValues(certVolumeName)
-	for _, componentName := range []string{"helmController", "sourceController"} {
-		values, ok := fluxValues[componentName].(map[string]any)
-		if !ok || values == nil {
-			values = make(map[string]any)
-		}
-		certVolumes := []any{registryCertVolume}
-		if existing, ok := values["volumes"].([]any); ok {
-			values["volumes"] = append(existing, certVolumes...)
-		} else {
-			values["volumes"] = certVolumes
-		}
-
-		volumeMounts := []any{registryCertMount}
-		if vm, ok := values["volumeMounts"].([]any); ok {
-			values["volumeMounts"] = append(vm, volumeMounts...)
-		} else {
-			values["volumeMounts"] = volumeMounts
-		}
-		fluxValues[componentName] = values
+	componentName := "sourceController"
+	values, ok := fluxValues[componentName].(map[string]any)
+	if !ok || values == nil {
+		values = make(map[string]any)
 	}
+	certVolumes := []any{registryCertVolume}
+	if existing, ok := values["volumes"].([]any); ok {
+		values["volumes"] = append(existing, certVolumes...)
+	} else {
+		values["volumes"] = certVolumes
+	}
+
+	volumeMounts := []any{registryCertMount}
+	if vm, ok := values["volumeMounts"].([]any); ok {
+		values["volumeMounts"] = append(vm, volumeMounts...)
+	} else {
+		values["volumeMounts"] = volumeMounts
+	}
+	fluxValues[componentName] = values
 	return fluxValues
 }
 

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -29,6 +30,8 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -36,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -314,6 +318,13 @@ func (r *ReleaseReconciler) reconcileKCMTemplates(ctx context.Context, releaseNa
 			return false, fmt.Errorf("some of the predeclared Secrets (%v) are missing (%v) in the %s namespace", helmRepositorySecrets, missingSecrets, r.SystemNamespace)
 		}
 
+		if r.DefaultRegistryConfig.CertSecretName != "" {
+			err = r.patchFluxWithRegistryCASecret(ctx)
+			if err != nil {
+				return false, fmt.Errorf("failed to patch flux components with registry CA secret volume: %w", err)
+			}
+		}
+
 		releaseName, err = utils.ReleaseNameFromVersion(build.Version)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Release name from version %q: %w", build.Version, err)
@@ -397,6 +408,76 @@ func (r *ReleaseReconciler) reconcileKCMTemplates(ctx context.Context, releaseNa
 		return true, nil
 	}
 	return false, nil
+}
+
+// Workaround for Flux issue https://github.com/fluxcd/flux2/issues/4838.
+// Applies only to the initial deployment to add the registry
+// CA certificate to flux components before installing kcm-templates HelmChart
+func (r *ReleaseReconciler) patchFluxWithRegistryCASecret(ctx context.Context) error {
+	const (
+		deploymentName       = "source-controller"
+		caCertVolumeName     = "registry-cert"
+		caCertFileName       = "registry-ca.pem"
+		managerContainerName = "manager"
+	)
+	mode := int32(420)
+
+	deployment := &appsv1.Deployment{}
+	if err := r.Get(ctx, client.ObjectKey{Name: deploymentName, Namespace: r.SystemNamespace}, deployment); err != nil {
+		return err
+	}
+
+	managerIdx := -1
+	for i, c := range deployment.Spec.Template.Spec.Containers {
+		if c.Name == managerContainerName {
+			managerIdx = i
+			break
+		}
+	}
+	if managerIdx == -1 {
+		return fmt.Errorf("container %q not found in deployment %q", managerContainerName, deploymentName)
+	}
+
+	hasVolume := slices.ContainsFunc(deployment.Spec.Template.Spec.Volumes, func(v corev1.Volume) bool {
+		return v.Name == caCertVolumeName
+	})
+	hasMount := slices.ContainsFunc(deployment.Spec.Template.Spec.Containers[managerIdx].VolumeMounts, func(vm corev1.VolumeMount) bool {
+		return vm.Name == caCertVolumeName
+	})
+
+	if hasVolume && hasMount {
+		return nil
+	}
+
+	patchHelper, err := patch.NewHelper(deployment, r.Client)
+	if err != nil {
+		return err
+	}
+
+	if !hasVolume {
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: caCertVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					DefaultMode: &mode,
+					Items: []corev1.KeyToPath{
+						{Key: "ca.crt", Path: caCertFileName},
+					},
+					SecretName: r.DefaultRegistryConfig.CertSecretName,
+				},
+			},
+		})
+	}
+
+	if !hasMount {
+		manager := &deployment.Spec.Template.Spec.Containers[managerIdx]
+		manager.VolumeMounts = append(manager.VolumeMounts, corev1.VolumeMount{
+			Name:      caCertVolumeName,
+			MountPath: "/etc/ssl/certs/" + caCertFileName,
+			SubPath:   caCertFileName,
+		})
+	}
+	return patchHelper.Patch(ctx, deployment)
 }
 
 func (r *ReleaseReconciler) getCurrentRelease(ctx context.Context) (*kcmv1.Release, error) {

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   version: 1.2.0
   kcm:
-    template: kcm-1-2-3
+    template: kcm-1-2-4
   capi:
     template: cluster-api-1-0-5
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-1-2-3
+  name: kcm-1-2-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 1.2.3
+      version: 1.2.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.3
+version: 1.2.4
 dependencies:
   - name: flux2
     version: 2.16.0

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -332,6 +332,8 @@ rules:
   - deployments
   verbs:
   - list
+  - watch
+  - patch
 - apiGroups:
   - k0rdent.mirantis.com
   resources:

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -325,8 +325,7 @@ rules:
   - '*'
   verbs:
   - '*'
-# managementbackups-ctrl
-- apiGroups: # required for autobackup on upgrade
+- apiGroups:
   - apps
   resources:
   - deployments


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the fix for the Flux issue to ensure that the registry CA certificate is mounted into the Flux source controller deployment before attempting to pull `kcm-templates` chart from a private registry. Without the certificate in place early, the `kcm-templates` installation fails on:
```
  - lastTransitionTime: "2025-08-08T21:08:06Z"
    message: 'HelmChart ''k0rdent/kcm-1-1-0-rc14-tpl'' is not ready: chart pull error:
      failed to download chart for remote reference: failed to get ''oci://registry.mke4dev.miratnis.com/mke/charts/kcm-templates:1.1.0-rc14'':
      failed to do request: Head "https://registry.mke4dev.miratnis.com/v2/mke/charts/kcm-templates/manifests/1.1.0-rc14":
      tls: failed to verify certificate: x509: certificate signed by unknown authority'
```
This patch should only run during the initial deployment, before the kcm-templates chart is installed.

Also removes volume overrides for the helm controller, since they are only required for the source controller.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_
Fixes #1841 
