### PR TITLE
fix: serviceset creation if no services defined in cld

### DIFF
--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -1560,10 +1560,6 @@ func (r *ClusterDeploymentReconciler) createOrUpdateServiceSet(
 	cd *kcmv1.ClusterDeployment,
 ) error {
 	l := ctrl.LoggerFrom(ctx).WithName("handle-service-set")
-	// nothing to deploy, no-op
-	if len(cd.Spec.ServiceSpec.Services) == 0 && !cd.Spec.PropagateCredentials {
-		return nil
-	}
 
 	var err error
 	providerSpec := cd.Spec.ServiceSpec.Provider


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes clusterdeployment-controller behavior and makes it create `ServiceSet` object if no services defined in `.spec.serviceSpec.services[]`. This unblocks resources propagation using only `policyRefs`/`templateResourcesRefs`.

**Which issue(s) this PR fixes**:
Fixes: #2166 
