### PR TITLE
feat: adapt services reconciliation to regional clusters

### DIFF
--- a/api/v1beta1/indexers.go
+++ b/api/v1beta1/indexers.go
@@ -280,6 +280,7 @@ func setupOwnerReferenceIndexers(ctx context.Context, mgr ctrl.Manager) error {
 	var merr error
 	for _, obj := range []client.Object{
 		&ProviderTemplate{},
+		&ServiceSet{},
 	} {
 		merr = errors.Join(merr, mgr.GetFieldIndexer().IndexField(ctx, obj, OwnerRefIndexKey, extractOwnerReferences))
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -452,6 +452,7 @@ func setupControllers(mgr ctrl.Manager, currentNamespace string, cfg config) err
 
 		setupLog.Info("setting up built-in ServiceSet controller")
 		if err = (&sveltos.ServiceSetReconciler{
+			SystemNamespace:  currentNamespace,
 			AdapterName:      deploymentName,
 			AdapterNamespace: currentNamespace,
 		}).SetupWithManager(mgr); err != nil {

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -49,11 +49,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+	"github.com/K0rdent/kcm/internal/controller/region"
 	"github.com/K0rdent/kcm/internal/record"
 	"github.com/K0rdent/kcm/internal/serviceset"
 	"github.com/K0rdent/kcm/internal/utils"
 	"github.com/K0rdent/kcm/internal/utils/pointer"
 	"github.com/K0rdent/kcm/internal/utils/ratelimit"
+	schemeutil "github.com/K0rdent/kcm/internal/utils/scheme"
 )
 
 const (
@@ -97,6 +99,7 @@ type ServiceSetReconciler struct {
 
 	timeFunc func() time.Time
 
+	SystemNamespace string
 	// AdapterName is the name of the workload running the controller
 	// effectively this name is used to identify adapter in the
 	// [github.com/k0rdent/kcm/api/v1beta1.StateManagementProvider] spec.
@@ -121,8 +124,26 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	var rgnClient client.Client
+	if serviceSet.Spec.Cluster != "" {
+		cd := new(kcmv1.ClusterDeployment)
+		cdKey := client.ObjectKey{Namespace: serviceSet.Namespace, Name: serviceSet.Spec.Cluster}
+		if err := r.Get(ctx, cdKey, cd); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get %s ClusterDeployment: %w", cdKey, err)
+		}
+		cred := new(kcmv1.Credential)
+		credKey := client.ObjectKey{Namespace: cd.Namespace, Name: cd.Spec.Credential}
+		if err := r.Get(ctx, credKey, cred); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get %s Credential: %w", credKey, err)
+		}
+		rgnClient, err = region.GetClientFromRegionName(ctx, r.Client, r.SystemNamespace, cred.Spec.Region, schemeutil.GetRegionalSchemeWithSveltos)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get regional client: %w", err)
+		}
+	}
+
 	if !serviceSet.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, serviceSet)
