### PR TITLE
test: fix support dump collecting

### DIFF
--- a/test/e2e/clusterdeployment/azure/azure.go
+++ b/test/e2e/clusterdeployment/azure/azure.go
@@ -47,14 +47,14 @@ func CheckEnv() {
 func PopulateEnvVars(architecture config.Architecture) {
 	GinkgoHelper()
 
+	GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageGallery, "aksubuntu-38d80f77-467a-481f-a8d4-09b6d4220bd2")
+
 	switch architecture {
 	case config.ArchitectureAmd64:
-		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageGallery, "aksazurelinux-f7c7cda5-1c9a-4bdc-a222-9614c968580b")
-		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageName, "V2")
-		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageVersion, "202409.23.0")
+		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageName, "2204containerd")
+		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageVersion, "202508.06.0")
 		GinkgoT().Setenv(clusterdeployment.EnvVarAzureVMSize, "Standard_A4_v2")
 	case config.ArchitectureArm64:
-		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageGallery, "aksubuntu-38d80f77-467a-481f-a8d4-09b6d4220bd2")
 		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageName, "2204gen2arm64containerd")
 		GinkgoT().Setenv(clusterdeployment.EnvVarAzureImageVersion, "202507.29.0")
 		GinkgoT().Setenv(clusterdeployment.EnvVarAzureVMSize, "Standard_D4plds_v5")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -41,7 +41,11 @@ import (
 	"github.com/K0rdent/kcm/test/utils"
 )
 
