### PR TITLE
fix: remote-cluster (hosted) respects useSudo

### DIFF
--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-12
+  template: remote-cluster-1-0-13
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -43,7 +43,7 @@ spec:
     {{- end }}
     {{- end }}
   preStartCommands:
-    - "sudo update-ca-certificates"
+    - {{ printf "%supdate-ca-certificates" (ternary "sudo " "" $machine.useSudo) | quote }}
   {{- end }}
   {{- if and $machine.k0s $machine.k0s.args }}
   args:

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-13.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-13.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-12
+  name: remote-cluster-1-0-13
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: remote-cluster
-      version: 1.0.12
+      version: 1.0.13
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
The remote-cluster template now respects per-machine .useSudo parameter.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #1879
