### PR TITLE
fix: add regional section to the Release spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,9 @@ generate-release: yq
 
 .PHONY: set-kcm-version
 set-kcm-version: yq
-	$(YQ) eval '.version = "$(VERSION)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm-regional/Chart.yaml
+	$(eval KCM_REGIONAL_VERSION := $(shell $(YQ) -r '.version' $(PROVIDER_TEMPLATES_DIR)/kcm-regional/Chart.yaml))
 	$(YQ) eval -i \
-		'.version = "$(VERSION)" | (.dependencies[] | select(.name == "kcm-regional") | .version) = "$(VERSION)"' \
+		'.version = "$(VERSION)" | (.dependencies[] | select(.name == "kcm-regional") | .version) = "$(KCM_REGIONAL_VERSION)"' \
 		$(PROVIDER_TEMPLATES_DIR)/kcm/Chart.yaml
 	$(YQ) eval '.version = "$(VERSION)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm-templates/Chart.yaml
 	$(YQ) eval '.image.tag = "$(VERSION)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm/values.yaml
@@ -111,11 +111,6 @@ templates-generate:
 .PHONY: bump-chart-version
 bump-chart-version: yq
 	@YQ=$(YQ) $(SHELL) hack/chart-version.bash
-	$(eval KCM_VERSION := $(shell $(YQ) -r '.version' $(PROVIDER_TEMPLATES_DIR)/kcm/Chart.yaml)) \
-	$(YQ) eval '.version = "$(KCM_VERSION)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm-regional/Chart.yaml
-	$(YQ) eval -i \
-		'(.dependencies[] | select(.name == "kcm-regional") | .version) = "$(KCM_VERSION)"' \
-		$(PROVIDER_TEMPLATES_DIR)/kcm/Chart.yaml
 
 .PHONY: update-release
 update-release: yq

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1887,6 +1887,7 @@ func (in *ReleaseList) DeepCopyObject() runtime.Object {
 func (in *ReleaseSpec) DeepCopyInto(out *ReleaseSpec) {
 	*out = *in
 	out.KCM = in.KCM
+	out.Regional = in.Regional
 	out.CAPI = in.CAPI
 	if in.Providers != nil {
 		in, out := &in.Providers, &out.Providers

--- a/hack/chart-version.bash
+++ b/hack/chart-version.bash
@@ -26,8 +26,7 @@ ALL_CHANGED_FILES=$(echo -e "$COMMITTED_CHANGED\n$TRACKED_CHANGED\n$UNTRACKED_CH
   | sort -u \
   | grep -E '^templates/(provider|cluster)/' \
   | grep -v '^templates/provider/kcm-templates/' \
-  | grep -v '^templates/provider/kcm/' \
-  | grep -v '^templates/provider/kcm-regional/' || true)
+  | grep -v '^templates/provider/kcm/' || true)
 
 declare -A UPDATED_CHARTS
 

--- a/hack/update-release.bash
+++ b/hack/update-release.bash
@@ -42,6 +42,17 @@ for file in $ALL_CHANGED; do
       ${YQ} e -i ".spec.kcm.template = \"$new_name\"" "$RELEASE_FILE"
       echo "Updated spec.kcm.template → $new_name"
     fi
+  # Update the annotation with the kcm-regional template name instead of using
+  # spec.regional.template. This ensures compatibility during upgrades, since
+  # older k0rdent instances does not have this field defined in old Region CRD.
+  # TODO: Rework to align with the standard/common approach.
+  elif [[ "$chart_name" == "kcm-regional" ]]; then
+    annotation_key="k0rdent.mirantis.com/kcm-regional-template"
+    current=$(${YQ} e ".metadata.annotations.\"$annotation_key\" // \"\"" "$RELEASE_FILE")
+    if [[ "$current" != "$new_name" ]]; then
+      ${YQ} e -i ".metadata.annotations.\"$annotation_key\" = \"$new_name\"" "$RELEASE_FILE"
+      echo "Updated kcm regional template in annotation → $new_name"
+    fi
   elif [[ "$chart_name" == "cluster-api" ]]; then
     current=$(${YQ} e '.spec.capi.template' "$RELEASE_FILE")
     if [[ "$current" != "$new_name" ]]; then

--- a/templates/provider/kcm-regional/Chart.yaml
+++ b/templates/provider/kcm-regional/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.8
+version: 1.0.0
 dependencies:
   - name: cert-manager
     version: 1.18.2

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kcm-1-3-1
   annotations:
     helm.sh/resource-policy: keep
+    k0rdent.mirantis.com/kcm-regional-template: kcm-regional-1-0-0
 spec:
   version: 1.3.1
   kcm:

--- a/templates/provider/kcm-templates/files/templates/kcm-regional.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm-regional.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-regional-1-3-8
+  name: kcm-regional-1-0-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm-regional
-      version: 1.3.8
+      version: 1.0.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.lock
+++ b/templates/provider/kcm/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.16.0
 - name: kcm-regional
   repository: file://../kcm-regional
-  version: 1.3.8
-digest: sha256:da7b70956876b6c2429e11337619f2f581a377ecc79b01c7d9d73e2a41b8c4bc
-generated: "2025-09-15T23:00:27.800163+04:00"
+  version: 1.0.0
+digest: sha256:8e99d8a7026b4c39e7f4ac826ee2818c9c6c2624cb9c1fab4d0b01db5d9b8da7
+generated: "2025-08-22T15:28:15.939908+04:00"

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -21,5 +21,5 @@ dependencies:
     condition: flux2.enabled
   - name: kcm-regional
     alias: regional
-    version: 1.3.8
+    version: 1.0.0
     repository: "file://../kcm-regional"

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_releases.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_releases.yaml
@@ -230,6 +230,16 @@ spec:
                   - template
                   type: object
                 type: array
+              regional:
+                description: Regional references the KCM regional template.
+                properties:
+                  template:
+                    description: Template references the Template associated with
+                      the provider.
+                    type: string
+                required:
+                - template
+                type: object
               version:
                 description: Version of the KCM Release in the semver format.
                 type: string


### PR DESCRIPTION
**What this PR does / why we need it**:

With the old approach, the kcm-regional version depended on the kcm version. During upgrades, the previous release was marked as not ready because the kcm controller attempted to find a template named `kcm-regional-<old-version>`, which did not exist.

To resolve this, `spec.regional` is reintroduced in the Release object, but `spec.regional.template` remains unset in v1.4.0.
This makes the upgrade path from v1.3.1 -> v1.4.0 possible. After v1.4.0 is released, this can be reworked.

Partially reverts https://github.com/k0rdent/kcm/pull/1996

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Related to #1903
