### PR TITLE
fix: network cfg in hosted tpls; fix standalone

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-13
+  template: aws-standalone-cp-1-0-14
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-14
+  template: azure-standalone-cp-1-0-15
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-13
+  template: gcp-standalone-cp-1-0-14
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-15
+  template: openstack-standalone-cp-1-0-16
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-13
+  template: remote-cluster-1-0-14
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-12
+  template: vsphere-standalone-cp-1-0-13
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -43,10 +43,9 @@ spec:
         extraArgs:
           {{- toYaml . | nindent 10 }}
       {{- end }}
-      network:
-        provider: calico
-        calico:
-          mode: ipip
+      {{- with .Values.k0s.network }}
+      network: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $global.registry }}
       images:
         konnectivity:

--- a/templates/cluster/aws-hosted-cp/values.schema.json
+++ b/templates/cluster/aws-hosted-cp/values.schema.json
@@ -167,6 +167,40 @@
             "arm"
           ]
         },
+        "network": {
+          "description": "Kubernetes cluster network configuration",
+          "type": "object",
+          "properties": {
+            "calico": {
+              "description": "Calico-specific configuration",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "description": "Calico network mode",
+                  "examples": [
+                    "ipip",
+                    "vxlan",
+                    "never"
+                  ],
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": true
+            },
+            "provider": {
+              "description": "Network provider to use",
+              "examples": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": true
+        },
         "version": {
           "description": "K0s version",
           "type": "string"

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -60,3 +60,7 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+  network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
+      mode: ipip # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -61,8 +61,9 @@ spec:
           {{- with .Values.k0s.api.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        network:
-          {{- toYaml .Values.k0s.network | nindent 10 }}
+        {{- with .Values.k0s.network }}
+        network: {{ toYaml . | nindent 10 }}
+        {{- end }}
         {{- if $global.registry }}
         images:
           metricsserver:

--- a/templates/cluster/aws-standalone-cp/values.schema.json
+++ b/templates/cluster/aws-standalone-cp/values.schema.json
@@ -219,16 +219,30 @@
               "type": "object",
               "properties": {
                 "mode": {
-                  "description": "Calico network mode (ipip, vxlan, never)",
-                  "type": "string"
+                  "description": "Calico network mode",
+                  "examples": [
+                    "ipip",
+                    "vxlan",
+                    "never"
+                  ],
+                  "type": "string",
+                  "minLength": 1
                 }
-              }
+              },
+              "additionalProperties": true
             },
             "provider": {
-              "description": "Network provider to use (e.g., calico, cilium, flannel, kube-router)",
-              "type": "string"
+              "description": "Network provider to use",
+              "examples": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
+              "type": "string",
+              "minLength": 1
             }
-          }
+          },
+          "additionalProperties": true
         },
         "version": {
           "description": "K0s version",

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -61,8 +61,8 @@ k0s: # @schema description: K0s parameters; type: object; additionalProperties: 
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
-  network: # @schema description: Kubernetes cluster network configuration; type: object
-    provider: calico # @schema description: Network provider to use (e.g., calico, cilium, flannel, kube-router); type: string
-    calico: # @schema description: Calico-specific configuration; type: object
-      mode: ipip # @schema description: Calico network mode (ipip, vxlan, never); type: string
+  network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
+      mode: ipip # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
   files: [] # @schema description: Specifies extra files to be passed to user_data upon creation; type: array; item: object

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.16
+version: 1.0.17
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -42,10 +42,9 @@ spec:
         extraArgs:
           {{- toYaml . | nindent 10 }}
       {{- end }}
-      network:
-        provider: calico
-        calico:
-          mode: vxlan
+      {{- with .Values.k0s.network }}
+      network: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $global.registry }}
       images:
         konnectivity:

--- a/templates/cluster/azure-hosted-cp/values.schema.json
+++ b/templates/cluster/azure-hosted-cp/values.schema.json
@@ -119,6 +119,40 @@
             "arm"
           ]
         },
