### PR TITLE
fix: templates: aws-csi image paths; azure required parameters

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-14
+  template: aws-standalone-cp-1-0-15
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-15
+  template: azure-standalone-cp-1-0-16
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -131,7 +131,7 @@ spec:
                     repository: {{ $global.registry }}/kubernetes-csi/external-attacher
                 snapshotter:
                   image:
-                    repository: {{ $global.registry }}kubernetes-csi/external-snapshotter/csi-snapshotter
+                    repository: {{ $global.registry }}/external-snapshotter/csi-snapshotter
                 livenessProbe:
                   image:
                     repository: {{ $global.registry }}/kubernetes-csi/livenessprobe

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -135,7 +135,7 @@ spec:
                         repository: {{ $global.registry }}/kubernetes-csi/external-attacher
                     snapshotter:
                       image:
-                        repository: {{ $global.registry }}kubernetes-csi/external-snapshotter/csi-snapshotter
+                        repository: {{ $global.registry }}/external-snapshotter/csi-snapshotter
                     livenessProbe:
                       image:
                         repository: {{ $global.registry }}/kubernetes-csi/livenessprobe

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.17
+version: 1.0.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/azurecluster.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/azurecluster.yaml
@@ -29,5 +29,5 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
-  subscriptionID: {{ .Values.subscriptionID }}
+  subscriptionID: {{ required ".Values.subscriptionID is required to create a cluster" .Values.subscriptionID }}
   resourceGroup: {{ .Values.resourceGroup }}

--- a/templates/cluster/azure-hosted-cp/templates/azuremachinetemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/azuremachinetemplate.yaml
@@ -11,7 +11,7 @@ spec:
       {{- if not ( .Values.sshPublicKey | empty) }}
       sshPublicKey: {{ .Values.sshPublicKey }}
       {{- end }}
-      vmSize: {{ .Values.vmSize }}
+      vmSize: {{ required ".Values.vmSize is required" .Values.vmSize }}
       {{- if not (quote .Values.image | empty) }}
       {{- with .Values.image }}
       image:

--- a/templates/cluster/azure-hosted-cp/values.schema.json
+++ b/templates/cluster/azure-hosted-cp/values.schema.json
@@ -2,6 +2,11 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "A KCM cluster azure-hosted-cp template",
   "type": "object",
