### PR TITLE
fix: k0s image url for azure-hosted-cp

### DIFF
--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -11,7 +11,7 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- if $global.registry }}
-  image: {{ $global.registry }}/k0s
+  image: {{ $global.registry }}/k0sproject/k0s
   etcd:
     image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
   {{- if $global.registryCertSecret }}

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-15.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-15.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-14
+  name: azure-hosted-cp-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: azure-hosted-cp
-      version: 1.0.14
+      version: 1.0.15
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Fixes incorrect (missing k0sproject subpath) k0s image url in `azure-hosted-cp` template.
The rest of the templates are correct.