-var clusterTemplates []string
+var (
+	clusterTemplates []string
+
+	kc *kubeclient.KubeClient
+)
 
 // Run e2e tests using the Ginkgo runner.
 func TestE2E(t *testing.T) {
@@ -69,7 +73,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	kc := kubeclient.NewFromLocal(internalutils.DefaultSystemNamespace)
+	kc = kubeclient.NewFromLocal(internalutils.DefaultSystemNamespace)
 
 	// TODO: remove after https://github.com/k0rdent/kcm/issues/1575 is fixed
 	removeInfobloxProvider(kc.CrClient)
@@ -102,7 +106,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	if cleanup() {
 		By("collecting the support bundle from the management cluster")
-		logs.SupportBundle("")
+		logs.SupportBundle(kc, "")
 
 		By("removing the controller-manager")
 		cmd := exec.Command("make", "dev-destroy")

--- a/test/e2e/multi_provider_test.go
+++ b/test/e2e/multi_provider_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -94,7 +95,12 @@ var _ = Context("Multi Cloud Templates", Label("provider:multi-cloud", "provider
 		// If we failed collect the support bundle before the cleanup
 		if CurrentSpecReport().Failed() && cleanup() {
 			By("collecting the support bundle from the management cluster")
-			logs.SupportBundle("")
+			logs.SupportBundle(kc, "")
+
+			for _, clusterName := range []string{awsClusterDeploymentName, azureClusterDeploymentName} {
+				By(fmt.Sprintf("collecting the support bundle from the %s cluster", awsClusterDeploymentName))
+				logs.SupportBundle(kc, clusterName)
+			}
 		}
 
 		By("deleting resources")

--- a/test/e2e/provider_adopted_test.go
+++ b/test/e2e/provider_adopted_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Adopted Cluster Templates", Label("provider:cloud", "provider:
 		// If we failed collect the support bundle before the cleanup
 		if CurrentSpecReport().Failed() && cleanup() {
 			By("Collecting the support bundle from the management cluster")
-			logs.SupportBundle("")
+			logs.SupportBundle(kc, "")
 		}
 
 		if cleanup() {
@@ -164,7 +164,9 @@ var _ = Describe("Adopted Cluster Templates", Label("provider:cloud", "provider:
 
 			// create the adopted cluster using the AWS standalone cluster
 			var rawData string
-			_, rawData, kubecfgDeleteFunc = kc.WriteKubeconfig(context.Background(), clusterName)
+			var err error
+			_, rawData, kubecfgDeleteFunc, err = kc.WriteKubeconfig(context.Background(), clusterName)
+			Expect(err).To(Succeed())
 			Expect(os.Setenv(clusterdeployment.EnvVarAdoptedKubeconfigData, rawData)).Should(Succeed())
 			credential.Apply("", "adopted")
 

--- a/test/e2e/provider_aws_test.go
+++ b/test/e2e/provider_aws_test.go
@@ -90,11 +90,11 @@ var _ = Describe("AWS Templates", Label("provider:cloud", "provider:aws"), Order
 		// If we failed collect the support bundle before the cleanup
 		if CurrentSpecReport().Failed() && cleanup() {
 			By("collecting the support bundle from the management cluster")
-			logs.SupportBundle("")
+			logs.SupportBundle(kc, "")
 
 			for _, clusterName := range standaloneClusters {
 				By(fmt.Sprintf("collecting the support bundle from the %s cluster", clusterName))
-				logs.SupportBundle(clusterName)
+				logs.SupportBundle(kc, clusterName)
 			}
 		}
 
@@ -211,12 +211,13 @@ var _ = Describe("AWS Templates", Label("provider:cloud", "provider:aws"), Order
 				// TODO(#472): Ideally we shouldn't use Make here and should just
 				// convert these Make targets into Go code, but this will require a
 				// helmclient.
-				kubeCfgPath, _, kubecfgDeleteFunc := kc.WriteKubeconfig(context.Background(), sdName)
+				kubeCfgPath, _, kubecfgDeleteFunc, err := kc.WriteKubeconfig(context.Background(), sdName)
+				Expect(err).To(Succeed())
 				kubeconfigDeleteFuncs = append(kubeconfigDeleteFuncs, kubecfgDeleteFunc)
 
 				GinkgoT().Setenv("KUBECONFIG", kubeCfgPath)
 				cmd := exec.Command("make", "test-apply")
-				_, err := utils.Run(cmd)
+				_, err = utils.Run(cmd)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(os.Unsetenv("KUBECONFIG")).To(Succeed())
 

--- a/test/e2e/provider_gcp_test.go
+++ b/test/e2e/provider_gcp_test.go
@@ -60,11 +60,11 @@ var _ = Context("GCP Templates", Label("provider:cloud", "provider:gcp"), Ordere
 		// If we failed collect the support bundle before the cleanup
 		if CurrentSpecReport().Failed() && cleanup() {
 			By("collecting the support bundle from the management cluster")
-			logs.SupportBundle("")
+			logs.SupportBundle(kc, "")
 
 			for _, clusterName := range standaloneClusters {
 				By(fmt.Sprintf("collecting the support bundle from the %s cluster", clusterName))
-				logs.SupportBundle(clusterName)
+				logs.SupportBundle(kc, clusterName)
 			}
 		}
 
@@ -148,13 +148,14 @@ var _ = Context("GCP Templates", Label("provider:cloud", "provider:gcp"), Ordere
 			standaloneClient := new(kubeclient.KubeClient)
 			var hdName string
 			if testingConfig.Hosted != nil {
-				kubeCfgPath, _, kubecfgDeleteFunc := kc.WriteKubeconfig(context.Background(), sdName)
+				kubeCfgPath, _, kubecfgDeleteFunc, err := kc.WriteKubeconfig(context.Background(), sdName)
+				Expect(err).To(Succeed())
 				kubeconfigDeleteFuncs = append(kubeconfigDeleteFuncs, kubecfgDeleteFunc)
 
 				By("Deploy onto standalone cluster")
 				GinkgoT().Setenv("KUBECONFIG", kubeCfgPath)
 				cmd := exec.Command("make", "test-apply")
-				_, err := utils.Run(cmd)
+				_, err = utils.Run(cmd)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(os.Unsetenv("KUBECONFIG")).To(Succeed())
 

--- a/test/e2e/provider_remote_test.go
+++ b/test/e2e/provider_remote_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Remote Cluster Templates", Label("provider:cloud", "provider:r
 		// If we failed collect the support bundle before the cleanup
 		if CurrentSpecReport().Failed() && cleanup() {
 			By("collecting the support bundle from the management cluster")
-			logs.SupportBundle("")
+			logs.SupportBundle(kc, "")
 		}
 
 		if cleanup() {

--- a/test/e2e/provider_vsphere_test.go
+++ b/test/e2e/provider_vsphere_test.go
@@ -61,11 +61,11 @@ var _ = Context("vSphere Templates", Label("provider:onprem", "provider:vsphere"
 		// If we failed collect the support bundle before the cleanup
 		if CurrentSpecReport().Failed() && cleanup() {
 			By("Collecting the support bundle from the management cluster")
-			logs.SupportBundle("")
+			logs.SupportBundle(kc, "")
 
 			for _, clusterName := range standaloneClusterNames {
 				By(fmt.Sprintf("Collecting the support bundle from the %s cluster", clusterName))
-				logs.SupportBundle(clusterName)
+				logs.SupportBundle(kc, clusterName)
 			}
 		}
 
@@ -146,12 +146,13 @@ var _ = Context("vSphere Templates", Label("provider:onprem", "provider:vsphere"
 			standaloneClient := new(kubeclient.KubeClient)
 			var hdName string
 			if testingConfig.Hosted != nil {
-				kubeCfgPath, _, kubecfgDeleteFunc := kc.WriteKubeconfig(context.Background(), sdName)
+				kubeCfgPath, _, kubecfgDeleteFunc, err := kc.WriteKubeconfig(context.Background(), sdName)
+				Expect(err).To(Succeed())
 				kubeconfigDeleteFuncs = append(kubeconfigDeleteFuncs, kubecfgDeleteFunc)
 
 				By("Deploy onto standalone cluster")
 				GinkgoT().Setenv("KUBECONFIG", kubeCfgPath)
-				_, err := utils.Run(exec.Command("make", "test-apply"))
+				_, err = utils.Run(exec.Command("make", "test-apply"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(os.Unsetenv("KUBECONFIG")).To(Succeed())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
* Always write the cluster kubeconfig before collecting the support dump
* Apply default e2e provider config if nothing is provided
* Several small fixes

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_: 
Fixes #1812
