### PR TITLE
feat: support ClusterDeployment reference in the Region spec

### DIFF
--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -221,7 +221,16 @@ func (r *TemplateReconciler) ReconcileTemplate(ctx context.Context, template tem
 
 			if namespace != r.SystemNamespace {
 				for _, secretName := range helmRepositorySecrets {
-					if err := kubeutil.CopySecret(ctx, r.Client, r.Client, client.ObjectKey{Namespace: r.SystemNamespace, Name: secretName}, namespace, nil, nil); err != nil {
+					if err := kubeutil.CopySecret(
+						ctx,
+						r.Client,
+						r.Client,
+						client.ObjectKey{Namespace: r.SystemNamespace, Name: secretName},
+						namespace,
+						"",
+						nil,
+						nil,
+					); err != nil {
 						l.Error(err, "failed to copy Secret for the HelmRepository")
 						return ctrl.Result{}, err
 					}

--- a/internal/util/kube/secrets.go
+++ b/internal/util/kube/secrets.go
@@ -133,6 +133,7 @@ func CopySecret(
 	targetClient client.Client,
 	key client.ObjectKey,
 	toNamespace string,
+	nameOverride string,
 	owner client.Object,
 	extraLabels map[string]string,
 ) error {
@@ -163,6 +164,9 @@ func CopySecret(
 	}
 
 	newSecret.SetNamespace(toNamespace)
+	if nameOverride != "" {
+		newSecret.SetName(nameOverride)
+	}
 
 	if len(extraLabels) > 0 {
 		if newSecret.Labels == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR includes:
1. Adds support for referencing an existing ClusterDeployment in the Region object.
2. Copies the ClusterDeployment’s kubeconfig to the system namespace to install regional cluster components.
3. Fixes the owner reference of the kubeconfig Secret copied to the ClusterDeployment namespace.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Related task #1905
