### PR TITLE
fix: update schema to require non-empty vmSize for azure charts

### DIFF
--- a/templates/cluster/azure-aks/values.schema.json
+++ b/templates/cluster/azure-aks/values.schema.json
@@ -161,7 +161,9 @@
               "type": "string"
             },
             "vmSize": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1,
+              "description": "vmSize must be specified"
             }
           }
         },
@@ -204,7 +206,9 @@
               "type": "string"
             },
             "vmSize": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1,
+              "description": "vmSize must be specified"
             }
           }
         }

--- a/templates/cluster/azure-hosted-cp/values.schema.json
+++ b/templates/cluster/azure-hosted-cp/values.schema.json
@@ -242,7 +242,9 @@
       "type": "string"
     },
     "vmSize": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "description": "vmSize must be specified"
     },
     "workersNumber": {
       "type": "integer"

--- a/templates/cluster/azure-standalone-cp/values.schema.json
+++ b/templates/cluster/azure-standalone-cp/values.schema.json
@@ -101,7 +101,9 @@
           "type": "string"
         },
         "vmSize": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "description": "vmSize for ControlPlane must be specified"
         }
       }
     },
@@ -233,7 +235,9 @@
           "type": "string"
         },
         "vmSize": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1,
+          "description": "vmSize for Workers must be specified"
         }
       }
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
This will enhance UX by restricting deployments of clusters without the vmSize specified

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes: #2087 