### PR TITLE
fix(infoblox): support arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ support-bundle*
 *.swo
 *~
 .vscode
+.vim/
 
 # Vendoring directory
 vendor/

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/segmentio/analytics-go/v3 v3.3.0
 	github.com/stretchr/testify v1.11.0
-	github.com/telekom/cluster-api-ipam-provider-infoblox v1.0.0
+	github.com/telekom/cluster-api-ipam-provider-infoblox v0.1.0
 	github.com/vmware-tanzu/velero v1.16.2
 	golang.org/x/crypto v0.41.0
 	golang.org/x/text v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQl8=
 github.com/stretchr/testify v1.11.0/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/telekom/cluster-api-ipam-provider-infoblox v1.0.0 h1:UOgRY+duPuF4tX8I9DXW1orQXK+MN99mfGwZLJKHUU0=
-github.com/telekom/cluster-api-ipam-provider-infoblox v1.0.0/go.mod h1:xMRNDmddkfvOVJ3x6vfSZ2Pv2eA4GbM7Va0cw+k/Sq8=
+github.com/telekom/cluster-api-ipam-provider-infoblox v0.1.0 h1:qMszy4MIL5+uDs1sTYkR6OGv1iOKjFsXn6gipqcHCfc=
+github.com/telekom/cluster-api-ipam-provider-infoblox v0.1.0/go.mod h1:xMRNDmddkfvOVJ3x6vfSZ2Pv2eA4GbM7Va0cw+k/Sq8=
 github.com/vmware-tanzu/velero v1.16.2 h1:Zhve1mKtX4n0oVhHwbEOsgB9fjKKwm96HJK4WaV/28o=
 github.com/vmware-tanzu/velero v1.16.2/go.mod h1:rGIxqbeVHne/47AMtA8vV0ebeQOzyF7VEullayyTEto=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/templates/provider/cluster-api-provider-infoblox/Chart.yaml
+++ b/templates/provider/cluster-api-provider-infoblox/Chart.yaml
@@ -13,11 +13,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.0-alpha.8"
+appVersion: "v0.1.0"
 annotations:
   cluster.x-k8s.io/provider: ipam-infoblox

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -28,6 +28,6 @@ spec:
     - name: cluster-api-provider-ipam
       template: cluster-api-provider-ipam-1-0-2
     - name: cluster-api-provider-infoblox
