### PR TITLE
fix: drop subpath from registry in hosted helm repositories

### DIFF
--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -77,7 +77,7 @@ spec:
               url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
           {{- else }}
             - name: global-registry
-              url: oci://{{ $global.registry }}
+              url: oci://{{ regexReplaceAll "/.*" $global.registry "" }}
               {{- if $global.registryCertSecret }}
               caFile: /usr/local/share/ca-certificates/registry/ca.crt
               {{- end }}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.15
+version: 1.0.16
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -76,7 +76,7 @@ spec:
               url: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
           {{- else }}
             - name: global-registry
-              url: oci://{{ $global.registry }}
+              url: oci://{{ regexReplaceAll "/.*" $global.registry "" }}
               {{- if $global.registryCertSecret }}
               caFile: /usr/local/share/ca-certificates/registry/ca.crt
               {{- end }}

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -74,7 +74,7 @@ spec:
               url: https://charts.mirantis.com
           {{- else }}
             - name: global-registry
-              url: oci://{{ $global.registry }}
+              url: oci://{{ regexReplaceAll "/.*" $global.registry "" }}
               {{- if $global.registryCertSecret }}
               caFile: /usr/local/share/ca-certificates/registry/ca.crt
               {{- end }}

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -74,7 +74,7 @@ spec:
               url: https://kubernetes.github.io/cloud-provider-openstack/
           {{- else }}
             - name: global-registry
-              url: oci://{{ $global.registry }}
+              url: oci://{{ regexReplaceAll "/.*" $global.registry "" }}
               {{- if $global.registryCertSecret }}
               caFile: /usr/local/share/ca-certificates/registry/ca.crt
               {{- end }}

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -76,7 +76,7 @@ spec:
               url: https://charts.mirantis.com
           {{- else }}
             - name: global-registry
-              url: oci://{{ $global.registry }}
+              url: oci://{{ regexReplaceAll "/.*" $global.registry "" }}
               {{- if $global.registryCertSecret }}
               caFile: /usr/local/share/ca-certificates/registry/ca.crt
               {{- end }}

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-13.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-13.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-12
+  name: aws-hosted-cp-1-0-13
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: aws-hosted-cp
-      version: 1.0.12
+      version: 1.0.13
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-16.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-16.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-13
+  name: azure-hosted-cp-1-0-16
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.13
+      chart: azure-hosted-cp
+      version: 1.0.16
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-14.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-14.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-11
+  name: gcp-hosted-cp-1-0-14
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.11
+      chart: gcp-hosted-cp
+      version: 1.0.14
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-4.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-4.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-3
+  name: openstack-hosted-cp-1-0-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-hosted-cp
-      version: 1.0.3
+      version: 1.0.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-12.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-12.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-15
+  name: vsphere-hosted-cp-1-0-12
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.15
+      chart: vsphere-hosted-cp
+      version: 1.0.12
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
`helm.repositories[].url` in the K0smotronControlPlane object should not contain any subpath to make the `caFile` parameter work properly. See (line 21): https://github.com/k0sproject/k0s/pull/5901/files#diff-5a07081f272ac5d5dcc8fbd240e2eb0dbea08f2717c9031ec779ab7d7cc3ba0dR21

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #1889 
