### PR TITLE
chore: post-release 1.4.0 version set

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Detailed documentation is available in [k0rdent Docs](https://docs.k0rdent.io)
 ### TL;DR
 
 ```bash
-helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 1.3.1 -n kcm-system --create-namespace
+helm install kcm oci://ghcr.io/k0rdent/kcm/charts/kcm --version 1.4.0 -n kcm-system --create-namespace
 ```
 
 Then follow the [Deploy a cluster deployment](#create-a-clusterdeployment) guide to
@@ -78,7 +78,7 @@ spec:
   - name: cluster-api-provider-ipam
   - name: cluster-api-provider-infoblox
   - name: projectsveltos
-  release: kcm-1-3-1
+  release: kcm-1-4-0
 ```
 
 There are two options to override the default management configuration

--- a/templates/provider/kcm-templates/Chart.yaml
+++ b/templates/provider/kcm-templates/Chart.yaml
@@ -13,4 +13,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1
+version: 1.4.0

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: Release
 metadata:
-  name: kcm-1-3-1
+  name: kcm-1-4-0
   annotations:
     helm.sh/resource-policy: keep
     k0rdent.mirantis.com/kcm-regional-template: kcm-regional-1-0-0
 spec:
-  version: 1.3.1
+  version: 1.4.0
   kcm:
-    template: kcm-1-3-8
+    template: kcm-1-4-0
   capi:
     template: cluster-api-1-0-6
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-1-3-8
+  name: kcm-1-4-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm
-      version: 1.3.8
+      version: 1.4.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.8
+version: 1.4.0
 dependencies:
   - name: flux2
     version: 2.16.0


### PR DESCRIPTION
Sets `1.4.0` version in all objects/README to avoid confusion
