### PR TITLE
chore: dockerfile: use buildplatform for builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LD_FLAGS


### PR DESCRIPTION
Sets explicit platform parameter in Dockerfile, so when crosscompiling docker would use image from native platform and not the target one (which is the default).