### PR TITLE
chore(bump): go@1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/K0rdent/kcm
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps go (implicitly) to the latest 1.24 build
**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Binary to include backport of the `#go/72991`