+        "network": {
+          "description": "Kubernetes cluster network configuration",
+          "type": "object",
+          "properties": {
+            "calico": {
+              "description": "Calico-specific configuration",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "description": "Calico network mode",
+                  "examples": [
+                    "ipip",
+                    "vxlan",
+                    "never"
+                  ],
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": true
+            },
+            "provider": {
+              "description": "Network provider to use",
+              "examples": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": true
+        },
         "version": {
           "description": "K0s version",
           "type": "string"

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -58,3 +58,7 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+  network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -46,8 +46,9 @@ spec:
             {{- with .Values.k0s.api.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-        network:
-          {{- toYaml .Values.k0s.network | nindent 10 }}
+        {{- with .Values.k0s.network }}
+        network: {{ toYaml . | nindent 10 }}
+        {{- end }}
         {{- if $global.registry }}
         images:
           metricsserver:

--- a/templates/cluster/azure-standalone-cp/values.schema.json
+++ b/templates/cluster/azure-standalone-cp/values.schema.json
@@ -150,16 +150,30 @@
               "type": "object",
               "properties": {
                 "mode": {
-                  "description": "Calico network mode (ipip, vxlan, never)",
-                  "type": "string"
+                  "description": "Calico network mode",
+                  "examples": [
+                    "ipip",
+                    "vxlan",
+                    "never"
+                  ],
+                  "type": "string",
+                  "minLength": 1
                 }
-              }
+              },
+              "additionalProperties": true
             },
             "provider": {
-              "description": "Network provider to use (e.g., calico, cilium, flannel, kube-router)",
-              "type": "string"
+              "description": "Network provider to use",
+              "examples": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
+              "type": "string",
+              "minLength": 1
             }
-          }
+          },
+          "additionalProperties": true
         },
         "version": {
           "description": "K0s version",

--- a/templates/cluster/azure-standalone-cp/values.yaml
+++ b/templates/cluster/azure-standalone-cp/values.yaml
@@ -58,7 +58,7 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
-  network: # @schema description: Kubernetes cluster network configuration; type: object
-    provider: calico # @schema description: Network provider to use (e.g., calico, cilium, flannel, kube-router); type: string
-    calico: # @schema description: Calico-specific configuration; type: object
-      mode: vxlan # @schema description: Calico network mode (ipip, vxlan, never); type: string
+  network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -42,10 +42,9 @@ spec:
         extraArgs:
           {{- toYaml . | nindent 10 }}
       {{- end }}
-      network:
-        provider: calico
-        calico:
-          mode: vxlan
+      {{- with .Values.k0s.network }}
+      network: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $global.registry }}
       images:
         konnectivity:

--- a/templates/cluster/gcp-hosted-cp/values.schema.json
+++ b/templates/cluster/gcp-hosted-cp/values.schema.json
@@ -105,6 +105,40 @@
             "arm"
           ]
         },
+        "network": {
+          "description": "Kubernetes cluster network configuration",
+          "type": "object",
+          "properties": {
+            "calico": {
+              "description": "Calico-specific configuration",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "description": "Calico network mode",
+                  "examples": [
+                    "ipip",
+                    "vxlan",
+                    "never"
+                  ],
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": true
+            },
+            "provider": {
+              "description": "Network provider to use",
+              "examples": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": true
+        },
         "version": {
           "description": "K0s version",
           "type": "string"

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -59,3 +59,7 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+  network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -46,8 +46,9 @@ spec:
           {{- with .Values.k0s.api.extraArgs }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        network:
-          {{- toYaml .Values.k0s.network | nindent 10 }}
+        {{- with .Values.k0s.network }}
+        network: {{ toYaml . | nindent 10 }}
+        {{- end }}
         {{- if $global.registry }}
         images:
           metricsserver:

--- a/templates/cluster/gcp-standalone-cp/values.schema.json
+++ b/templates/cluster/gcp-standalone-cp/values.schema.json
@@ -212,16 +212,30 @@
               "type": "object",
               "properties": {
                 "mode": {
-                  "description": "Calico network mode (ipip, vxlan, never)",
-                  "type": "string"
+                  "description": "Calico network mode",
+                  "examples": [
+                    "ipip",
+                    "vxlan",
+                    "never"
+                  ],
+                  "type": "string",
+                  "minLength": 1
                 }
-              }
+              },
+              "additionalProperties": true
             },
             "provider": {
-              "description": "Network provider to use (e.g., calico, cilium, flannel, kube-router)",
-              "type": "string"
+              "description": "Network provider to use",
+              "examples": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
+              "type": "string",
+              "minLength": 1
             }
-          }
+          },
+          "additionalProperties": true
         },
         "version": {
           "description": "K0s version",

--- a/templates/cluster/gcp-standalone-cp/values.yaml
+++ b/templates/cluster/gcp-standalone-cp/values.yaml
@@ -69,7 +69,7 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
-  network: # @schema description: Kubernetes cluster network configuration; type: object
-    provider: calico # @schema description: Network provider to use (e.g., calico, cilium, flannel, kube-router); type: string
-    calico: # @schema description: Calico-specific configuration; type: object
-      mode: ipip # @schema description: Calico network mode (ipip, vxlan, never); type: string
+  network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
+      mode: ipip # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -42,10 +42,9 @@ spec:
         extraArgs:
           {{- toYaml . | nindent 10 }}
       {{- end }}
-      network:
-        provider: calico
-        calico:
-          mode: vxlan
+      {{- with .Values.k0s.network }}
+      network: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $global.registry }}
       images:
         konnectivity:

