### PR TITLE
fix: increase default helm timeout for dev setup

### DIFF
--- a/config/dev/kcm_values.yaml
+++ b/config/dev/kcm_values.yaml
@@ -2,6 +2,7 @@ image:
   repository: localhost/kcm/controller
   tag: latest
 controller:
+  defaultHelmTimeout: 20m
   templatesRepoURL: oci://kcm-local-registry:5000/charts
   insecureRegistry: true
   createRelease: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase the default Helm install/upgrade timeout to 20 minutes to account for slow network.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
