### PR TITLE
fix: do not update mgmt release immediately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -529,8 +529,6 @@ dev-upgrade: yq generate-all dev-push dev-templates ## Upgrade dev environment a
 	@$(KUBECTL) patch management kcm --type=merge -p '{"spec":{"release":"kcm-$(FQDN_VERSION)"}}'
 
 	@$(KUBECTL) rollout restart -n $(NAMESPACE) deployment/kcm-controller-manager
-	@echo "Sleeping 30s to allow Management status to update.."
-	@sleep 30
 	@echo "Waiting for Management object status.release to match kcm-$(FQDN_VERSION)..."
 	@$(KUBECTL) wait management kcm --for="jsonpath={.status.release}=kcm-$(FQDN_VERSION)" --timeout=$(READINESS_TIMEOUT)
 	@echo "Waiting for Management object to become Ready..."

--- a/api/v1beta1/management_types.go
+++ b/api/v1beta1/management_types.go
@@ -55,6 +55,8 @@ const (
 	ReleaseIsNotFoundReason = "ReleaseIsNotFound"
 	// ReleaseIsNotReadyReason declares that the referenced in the [Management] [Release] object is not (yet) ready.
 	ReleaseIsNotReadyReason = "ReleaseIsNotReady"
+	// ReleaseIsNotObserved declares that the referenced in the [Management] [Release] object is not (yet) observed.
+	ReleaseIsNotObserved = "ReleaseIsNotObserved"
 	// HasIncompatibleContractsReason declares that the [Management] object has incompatible CAPI contracts in providers.
 	HasIncompatibleContractsReason = "HasIncompatibleContracts"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
The fix does not do much in the sense of the "not immediate update" but gives a more robust status in case of any component errors, providing backward compatibility with the current approach.

The more correct approach would be to set the observed release after all of its components reconcile and be ready, though that does not align well with the current approach and might lead to bad UX where the `.status.release` shows the previous release and the errors from a new one from the `.spec.release`. Thus no changes in this matter.

We could consider changing this in the future, though it should be done carefully since some of the other controllers might rely on the current `managements` status.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #1971