### PR TITLE
fix: install yq before generating release.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt",year="$(shell date +%Y)" paths="./..."
 
 .PHONY: generate-release
-generate-release:
+generate-release: yq
 	@release_file="$(PROVIDER_TEMPLATES_DIR)/kcm-templates/files/release.yaml"; \
 	if [ -n "$$OUTPUT" ]; then \
 		$(YQ) eval \


### PR DESCRIPTION
**What this PR does / why we need it**:
`yq` is required in the `generate-release` Makefile target.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