-      template: cluster-api-provider-infoblox-1-0-1
+      template: cluster-api-provider-infoblox-1-0-2
     - name: projectsveltos
       template: projectsveltos-0-57-2

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-infoblox.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-infoblox.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-infoblox-1-0-1
+  name: cluster-api-provider-infoblox-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-infoblox
-      version: 1.0.1
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -75,9 +75,6 @@ var _ = BeforeSuite(func() {
 
 	kc = kubeclient.NewFromLocal(internalutils.DefaultSystemNamespace)
 
-	// TODO: remove after https://github.com/k0rdent/kcm/issues/1575 is fixed
-	removeInfobloxProvider(kc.CrClient)
-
 	By("validating that all K0rdent management components are ready")
 	Eventually(func() error {
 		err = verifyManagementReadiness(kc)
@@ -140,33 +137,4 @@ func templateBy(t templates.Type, description string) {
 
 func cleanup() bool {
 	return os.Getenv(clusterdeployment.EnvVarNoCleanup) == ""
-}
-
-// TODO: remove after https://github.com/k0rdent/kcm/issues/1575 is fixed
-func removeInfobloxProvider(client crclient.Client) {
-	By("applying workaround to disable infoblox provider")
-	mgmt := &kcmv1.Management{}
-	Eventually(func() error {
-		return client.Get(context.Background(), crclient.ObjectKey{Name: kcmv1.ManagementName}, mgmt)
-	}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
-
-	capiInfobloxProviderName := "cluster-api-provider-infoblox"
-	Eventually(func() error {
-		patch := crclient.MergeFrom(mgmt.DeepCopy())
-		mgmt.Spec.Providers = slices.DeleteFunc(mgmt.Spec.Providers, func(provider kcmv1.Provider) bool {
-			return provider.Name == capiInfobloxProviderName
-		})
-		if err := client.Patch(context.Background(), mgmt, patch); err != nil {
-			return err
-		}
-		if err := client.Get(context.Background(), crclient.ObjectKey{Name: kcmv1.ManagementName}, mgmt); err != nil {
-			return err
-		}
-		if !slices.ContainsFunc(mgmt.Spec.Providers, func(provider kcmv1.Provider) bool {
-			return provider.Name == capiInfobloxProviderName
-		}) {
-			return nil
-		}
-		return fmt.Errorf("%s provider is still present in Management spec", capiInfobloxProviderName)
-	}).WithTimeout(10 * time.Minute).WithPolling(20 * time.Second).Should(Succeed())
 }

--- a/test/e2e/provider_aws_test.go
+++ b/test/e2e/provider_aws_test.go
@@ -223,11 +223,6 @@ var _ = Describe("AWS Templates", Label("provider:cloud", "provider:aws"), Order
 
 				templateBy(templates.TemplateAWSHostedCP, "validating that the controller is ready")
 
-				// TODO: remove after https://github.com/k0rdent/kcm/issues/1575 is fixed
-				if testingConfig.Architecture == config.ArchitectureArm64 {
-					removeInfobloxProvider(standaloneClient.CrClient)
-				}
-
 				Eventually(func() error {
 					err := verifyManagementReadiness(standaloneClient)
 					if err != nil {

--- a/test/e2e/provider_azure_test.go
+++ b/test/e2e/provider_azure_test.go
@@ -162,11 +162,6 @@ var _ = Context("Azure Templates", Label("provider:cloud", "provider:azure"), Or
 
 				standaloneClient = kc.NewFromCluster(context.Background(), internalutils.DefaultSystemNamespace, sdName)
 
-				// TODO: remove after https://github.com/k0rdent/kcm/issues/1575 is fixed
-				if testingConfig.Architecture == config.ArchitectureArm64 {
-					removeInfobloxProvider(standaloneClient.CrClient)
-				}
-
 				// verify the cluster is ready prior to creating credentials
 				Eventually(func() error {
 					err := verifyManagementReadiness(standaloneClient)

--- a/test/e2e/provider_gcp_test.go
+++ b/test/e2e/provider_gcp_test.go
@@ -161,11 +161,6 @@ var _ = Context("GCP Templates", Label("provider:cloud", "provider:gcp"), Ordere
 
 				standaloneClient = kc.NewFromCluster(context.Background(), internalutils.DefaultSystemNamespace, sdName)
 
-				// TODO: remove after https://github.com/k0rdent/kcm/issues/1575 is fixed
-				if testingConfig.Architecture == config.ArchitectureArm64 {
-					removeInfobloxProvider(standaloneClient.CrClient)
-				}
-
 				// verify the cluster is ready prior to creating credentials
 				Eventually(func() error {
 					err := verifyManagementReadiness(standaloneClient)

--- a/test/e2e/provider_vsphere_test.go
+++ b/test/e2e/provider_vsphere_test.go
@@ -159,11 +159,6 @@ var _ = Context("vSphere Templates", Label("provider:onprem", "provider:vsphere"
 				By("Verifying the cluster is ready prior to creating credentials")
 				standaloneClient = kc.NewFromCluster(context.Background(), internalutils.DefaultSystemNamespace, sdName)
 
-				// TODO: remove after https://github.com/k0rdent/kcm/issues/1575 is fixed
-				if testingConfig.Architecture == config.ArchitectureArm64 {
-					removeInfobloxProvider(standaloneClient.CrClient)
-				}
-
 				Eventually(func() error {
 					if err := verifyManagementReadiness(standaloneClient); err != nil {
 						_, _ = fmt.Fprintf(GinkgoWriter, "%v\n", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps infoblox to v0.1.0 with arm64 support.
Removes kludge in e2e tests.
**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #1885 
