### PR TITLE
feat: enhance KSM types representation

### DIFF
--- a/api/v1beta1/multiclusterservice_types.go
+++ b/api/v1beta1/multiclusterservice_types.go
@@ -340,8 +340,9 @@ type UpgradePath struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=mcs
-// +kubebuilder:printcolumn:name="Services",type="string",JSONPath=`.status.conditions[?(@.type=="ServicesInReadyState")].message`,description="Number of ready out of total services",priority=0
 // +kubebuilder:printcolumn:name="Clusters",type="string",JSONPath=`.status.conditions[?(@.type=="ClusterInReadyState")].message`,description="Number of ready out of total selected clusters",priority=0
+// +kubebuilder:printcolumn:name="provider",type=string,JSONPath=`.spec.serviceSpec.provider.name`,description="StateManagementProvider name",priority=0
+// +kubebuilder:printcolumn:name="self-management",type=boolean,JSONPath=`.spec.serviceSpec.provider.selfManagement`,description="Is the MultiClusterService for self-management",priority=0
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time elapsed since object creation",priority=0
 
 // MultiClusterService is the Schema for the multiclusterservices API

--- a/api/v1beta1/serviceset_types.go
+++ b/api/v1beta1/serviceset_types.go
@@ -230,6 +230,10 @@ type ServiceState struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="cluster",type=string,JSONPath=`.spec.cluster`,description="Corresponding ClusterDeployment name",priority=0
+// +kubebuilder:printcolumn:name="multiClusterServer",type=string,JSONPath=`.spec.multiClusterService`,description="Corresponding MultiClusterService name",priority=0
+// +kubebuilder:printcolumn:name="provider",type=string,JSONPath=`.spec.provider.name`,description="StateManagementProvider name",priority=0
+// +kubebuilder:printcolumn:name="self-management",type=boolean,JSONPath=`.spec.provider.selfManagement`,description="Is the ServiceSet for self-management",priority=0
 // +kubebuilder:printcolumn:name="age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time elapsed since object creation",priority=0
 
 // ServiceSet is the Schema for the servicesets API

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -582,14 +582,18 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - description: Number of ready out of total services
-      jsonPath: .status.conditions[?(@.type=="ServicesInReadyState")].message
-      name: Services
-      type: string
     - description: Number of ready out of total selected clusters
       jsonPath: .status.conditions[?(@.type=="ClusterInReadyState")].message
       name: Clusters
       type: string
+    - description: StateManagementProvider name
+      jsonPath: .spec.serviceSpec.provider.name
+      name: provider
+      type: string
+    - description: Is the MultiClusterService for self-management
+      jsonPath: .spec.serviceSpec.provider.selfManagement
+      name: self-management
+      type: boolean
     - description: Time elapsed since object creation
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
@@ -15,6 +15,22 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - description: Corresponding ClusterDeployment name
+      jsonPath: .spec.cluster
+      name: cluster
+      type: string
+    - description: Corresponding MultiClusterService name
+      jsonPath: .spec.multiClusterService
+      name: multiClusterServer
+      type: string
+    - description: StateManagementProvider name
+      jsonPath: .spec.provider.name
+      name: provider
+      type: string
+    - description: Is the ServiceSet for self-management
+      jsonPath: .spec.provider.selfManagement
+      name: self-management
+      type: boolean
     - description: Time elapsed since object creation
       jsonPath: .metadata.creationTimestamp
       name: age


### PR DESCRIPTION
**What this PR does / why we need it**:
Add printcolumns for `ServiceSet` type:
```
> k get serviceset -A
NAMESPACE    NAME                             CLUSTER                 MULTICLUSTERSERVER     PROVIDER             SELF-MANAGEMENT   AGE
kcm-system   abortnikov-aws-kcm-01            abortnikov-aws-kcm-01                          ksm-projectsveltos                     96m
kcm-system   abortnikov-aws-kcm-01-86c11881   abortnikov-aws-kcm-01   mcs-without-services   ksm-projectsveltos                     82m
kcm-system   management-86c11881                                      mcs-without-services   ksm-projectsveltos   true              79m
```

```
> k get mcs
NAME                   CLUSTERS   PROVIDER             SELF-MANAGEMENT   AGE
mcs-without-services   2/2        ksm-projectsveltos   true              88m
```

**Which issue(s) this PR fixes**:
Fixes: #2048
