### PR TITLE
fix(utils): patch object's component labels

### DIFF
--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -123,8 +123,7 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return r.reconcileDelete(ctx, serviceSet)
 	}
 
-	if !controllerutil.ContainsFinalizer(serviceSet, kcmv1.ServiceSetFinalizer) {
-		controllerutil.AddFinalizer(serviceSet, kcmv1.ServiceSetFinalizer)
+	if controllerutil.AddFinalizer(serviceSet, kcmv1.ServiceSetFinalizer) {
 		return ctrl.Result{}, r.Update(ctx, serviceSet)
 	}
 
@@ -234,10 +233,12 @@ func (r *ServiceSetReconciler) reconcileDelete(ctx context.Context, serviceSet *
 	}
 
 	// otherwise the Profile was not found, so we can remove the finalizer
-	controllerutil.RemoveFinalizer(serviceSet, kcmv1.ServiceSetFinalizer)
-	if err = r.Update(ctx, serviceSet); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+	if controllerutil.RemoveFinalizer(serviceSet, kcmv1.ServiceSetFinalizer) {
+		if err := r.Update(ctx, serviceSet); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", err)
+		}
 	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/providerinterface_controller.go
+++ b/internal/controller/providerinterface_controller.go
@@ -134,13 +134,15 @@ func (r *ProviderInterfaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return respFunc(ctx, obj)
 		}), builder.WithPredicates(predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {
-				return utils.HasLabel(e.Object, kcmv1.GenericComponentNameLabel)
+				v, ok := e.Object.GetLabels()[kcmv1.GenericComponentNameLabel]
+				return ok && v == kcmv1.GenericComponentLabelValueKCM
 			},
 			DeleteFunc: func(event.DeleteEvent) bool {
 				return true
 			},
 			UpdateFunc: func(e event.UpdateEvent) bool {
-				if !utils.HasLabel(e.ObjectNew, kcmv1.GenericComponentNameLabel) {
+				v, ok := e.ObjectNew.GetLabels()[kcmv1.GenericComponentNameLabel]
+				if !ok || v != kcmv1.GenericComponentLabelValueKCM {
 					return false
 				}
 

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   version: 1.3.0
   kcm:
-    template: kcm-1-3-2
+    template: kcm-1-3-3
   capi:
     template: cluster-api-1-0-6
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-1-3-2
+  name: kcm-1-3-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 1.3.2
+      version: 1.3.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.2
+version: 1.3.3
 dependencies:
   - name: flux2
     version: 2.16.0

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -98,7 +98,7 @@ rules:
   - get
   - list
   - watch
-  - update # labels
+  - patch # labels
 - apiGroups:
   - k0rdent.mirantis.com
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Patches object's component KCM label instead of updating the whole object.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #1942 
