### PR TITLE
test(e2e): add OpenStack Standalone and Hosted Control Plane tests

### DIFF
--- a/test/e2e/clusterdeployment/clusterdeployment.go
+++ b/test/e2e/clusterdeployment/clusterdeployment.go
@@ -39,12 +39,13 @@ import (
 type ProviderType string
 
 const (
-	ProviderCAPI    ProviderType = "cluster-api"
-	ProviderAWS     ProviderType = "infrastructure-aws"
-	ProviderAzure   ProviderType = "infrastructure-azure"
-	ProviderGCP     ProviderType = "infrastructure-gcp"
-	ProviderVSphere ProviderType = "infrastructure-vsphere"
-	ProviderAdopted ProviderType = "infrastructure-internal"
+	ProviderCAPI      ProviderType = "cluster-api"
+	ProviderAWS       ProviderType = "infrastructure-aws"
+	ProviderAzure     ProviderType = "infrastructure-azure"
+	ProviderGCP       ProviderType = "infrastructure-gcp"
+	ProviderOpenStack ProviderType = "infrastructure-openstack"
+	ProviderVSphere   ProviderType = "infrastructure-vsphere"
+	ProviderAdopted   ProviderType = "infrastructure-internal"
 )
 
 const KCMControllerLabel = "app.kubernetes.io/name=kcm"
@@ -75,6 +76,12 @@ var gcpHostedCPClusterDeploymentTemplateBytes []byte
 
 //go:embed resources/gcp-gke.yaml.tpl
 var gcpGkeClusterDeploymentTemplateBytes []byte
+
+//go:embed resources/openstack-standalone-cp.yaml.tpl
+var openstackStandaloneCPClusterDeploymentTemplateBytes []byte
+
+//go:embed resources/openstack-hosted-cp.yaml.tpl
+var openstackHostedCPClusterDeploymentTemplateBytes []byte
 
 //go:embed resources/vsphere-standalone-cp.yaml.tpl
 var vsphereStandaloneCPClusterDeploymentTemplateBytes []byte
@@ -150,6 +157,10 @@ func Generate(templateType templates.Type, clusterName, template string) *kcmv1.
 		clusterDeploymentTemplateBytes = gcpStandaloneCPClusterDeploymentTemplateBytes
 	case templates.TemplateGCPGKE:
 		clusterDeploymentTemplateBytes = gcpGkeClusterDeploymentTemplateBytes
+	case templates.TemplateOpenStackStandaloneCP:
+		clusterDeploymentTemplateBytes = openstackStandaloneCPClusterDeploymentTemplateBytes
+	case templates.TemplateOpenStackHostedCP:
+		clusterDeploymentTemplateBytes = openstackHostedCPClusterDeploymentTemplateBytes
 	case templates.TemplateAdoptedCluster:
 		clusterDeploymentTemplateBytes = adoptedClusterDeploymentTemplateBytes
 	case templates.TemplateRemoteCluster:

--- a/test/e2e/clusterdeployment/common.go
+++ b/test/e2e/clusterdeployment/common.go
@@ -51,6 +51,9 @@ func PatchHostedClusterReady(kc *kubeclient.KubeClient, provider ProviderType, c
 	case ProviderAzure:
 		version = "v1beta1"
 		resource = "azureclusters"
+	case ProviderOpenStack:
+		version = "v1beta1"
+		resource = "openstackclusters"
 	case ProviderVSphere:
 		return
 	default:

--- a/test/e2e/clusterdeployment/constants.go
+++ b/test/e2e/clusterdeployment/constants.go
@@ -70,6 +70,17 @@ const (
 	EnvVarGCPImage              = "GCP_IMAGE"
 	EnvVarGCPRootDeviceType     = "GCP_ROOT_DEVICE_TYPE"
 
+	// OpenStack
+	EnvVarOpenStackCPFlavor          = "OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR"
+	EnvVarOpenStackNodeFlavor        = "OPENSTACK_NODE_MACHINE_FLAVOR"
+	EnvVarOpenStackImageName         = "OPENSTACK_IMAGE_NAME"
+	EnvVarOpenStackExternalNetwork   = "OPENSTACK_EXTERNAL_NETWORK_NAME"
+	EnvVarOpenStackCloudName         = "OPENSTACK_CLOUD_NAME"
+	EnvVarOpenStackRegion            = "OS_REGION_NAME"
+	EnvVarOpenStackNetworkFilterJSON = "OPENSTACK_NETWORK_FILTER_JSON"
+	EnvVarOpenStackSubnetFilterJSON  = "OPENSTACK_SUBNET_FILTER_JSON"
+	EnvVarOpenStackRouterFilterJSON  = "OPENSTACK_ROUTER_FILTER_JSON"
+
 	// Adopted
 	EnvVarAdoptedKubeconfigData = "KUBECONFIG_DATA"
 

--- a/test/e2e/clusterdeployment/openstack/openstack.go
+++ b/test/e2e/clusterdeployment/openstack/openstack.go
@@ -1,0 +1,177 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package openstack contains specific helpers for testing a cluster deployment
+// that uses the OpenStack infrastructure provider.
+package openstack
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/K0rdent/kcm/test/e2e/clusterdeployment"
+	"github.com/K0rdent/kcm/test/e2e/config"
+	"github.com/K0rdent/kcm/test/e2e/kubeclient"
+)
+
+// CheckEnv validates the presence of required OpenStack credentials env vars.
+func CheckEnv() {
+	clusterdeployment.ValidateDeploymentVars([]string{
+		"OS_AUTH_URL",
+		"OS_APPLICATION_CREDENTIAL_ID",
+		"OS_APPLICATION_CREDENTIAL_SECRET",
+		"OS_REGION_NAME",
+		"OS_INTERFACE",
+		"OS_IDENTITY_API_VERSION",
+		"OS_AUTH_TYPE",
+	})
+}
+
+// PopulateEnvVars sets architecture-dependent defaults and required template envs
+// if they are not already provided in the environment.
+// For now we require explicit values for flavors and image name, but we wire
+// architecture to allow future defaults if desired.
+func PopulateEnvVars(_ config.Architecture) {
+	GinkgoHelper()
+	// No strict defaults provided here to avoid accidental resource choices.
+	// The e2e templates reference these env vars; ensure they're set upstream.
+	clusterdeployment.ValidateDeploymentVars([]string{
+		clusterdeployment.EnvVarOpenStackImageName,
+		clusterdeployment.EnvVarOpenStackCPFlavor,
+		clusterdeployment.EnvVarOpenStackNodeFlavor,
+		clusterdeployment.EnvVarOpenStackRegion,
+	})
+}
+
+// PopulateHostedTemplateVars reads network/subnet/router (and region) from the
+// standalone OpenStackCluster and sets env vars used by the hosted template.
+// It also attempts to derive worker flavor/image from the MachineDeployment's
+// OpenStackMachineTemplate.
+func PopulateHostedTemplateVars(ctx context.Context, kc *kubeclient.KubeClient, standaloneClusterName string) {
+	GinkgoHelper()
+
+	osc := getOpenStackCluster(ctx, kc, standaloneClusterName)
+	populateNetworkVars(osc)
+	populateIdentityVars(osc)
+	populateMachineVars(ctx, kc, standaloneClusterName)
+}
+
+func getOpenStackCluster(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) *unstructured.Unstructured {
+	oscGVR := schema.GroupVersionResource{
+		Group:    "infrastructure.cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "openstackclusters",
+	}
+	oscCli := kc.GetDynamicClient(oscGVR, true)
+	osc, err := oscCli.Get(ctx, clusterName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to get OpenStackCluster")
+	return osc
+}
+
+func setJSONFilter(envName, key, val string) {
+	if val == "" {
+		return
+	}
+	m := map[string]string{key: val}
+	b, err := json.Marshal(m)
+	Expect(err).NotTo(HaveOccurred(), "failed to marshal JSON filter")
+	GinkgoT().Setenv(envName, string(b))
+}
+
+func populateNetworkVars(osc *unstructured.Unstructured) {
+	if netMap, found, _ := unstructured.NestedMap(osc.Object, "status", "network"); found {
+		if name, ok := netMap["name"].(string); ok && name != "" {
+			setJSONFilter(clusterdeployment.EnvVarOpenStackNetworkFilterJSON, "name", name)
+		} else if id, ok := netMap["id"].(string); ok && id != "" {
+			setJSONFilter(clusterdeployment.EnvVarOpenStackNetworkFilterJSON, "id", id)
+		}
+	}
+
+	if subs, found, _ := unstructured.NestedSlice(osc.Object, "status", "network", "subnets"); found && len(subs) > 0 {
+		if sub, ok := subs[0].(map[string]any); ok {
+			if name, ok := sub["name"].(string); ok && name != "" {
+				setJSONFilter(clusterdeployment.EnvVarOpenStackSubnetFilterJSON, "name", name)
+			} else if id, ok := sub["id"].(string); ok && id != "" {
+				setJSONFilter(clusterdeployment.EnvVarOpenStackSubnetFilterJSON, "id", id)
+			}
+		}
+	}
+
+	if rMap, found, _ := unstructured.NestedMap(osc.Object, "status", "router"); found {
+		if name, ok := rMap["name"].(string); ok && name != "" {
+			setJSONFilter(clusterdeployment.EnvVarOpenStackRouterFilterJSON, "name", name)
+		} else if id, ok := rMap["id"].(string); ok && id != "" {
+			setJSONFilter(clusterdeployment.EnvVarOpenStackRouterFilterJSON, "id", id)
+		}
+	}
+}
+
+func populateIdentityVars(osc *unstructured.Unstructured) {
+	if specIDRef, found, _ := unstructured.NestedMap(osc.Object, "spec", "identityRef"); found {
+		if region, ok := specIDRef["region"].(string); ok && region != "" {
+			GinkgoT().Setenv(clusterdeployment.EnvVarOpenStackRegion, region)
+		}
+		if cloud, ok := specIDRef["cloudName"].(string); ok && cloud != "" {
+			GinkgoT().Setenv(clusterdeployment.EnvVarOpenStackCloudName, cloud)
+		}
+	}
+}
+
+func populateMachineVars(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) {
+	mdGVR := schema.GroupVersionResource{
+		Group:    "cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "machinedeployments",
+	}
+	mdCli := kc.GetDynamicClient(mdGVR, true)
+	mds, err := mdCli.List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{"cluster.x-k8s.io/cluster-name": clusterName}).String(),
+	})
+	Expect(err).NotTo(HaveOccurred(), "failed to list MachineDeployments")
+	if len(mds.Items) == 0 {
+		return
+	}
+
+	infraRefName, _, _ := unstructured.NestedString(mds.Items[0].Object, "spec", "template", "spec", "infrastructureRef", "name")
+	if infraRefName == "" {
+		return
+	}
+
+	osmtGVR := schema.GroupVersionResource{
+		Group:    "infrastructure.cluster.x-k8s.io",
+		Version:  "v1beta1",
+		Resource: "openstackmachinetemplates",
+	}
+	osmtCli := kc.GetDynamicClient(osmtGVR, true)
+	mt, err := osmtCli.Get(ctx, infraRefName, metav1.GetOptions{})
+	if err != nil {
+		return
+	}
+
+	if flavor, _, _ := unstructured.NestedString(mt.Object, "spec", "template", "spec", "flavor"); flavor != "" {
+		GinkgoT().Setenv(clusterdeployment.EnvVarOpenStackNodeFlavor, flavor)
+	}
+	if imgFilter, found, _ := unstructured.NestedMap(mt.Object, "spec", "template", "spec", "image", "filter"); found {
+		if name, ok := imgFilter["name"].(string); ok && name != "" {
+			GinkgoT().Setenv(clusterdeployment.EnvVarOpenStackImageName, name)
+		}
+	}
+}

