### PR TITLE
fix(telemetry): incorrect addressing

### DIFF
--- a/internal/telemetry/collector/data_fetcher.go
+++ b/internal/telemetry/collector/data_fetcher.go
@@ -102,12 +102,13 @@ func (f *parentDataFetcher) fetch(ctx context.Context, parentClient client.Clien
 			return fmt.Errorf("failed to list ClusterDeployments: %w", err)
 		}
 
-		f.clusters = make([]client.Object, len(clds.Items))
-		for i, v := range clds.Items {
+		f.clusters = make([]client.Object, 0, len(clds.Items))
+		for _, v := range clds.Items {
 			if v.Status.Region != "" {
 				continue
 			}
-			f.clusters[i] = &v
+
+			f.clusters = append(f.clusters, &v)
 		}
 	}
 

--- a/internal/telemetry/collector/segmentio.go
+++ b/internal/telemetry/collector/segmentio.go
@@ -95,6 +95,10 @@ func (t *SegmentIO) Collect(ctx context.Context) error {
 	}
 
 	for _, cluster := range parentData.clusters {
+		if cluster == nil { // sanity check
+			continue
+		}
+
 		wg.Add(1)
 		sem <- struct{}{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes incorrect addresses in a slice, where some of the source elements have been skipped

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2160