### PR TITLE
feat: add RBAC manager as the KCM management component

### DIFF
--- a/templates/provider/kcm/Chart.lock
+++ b/templates/provider/kcm/Chart.lock
@@ -2,8 +2,11 @@ dependencies:
 - name: flux2
   repository: https://fluxcd-community.github.io/helm-charts
   version: 2.16.4
+- name: rbac-manager
+  repository: https://charts.fairwinds.com/stable
+  version: 1.21.2
 - name: kcm-regional
   repository: file://../kcm-regional
   version: 1.0.4
-digest: sha256:e7d16138bc72ec47d40b4467916b7df671009d8a2c8588a8a06dfd276366d1b8
-generated: "2025-10-16T15:04:18.080748+02:00"
+digest: sha256:5dc853ad54ee9086b87c4432219fd019c884be87c3aa57c34fc41ca9a436b9f8
+generated: "2025-10-21T17:06:01.287237+04:00"

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -19,6 +19,10 @@ dependencies:
     version: 2.16.4
     repository: https://fluxcd-community.github.io/helm-charts
     condition: flux2.enabled
+  - name: rbac-manager
+    version: 1.21.2
+    repository: https://charts.fairwinds.com/stable
+    condition: rbac-manager.enabled
   - name: kcm-regional
     alias: regional
     version: 1.0.4

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -297,6 +297,14 @@
     "nameOverride": {
       "type": "string"
     },
+    "rbac-manager": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
     "replicas": {
       "type": "integer"
     },

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -121,3 +121,6 @@ flux2:
     container:
       additionalArgs:
         - --watch-label-selector=k0rdent.mirantis.com/managed=true
+
+rbac-manager:
+  enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the RBAC Manager as a KCM management component. Enabled by default. It's supported to disable it in the Management object by configuring:
```
spec:
  core:
    kcm:
      config:
        rbac-manager:
          enabled: false <<<
```


**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2104
