### PR TITLE
chore: kcm-regional global registry values + imagePullSecrets

### DIFF
--- a/templates/provider/kcm-regional/Chart.yaml
+++ b/templates/provider/kcm-regional/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 dependencies:
   - name: cert-manager
     version: 1.19.1

--- a/templates/provider/kcm-regional/templates/deployment.yaml
+++ b/templates/provider/kcm-regional/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $global := .Values.global | default dict }}
 {{- $tel := .Values.telemetry -}}
 {{- $telController := .Values.telemetry.controller -}}
 {{- $isTelemetryEnabled := ne $tel.mode "disabled" -}}
@@ -23,7 +24,11 @@ spec:
       {{- if $isLocalTelemetry }}
       initContainers:
         - name: telemetry-data-permissions
-          image: busybox:latest
+          image: {{ if $global.registry }}
+          {{- $global.registry }}/busybox
+          {{- else }}
+          {{- $telController.image.initContainer.repository }}
+          {{- end }}:{{ $telController.image.initContainer.tag }}
           command: ["sh","-c","chown -R 65532:65532 {{ $baseDir }} || true"]
           securityContext:
             runAsUser: 0
@@ -56,7 +61,11 @@ spec:
         - --pprof-bind-address={{ $telController.debug.pprofBindAddress }}
         command:
         - /telemetry
-        image: {{ $telController.image.repository }}:{{ $telController.image.tag | default .Chart.AppVersion }}
+        image: {{ if $global.registry }}
+        {{- $global.registry }}/kcm-telemetry
+        {{- else }}
+        {{- $telController.image.repository }}
+        {{- end }}:{{ $telController.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ $telController.image.pullPolicy }}
         name: telemetry
         ports:
@@ -105,6 +114,9 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ include "kcm-regional.fullname" . }}-telemetry
       terminationGracePeriodSeconds: 10
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       {{- if $isLocalTelemetry }}
       volumes:
         - name: telemetry-storage

--- a/templates/provider/kcm-regional/values.schema.json
+++ b/templates/provider/kcm-regional/values.schema.json
@@ -65,6 +65,9 @@
     "fullnameOverride": {
       "type": "string"
     },
+    "imagePullSecrets": {
+      "type": "array"
+    },
     "nameOverride": {
       "type": "string"
     },
@@ -100,6 +103,17 @@
             "image": {
               "type": "object",
               "properties": {
+                "initContainer": {
+                  "type": "object",
+                  "properties": {
+                    "repository": {
+                      "type": "string"
+                    },
+                    "tag": {
+                      "type": "string"
+                    }
+                  }
+                },
                 "pullPolicy": {
                   "description": "Image pull policy",
                   "type": "string",

--- a/templates/provider/kcm-regional/values.yaml
+++ b/templates/provider/kcm-regional/values.yaml
@@ -5,6 +5,9 @@ telemetry: # @schema type: object; description: Telemetry collection configurati
   controller: # @schema type: object; description: Telemetry runner configuration; additionalProperties: false
     replicas: 1
     image:
+      initContainer:
+        repository: busybox
+        tag: latest
       repository: ghcr.io/k0rdent/kcm/telemetry
       tag: latest
       pullPolicy: IfNotPresent # @schema type: string; enum: [IfNotPresent, Always, Never]; description: Image pull policy
@@ -74,6 +77,8 @@ cluster-api-operator:
       requests:
         cpu: 200m
         memory: 150Mi
+
+imagePullSecrets: []
 
 velero:
   enabled: true

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -9,7 +9,7 @@ spec:
   kcm:
     template: kcm-1-5-0
   regional:
-    template: kcm-regional-1-0-5
+    template: kcm-regional-1-0-6
   capi:
     template: cluster-api-1-0-8
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm-regional.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm-regional.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-regional-1-0-5
+  name: kcm-regional-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm-regional
-      version: 1.0.5
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.lock
+++ b/templates/provider/kcm/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.21.2
 - name: kcm-regional
   repository: file://../kcm-regional
-  version: 1.0.5
-digest: sha256:dee06f52f655b48b154d813e8676471032feffb19cce490ce265fc5943e7e9e4
-generated: "2025-10-22T17:05:19.005246+02:00"
+  version: 1.0.6
+digest: sha256:92eea6e3bc18eb20fe6c47190bd410b09efcda3b05500e8b00428d406e1391c1
+generated: "2025-11-24T13:45:47.831770678-05:00"

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -25,5 +25,5 @@ dependencies:
     condition: rbac-manager.enabled
   - name: kcm-regional
     alias: regional
-    version: 1.0.5
+    version: 1.0.6
     repository: "file://../kcm-regional"

--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -65,7 +65,11 @@ spec:
           value: {{ include "kcm.fullname" . }}-controller-manager
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+        image: {{ if .Values.controller.globalRegistry }}
+        {{- .Values.controller.globalRegistry }}/kcm-controller
+        {{- else }}
+        {{- .Values.image.repository }}
+        {{- end }}:{{ .Values.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.admissionWebhook.enabled }}
         ports:
@@ -107,6 +111,9 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ include "kcm.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       {{- if .Values.admissionWebhook.enabled }}
       volumes:
         - name: cert

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -263,6 +263,9 @@
         }
       }
     },
+    "imagePullSecrets": {
+      "type": "array"
+    },
     "kubernetesClusterDomain": {
       "type": "string"
     },

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -68,6 +68,8 @@ metricsService:
       targetPort: 8080
   type: ClusterIP
 
+imagePullSecrets: []
+
 # Subcharts
 flux2:
   enabled: true


### PR DESCRIPTION
Resolves #2129 

Adds global registry configuration for kcm-regional.

Additionally adds missing imagePullSecrets configuration option for both kcm and kcm-regional charts