+		return r.reconcileDelete(ctx, rgnClient, serviceSet)
 	}
 
 	if controllerutil.AddFinalizer(serviceSet, kcmv1.ServiceSetFinalizer) {
@@ -170,21 +191,26 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// first we'll ensure the profile exists and up-to-date
-	if err = r.ensureProfile(ctx, serviceSet); err != nil {
+	if err = r.ensureProfile(ctx, rgnClient, serviceSet); err != nil {
 		record.Warnf(serviceSet, serviceSet.Generation, kcmv1.ServiceSetEnsureProfileFailedEvent,
 			"Failed to ensure Profile for ServiceSet %s: %v", serviceSet.Name, err)
 		return ctrl.Result{}, err
 	}
 	// then we'll collect the statuses of the services
-	if err = r.collectServiceStatuses(ctx, serviceSet); err != nil {
+	requeue, err := r.collectServiceStatuses(ctx, rgnClient, serviceSet)
+	if err != nil {
 		record.Warnf(serviceSet, serviceSet.Generation, kcmv1.ServiceSetCollectServiceStatusesFailedEvent,
 			"Failed to collect Service statuses for ServiceSet %s: %v", serviceSet.Name, err)
 		return ctrl.Result{}, err
 	}
+
+	if requeue {
+		return ctrl.Result{RequeueAfter: r.requeueInterval}, nil
+	}
 	return ctrl.Result{}, nil
 }
 
-func (r *ServiceSetReconciler) reconcileDelete(ctx context.Context, serviceSet *kcmv1.ServiceSet) (ctrl.Result, error) {
+func (r *ServiceSetReconciler) reconcileDelete(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) (ctrl.Result, error) {
 	l := ctrl.LoggerFrom(ctx)
 	l.Info("Reconciling ServiceSet deletion")
 
@@ -214,7 +240,7 @@ func (r *ServiceSetReconciler) reconcileDelete(ctx context.Context, serviceSet *
 	}
 
 	key := client.ObjectKeyFromObject(serviceSet)
-	err := r.Get(ctx, key, profile)
+	err := rgnClient.Get(ctx, key, profile)
 	// if IgnoreNotFound returns non-nil error, it means that the error
 	// occurred while sending the request to the kube-apiserver.
 	if client.IgnoreNotFound(err) != nil {
@@ -225,7 +251,7 @@ func (r *ServiceSetReconciler) reconcileDelete(ctx context.Context, serviceSet *
 	if err == nil {
 		if profile.GetDeletionTimestamp().IsZero() {
 			l.Info("Deleting Profile", "profile", profile.GetName())
-			if err = r.Delete(ctx, profile); err != nil {
+			if err = rgnClient.Delete(ctx, profile); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete Profile: %w", err)
 			}
 			return ctrl.Result{RequeueAfter: r.requeueInterval}, nil
@@ -338,7 +364,7 @@ func (r *ServiceSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // ensureProfile ensures that a [github.com/projectsveltos/addon-controller/api/v1beta1.Profile]
 // object exists for a given [github.com/K0rdent/kcm/api/v1beta1.ServiceSet].
-func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, serviceSet *kcmv1.ServiceSet) error {
+func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) error {
 	start := time.Now()
 	l := ctrl.LoggerFrom(ctx)
 	l.Info("Ensuring ProjectSveltos Profile")
@@ -357,7 +383,7 @@ func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, serviceSet *kc
 		l.V(1).Info("Finished ensuring ProjectSveltos Profile", "duration", time.Since(start))
 	}()
 
-	spec, err := r.profileSpec(ctx, serviceSet)
+	spec, err := r.profileSpec(ctx, rgnClient, serviceSet)
 	if errors.Is(err, errBuildProfileFromConfigFailed) {
 		reason = kcmv1.ServiceSetProfileBuildFailedReason
 		message = fmt.Sprintf("Failed to build Profile from ServiceSet %s configuration: %v", serviceSet.Name, err)
@@ -379,11 +405,11 @@ func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, serviceSet *kc
 	}
 
 	if serviceSet.Spec.Provider.SelfManagement {
-		if err = r.createOrUpdateClusterProfile(ctx, serviceSet, spec); err != nil {
+		if err = r.createOrUpdateClusterProfile(ctx, rgnClient, serviceSet, spec); err != nil {
 			return fmt.Errorf("failed to create or update ClusterProfile: %w", err)
 		}
 	} else {
-		if err = r.createOrUpdateProfile(ctx, serviceSet, spec); err != nil {
+		if err = r.createOrUpdateProfile(ctx, rgnClient, serviceSet, spec); err != nil {
 			return fmt.Errorf("failed to create or update Profile: %w", err)
 		}
 	}
@@ -394,12 +420,12 @@ func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, serviceSet *kc
 	return nil
 }
 
-func (r *ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, serviceSet *kcmv1.ServiceSet, spec *addoncontrollerv1beta1.Spec) error {
+func (*ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet, spec *addoncontrollerv1beta1.Spec) error {
 	ownerReference := metav1.NewControllerRef(serviceSet, kcmv1.GroupVersion.WithKind(kcmv1.ServiceSetKind))
 
 	profile := new(addoncontrollerv1beta1.Profile)
 	key := client.ObjectKeyFromObject(serviceSet)
-	err := r.Get(ctx, key, profile)
+	err := rgnClient.Get(ctx, key, profile)
 	// if IgnoreNotFound returns non-nil error, this means that
 	// an error occurred while trying to request kube-apiserver
 	if client.IgnoreNotFound(err) != nil {
@@ -417,7 +443,7 @@ func (r *ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, servic
 		}
 		profile.OwnerReferences = []metav1.OwnerReference{*ownerReference}
 		profile.Spec = *spec
-		if err = r.Create(ctx, profile); err != nil {
+		if err = rgnClient.Create(ctx, profile); err != nil {
 			return fmt.Errorf("failed to create Profile for ServiceSet %s: %w", serviceSet.Name, err)
 		}
 	// if profile spec is not equal to the spec we just created,
@@ -425,19 +451,19 @@ func (r *ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, servic
 	case !equality.Semantic.DeepEqual(profile.Spec, *spec):
 		profile.OwnerReferences = []metav1.OwnerReference{*ownerReference}
 		profile.Spec = *spec
-		if err = r.Update(ctx, profile); err != nil {
+		if err = rgnClient.Update(ctx, profile); err != nil {
 			return fmt.Errorf("failed to update Profile for ServiceSet %s: %w", serviceSet.Name, err)
 		}
 	}
 	return nil
 }
 
-func (r *ServiceSetReconciler) createOrUpdateClusterProfile(ctx context.Context, serviceSet *kcmv1.ServiceSet, spec *addoncontrollerv1beta1.Spec) error {
+func (*ServiceSetReconciler) createOrUpdateClusterProfile(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet, spec *addoncontrollerv1beta1.Spec) error {
 	ownerReference := metav1.NewControllerRef(serviceSet, kcmv1.GroupVersion.WithKind(kcmv1.ServiceSetKind))
 
 	profile := new(addoncontrollerv1beta1.ClusterProfile)
 	key := client.ObjectKeyFromObject(serviceSet)
-	err := r.Get(ctx, key, profile)
+	err := rgnClient.Get(ctx, key, profile)
 	// if IgnoreNotFound returns non-nil error, this means that
 	// an error occurred while trying to request kube-apiserver
 	if client.IgnoreNotFound(err) != nil {
@@ -454,7 +480,7 @@ func (r *ServiceSetReconciler) createOrUpdateClusterProfile(ctx context.Context,
 		}
 		profile.OwnerReferences = []metav1.OwnerReference{*ownerReference}
 		profile.Spec = *spec
-		if err = r.Create(ctx, profile); err != nil {
+		if err = rgnClient.Create(ctx, profile); err != nil {
 			return fmt.Errorf("failed to create Profile for ServiceSet %s: %w", serviceSet.Name, err)
 		}
 	// if profile spec is not equal to the spec we just created,
@@ -462,14 +488,14 @@ func (r *ServiceSetReconciler) createOrUpdateClusterProfile(ctx context.Context,
 	case !equality.Semantic.DeepEqual(profile.Spec, *spec):
 		profile.OwnerReferences = []metav1.OwnerReference{*ownerReference}
 		profile.Spec = *spec
-		if err = r.Update(ctx, profile); err != nil {
+		if err = rgnClient.Update(ctx, profile); err != nil {
 			return fmt.Errorf("failed to update Profile for ServiceSet %s: %w", serviceSet.Name, err)
 		}
 	}
 	return nil
 }
 
-func (r *ServiceSetReconciler) profileSpec(ctx context.Context, serviceSet *kcmv1.ServiceSet) (*addoncontrollerv1beta1.Spec, error) {
+func (r *ServiceSetReconciler) profileSpec(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) (*addoncontrollerv1beta1.Spec, error) {
 	var (
 		clusterSelector             libsveltosv1beta1.Selector
 		clusterReference            corev1.ObjectReference
@@ -509,7 +535,7 @@ func (r *ServiceSetReconciler) profileSpec(ctx context.Context, serviceSet *kcmv
 		if err := r.Get(ctx, key, cred); err != nil {
 			return nil, fmt.Errorf("failed to get Credential: %w", err)
 		}
-		clusterReference, err = r.getClusterReference(ctx, client.ObjectKeyFromObject(cd))
+		clusterReference, err = r.getClusterReference(ctx, rgnClient, client.ObjectKeyFromObject(cd))
 		if err != nil {
 			return nil, fmt.Errorf("failed to get ClusterReference for ClusterDeployment %s/%s: %w", cd.Namespace, cd.Name, err)
 		}
@@ -559,11 +585,11 @@ func (r *ServiceSetReconciler) profileSpec(ctx context.Context, serviceSet *kcmv
 
 // getClusterReference returns the v1.ObjectReference to the underlying cluster object. It might be either CAPI Cluster
 // or ProjectSveltos SveltosCluster.
-func (r *ServiceSetReconciler) getClusterReference(ctx context.Context, key client.ObjectKey) (corev1.ObjectReference, error) {
+func (*ServiceSetReconciler) getClusterReference(ctx context.Context, rgnClient client.Client, key client.ObjectKey) (corev1.ObjectReference, error) {
 	// we'll try to find underlying CAPI Cluster object, in case of success we'll return object
 	// reference to it
 	capiCluster := new(clusterapiv1.Cluster)
-	err := r.Get(ctx, key, capiCluster)
+	err := rgnClient.Get(ctx, key, capiCluster)
 	// in this case an error should be returned
 	if client.IgnoreNotFound(err) != nil {
 		return corev1.ObjectReference{}, err
@@ -579,7 +605,7 @@ func (r *ServiceSetReconciler) getClusterReference(ctx context.Context, key clie
 	}
 	// otherwise we'll try to get underlying ProjectSveltos SveltosCluster object.
 	sveltosCluster := new(libsveltosv1beta1.SveltosCluster)
-	err = r.Get(ctx, key, sveltosCluster)
+	err = rgnClient.Get(ctx, key, sveltosCluster)
 	if err == nil {
 		return corev1.ObjectReference{
 			Kind:       libsveltosv1beta1.SveltosClusterKind,
@@ -591,15 +617,15 @@ func (r *ServiceSetReconciler) getClusterReference(ctx context.Context, key clie
 	return corev1.ObjectReference{}, err
 }
 
-func (r *ServiceSetReconciler) collectServiceStatuses(ctx context.Context, serviceSet *kcmv1.ServiceSet) error {
+func (*ServiceSetReconciler) collectServiceStatuses(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) (requeue bool, _ error) {
 	start := time.Now()
 	l := ctrl.LoggerFrom(ctx)
 	l.Info("Collecting Service statuses")
 
 	profile := new(addoncontrollerv1beta1.Profile)
 	key := client.ObjectKeyFromObject(serviceSet)
-	if err := r.Get(ctx, key, profile); err != nil {
-		return fmt.Errorf("failed to get Profile: %w", err)
+	if err := rgnClient.Get(ctx, key, profile); err != nil {
+		return false, fmt.Errorf("failed to get Profile: %w", err)
 	}
 
 	// we expect that the profile matches the only single cluster,
@@ -607,7 +633,7 @@ func (r *ServiceSetReconciler) collectServiceStatuses(ctx context.Context, servi
 	if len(profile.Status.MatchingClusterRefs) == 0 {
 		l.Info("No matching clusters found for ServiceSet")
 		serviceSet.Status.Deployed = false
-		return nil
+		return true, nil
 	}
 
 	l.V(1).Info("Found matching profile", "profile", client.ObjectKeyFromObject(profile))
@@ -616,8 +642,8 @@ func (r *ServiceSetReconciler) collectServiceStatuses(ctx context.Context, servi
 	summaryName := sveltoscontrollers.GetClusterSummaryName(addoncontrollerv1beta1.ProfileKind, profile.Name, obj.Name, isSveltosCluster)
 	summary := new(addoncontrollerv1beta1.ClusterSummary)
 	summaryRef := client.ObjectKey{Name: summaryName, Namespace: obj.Namespace}
-	if err := r.Get(ctx, summaryRef, summary); err != nil {
-		return fmt.Errorf("failed to get ClusterSummary %s to fetch status: %w", summaryRef.String(), err)
+	if err := rgnClient.Get(ctx, summaryRef, summary); err != nil {
+		return false, fmt.Errorf("failed to get ClusterSummary %s to fetch status: %w", summaryRef.String(), err)
 	}
 	l.V(1).Info("Found matching ClusterSummary", "summary", summaryRef)
 	serviceSet.Status.Services = servicesStateFromSummary(l, summary, serviceSet)
@@ -626,7 +652,8 @@ func (r *ServiceSetReconciler) collectServiceStatuses(ctx context.Context, servi
 	})
 
 	l.Info("Collecting Service statuses completed", "duration", time.Since(start))
-	return nil
+	requeue = !serviceSet.Status.Deployed
+	return requeue, nil
 }
 
 // getHelmCharts returns slice of helm chart options to use with Sveltos.

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -330,35 +330,6 @@ func (r *ServiceSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 			return requests
 		})).
-		Watches(&addoncontrollerv1beta1.Profile{}, handler.EnqueueRequestForOwner(
-			mgr.GetScheme(), mgr.GetRESTMapper(), &kcmv1.ServiceSet{}, handler.OnlyControllerOwner())).
-		Watches(&addoncontrollerv1beta1.ClusterSummary{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
-			summary, ok := o.(*addoncontrollerv1beta1.ClusterSummary)
-			if !ok {
-				return nil
-			}
-			profile, _, err := addoncontrollerv1beta1.GetProfileOwnerAndTier(ctx, r.Client, summary)
-			if err != nil {
-				return nil
-			}
-			if profile == nil {
-				return nil
-			}
-			for _, ref := range profile.GetOwnerReferences() {
-				if ref.Kind != kcmv1.ServiceSetKind {
-					continue
-				}
-				return []ctrl.Request{
-					{
-						NamespacedName: client.ObjectKey{
-							Namespace: profile.GetNamespace(),
-							Name:      ref.Name,
-						},
-					},
-				}
-			}
-			return nil
-		})).
 		Complete(r)
 }
 

--- a/internal/controller/credential_controller.go
+++ b/internal/controller/credential_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/K0rdent/kcm/internal/record"
 	"github.com/K0rdent/kcm/internal/utils"
 	"github.com/K0rdent/kcm/internal/utils/ratelimit"
+	schemeutil "github.com/K0rdent/kcm/internal/utils/scheme"
 )
 
 // CredentialReconciler reconciles a Credential object
@@ -71,7 +72,7 @@ func (r *CredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		err = errors.Join(err, r.updateStatus(ctx, cred))
 	}()
 
-	rgnClient, err := region.GetClientFromRegionName(ctx, r.MgmtClient, r.SystemNamespace, cred.Spec.Region)
+	rgnClient, err := region.GetClientFromRegionName(ctx, r.MgmtClient, r.SystemNamespace, cred.Spec.Region, schemeutil.GetRegionalScheme)
 	if err != nil {
 		apimeta.SetStatusCondition(cred.GetConditions(), metav1.Condition{
 			Type:               kcmv1.CredentialReadyCondition,

--- a/internal/controller/region/client.go
+++ b/internal/controller/region/client.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	"github.com/K0rdent/kcm/internal/utils/kube"
-	schemeutil "github.com/K0rdent/kcm/internal/utils/scheme"
 )
 
 // GetKubeConfigSecretRef retrieves the kubeconfig secret reference from the given
@@ -52,7 +52,12 @@ func GetKubeConfigSecretRef(region *kcmv1.Region) (*fluxmeta.SecretKeyReference,
 
 // GetClientFromRegionName returns the controller-runtime client for the given region name.
 // If region is empty, returns the client of the management cluster.
-func GetClientFromRegionName(ctx context.Context, mgmtClient client.Client, systemNamespace, region string) (client.Client, error) {
+func GetClientFromRegionName(
+	ctx context.Context,
+	mgmtClient client.Client,
+	systemNamespace, region string,
+	getSchemeFunc func() (*runtime.Scheme, error),
+) (client.Client, error) {
 	if region == "" {
 		return mgmtClient, nil
 	}
@@ -61,7 +66,7 @@ func GetClientFromRegionName(ctx context.Context, mgmtClient client.Client, syst
 	if err != nil {
 		return nil, fmt.Errorf("failed to get %s region: %w", region, err)
 	}
-	rgnClient, _, err := GetClient(ctx, mgmtClient, systemNamespace, rgn)
+	rgnClient, _, err := GetClient(ctx, mgmtClient, systemNamespace, rgn, getSchemeFunc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client for %s region %w", region, err)
 	}
@@ -75,8 +80,9 @@ func GetClient(
 	mgmtClient client.Client,
 	systemNamespace string,
 	region *kcmv1.Region,
+	getSchemeFunc func() (*runtime.Scheme, error),
 ) (client.Client, *rest.Config, error) {
-	scheme, err := schemeutil.GetRegionalScheme()
+	scheme, err := getSchemeFunc()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get regional scheme for the %s region: %w", region.Name, err)
 	}

--- a/internal/controller/region/controller.go
+++ b/internal/controller/region/controller.go
@@ -44,6 +44,7 @@ import (
 	"github.com/K0rdent/kcm/internal/record"
 	"github.com/K0rdent/kcm/internal/utils"
 	"github.com/K0rdent/kcm/internal/utils/ratelimit"
+	schemeutil "github.com/K0rdent/kcm/internal/utils/scheme"
 )
 
 // Reconciler reconciles a Region object
@@ -75,7 +76,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	rgnlClient, restCfg, err := GetClient(ctx, r.MgmtClient, r.SystemNamespace, region)
+	rgnlClient, restCfg, err := GetClient(ctx, r.MgmtClient, r.SystemNamespace, region, schemeutil.GetRegionalScheme)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get clients for the %s region: %w", region.Name, err)
 	}

--- a/internal/utils/validation/cd.go
+++ b/internal/utils/validation/cd.go
@@ -25,6 +25,7 @@ import (
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	"github.com/K0rdent/kcm/internal/controller/region"
 	"github.com/K0rdent/kcm/internal/providerinterface"
+	schemeutil "github.com/K0rdent/kcm/internal/utils/scheme"
 )
 
 // ClusterDeployCredential validates a [github.com/K0rdent/kcm/api/v1beta1.Credential] object referred
@@ -77,7 +78,7 @@ func isCredIdentitySupportsClusterTemplate(ctx context.Context, mgmtClient clien
 	}
 
 	const secretKind = "Secret"
-	rgnClient, err := region.GetClientFromRegionName(ctx, mgmtClient, systemNamespace, cred.Spec.Region)
+	rgnClient, err := region.GetClientFromRegionName(ctx, mgmtClient, systemNamespace, cred.Spec.Region, schemeutil.GetRegionalScheme)
 	if err != nil {
 		return fmt.Errorf("failed to get client for %s region: %w", cred.Spec.Region, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
* Use the regional client to access sveltos objects.
* Do not allow removal of ClusterDeployment until all ServiceSets are removed.
* Since kcm controller can't watch regional sveltos objects (profile, clustersummary), requeue the reconciler until the service is deployed.
* Refactor scheme getter functions.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Relates to #1979 