### PR TITLE
fix: drop selector from dev aws credential

### DIFF
--- a/config/dev/aws-credentials.yaml
+++ b/config/dev/aws-credentials.yaml
@@ -8,9 +8,7 @@ metadata:
     k0rdent.mirantis.com/component: "kcm"
 spec:
   secretRef: aws-cluster-identity-secret
-  allowedNamespaces:
-    selector:
-      matchLabels: {}
+  allowedNamespaces: {}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
**What this PR does / why we need it**:
With CAPA v2.9.1, an `AWSClusterStaticIdentity` defined with the following spec:
```
 spec:
   secretRef: aws-cluster-identity-secret
   allowedNamespaces:
     selector:
       matchLabels: {}
``` 
no longer works and the capa controller is failing:
```
E0918 13:32:16.178876       1 controller.go:347] "Reconciler error" err="error getting infra provider cluster or control plane object: failed to create aws V2 session: Failed to get providers for cluster: Namespace is not permitted to use AWSClusterStaticIdentity: aws-cluster-identity" controller="awsmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSMachine" AWSMachine="kcm-system/ci-01095-aws-0-md-r8r26-cq857" namespace="kcm-system" name="ci-01095-aws-0-md-r8r26-cq857" reconcileID="f188af93-2b11-4d2a-b88e-a1e67679af46"
```

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2022
