### PR TITLE
fix: drop kcm regional version annotation from Release

### DIFF
--- a/hack/update-release.bash
+++ b/hack/update-release.bash
@@ -42,16 +42,11 @@ for file in $ALL_CHANGED; do
       ${YQ} e -i ".spec.kcm.template = \"$new_name\"" "$RELEASE_FILE"
       echo "Updated spec.kcm.template → $new_name"
     fi
-  # Update the annotation with the kcm-regional template name instead of using
-  # spec.regional.template. This ensures compatibility during upgrades, since
-  # older k0rdent instances does not have this field defined in old Region CRD.
-  # TODO: Rework to align with the standard/common approach.
   elif [[ "$chart_name" == "kcm-regional" ]]; then
-    annotation_key="k0rdent.mirantis.com/kcm-regional-template"
-    current=$(${YQ} e ".metadata.annotations.\"$annotation_key\" // \"\"" "$RELEASE_FILE")
+    current=$(${YQ} e '.spec.regional.template' "$RELEASE_FILE")
     if [[ "$current" != "$new_name" ]]; then
-      ${YQ} e -i ".metadata.annotations.\"$annotation_key\" = \"$new_name\"" "$RELEASE_FILE"
-      echo "Updated kcm regional template in annotation → $new_name"
+      ${YQ} e -i ".spec.regional.template = \"$new_name\"" "$RELEASE_FILE"
+      echo "Updated spec.regional.template → $new_name"
     fi
   elif [[ "$chart_name" == "cluster-api" ]]; then
     current=$(${YQ} e '.spec.capi.template' "$RELEASE_FILE")

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -4,11 +4,12 @@ metadata:
   name: kcm-1-4-0
   annotations:
     helm.sh/resource-policy: keep
-    k0rdent.mirantis.com/kcm-regional-template: kcm-regional-1-0-4
 spec:
   version: 1.4.0
   kcm:
     template: kcm-1-4-0
+  regional:
+    template: kcm-regional-1-0-4
   capi:
     template: cluster-api-1-0-7
   providers:


### PR DESCRIPTION
**What this PR does / why we need it**:
This annotation was previously required for upgrades from 1.3.0 -> 1.4.0, since `spec.regional` field was missing in the Release objects in KCM 1.3.0. Now replaced by the common approach, with annotation support still available (mainly for the enterprise version to properly handle upgrades).

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