--- a/templates/cluster/openstack-hosted-cp/values.schema.json
+++ b/templates/cluster/openstack-hosted-cp/values.schema.json
@@ -246,6 +246,40 @@
             "arm"
           ]
         },
+        "network": {
+          "description": "Kubernetes cluster network configuration",
+          "type": "object",
+          "properties": {
+            "calico": {
+              "description": "Calico-specific configuration",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "description": "Calico network mode",
+                  "examples": [
+                    "ipip",
+                    "vxlan",
+                    "never"
+                  ],
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": true
+            },
+            "provider": {
+              "description": "Network provider to use",
+              "examples": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": true
+        },
         "version": {
           "description": "K0s version",
           "type": "string"

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -86,3 +86,7 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+  network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.15
+version: 1.0.16
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -46,8 +46,9 @@ spec:
             {{- with .Values.k0s.api.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-        network:
-          {{- toYaml .Values.k0s.network | nindent 10 }}
+        {{- with .Values.k0s.network }}
+        network: {{ toYaml . | nindent 10 }}
+        {{- end }}
         {{- if $global.registry }}
         images:
           metricsserver:

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -341,16 +341,30 @@
               "type": "object",
               "properties": {
                 "mode": {
-                  "description": "Calico network mode (ipip, vxlan, never)",
-                  "type": "string"
+                  "description": "Calico network mode",
+                  "examples": [
+                    "ipip",
+                    "vxlan",
+                    "never"
+                  ],
+                  "type": "string",
+                  "minLength": 1
                 }
-              }
+              },
+              "additionalProperties": true
             },
             "provider": {
-              "description": "Network provider to use (e.g., calico, cilium, flannel, kube-router)",
-              "type": "string"
+              "description": "Network provider to use",
+              "examples": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
+              "type": "string",
+              "minLength": 1
             }
-          }
+          },
+          "additionalProperties": true
         },
         "version": {
           "description": "K0s version",

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -95,8 +95,7 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
-  network: # @schema description: Kubernetes cluster network configuration; type: object
-    provider: calico # @schema description: Network provider to use (e.g., calico, cilium, flannel, kube-router); type: string
-    calico: # @schema description: Calico-specific configuration; type: object
-      mode: vxlan # @schema description: Calico network mode (ipip, vxlan, never); type: string
-
+  network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
@@ -41,8 +41,7 @@ spec:
           {{- toYaml . | nindent 10 }}
       {{- end }}
       {{- with .Values.k0s.network }}
-      network:
-        {{- toYaml . | nindent 8 }}
+      network: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- if $global.registry }}
       images:

--- a/templates/cluster/remote-cluster/values.schema.json
+++ b/templates/cluster/remote-cluster/values.schema.json
@@ -113,7 +113,8 @@
         },
         "network": {
           "description": "K0s network configuration",
-          "type": "object"
+          "type": "object",
+          "additionalProperties": true
         },
         "version": {
           "description": "K0s version",

--- a/templates/cluster/remote-cluster/values.yaml
+++ b/templates/cluster/remote-cluster/values.yaml
@@ -47,7 +47,7 @@ k0s: # @schema description: K0s parameters; type: object
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
-  network: {} # @schema description: K0s network configuration; type: object
+  network: {} # @schema description: K0s network configuration; type: object; additionalProperties: true
   extensions: # @schema description: K0s extensions configuration; type: object
     helm: # @schema description: K0s helm repositories and charts configuration; type: object
       repositories: [] # @schema description: The list of Helm repositories for deploying charts during cluster bootstrap; type: array; item: object

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -42,10 +42,9 @@ spec:
         extraArgs:
           {{- toYaml . | nindent 10 }}
       {{- end }}
-      network:
-        provider: calico
-        calico:
-          mode: vxlan
+      {{- with .Values.k0s.network }}
+      network: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $global.registry }}
       images:
         konnectivity:

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -78,6 +78,40 @@
             "arm"
           ]
         },
