### PR TITLE
fix(regions): propagate kubconfig if cld ref

### DIFF
--- a/internal/util/kube/client.go
+++ b/internal/util/kube/client.go
@@ -117,13 +117,11 @@ func GetRegionalKubeconfigSecretRef(region *kcmv1.Region) (*fluxmeta.SecretKeyRe
 	if region.Spec.ClusterDeployment != nil {
 		const kubeConfigSecretDataKey = "value"
 
-		kubeconfigSecretKey := GetKubeconfigSecretKey(client.ObjectKey{
-			Namespace: region.Spec.ClusterDeployment.Namespace,
-			Name:      region.Spec.ClusterDeployment.Name,
-		})
 		return &fluxmeta.SecretKeyReference{
-			Name: kubeconfigSecretKey.Name,
-			Key:  kubeConfigSecretDataKey,
+			Name: GetKubeconfigSecretKey(client.ObjectKey{
+				Name: region.Spec.ClusterDeployment.Name,
+			}).Name,
+			Key: kubeConfigSecretDataKey,
 		}, nil
 	}
 

--- a/internal/util/validation/provider_template.go
+++ b/internal/util/validation/provider_template.go
@@ -60,6 +60,7 @@ func getInUseProvidersWithContracts(ctx context.Context, cl client.Client, pTpl 
 			clds := new(kcmv1.ClusterDeploymentList)
 			if err := cl.List(ctx, clds,
 				client.MatchingFields{kcmv1.ClusterDeploymentTemplateIndexKey: cltpl.Name},
+				client.InNamespace(cltpl.Namespace),
 				client.Limit(1)); err != nil {
 				return nil, fmt.Errorf("failed to list ClusterDeployments: %w", err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Propagates regional clusterdeployment's kubeconfig to a region-based clusterdeployment's namespace, so the latter can properly connect to the parent's (the former) kubeconfig and provision a new cluster in the region.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2152
