### PR TITLE
fix(templates): allow null location policy for GKE

### DIFF
--- a/config/dev/gke-clusterdeployment.yaml
+++ b/config/dev/gke-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-gke-1-0-4
+  template: gcp-gke-1-0-5
   credential: gcp-credential
   propagateCredentials: false
   config:

--- a/templates/cluster/gcp-gke/Chart.yaml
+++ b/templates/cluster/gcp-gke/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-gke/values.schema.json
+++ b/templates/cluster/gcp-gke/values.schema.json
@@ -181,7 +181,10 @@
             },
             "locationPolicy": {
               "description": "Location policy used when scaling up a nodepool",
-              "type": "string",
+              "type": [
+                "string",
+                "null"
+              ],
               "enum": [
                 "balanced",
                 "any"

--- a/templates/cluster/gcp-gke/values.yaml
+++ b/templates/cluster/gcp-gke/values.yaml
@@ -34,17 +34,17 @@ machines: # @schema description: Managed machines' parameters; type: object
   nodePoolName: "" # @schema description: The name of the GKE node pool corresponding to this MachinePool. If you don't specify a name then a default name will be created based on the namespace and name of the managed machine pool; type: string
   machineType: "" # @schema description: the name of a Google Compute Engine [machine type](https://cloud.google.com/compute/docs/machine-types). If unspecified, the default machine type is `e2-medium`; type: string
   diskSizeGB: 100 # @schema description: The size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB. If unspecified, the default disk size is 100GB; type: number; minimum: 10
-  localSsdCount: # @schema description: LocalSsdCount is the number of local SSD disks to be attached to the node; type: number,null
+  localSsdCount: # @schema description: LocalSsdCount is the number of local SSD disks to be attached to the node; type: [number, null]
   scaling: # @schema description: Scaling specifies scaling for the node pool; type: object
     enableAutoscaling: true # @schema description: Is autoscaling enabled for this node pool. If unspecified, the default value is true; type: boolean
-    minCount: # @schema description: The minimum number of nodes in the node pool; type: number,null
-    maxCount: # @schema description: The maximum number of nodes in the node pool; type: number,null
-    locationPolicy: "balanced" # @schema description: Location policy used when scaling up a nodepool; type: string; enum: balanced,any
+    minCount: # @schema description: The minimum number of nodes in the node pool; type: [number, null]
+    maxCount: # @schema description: The maximum number of nodes in the node pool; type: [number, null]
+    locationPolicy: "balanced" # @schema description: Location policy used when scaling up a nodepool; type: [string, null]; enum: balanced,any
   nodeLocations: [] # @schema description: The list of zones in which the NodePool's nodes should be located; type: array; item: string
   imageType: "" # @schema description: The image type to use for this nodepool; type: string
   instanceType: "" # @schema description: The name of Compute Engine machine type; type: string
   diskType: "" # @schema description: The type of the disk attached to each node; type: string
-  maxPodsPerNode: # @schema description: The constraint enforced on the max num of pods per node; type: number,null; minimum: 8; maximum: 256
+  maxPodsPerNode: # @schema description: The constraint enforced on the max num of pods per node; type: [number, null]; minimum: 8; maximum: 256
   kubernetesLabels: {} # @schema description: The labels to apply to the nodes of the node pool; type: object; additionalProperties: true
   kubernetesTaints: [] # @schema description: The taints to apply to the nodes of the node pool; type: array; additionalProperties: false
   additionalLabels: {} # @schema description: AdditionalLabels is an optional set of tags to add to GCP resources managed by the GCP provider, in addition to the ones added by default; type: object; additionalProperties: false; patternProperties: {"^[a-zA-Z0-9._-]+$": {"type": "string"}}
@@ -52,4 +52,4 @@ machines: # @schema description: Managed machines' parameters; type: object
     autoUpgrade: true # @schema description: AutoUpgrade specifies whether node auto-upgrade is enabled for the node pool. If enabled, node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes; type: boolean
     autoRepair: false # @schema description: AutoRepair specifies whether the node auto-repair is enabled for the node pool. If enabled, the nodes in this node pool will be monitored and, if they fail health checks too many times, an automatic repair action will be triggered; type: boolean
 
-version: 1.32.6-gke.1096000 # @schema description: Version represents the version of the GKE control plane. See: https://cloud.google.com/kubernetes-engine/docs/release-notes; type: string
+version: 1.32.8-gke.1026000 # @schema description: Version represents the version of the GKE control plane. See: https://cloud.google.com/kubernetes-engine/docs/release-notes; type: string

--- a/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-5.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-5.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-gke-1-0-4
+  name: gcp-gke-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-gke
-      version: 1.0.4
+      version: 1.0.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows null in machine pool scaling location policy to unblock GKE cluster deployments when autoscaling is turned off.

Bumps the default GKE version to the most latest from the stable channel.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2034 