### PR TITLE
fix(os-tpls): correct identity name in identityref

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-14
+  template: openstack-standalone-cp-1-0-15
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}
@@ -26,6 +26,5 @@ spec:
         name: "public"
     authURL: ${OS_AUTH_URL}
     identityRef:
-      name: "openstack-cloud-config"
       cloudName: "openstack"
       region: ${OS_REGION_NAME}

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/openstackmachinetemplate.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/openstackmachinetemplate.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       flavor: {{ .Values.flavor }}
       identityRef:
-        name: {{ .Values.identityRef.name }}
+        name: {{ .Values.clusterIdentity.name }}
         region: {{ .Values.identityRef.region }}
         cloudName: {{ .Values.identityRef.cloudName}}
       image:

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       flavor: {{ .Values.controlPlane.flavor }}
       identityRef:
-        name: {{ .Values.identityRef.name }}
+        name: {{ .Values.clusterIdentity.name }}
         region: {{ .Values.identityRef.region }}
         cloudName: {{ .Values.identityRef.cloudName}}
       image:

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       flavor: {{ .Values.worker.flavor }}
       identityRef:
-        name: {{ .Values.identityRef.name }}
+        name: {{ .Values.clusterIdentity.name }}
         region: {{ .Values.identityRef.region }}
         cloudName: {{ .Values.identityRef.cloudName}}
       image:

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-5.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-5.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-4
+  name: openstack-hosted-cp-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-hosted-cp
-      version: 1.0.4
+      version: 1.0.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-15.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-15.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-14
+  name: openstack-standalone-cp-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-standalone-cp
-      version: 1.0.14
+      version: 1.0.15
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/k0rdent/kcm/pull/1794 introduced `clusterIdentity` but missed replacing the old values in the machine templates. This PR addresses it

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
