### PR TITLE
fix: poll cluster summaries

### DIFF
--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -57,6 +57,7 @@ spec:
         {{- if .Values.controller.defaultHelmTimeout }}
         - --default-helm-timeout={{ .Values.controller.defaultHelmTimeout }}
         {{- end }}
+        - --max-concurrent-reconciles={{ .Values.controller.maxConcurrentReconciles }}
         command:
         - /manager
         env:

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -137,6 +137,10 @@
             }
           }
         },
+        "maxConcurrentReconciles": {
+          "description": "Specifies the maximum number of concurrent reconciles that will be run for each controller",
+          "type": "integer"
+        },
         "nodeSelector": {
           "description": "Node selector to constrain the pod to run on specific nodes",
           "type": "object"

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -25,6 +25,7 @@ controller:
   enableSveltosCtrl: true # @schema type: boolean; description: Enables built-in ServiceSet controller to reconcile ProjectSveltos objects
   enableSveltosExpiredCtrl: false # @schema type: boolean; description: Enables SveltosCluster controller, updating stuck (expired) sveltos management cluster kubeconfig tokens
   defaultHelmTimeout: "" # @schema type: string; description: Specifies the timeout duration for Helm install or upgrade operations. If unset, Flux’s default value will be used
+  maxConcurrentReconciles: 10 # @schema type: integer; description: Specifies the maximum number of concurrent reconciles that will be run for each controller
   logger: # @schema title: Logger Settings; description: Global controllers logger settings; type: object
     devel: false # @schema type: boolean; description: Development defaults(encoder=console,logLevel=debug,stackTraceLevel=warn) Production defaults(encoder=json,logLevel=info,stackTraceLevel=error)
     encoder: "" # @schema enum:[json, console, ""] ; type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds poller for `ClusterSummary` objects added to serviceset-controller to replace removed watchers.

**Which issue(s) this PR fixes**:
Fixes: #2136 
