### PR TITLE
fix(openstack): relax managedSecurityGroups schema and align standalone and hosted cp charts

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-18
+  template: openstack-standalone-cp-1-0-19
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/values.schema.json
+++ b/templates/cluster/openstack-hosted-cp/values.schema.json
@@ -361,7 +361,7 @@
       }
     },
     "managedSecurityGroups": {
-      "description": "Defines whether OpenStack security groups are managed by the provider or specific rules are provided",
+      "description": "Passed through to OpenStackCluster.spec.managedSecurityGroups",
       "type": [
         "object",
         "null"

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -42,7 +42,7 @@ bastion: # @schema description: Configuration of the bastion host; type: object
         name: "" # @schema description: Name of the image; type: string
         tags: [] # @schema description: The tags associated with the desired image; type: array; item: string
 
-managedSecurityGroups: null # @schema description: Defines whether OpenStack security groups are managed by the provider or specific rules are provided; type: [object, null]
+managedSecurityGroups: {} # @schema description: Passed through to OpenStackCluster.spec.managedSecurityGroups; type: [object, null]
 
 externalNetwork: # @schema description: External network configuration for the cluster; type: object
   id: # @schema description: ID of the external network; type: [string, null]

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.18
+version: 1.0.19
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/openstackcluster.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackcluster.yaml
@@ -22,8 +22,10 @@ spec:
     name: {{ .Values.clusterIdentity.name }}
     cloudName: {{ .Values.identityRef.cloudName | default "openstack" }}
     region: {{ .Values.identityRef.region | default "RegionOne" }}
+  {{- if .Values.managedSecurityGroups }}
   managedSecurityGroups:
     {{- toYaml .Values.managedSecurityGroups | nindent 4 }}
+  {{- end }}
   {{- if .Values.managedSubnets }}
   managedSubnets:
     {{- toYaml .Values.managedSubnets | nindent 4 }}

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -409,17 +409,11 @@
       }
     },
     "managedSecurityGroups": {
-      "description": "Defines whether OpenStack security groups are managed by the provider or specific rules are provided",
-      "type": "object",
-      "required": [
-        "allowAllInClusterTraffic"
-      ],
-      "properties": {
-        "allowAllInClusterTraffic": {
-          "description": "Allow all traffic within the cluster security groups",
-          "type": "boolean"
-        }
-      }
+      "description": "Passed through to OpenStackCluster.spec.managedSecurityGroups",
+      "type": [
+        "object",
+        "null"
+      ]
     },
     "managedSubnets": {
       "description": "Subnets managed by OpenStack for the cluster",

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -46,8 +46,7 @@ bastion: # @schema description: Configuration of the bastion host; type: object
         name: "" # @schema description: Name of the image; type: string
         tags: [] # @schema description: The tags associated with the desired image; type: array; item: string
 
-managedSecurityGroups: # @schema description: Defines whether OpenStack security groups are managed by the provider or specific rules are provided; type: object
-  allowAllInClusterTraffic: false # @schema description: Allow all traffic within the cluster security groups; type: boolean; required: true
+managedSecurityGroups: {} # @schema description: Passed through to OpenStackCluster.spec.managedSecurityGroups; type: [object, null]
 
 managedSubnets: # @schema description: Subnets managed by OpenStack for the cluster; type: array; item: object
   - cidr: 10.6.0.0/24 # @schema description: CIDR block for the subnet; type: string

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-9.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-9.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-8
+  name: openstack-hosted-cp-1-0-9
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-hosted-cp
-      version: 1.0.8
+      version: 1.0.9
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-19.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-19.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-18
+  name: openstack-standalone-cp-1-0-19
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-standalone-cp
-      version: 1.0.18
+      version: 1.0.19
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Fixes #2076 