### PR TITLE
Add missing identityRef.name field to OpenStack values files

### DIFF
--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -19,6 +19,7 @@ clusterIdentity: # @schema description: The OpenStack credentials secret referen
   name: "" # @schema description: Name of the secret with OpenStack credentials; type: string; required: true
 
 identityRef: # @schema description: OpenStack cluster identity object reference; type: object; required: true
+  name: "" # @schema description: Name of the secret with OpenStack credentials; type: string; required: true
   cloudName: "" # @schema description: Name of the entry in the clouds.yaml file to use; type: string; required: true
   region: "" # @schema description: OpenStack region; type: string; required: true
   caCert: # @schema description: Reference to the secret with the content of a custom CA; type: object

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -22,6 +22,7 @@ clusterIdentity: # @schema description: The OpenStack credentials secret referen
   name: "" # @schema description: Name of the secret with OpenStack credentials; type: string; required: true
 
 identityRef: # @schema description: OpenStack cluster identity object reference; type: object; required: true
+  name: "" # @schema description: Name of the secret with OpenStack credentials; type: string; required: true
   cloudName: "" # @schema description: Name of the entry in the clouds.yaml file to use; type: string; required: true
   region: "" # @schema description: OpenStack region; type: string; required: true
   caCert: # @schema description: Reference to the secret with the content of a custom CA; type: object


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the missing identityRef.name field to both OpenStack values files used by the standalone and hosted control-plane templates.
Files updated:
- templates/cluster/openstack-standalone-cp/values.yaml
- templates/cluster/openstack-hosted-cp/values.yaml

The templates reference .Values.identityRef.name in OpenStackMachineTemplate but the values files lacked this key, causing validation/render errors.