### PR TITLE
feat: add aggregate role for kcm manager

### DIFF
--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   version: 1.3.1
   kcm:
-    template: kcm-1-3-4
+    template: kcm-1-3-5
   capi:
     template: cluster-api-1-0-6
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-1-3-4
+  name: kcm-1-3-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 1.3.4
+      version: 1.3.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.4
+version: 1.3.5
 dependencies:
   - name: flux2
     version: 2.16.0

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -4,6 +4,18 @@ metadata:
   name: {{ include "kcm.fullname" . }}-manager-role
   labels:
   {{- include "kcm.labels" . | nindent 4 }}
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        k0rdent.mirantis.com/aggregate-to-manager: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kcm.fullname" . }}-controller-manager-role
+  labels:
+    k0rdent.mirantis.com/aggregate-to-manager: "true"
+  {{- include "kcm.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
Added aggregation for the kcm manager role based on the `k0rdent.mirantis.com/aggregate-to-manager: "true"` label.
The label can be used for roles in OOT providers to eliminate the need for creating an extra rolebinding.

Fixes: #1692 