### PR TITLE
fix: update Credential status when Region is not ready

### DIFF
--- a/api/v1beta1/indexers.go
+++ b/api/v1beta1/indexers.go
@@ -397,11 +397,11 @@ func ExtractServiceSetProvider(o client.Object) []string {
 const CredentialRegionIndexKey = "spec.region"
 
 func setupCredentialRegionIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &Credential{}, CredentialRegionIndexKey, ExtractCredentialRegion)
+	return mgr.GetFieldIndexer().IndexField(ctx, &Credential{}, CredentialRegionIndexKey, extractCredentialRegion)
 }
 
-// ExtractCredentialRegion returns the region name from [Credential] object.
-func ExtractCredentialRegion(o client.Object) []string {
+// extractCredentialRegion returns the region name from [Credential] object.
+func extractCredentialRegion(o client.Object) []string {
 	cred, ok := o.(*Credential)
 	if !ok {
 		return nil

--- a/internal/controller/credential_controller.go
+++ b/internal/controller/credential_controller.go
@@ -94,7 +94,7 @@ func (r *CredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				ObservedGeneration: cred.Generation,
 				Message:            failedMsg,
 			})
-			return ctrl.Result{}, errors.New(failedMsg)
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 
 		rgnClient, _, err = kube.GetRegionalClient(ctx, r.MgmtClient, r.SystemNamespace, rgn, schemeutil.GetRegionalScheme)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, when the Region is removed, the Credential object remains valid. This PR fixes it and sets the up-to-date status to the regional Credential object.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2056
