### PR TITLE
feat: add JSON Schema configmap for templates if available

### DIFF
--- a/api/v1beta1/templates_common.go
+++ b/api/v1beta1/templates_common.go
@@ -85,6 +85,8 @@ type TemplateStatusCommon struct {
 	ChartVersion string `json:"chartVersion,omitempty"`
 	// Description contains information about the template.
 	Description string `json:"description,omitempty"`
+	// SchemaConfigMapName specifies the name of the ConfigMap that contains the JSON Schema definition for Helm Chart validation.
+	SchemaConfigMapName string `json:"schemaConfigMapName,omitempty"`
 
 	TemplateValidationStatus `json:",inline"`
 

--- a/internal/controller/template_controller_test.go
+++ b/internal/controller/template_controller_test.go
@@ -17,12 +17,14 @@ package controller
 import (
 	"context"
 	"fmt"
+	"testing"
 	"time"
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/chart"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -320,3 +322,58 @@ var _ = Describe("Template Controller", func() {
 		})
 	})
 })
+
+func Test_generateSchemaConfigMapName(t *testing.T) {
+	tests := []struct {
+		name     string
+		template templateCommon
+		expected string
+	}{
+		{
+			name: "cluster template",
+			template: &kcmv1.ClusterTemplate{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kcmv1.GroupVersion.String(),
+					Kind:       kcmv1.ClusterTemplateKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-template",
+				},
+			},
+			expected: "schema-ct-test-template",
+		},
+		{
+			name: "provider template",
+			template: &kcmv1.ProviderTemplate{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kcmv1.GroupVersion.String(),
+					Kind:       kcmv1.ProviderTemplateKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-template",
+				},
+			},
+			expected: "schema-pt-test-template",
+		},
+		{
+			name: "service template",
+			template: &kcmv1.ServiceTemplate{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: kcmv1.GroupVersion.String(),
+					Kind:       kcmv1.ServiceTemplateKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-template",
+				},
+			},
+			expected: "schema-st-test-template",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateSchemaConfigMapName(tt.template)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   version: 1.3.1
   kcm:
-    template: kcm-1-3-3
+    template: kcm-1-3-4
   capi:
     template: cluster-api-1-0-6
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-1-3-3
+  name: kcm-1-3-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 1.3.3
+      version: 1.3.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.3
+version: 1.3.4
 dependencies:
   - name: flux2
     version: 2.16.0

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
@@ -1993,6 +1993,10 @@ spec:
                 items:
                   type: string
                 type: array
+              schemaConfigMapName:
+                description: SchemaConfigMapName specifies the name of the ConfigMap
+                  that contains the JSON Schema definition for Helm Chart validation.
+                type: string
               valid:
                 description: Valid indicates whether the template passed validation
                   or not.

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
@@ -1973,6 +1973,10 @@ spec:
                 items:
                   type: string
                 type: array
+              schemaConfigMapName:
+                description: SchemaConfigMapName specifies the name of the ConfigMap
+                  that contains the JSON Schema definition for Helm Chart validation.
+                type: string
               valid:
                 description: Valid indicates whether the template passed validation
                   or not.

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
@@ -4664,6 +4664,10 @@ spec:
                 description: ObservedGeneration is the last observed generation.
                 format: int64
                 type: integer
+              schemaConfigMapName:
+                description: SchemaConfigMapName specifies the name of the ConfigMap
+                  that contains the JSON Schema definition for Helm Chart validation.
+                type: string
               sourceStatus:
                 description: SourceStatus reflects the status of the source.
                 properties:


### PR DESCRIPTION
Added the `schemaConfigMapName` field to the template’s status and enabled the generation of the ConfigMap. If the referenced Helm chart includes values.schema.json (as it normally should), the schema will be available in the ConfigMap.

Resolves: #1839