### PR TITLE
chore: default e2e config to aws if empty

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -447,7 +447,18 @@ jobs:
       - name: Load testing configuration
         if: ${{ steps.provider_check.outputs.onprem_present == 'true' && needs.authorize.outputs.config != '' }}
         run: |
-          echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
+          echo "Decoding provided configuration..."
+          config_content=$(echo -n "${{ needs.authorize.outputs.config }}" | base64 -d)
+          
+          echo "Validating provided configuration..."
+          if ! echo "$config_content" | yq eval > /dev/null 2>&1; then
+            echo "Invalid YAML configuration provided:"
+            echo "$config_content"
+            exit 1
+          fi
+          
+          echo "$config_content" > test/e2e/config/config.yaml
+          
           echo "Testing configuration was overwritten:"
           cat test/e2e/config/config.yaml
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds:
- defaulting to `aws: []` on `provider-cloud-e2etest`'s "Load testing configuration" step, if no e2e test configuration provided on "authorize";
- validation of provided config using `yq eval` on `provider-cloud-e2etest`'s "Load testing configuration" step;
- validation of provided config using `yq eval` on `provider-onprem-e2etest`'s "Load testing configuration" step;

E2E Test Job            | No config                     | Cloud only config         | Onprem only config       | Mixed config              |
------------------------|-------------------------------|---------------------------|-----------------------------|---------------------------|
provider-cloud-e2etest  | defaults to `aws:[]`, run: ✅ | parse & validate, run: ✅ | parse & validate, run: ❌ | parse & validate, run: ✅ |
provider-onprem-e2etest | no config, run: ❌            | parse & validate, run: ❌ | parse & validate, run: ✅ | parse & validate, run: ✅ |