--- a/test/e2e/clusterdeployment/providervalidator.go
+++ b/test/e2e/clusterdeployment/providervalidator.go
@@ -90,7 +90,7 @@ func NewProviderValidator(templateType templates.Type, clusterName string, actio
 		switch templateType {
 		case templates.TemplateVSphereStandaloneCP, templates.TemplateVSphereHostedCP:
 			// defaults suffice
-		case templates.TemplateAWSStandaloneCP, templates.TemplateAWSHostedCP, templates.TemplateGCPStandaloneCP, templates.TemplateGCPHostedCP:
+		case templates.TemplateAWSStandaloneCP, templates.TemplateAWSHostedCP, templates.TemplateGCPStandaloneCP, templates.TemplateGCPHostedCP, templates.TemplateOpenStackStandaloneCP, templates.TemplateOpenStackHostedCP:
 			resourcesToValidate["ccm"] = validateCCM
 			resourceOrder = append(resourceOrder, "ccm")
 		case templates.TemplateAWSEKS:

--- a/test/e2e/clusterdeployment/resources/openstack-hosted-cp.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/openstack-hosted-cp.yaml.tpl
@@ -1,0 +1,24 @@
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ClusterDeployment
+metadata:
+  name: ${CLUSTER_DEPLOYMENT_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template: ${CLUSTER_DEPLOYMENT_TEMPLATE}
+  credential: openstack-cluster-identity-cred
+  config:
+    workersNumber: ${WORKERS_NUMBER:=1}
+    flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
+    image:
+      filter:
+        name: ${OPENSTACK_IMAGE_NAME}
+    identityRef:
+      cloudName: ${OPENSTACK_CLOUD_NAME:=openstack}
+      region: ${OS_REGION_NAME}
+    network:
+      filter: ${OPENSTACK_NETWORK_FILTER_JSON:={}}
+    subnets:
+      - filter: ${OPENSTACK_SUBNET_FILTER_JSON:={}}
+    router:
+      filter: ${OPENSTACK_ROUTER_FILTER_JSON:={}}
+

--- a/test/e2e/clusterdeployment/resources/openstack-standalone-cp.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/openstack-standalone-cp.yaml.tpl
@@ -1,0 +1,28 @@
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ClusterDeployment
+metadata:
+  name: ${CLUSTER_DEPLOYMENT_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  template: ${CLUSTER_DEPLOYMENT_TEMPLATE}
+  credential: openstack-cluster-identity-cred
+  config:
+    controlPlaneNumber: ${CONTROL_PLANE_NUMBER:=1}
+    workersNumber: ${WORKERS_NUMBER:=1}
+    controlPlane:
+      flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
+      image:
+        filter:
+          name: ${OPENSTACK_IMAGE_NAME}
+    worker:
+      flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
+      image:
+        filter:
+          name: ${OPENSTACK_IMAGE_NAME}
+    externalNetwork:
+      filter:
+        name: ${OPENSTACK_EXTERNAL_NETWORK_NAME:=public}
+    identityRef:
+      cloudName: ${OPENSTACK_CLOUD_NAME:=openstack}
+      region: ${OS_REGION_NAME}
+

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -30,12 +30,13 @@ import (
 type TestingProvider string
 
 const (
-	TestingProviderAWS     TestingProvider = "aws"
-	TestingProviderAzure   TestingProvider = "azure"
-	TestingProviderGCP     TestingProvider = "gcp"
-	TestingProviderVsphere TestingProvider = "vsphere"
-	TestingProviderAdopted TestingProvider = "adopted"
-	TestingProviderRemote  TestingProvider = "remote"
+	TestingProviderAWS       TestingProvider = "aws"
+	TestingProviderAzure     TestingProvider = "azure"
+	TestingProviderGCP       TestingProvider = "gcp"
+	TestingProviderOpenstack TestingProvider = "openstack"
+	TestingProviderVsphere   TestingProvider = "vsphere"
+	TestingProviderAdopted   TestingProvider = "adopted"
+	TestingProviderRemote    TestingProvider = "remote"
 )
 
 type Architecture string
@@ -102,6 +103,7 @@ func initialize() {
 		TestingProviderAWS,
 		TestingProviderAzure,
 		TestingProviderGCP,
+		TestingProviderOpenstack,
 		TestingProviderVsphere,
 		TestingProviderAdopted,
 		TestingProviderRemote,

--- a/test/e2e/config/config.yaml
+++ b/test/e2e/config/config.yaml
@@ -29,6 +29,11 @@
 #- template: azure-standalone-cp-0-2-0
 #  hosted:
 #    template: azure-hosted-cp-0-2-0
+# openstack:
+# - template: openstack-standalone-cp-1-0-16
+#   hosted:
+#     template: openstack-hosted-cp-1-0-6
+#   upgrade: false
 #vsphere:
 #- template: vsphere-standalone-cp-0-2-0
 

--- a/test/e2e/config/defaults.go
+++ b/test/e2e/config/defaults.go
@@ -30,6 +30,8 @@ func getTemplateType(provider TestingProvider) templates.Type {
 		return templates.TemplateAzureStandaloneCP
 	case TestingProviderGCP:
 		return templates.TemplateGCPStandaloneCP
+	case TestingProviderOpenstack:
+		return templates.TemplateOpenStackStandaloneCP
 	case TestingProviderVsphere:
 		return templates.TemplateVSphereStandaloneCP
 	case TestingProviderAdopted:
@@ -49,6 +51,8 @@ func getHostedTemplateType(provider TestingProvider) templates.Type {
 		return templates.TemplateAzureHostedCP
 	case TestingProviderGCP:
 		return templates.TemplateGCPHostedCP
+	case TestingProviderOpenstack:
+		return templates.TemplateOpenStackHostedCP
 	case TestingProviderVsphere:
 		return templates.TemplateVSphereHostedCP
 	default:

--- a/test/e2e/provider_openstack_test.go
+++ b/test/e2e/provider_openstack_test.go
@@ -1,0 +1,257 @@
+// Copyright 2025
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kubeutil "github.com/K0rdent/kcm/internal/util/kube"
+	"github.com/K0rdent/kcm/test/e2e/clusterdeployment"
+	ostk "github.com/K0rdent/kcm/test/e2e/clusterdeployment/openstack"
+	"github.com/K0rdent/kcm/test/e2e/config"
+	"github.com/K0rdent/kcm/test/e2e/credential"
+	"github.com/K0rdent/kcm/test/e2e/kubeclient"
+	"github.com/K0rdent/kcm/test/e2e/logs"
+	"github.com/K0rdent/kcm/test/e2e/templates"
+	"github.com/K0rdent/kcm/test/e2e/upgrade"
+	executil "github.com/K0rdent/kcm/test/util/exec"
+)
+
+var _ = Context("OpenStack Templates", Label("provider:onprem", "provider:openstack"), Ordered, ContinueOnFailure, func() {
+	var (
+		kc                    *kubeclient.KubeClient
+		standaloneClusters    []string
+		hostedDeleteFuncs     []func() error
+		standaloneDeleteFuncs []func() error
+		kubeconfigDeleteFuncs []func() error
+	)
+
+	BeforeAll(func() {
+		ostk.CheckEnv()
+
+		kc = kubeclient.NewFromLocal(kubeutil.DefaultSystemNamespace)
+
+		// Provide credentials to the management cluster
+		credential.Apply("", "openstack")
+	})
+
+	AfterAll(func() {
+		if CurrentSpecReport().Failed() && cleanup() {
+			By("collecting the support bundle from the management cluster")
+			logs.SupportBundle(kc, "")
+
+			for _, clusterName := range standaloneClusters {
+				By(fmt.Sprintf("collecting the support bundle from the %s cluster", clusterName))
+				logs.SupportBundle(kc, clusterName)
+			}
+		}
+
+		if cleanup() {
+			By("deleting resources")
+			deleteFuncs := append(hostedDeleteFuncs, append(standaloneDeleteFuncs, kubeconfigDeleteFuncs...)...)
+			for _, deleteFunc := range deleteFuncs {
+				if deleteFunc != nil {
+					err := deleteFunc()
+					Expect(err).NotTo(HaveOccurred())
+				}
+			}
+		}
+	})
+
+	for i, testingConfig := range config.Config[config.TestingProviderOpenstack] {
+		It(fmt.Sprintf("Verifying OpenStack cluster deployment. Iteration: %d", i), func() {
+			defer GinkgoRecover()
+			testingConfig.SetDefaults(clusterTemplates, config.TestingProviderOpenstack)
+
+			By(testingConfig.Description())
+
+			sdName := clusterdeployment.GenerateClusterName(fmt.Sprintf("openstack-%d", i))
+			sdTemplate := testingConfig.Template
+			sdTemplateType := templates.GetType(sdTemplate)
+
+			// Ensure required OpenStack template envs
+			ostk.PopulateEnvVars(testingConfig.Architecture)
+
+			templateBy(sdTemplateType, fmt.Sprintf("creating a ClusterDeployment %s with template %s", sdName, sdTemplate))
+			sd := clusterdeployment.Generate(sdTemplateType, sdName, sdTemplate)
+
+			standaloneDeleteFunc := clusterdeployment.Create(context.Background(), kc.CrClient, sd)
+			standaloneClusters = append(standaloneClusters, sdName)
+			standaloneDeleteFuncs = append(standaloneDeleteFuncs, func() error {
+				By(fmt.Sprintf("Deleting the %s ClusterDeployment", sdName))
+				err := standaloneDeleteFunc()
+				Expect(err).NotTo(HaveOccurred())
+
+				By(fmt.Sprintf("Verifying the %s ClusterDeployment deleted successfully", sdName))
+				deletionValidator := clusterdeployment.NewProviderValidator(
+					sdTemplateType,
+					sdName,
+					clusterdeployment.ValidationActionDelete,
+				)
+				Eventually(func() error {
+					return deletionValidator.Validate(context.Background(), kc)
+				}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+				return nil
+			})
+
+			deploymentValidator := clusterdeployment.NewProviderValidator(
+				sdTemplateType,
+				sdName,
+				clusterdeployment.ValidationActionDeploy,
+			)
+
+			templateBy(sdTemplateType, "waiting for infrastructure provider to deploy successfully")
+			Eventually(func() error {
+				return deploymentValidator.Validate(context.Background(), kc)
+			}).WithTimeout(90 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+			if !testingConfig.Upgrade && testingConfig.Hosted == nil {
+				return
+			}
+
+			standaloneClient := new(kubeclient.KubeClient)
+			var hdName string
+			if testingConfig.Hosted != nil {
+				// Write kubeconfig for the standalone cluster and install controller/templates
+				kubeCfgPath, _, kubecfgDeleteFunc, err := kc.WriteKubeconfig(context.Background(), sdName)
+				Expect(err).To(Succeed())
+				kubeconfigDeleteFuncs = append(kubeconfigDeleteFuncs, kubecfgDeleteFunc)
+
+				By("Deploy onto standalone cluster")
+				GinkgoT().Setenv("KUBECONFIG", kubeCfgPath)
+				cmd := exec.Command("make", "test-apply")
+				_, err = executil.Run(cmd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.Unsetenv("KUBECONFIG")).To(Succeed())
+
+				standaloneClient = kc.NewFromCluster(context.Background(), kubeutil.DefaultSystemNamespace, sdName)
+
+				Eventually(func() error {
+					err := verifyManagementReadiness(standaloneClient)
+					if err != nil {
+						_, _ = fmt.Fprintf(GinkgoWriter, "%v\n", err)
+						return err
+					}
+					return nil
+				}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+				if testingConfig.Hosted.Upgrade {
+					By("installing stable templates for further hosted upgrade testing")
+					_, err = executil.Run(exec.Command("make", "stable-templates"))
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				Eventually(func() error {
+					err = clusterdeployment.ValidateClusterTemplates(context.Background(), standaloneClient)
+					if err != nil {
+						_, _ = fmt.Fprintf(GinkgoWriter, "cluster template validation failed: %v\n", err)
+						return err
+					}
+					return nil
+				}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+				// Provide credentials to the standalone cluster
+				credential.Apply(kubeCfgPath, "openstack")
+
+				// Auto-populate hosted template vars from the standalone cluster
+				ostk.PopulateHostedTemplateVars(context.Background(), standaloneClient, sdName)
+
+				hdName = clusterdeployment.GenerateClusterName(fmt.Sprintf("openstack-hosted-%d", i))
+				hdTemplate := testingConfig.Hosted.Template
+				templateBy(templates.TemplateOpenStackHostedCP, fmt.Sprintf("creating a hosted ClusterDeployment %s with template %s", hdName, hdTemplate))
+
+				hd := clusterdeployment.Generate(templates.TemplateOpenStackHostedCP, hdName, hdTemplate)
+
+				hostedDeleteFunc := clusterdeployment.Create(context.Background(), standaloneClient.CrClient, hd)
+				hostedDeleteFuncs = append(hostedDeleteFuncs, func() error {
+					By(fmt.Sprintf("Deleting the %s ClusterDeployment", hdName))
+					err = hostedDeleteFunc()
+					Expect(err).NotTo(HaveOccurred())
+
+					By(fmt.Sprintf("Verifying the %s ClusterDeployment deleted successfully", hdName))
+					deletionValidator := clusterdeployment.NewProviderValidator(
+						templates.TemplateOpenStackHostedCP,
+						hdName,
+						clusterdeployment.ValidationActionDelete,
+					)
+					Eventually(func() error {
+						return deletionValidator.Validate(context.Background(), standaloneClient)
+					}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+					return nil
+				})
+
+				templateBy(templates.TemplateOpenStackHostedCP, "Patching OpenStackCluster to ready")
+				clusterdeployment.PatchHostedClusterReady(standaloneClient, clusterdeployment.ProviderOpenStack, hdName)
+
+				templateBy(templates.TemplateOpenStackHostedCP, "waiting for infrastructure to deploy successfully")
+				deploymentValidator = clusterdeployment.NewProviderValidator(
+					templates.TemplateOpenStackHostedCP,
+					hdName,
+					clusterdeployment.ValidationActionDeploy,
+				)
+				Eventually(func() error {
+					return deploymentValidator.Validate(context.Background(), standaloneClient)
+				}).WithTimeout(30 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+			}
+
+			if testingConfig.Upgrade {
+				clusterUpgrade := upgrade.NewClusterUpgrade(
+					kc.CrClient,
+					standaloneClient.CrClient,
+					kubeutil.DefaultSystemNamespace,
+					sdName,
+					testingConfig.UpgradeTemplate,
+					upgrade.NewDefaultClusterValidator(),
+				)
+				clusterUpgrade.Run(context.Background())
+
+				Eventually(func() error {
+					return deploymentValidator.Validate(context.Background(), kc)
+				}).WithTimeout(30 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+				if testingConfig.Hosted != nil {
+					Eventually(func() error {
+						return deploymentValidator.Validate(context.Background(), standaloneClient)
+					}).WithTimeout(30 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+				}
+			}
+			if testingConfig.Hosted != nil && testingConfig.Hosted.Upgrade {
+				By(fmt.Sprintf("updating hosted cluster to the %s template", testingConfig.Hosted.UpgradeTemplate))
+
+				hostedClient := standaloneClient.NewFromCluster(context.Background(), kubeutil.DefaultSystemNamespace, hdName)
+				clusterUpgrade := upgrade.NewClusterUpgrade(
+					standaloneClient.CrClient,
+					hostedClient.CrClient,
+					kubeutil.DefaultSystemNamespace,
+					hdName,
+					testingConfig.Hosted.UpgradeTemplate,
+					upgrade.NewDefaultClusterValidator(),
+				)
+				clusterUpgrade.Run(context.Background())
+
+				Eventually(func() error {
+					return deploymentValidator.Validate(context.Background(), standaloneClient)
+				}).WithTimeout(30 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+			}
+		})
+	}
+})

--- a/test/e2e/templates/templates.go
+++ b/test/e2e/templates/templates.go
@@ -33,19 +33,21 @@ import (
 type Type string
 
 const (
-	TemplateAWSStandaloneCP     Type = "aws-standalone-cp"
-	TemplateAWSHostedCP         Type = "aws-hosted-cp"
-	TemplateAWSEKS              Type = "aws-eks"
-	TemplateAzureStandaloneCP   Type = "azure-standalone-cp"
-	TemplateAzureHostedCP       Type = "azure-hosted-cp"
-	TemplateAzureAKS            Type = "azure-aks"
-	TemplateGCPStandaloneCP     Type = "gcp-standalone-cp"
-	TemplateGCPHostedCP         Type = "gcp-hosted-cp"
-	TemplateGCPGKE              Type = "gcp-gke"
-	TemplateVSphereStandaloneCP Type = "vsphere-standalone-cp"
-	TemplateVSphereHostedCP     Type = "vsphere-hosted-cp"
-	TemplateAdoptedCluster      Type = "adopted-cluster"
-	TemplateRemoteCluster       Type = "remote-cluster"
+	TemplateAWSStandaloneCP       Type = "aws-standalone-cp"
+	TemplateAWSHostedCP           Type = "aws-hosted-cp"
+	TemplateAWSEKS                Type = "aws-eks"
+	TemplateAzureStandaloneCP     Type = "azure-standalone-cp"
+	TemplateAzureHostedCP         Type = "azure-hosted-cp"
+	TemplateAzureAKS              Type = "azure-aks"
+	TemplateGCPStandaloneCP       Type = "gcp-standalone-cp"
+	TemplateGCPHostedCP           Type = "gcp-hosted-cp"
+	TemplateGCPGKE                Type = "gcp-gke"
+	TemplateOpenStackStandaloneCP Type = "openstack-standalone-cp"
+	TemplateOpenStackHostedCP     Type = "openstack-hosted-cp"
+	TemplateVSphereStandaloneCP   Type = "vsphere-standalone-cp"
+	TemplateVSphereHostedCP       Type = "vsphere-hosted-cp"
+	TemplateAdoptedCluster        Type = "adopted-cluster"
+	TemplateRemoteCluster         Type = "remote-cluster"
 )
 
 // Types is an array of all the supported template types
@@ -59,6 +61,8 @@ var Types = []Type{
 	TemplateGCPStandaloneCP,
 	TemplateGCPHostedCP,
 	TemplateGCPGKE,
+	TemplateOpenStackStandaloneCP,
+	TemplateOpenStackHostedCP,
 	TemplateVSphereStandaloneCP,
 	TemplateVSphereHostedCP,
 	TemplateAdoptedCluster,


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds e2e test for OpenStack - both standalone and hosted control plane.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:

#596 