+        "network": {
+          "description": "Kubernetes cluster network configuration",
+          "type": "object",
+          "properties": {
+            "calico": {
+              "description": "Calico-specific configuration",
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "description": "Calico network mode",
+                  "examples": [
+                    "ipip",
+                    "vxlan",
+                    "never"
+                  ],
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "additionalProperties": true
+            },
+            "provider": {
+              "description": "Network provider to use",
+              "examples": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": true
+        },
         "version": {
           "description": "K0s version",
           "type": "string"

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -50,3 +50,7 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
+  network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -53,8 +53,9 @@ spec:
             {{- with .Values.k0s.api.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-        network:
-          {{- toYaml .Values.k0s.network | nindent 10 }}
+        {{- with .Values.k0s.network }}
+        network: {{ toYaml . | nindent 10 }}
+        {{- end }}
         {{- if $global.registry }}
         images:
           metricsserver:

--- a/templates/cluster/vsphere-standalone-cp/values.schema.json
+++ b/templates/cluster/vsphere-standalone-cp/values.schema.json
@@ -126,16 +126,30 @@
               "type": "object",
               "properties": {
                 "mode": {
-                  "description": "Calico network mode (ipip, vxlan, never)",
-                  "type": "string"
+                  "description": "Calico network mode",
+                  "examples": [
+                    "ipip",
+                    "vxlan",
+                    "never"
+                  ],
+                  "type": "string",
+                  "minLength": 1
                 }
-              }
+              },
+              "additionalProperties": true
             },
             "provider": {
-              "description": "Network provider to use (e.g., calico, cilium, flannel, kube-router)",
-              "type": "string"
+              "description": "Network provider to use",
+              "examples": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
+              "type": "string",
+              "minLength": 1
             }
-          }
+          },
+          "additionalProperties": true
         },
         "version": {
           "description": "K0s version",

--- a/templates/cluster/vsphere-standalone-cp/values.yaml
+++ b/templates/cluster/vsphere-standalone-cp/values.yaml
@@ -57,8 +57,7 @@ k0s: # @schema description: K0s parameters; type: object
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
-  network: # @schema description: Kubernetes cluster network configuration; type: object
-    provider: calico # @schema description: Network provider to use (e.g., calico, cilium, flannel, kube-router); type: string
-    calico: # @schema description: Calico-specific configuration; type: object
-      mode: vxlan # @schema description: Calico network mode (ipip, vxlan, never); type: string
-
+  network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-14.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-14.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-13
+  name: aws-hosted-cp-1-0-14
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.13
+      chart: aws-hosted-cp
+      version: 1.0.14
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-14.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-14.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-12
+  name: aws-standalone-cp-1-0-14
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.12
+      chart: aws-standalone-cp
+      version: 1.0.14
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-17.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-17.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-14
+  name: azure-hosted-cp-1-0-17
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.14
+      chart: azure-hosted-cp
+      version: 1.0.17
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-15.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-15.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-15
+  name: azure-standalone-cp-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
+      chart: azure-standalone-cp
       version: 1.0.15
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-15.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-15.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-16
+  name: gcp-hosted-cp-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.16
+      chart: gcp-hosted-cp
+      version: 1.0.15
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-14.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-14.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-13
+  name: gcp-standalone-cp-1-0-14
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-standalone-cp
-      version: 1.0.13
+      version: 1.0.14
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-12
+  name: openstack-hosted-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.12
+      chart: openstack-hosted-cp
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-16.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-16.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-13
+  name: openstack-standalone-cp-1-0-16
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.13
+      chart: openstack-standalone-cp
+      version: 1.0.16
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-14.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-14.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-13
+  name: remote-cluster-1-0-14
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.13
+      chart: remote-cluster
+      version: 1.0.14
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-13.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-13.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-5
+  name: vsphere-hosted-cp-1-0-13
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.5
+      chart: vsphere-hosted-cp
+      version: 1.0.13
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-13.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-13.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-14
+  name: vsphere-standalone-cp-1-0-13
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.14
+      chart: vsphere-standalone-cp
+      version: 1.0.13
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds configuration of k0s network to all of the hosted templates.

Fixes potentially dangerous configuration in standalone templates introduced by #1887.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:

Closes #1873 