+  "required": [
+    "location",
+    "subscriptionID",
+    "vmSize"
+  ],
   "properties": {
     "bastion": {
       "type": "object",
@@ -210,6 +215,7 @@
       }
     },
     "location": {
+      "description": "Azure location to use",
       "type": "string"
     },
     "network": {
@@ -239,9 +245,11 @@
       "type": "string"
     },
     "subscriptionID": {
+      "description": "Subscription ID where all cluster resources will be created",
       "type": "string"
     },
     "vmSize": {
+      "description": "VM size to use for worker nodes",
       "type": "string"
     },
     "workersNumber": {

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -14,8 +14,8 @@ clusterLabels: {}
 clusterAnnotations: {}
 
 # Azure cluster parameters
-location: ""
-subscriptionID: ""
+location: "" # @schema description: Azure location to use; type: string; required: true
+subscriptionID: "" # @schema description: Subscription ID where all cluster resources will be created; type: string; required: true
 bastion:
   enabled: false
   bastionSpec:
@@ -32,7 +32,7 @@ network:
 # Azure machines parameters
 
 sshPublicKey: ""
-vmSize: ""
+vmSize: "" # @schema description: VM size to use for worker nodes; type: string; required: true
 rootVolumeSize: 30
 image:
   id: ""

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.15
+version: 1.0.16
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/azurecluster.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/azurecluster.yaml
@@ -16,4 +16,4 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
-  subscriptionID: {{ .Values.subscriptionID }}
+  subscriptionID: {{ required ".Values.subscriptionID is required to create a cluster" .Values.subscriptionID }}

--- a/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-controlplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-controlplane.yaml
@@ -11,7 +11,7 @@ spec:
       {{- if not (quote .Values.controlPlane.sshPublicKey | empty) }}
       sshPublicKey: {{ .Values.controlPlane.sshPublicKey }}
       {{- end }}
-      vmSize: {{ .Values.controlPlane.vmSize }}
+      vmSize: {{ required ".Values.controlPlane.vmSize is required" .Values.controlPlane.vmSize }}
       {{- if not (quote .Values.controlPlane.image | empty) }}
       {{- with .Values.controlPlane.image }}
       image:

--- a/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-worker.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-worker.yaml
@@ -11,7 +11,7 @@ spec:
       {{- if not (quote .Values.worker.sshPublicKey | empty) }}
       sshPublicKey: {{ .Values.worker.sshPublicKey }}
       {{- end }}
-      vmSize: {{ .Values.worker.vmSize }}
+      vmSize: {{ required ".Values.worker.vmSize is required" .Values.worker.vmSize }}
       {{- if not (quote .Values.worker.image | empty) }}
       {{- with .Values.worker.image }}
       image:

--- a/templates/cluster/azure-standalone-cp/values.schema.json
+++ b/templates/cluster/azure-standalone-cp/values.schema.json
@@ -2,6 +2,12 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "A KCM cluster azure-standalone-cp template",
   "type": "object",
+  "required": [
+    "location",
+    "subscriptionID",
+    "controlPlane",
+    "worker"
+  ],
   "properties": {
     "bastion": {
       "type": "object",
@@ -64,7 +70,11 @@
       }
     },
     "controlPlane": {
+      "description": "Control plane nodes parameters",
       "type": "object",
+      "required": [
+        "vmSize"
+      ],
       "properties": {
         "image": {
           "type": "object",
@@ -101,6 +111,7 @@
           "type": "string"
         },
         "vmSize": {
+          "description": "VM size to use for control plane nodes",
           "type": "string"
         }
       }
@@ -190,13 +201,19 @@
       }
     },
     "location": {
+      "description": "Azure location to use",
       "type": "string"
     },
     "subscriptionID": {
+      "description": "Subscription ID where all cluster resources will be created",
       "type": "string"
     },
     "worker": {
+      "description": "Worker nodes parameters",
       "type": "object",
+      "required": [
+        "vmSize"
+      ],
       "properties": {
         "image": {
           "type": "object",
@@ -233,6 +250,7 @@
           "type": "string"
         },
         "vmSize": {
+          "description": "VM size to use for worker nodes",
           "type": "string"
         }
       }

--- a/templates/cluster/azure-standalone-cp/values.yaml
+++ b/templates/cluster/azure-standalone-cp/values.yaml
@@ -14,8 +14,8 @@ clusterLabels: {}
 clusterAnnotations: {}
 
 # Azure cluster parameters
-location: ""
-subscriptionID: ""
+location: "" # @schema description: Azure location to use; type: string; required: true
+subscriptionID: "" # @schema description: Subscription ID where all cluster resources will be created; type: string; required: true
 bastion:
   enabled: false
   bastionSpec:
@@ -24,9 +24,9 @@ clusterIdentity:
   name: ""
   namespace: kcm-system
 # Azure machines parameters
-controlPlane:
+controlPlane: # @schema description: Control plane nodes parameters; type: object; required: true
   sshPublicKey: ""
-  vmSize: ""
+  vmSize: "" # @schema description: VM size to use for control plane nodes; type: string; required: true
   rootVolumeSize: 30
   image:
     id: ""
@@ -37,9 +37,9 @@ controlPlane:
       sku: "ubuntu-2204-gen1"
       version: "130.3.20240717"
 
-worker:
+worker: # @schema description: Worker nodes parameters; type: object; required: true
   sshPublicKey: ""
-  vmSize: ""
+  vmSize: "" # @schema description: VM size to use for worker nodes; type: string; required: true
   rootVolumeSize: 30
   image:
     id: ""

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-15.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-15.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-17
+  name: aws-hosted-cp-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.17
+      chart: aws-hosted-cp
+      version: 1.0.15
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-15.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-15.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-15
+  name: aws-standalone-cp-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
+      chart: aws-standalone-cp
       version: 1.0.15
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-18.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-18.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-14
+  name: azure-hosted-cp-1-0-18
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.14
+      chart: azure-hosted-cp
+      version: 1.0.18
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-16.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-16.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-14
+  name: azure-standalone-cp-1-0-16
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.14
+      chart: azure-standalone-cp
+      version: 1.0.16
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Resolves #2087

Adds required fields for Azure templates as well as actual required parameters on the chart level. This is needed to have clear error, since CAPZ won't check if vmsize or subscription ID is correct. Thus the cause cluster creation error is unclear to the user and if fails much later.

Fixed some some typos in aws-csi images paths
