### PR TITLE
fix: moved network configuration for standalone charts into values.yaml

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-12
+  template: aws-standalone-cp-1-0-13
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-13
+  template: azure-standalone-cp-1-0-14
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-12
+  template: gcp-standalone-cp-1-0-13
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-14
+  template: openstack-standalone-cp-1-0-15
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-11
+  template: vsphere-standalone-cp-1-0-12
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -62,9 +62,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         network:
-          provider: calico
-          calico:
-            mode: ipip
+          {{- toYaml .Values.k0s.network | nindent 10 }}
         {{- if $global.registry }}
         images:
           metricsserver:

--- a/templates/cluster/aws-standalone-cp/values.schema.json
+++ b/templates/cluster/aws-standalone-cp/values.schema.json
@@ -210,6 +210,26 @@
             "type": "object"
           }
         },
+        "network": {
+          "description": "Kubernetes cluster network configuration",
+          "type": "object",
+          "properties": {
+            "calico": {
+              "description": "Calico-specific configuration",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "description": "Calico network mode (ipip, vxlan, never)",
+                  "type": "string"
+                }
+              }
+            },
+            "provider": {
+              "description": "Network provider to use (e.g., calico, cilium, flannel, kube-router)",
+              "type": "string"
+            }
+          }
+        },
         "version": {
           "description": "K0s version",
           "type": "string"

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -61,4 +61,8 @@ k0s: # @schema description: K0s parameters; type: object; additionalProperties: 
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+  network: # @schema description: Kubernetes cluster network configuration; type: object
+    provider: calico # @schema description: Network provider to use (e.g., calico, cilium, flannel, kube-router); type: string
+    calico: # @schema description: Calico-specific configuration; type: object
+      mode: ipip # @schema description: Calico network mode (ipip, vxlan, never); type: string
   files: [] # @schema description: Specifies extra files to be passed to user_data upon creation; type: array; item: object

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -47,9 +47,7 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
         network:
-          provider: calico
-          calico:
-            mode: vxlan
+          {{- toYaml .Values.k0s.network | nindent 10 }}
         {{- if $global.registry }}
         images:
           metricsserver:

--- a/templates/cluster/azure-standalone-cp/values.schema.json
+++ b/templates/cluster/azure-standalone-cp/values.schema.json
@@ -141,6 +141,26 @@
             "type": "string"
           }
         },
+        "network": {
+          "description": "Kubernetes cluster network configuration",
+          "type": "object",
+          "properties": {
+            "calico": {
+              "description": "Calico-specific configuration",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "description": "Calico network mode (ipip, vxlan, never)",
+                  "type": "string"
+                }
+              }
+            },
+            "provider": {
+              "description": "Network provider to use (e.g., calico, cilium, flannel, kube-router)",
+              "type": "string"
+            }
+          }
+        },
         "version": {
           "description": "K0s version",
           "type": "string"

--- a/templates/cluster/azure-standalone-cp/values.yaml
+++ b/templates/cluster/azure-standalone-cp/values.yaml
@@ -58,3 +58,7 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+  network: # @schema description: Kubernetes cluster network configuration; type: object
+    provider: calico # @schema description: Network provider to use (e.g., calico, cilium, flannel, kube-router); type: string
+    calico: # @schema description: Calico-specific configuration; type: object
+      mode: vxlan # @schema description: Calico network mode (ipip, vxlan, never); type: string

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -47,9 +47,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         network:
-          provider: calico
-          calico:
-            mode: ipip
+          {{- toYaml .Values.k0s.network | nindent 10 }}
         {{- if $global.registry }}
         images:
           metricsserver:

--- a/templates/cluster/gcp-standalone-cp/values.schema.json
+++ b/templates/cluster/gcp-standalone-cp/values.schema.json
@@ -203,6 +203,26 @@
             "type": "string"
           }
         },
