### PR TITLE
chore: use CAPO fork instead of upstream version

### DIFF
--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.12.4"
+appVersion: "v0.12.5-mirantis.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-openstack
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
@@ -19,4 +19,7 @@ spec:
     containers:
       - name: manager
         imageUrl: {{ $global.registry }}/capi/capi-openstack-controller:{{ $version }}
+  {{- else }}
+  fetchConfig:
+    url: https://github.com/Mirantis/cluster-api-provider-openstack/releases/download/{{ $version }}/infrastructure-components.yaml
   {{- end }}

--- a/templates/provider/cluster-api-provider-openstack/templates/rbac.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/rbac.yaml
@@ -14,3 +14,11 @@ rules:
       - list
       - patch
       - watch
+  - apiGroups:
+      - infrastructure.cluster.x-k8s.io
+    resources:
+      - openstackclusteridentity
+    verbs:
+      - get
+      - list
+      - watch

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -21,7 +21,7 @@ spec:
     - name: cluster-api-provider-aws
       template: cluster-api-provider-aws-1-0-6
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-1-0-7
+      template: cluster-api-provider-openstack-1-0-8
     - name: cluster-api-provider-docker
       template: cluster-api-provider-docker-1-0-3
     - name: cluster-api-provider-gcp

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-1-0-7
+  name: cluster-api-provider-openstack-1-0-8
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 1.0.7
+      version: 1.0.8
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Resolves #1983 

Add a forked CAPO with several fixes and a new resource `openstackclusteridentity`