### PR TITLE
feat: copy certificate secrets to regional clusters

### DIFF
--- a/api/v1beta1/region_types.go
+++ b/api/v1beta1/region_types.go
@@ -97,6 +97,11 @@ type ComponentsCommonStatus struct {
 	AvailableProviders Providers `json:"availableProviders,omitempty"`
 }
 
+// GetConditions returns Region conditions
+func (in *Region) GetConditions() *[]metav1.Condition {
+	return &in.Status.Conditions
+}
+
 // Components returns core components and a list of providers defined in the Region object
 func (in *Region) Components() ComponentsCommonSpec {
 	return in.Spec.ComponentsCommonSpec

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -1208,7 +1208,7 @@ func (r *ClusterDeploymentReconciler) handleCertificateSecrets(ctx context.Conte
 
 	l.V(1).Info("Copying certificate secrets from the system namespace to the ClusterDeployment namespace")
 	for _, secretName := range secretsToHandle {
-		if err := utils.CopySecret(ctx, rgnClient, client.ObjectKey{Namespace: r.SystemNamespace, Name: secretName}, cd.Namespace); err != nil {
+		if err := utils.CopySecret(ctx, r.MgmtClient, rgnClient, client.ObjectKey{Namespace: r.SystemNamespace, Name: secretName}, cd.Namespace, nil); err != nil {
 			l.Error(err, "failed to copy Secret for the ClusterDeployment")
 			return err
 		}

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -1197,11 +1197,6 @@ func (r *ClusterDeploymentReconciler) handleCertificateSecrets(ctx context.Conte
 
 	l := ctrl.LoggerFrom(ctx).WithName("handle-secrets")
 
-	if _, err := utils.SetPredeclaredSecretsCondition(ctx, rgnClient, cd, record.Warnf, r.SystemNamespace, secretsToHandle...); err != nil {
-		l.Error(err, "failed to check if given Secrets exist")
-		return err
-	}
-
 	if cd.Namespace == r.SystemNamespace { // nothing to copy
 		return nil
 	}
@@ -1214,6 +1209,10 @@ func (r *ClusterDeploymentReconciler) handleCertificateSecrets(ctx context.Conte
 		}
 	}
 
+	if _, err := utils.SetPredeclaredSecretsCondition(ctx, rgnClient, cd, record.Warnf, cd.Namespace, secretsToHandle...); err != nil {
+		l.Error(err, "failed to check if given Secrets exist")
+		return err
+	}
 	return nil
 }
 

--- a/internal/controller/credential_controller.go
+++ b/internal/controller/credential_controller.go
@@ -73,6 +73,13 @@ func (r *CredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	rgnClient, err := region.GetClientFromRegionName(ctx, r.MgmtClient, r.SystemNamespace, cred.Spec.Region)
 	if err != nil {
+		apimeta.SetStatusCondition(cred.GetConditions(), metav1.Condition{
+			Type:               kcmv1.CredentialReadyCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             kcmv1.FailedReason,
+			ObservedGeneration: cred.Generation,
+			Message:            err.Error(),
+		})
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/region/controller.go
+++ b/internal/controller/region/controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,15 +75,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	if !region.DeletionTimestamp.IsZero() {
-		l.Info("Deleting Region")
-		return r.delete(ctx, region)
+	rgnlClient, restCfg, err := GetClient(ctx, r.MgmtClient, r.SystemNamespace, region)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get clients for the %s region: %w", region.Name, err)
 	}
 
-	return r.update(ctx, region)
+	if !region.DeletionTimestamp.IsZero() {
+		l.Info("Deleting Region")
+		return r.delete(ctx, rgnlClient, region)
+	}
+
+	return r.update(ctx, rgnlClient, restCfg, region)
 }
 
-func (r *Reconciler) update(ctx context.Context, region *kcmv1.Region) (result ctrl.Result, err error) {
+func (r *Reconciler) update(ctx context.Context, rgnlClient client.Client, restConfig *rest.Config, region *kcmv1.Region) (result ctrl.Result, err error) {
 	l := ctrl.LoggerFrom(ctx)
 
 	if controllerutil.AddFinalizer(region, kcmv1.RegionFinalizer) {
@@ -150,12 +156,14 @@ func (r *Reconciler) update(ctx context.Context, region *kcmv1.Region) (result c
 		},
 	}
 
-	rgnlClient, restCfg, err := GetClient(ctx, r.MgmtClient, r.SystemNamespace, region)
+	err = r.handleCertificateSecret(ctx, r.MgmtClient, rgnlClient, region)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get clients for the %s region: %w", region.Name, err)
+		l.Error(err, "failed to handle certificate secrets")
+		r.warnf(region, "CertificateSecretsSetupFailed", "Failed to handle certificate secrets: %s", err)
+		return ctrl.Result{}, err
 	}
 
-	requeue, err := components.Reconcile(ctx, r.MgmtClient, rgnlClient, region, restCfg, release, opts)
+	requeue, err := components.Reconcile(ctx, r.MgmtClient, rgnlClient, region, restConfig, release, opts)
 	region.Status.ObservedGeneration = region.Generation
 
 	r.setReadyCondition(region)
@@ -169,6 +177,36 @@ func (r *Reconciler) update(ctx context.Context, region *kcmv1.Region) (result c
 		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
 	}
 	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) handleCertificateSecret(ctx context.Context, mgmtClient, rgnClient client.Client, region *kcmv1.Region) error {
+	if r.RegistryCertSecretName == "" {
+		return nil
+	}
+	secretsToHandle := []string{r.RegistryCertSecretName}
+
+	l := ctrl.LoggerFrom(ctx).WithName("handle-secrets")
+
+	l.V(1).Info("Copying certificate secrets from the management to the regional cluster")
+	for _, secretName := range secretsToHandle {
+		if err := utils.CopySecret(
+			ctx,
+			mgmtClient,
+			rgnClient,
+			client.ObjectKey{Namespace: r.SystemNamespace, Name: secretName},
+			r.SystemNamespace,
+			map[string]string{kcmv1.KCMRegionLabelKey: region.Name},
+		); err != nil {
+			l.Error(err, "failed to copy Secret for the regional cluster")
+			return err
+		}
+	}
+
+	if _, err := utils.SetPredeclaredSecretsCondition(ctx, rgnClient, region, record.Warnf, r.SystemNamespace, secretsToHandle...); err != nil {
+		l.Error(err, "failed to check if given Secrets exist")
+		return err
+	}
+	return nil
 }
 
 // setReadyCondition updates the Region resource's "Ready" condition based on whether
@@ -199,7 +237,7 @@ func (r *Reconciler) setReadyCondition(region *kcmv1.Region) {
 	}
 }
 
-func (r *Reconciler) delete(ctx context.Context, region *kcmv1.Region) (ctrl.Result, error) {
+func (r *Reconciler) delete(ctx context.Context, rgnClient client.Client, region *kcmv1.Region) (ctrl.Result, error) {
 	l := ctrl.LoggerFrom(ctx)
 
 	r.eventf(region, "RemovingRegion", "Removing KCM regional components")
@@ -215,6 +253,11 @@ func (r *Reconciler) delete(ctx context.Context, region *kcmv1.Region) (ctrl.Res
 	}
 	if requeue {
 		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
+	}
+
+	err = rgnClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(r.SystemNamespace), client.MatchingLabels{kcmv1.KCMRegionLabelKey: region.Name})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to delete all secrets managed by %s region: %w", region.Name, err)
 	}
 
 	r.eventf(region, "RemovedRegion", "Region has been removed")

--- a/internal/controller/region/controller.go
+++ b/internal/controller/region/controller.go
@@ -195,6 +195,7 @@ func (r *Reconciler) handleCertificateSecret(ctx context.Context, mgmtClient, rg
 			rgnClient,
 			client.ObjectKey{Namespace: r.SystemNamespace, Name: secretName},
 			r.SystemNamespace,
+			nil,
 			map[string]string{kcmv1.KCMRegionLabelKey: region.Name},
 		); err != nil {
 			l.Error(err, "failed to copy Secret for the regional cluster")

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -219,7 +219,7 @@ func (r *TemplateReconciler) ReconcileTemplate(ctx context.Context, template tem
 
 			if namespace != r.SystemNamespace {
 				for _, secretName := range helmRepositorySecrets {
-					if err := utils.CopySecret(ctx, r.Client, r.Client, client.ObjectKey{Namespace: r.SystemNamespace, Name: secretName}, namespace, nil); err != nil {
+					if err := utils.CopySecret(ctx, r.Client, r.Client, client.ObjectKey{Namespace: r.SystemNamespace, Name: secretName}, namespace, nil, nil); err != nil {
 						l.Error(err, "failed to copy Secret for the HelmRepository")
 						return ctrl.Result{}, err
 					}

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -219,7 +219,7 @@ func (r *TemplateReconciler) ReconcileTemplate(ctx context.Context, template tem
 
 			if namespace != r.SystemNamespace {
 				for _, secretName := range helmRepositorySecrets {
-					if err := utils.CopySecret(ctx, r.Client, client.ObjectKey{Namespace: r.SystemNamespace, Name: secretName}, namespace); err != nil {
+					if err := utils.CopySecret(ctx, r.Client, r.Client, client.ObjectKey{Namespace: r.SystemNamespace, Name: secretName}, namespace, nil); err != nil {
 						l.Error(err, "failed to copy Secret for the HelmRepository")
 						return ctrl.Result{}, err
 					}

--- a/internal/utils/secrets.go
+++ b/internal/utils/secrets.go
@@ -132,6 +132,7 @@ func CopySecret(
 	targetClient client.Client,
 	key client.ObjectKey,
 	toNamespace string,
+	owner client.Object,
 	extraLabels map[string]string,
 ) error {
 	if key.Name == "" { // sanity check
@@ -151,6 +152,10 @@ func CopySecret(
 	newSecret.SetResourceVersion("")
 	newSecret.SetSelfLink("")
 	newSecret.SetUID("")
+
+	if owner != nil {
+		AddOwnerReference(newSecret, owner)
+	}
 
 	newSecret.SetNamespace(toNamespace)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When k0rdent was deployed with the custom registry and/or k0s URL and with the `registryCertSecret` or `k0sURLCertSecret` defined, the certificate secrets should be present in the mothership cluster. In case the cluster is deployed in the region, the certificates' secrets are copied to the regional cluster.

Additionally, this PR contains several fixes: 
1. `cluster-api-operator`, `velero`, and `cert-manager` configuration was moved to the `regional` section of the `kcm` helm chart. To support backward compatibility, the values of these components are still retrieved from these sections.
2.  Credential now contains an error if it fails to get the regional client (ex. if the region is not found).
3. While copying the certificate to the child cluster namespace, check that the certificate secret exists in the namespace after trying to copy it (otherwise, it will constantly fail with the not found error).
4. If the ClusterDeployment was created in a non-system namespace, copy the regional cluster kubeconfig to the ClusterDeployment namespace (in case the region is set).

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Relates to #1979 
