### PR TITLE
fix(providerinterface): azure clusteridentities

### DIFF
--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-azure/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-azure/templates/interface.yaml
@@ -22,4 +22,7 @@ spec:
           kind: Secret
           nameFieldPath: spec.clientSecret.name
           namespaceFieldPath: spec.clientSecret.namespace
+    - group: ""
+      version: v1
+      kind: Secret
   description: "Azure infrastructure provider for Cluster API"

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -15,7 +15,7 @@ spec:
     - name: cluster-api-provider-k0sproject-k0smotron
       template: cluster-api-provider-k0sproject-k0smotron-1-0-10
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-1-0-8
+      template: cluster-api-provider-azure-1-0-9
     - name: cluster-api-provider-vsphere
       template: cluster-api-provider-vsphere-1-0-6
     - name: cluster-api-provider-aws

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-1-0-8
+  name: cluster-api-provider-azure-1-0-9
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-azure
-      version: 1.0.8
+      version: 1.0.9
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes forgotten supported cluster identity for the azure provider

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2089
