### PR TITLE
test: set default architecture for the adopted deployment

### DIFF
--- a/test/e2e/provider_adopted_test.go
+++ b/test/e2e/provider_adopted_test.go
@@ -109,6 +109,7 @@ var _ = Describe("Adopted Cluster Templates", Label("provider:cloud", "provider:
 	for i, testingConfig := range config.Config[config.TestingProviderAdopted] {
 		It(fmt.Sprintf("Verifying Asopted cluster deployment. Iteration: %d", i), func() {
 			defer GinkgoRecover()
+			testingConfig.SetDefaults(clusterTemplates, config.TestingProviderAdopted)
 			// Deploy a standalone cluster and verify it is running/ready. Then, delete the management cluster and
 			// recreate it. Next "adopt" the cluster we created and verify the services were deployed. Next we delete
 			// the adopted cluster and finally the management cluster (AWS standalone).


### PR DESCRIPTION
**What this PR does / why we need it**: Adopted e2e tests are missing the default architecture configuration.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
