### PR TITLE
feat: several minor Region improvements

### DIFF
--- a/api/v1beta1/region_types.go
+++ b/api/v1beta1/region_types.go
@@ -126,6 +126,8 @@ func (in *Region) GetComponentsStatus() *ComponentsCommonStatus {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=rgn,scope=Cluster
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status",description="Overall readiness of the Region resource"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Region"
 
 // Region is the Schema for the regions API
 type Region struct {

--- a/internal/controller/components/reconciler.go
+++ b/internal/controller/components/reconciler.go
@@ -164,6 +164,7 @@ func Reconcile(
 			})
 		}
 		hrReconcileOpts := helm.ReconcileHelmReleaseOpts{
+			ReleaseName:     component.name,
 			Values:          component.Config,
 			ChartRef:        template.Status.ChartRef,
 			DependsOn:       dependsOn,

--- a/internal/controller/region/controller.go
+++ b/internal/controller/region/controller.go
@@ -155,6 +155,10 @@ func (r *Reconciler) update(ctx context.Context, region *kcmv1.Region) (result c
 	}
 
 	requeue, err := components.Reconcile(ctx, r.MgmtClient, rgnlClient, region, restCfg, release, opts)
+	region.Status.ObservedGeneration = region.Generation
+
+	r.setReadyCondition(region)
+
 	if err != nil {
 		l.Error(err, "failed to reconcile KCM Regional components")
 		r.warnf(region, "RegionComponentsInstallationFailed", "Failed to install KCM components on the regional cluster: %w", err.Error())
@@ -163,8 +167,6 @@ func (r *Reconciler) update(ctx context.Context, region *kcmv1.Region) (result c
 	if requeue {
 		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
 	}
-
-	r.setReadyCondition(region)
 	return ctrl.Result{}, nil
 }
 

--- a/internal/helm/release.go
+++ b/internal/helm/release.go
@@ -43,6 +43,7 @@ type ReconcileHelmReleaseOpts struct {
 	KubeConfigRef     *meta.SecretKeyReference
 	Labels            map[string]string
 
+	ReleaseName     string
 	TargetNamespace string
 	DependsOn       []meta.NamespacedObjectReference
 	Timeout         time.Duration
@@ -80,6 +81,9 @@ func ReconcileHelmRelease(ctx context.Context,
 			return DefaultReconcileInterval
 		}()}
 		hr.Spec.ReleaseName = name
+		if opts.ReleaseName != "" {
+			hr.Spec.ReleaseName = opts.ReleaseName
+		}
 
 		if opts.Values != nil {
 			hr.Spec.Values = opts.Values

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_regions.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_regions.yaml
@@ -16,7 +16,16 @@ spec:
     singular: region
   scope: Cluster
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Overall readiness of the Region resource
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: Time duration since creation of Region
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Region is the Schema for the regions API


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Add Ready and Age printcolumns to Region objects.
2. Ensure the Ready condition is updated correctly for Region objects.
3. Do not prefix regional releases with the region name. Previously helm releases were installed with a name that equals the HelmRelease object name. With this change, the new field (ReleaseName) was introduced to the `ReconcileHelmReleaseOpts` that allows overriding the name of the deployed helm release. It's needed to avoid an unnecessary prefix for all the regional helm releases.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Related task #1979 
