### PR TITLE
fix: support empty ClusterDataSource status

### DIFF
--- a/api/v1beta1/clusterdatasource_types.go
+++ b/api/v1beta1/clusterdatasource_types.go
@@ -63,7 +63,7 @@ type ClusterDataSource struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   ClusterDataSourceSpec   `json:"spec"`
-	Status ClusterDataSourceStatus `json:"status"`
+	Status ClusterDataSourceStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdatasources.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdatasources.yaml
@@ -111,7 +111,6 @@ spec:
             type: object
         required:
         - spec
-        - status
         type: object
     served: true
     storage: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Without that, the controller fails with:

```
failed to ensure DataSource ekaz references: failed to create ClusterDataSource kcm-system/ekaz-hcp: ClusterDataSource.k0rdent.mirantis.com "ekaz-hcp" is invalid: [status: Required value, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
```

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
