### PR TITLE
fix: multiclusterservice cleanup

### DIFF
--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -302,7 +302,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 
 		It("should successfully reconcile the resource", func() {
 			By("reconciling MultiClusterService")
-			multiClusterServiceReconciler := &MultiClusterServiceReconciler{Client: k8sClient, SystemNamespace: testSystemNamespace}
+			multiClusterServiceReconciler := &MultiClusterServiceReconciler{Client: mgrClient, SystemNamespace: testSystemNamespace}
 
 			_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug when services are not removed from cluster when labels on corresponding `ClusterDeployment` are no longer match selector in MultiClusterService

**Which issue(s) this PR fixes**:
Fixes: #1927 