+        "network": {
+          "description": "Kubernetes cluster network configuration",
+          "type": "object",
+          "properties": {
+            "calico": {
+              "description": "Calico-specific configuration",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "description": "Calico network mode (ipip, vxlan, never)",
+                  "type": "string"
+                }
+              }
+            },
+            "provider": {
+              "description": "Network provider to use (e.g., calico, cilium, flannel, kube-router)",
+              "type": "string"
+            }
+          }
+        },
         "version": {
           "description": "K0s version",
           "type": "string"

--- a/templates/cluster/gcp-standalone-cp/values.yaml
+++ b/templates/cluster/gcp-standalone-cp/values.yaml
@@ -69,3 +69,7 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+  network: # @schema description: Kubernetes cluster network configuration; type: object
+    provider: calico # @schema description: Network provider to use (e.g., calico, cilium, flannel, kube-router); type: string
+    calico: # @schema description: Calico-specific configuration; type: object
+      mode: ipip # @schema description: Calico network mode (ipip, vxlan, never); type: string

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -47,9 +47,7 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
         network:
-          provider: calico
-          calico:
-            mode: vxlan
+          {{- toYaml .Values.k0s.network | nindent 10 }}
         {{- if $global.registry }}
         images:
           metricsserver:

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -332,6 +332,26 @@
             "type": "string"
           }
         },
+        "network": {
+          "description": "Kubernetes cluster network configuration",
+          "type": "object",
+          "properties": {
+            "calico": {
+              "description": "Calico-specific configuration",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "description": "Calico network mode (ipip, vxlan, never)",
+                  "type": "string"
+                }
+              }
+            },
+            "provider": {
+              "description": "Network provider to use (e.g., calico, cilium, flannel, kube-router)",
+              "type": "string"
+            }
+          }
+        },
         "version": {
           "description": "K0s version",
           "type": "string"

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -95,4 +95,8 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+  network: # @schema description: Kubernetes cluster network configuration; type: object
+    provider: calico # @schema description: Network provider to use (e.g., calico, cilium, flannel, kube-router); type: string
+    calico: # @schema description: Calico-specific configuration; type: object
+      mode: vxlan # @schema description: Calico network mode (ipip, vxlan, never); type: string
 

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -54,9 +54,7 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
         network:
-          provider: calico
-          calico:
-            mode: vxlan
+          {{- toYaml .Values.k0s.network | nindent 10 }}
         {{- if $global.registry }}
         images:
           metricsserver:

--- a/templates/cluster/vsphere-standalone-cp/values.schema.json
+++ b/templates/cluster/vsphere-standalone-cp/values.schema.json
@@ -117,6 +117,26 @@
             "type": "string"
           }
         },
+        "network": {
+          "description": "Kubernetes cluster network configuration",
+          "type": "object",
+          "properties": {
+            "calico": {
+              "description": "Calico-specific configuration",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "description": "Calico network mode (ipip, vxlan, never)",
+                  "type": "string"
+                }
+              }
+            },
+            "provider": {
+              "description": "Network provider to use (e.g., calico, cilium, flannel, kube-router)",
+              "type": "string"
+            }
+          }
+        },
         "version": {
           "description": "K0s version",
           "type": "string"

--- a/templates/cluster/vsphere-standalone-cp/values.yaml
+++ b/templates/cluster/vsphere-standalone-cp/values.yaml
@@ -57,4 +57,8 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+  network: # @schema description: Kubernetes cluster network configuration; type: object
+    provider: calico # @schema description: Network provider to use (e.g., calico, cilium, flannel, kube-router); type: string
+    calico: # @schema description: Calico-specific configuration; type: object
+      mode: vxlan # @schema description: Calico network mode (ipip, vxlan, never); type: string
 

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-13.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-13.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-13
+  name: aws-standalone-cp-1-0-13
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
+      chart: aws-standalone-cp
       version: 1.0.13
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-14.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-14.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-12
+  name: azure-standalone-cp-1-0-14
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.12
+      chart: azure-standalone-cp
+      version: 1.0.14
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-13.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-13.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-12
+  name: gcp-standalone-cp-1-0-13
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-standalone-cp
-      version: 1.0.12
+      version: 1.0.13
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-15.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-15.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-11
+  name: openstack-standalone-cp-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.11
+      chart: openstack-standalone-cp
+      version: 1.0.15
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-12.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-12.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-14
+  name: vsphere-standalone-cp-1-0-12
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.14
+      chart: vsphere-standalone-cp
+      version: 1.0.12
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows for more simple network configuration ergonomics when  building custom ClusterTemplate charts. Configuring networks is an extremely common use case. So we should make this as simple as possible.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #1873 
