### PR TITLE
chore: fallback to aws when no config provided in provider check

### DIFF
--- a/.github/actions/check-provider-in-config/action.yml
+++ b/.github/actions/check-provider-in-config/action.yml
@@ -32,11 +32,11 @@ runs:
         echo "cloud_present=false" >> "$GITHUB_OUTPUT"
 
         if [ -z "${{ inputs.config }}" ]; then
-          echo "No config provided — skipping checks"
-          exit 0
+          echo "No config provided — fallback to aws"
+          echo "aws: []" > config.yaml
+        else
+          echo "${{ inputs.config }}" | base64 -d > config.yaml
         fi
-
-        echo "${{ inputs.config }}" | base64 -d > config.yaml
 
         # Set of on-prem providers (hardcoded)
         ONPREM_PROVIDERS=("vsphere" "openstack")


### PR DESCRIPTION
**What this PR does / why we need it**:
Fallback to `aws: []` when no config provided for `authorize` job. Empty config makes CI exit with no e2e tests run, due to checks return false on `Check cloud providers presence` and `Check remote presence` steps.
