### PR TITLE
chore(deps): bump cluster-api-provider-aws from 2.9.2 to 2.10.0

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-19
+  template: aws-standalone-cp-1-0-20
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/eks-clusterdeployment.yaml
+++ b/config/dev/eks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-eks-1-0-3
+  template: aws-eks-1-0-4
   credential: "aws-cluster-identity-cred"
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-eks/templates/cluster.yaml
+++ b/templates/cluster/aws-eks/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -14,10 +14,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: AWSManagedControlPlane
     name: {{ include "awsmanagedcontrolplane.name" .  }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AWSManagedCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/aws-eks/templates/machinedeployment.yaml
+++ b/templates/cluster/aws-eks/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: {{ include "machinedeployment.name" . }}
@@ -19,10 +19,10 @@ spec:
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: EKSConfigTemplate
           name: {{ include "eksconfigtemplate.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: AWSMachineTemplate
         name: {{ include "awsmachinetemplate.worker.name" . }}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.20
+version: 1.0.21
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/cluster.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -14,10 +14,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: K0smotronControlPlane
     name: {{ include "k0smotroncontrolplane.name" .  }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AWSCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/aws-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: {{ include "machinedeployment.name" . }}
@@ -20,10 +20,10 @@ spec:
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: K0sWorkerConfigTemplate
           name: {{ include "k0sworkerconfigtemplate.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: AWSMachineTemplate
         name: {{ include "awsmachinetemplate.name" . }}

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.19
+version: 1.0.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/cluster.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -14,10 +14,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: K0sControlPlane
     name: {{ include "k0scontrolplane.name" .  }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AWSCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/aws-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: {{ include "machinedeployment.name" . }}
@@ -20,10 +20,10 @@ spec:
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: K0sWorkerConfigTemplate
           name: {{ include "k0sworkerconfigtemplate.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: AWSMachineTemplate
         name: {{ include "awsmachinetemplate.worker.name" . }}

--- a/templates/provider/cluster-api-provider-aws/Chart.yaml
+++ b/templates/provider/cluster-api-provider-aws/Chart.yaml
@@ -13,12 +13,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.9.2"
+appVersion: "v2.10.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
+  # NOTE: v2.10.0 does not have this label though the provider does support v1beta2 CAPI
+  cluster.x-k8s.io/v1beta2: v1beta1_v1beta2

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -20,7 +20,7 @@ spec:
     - name: cluster-api-provider-vsphere
       template: cluster-api-provider-vsphere-1-0-6
     - name: cluster-api-provider-aws
-      template: cluster-api-provider-aws-1-0-8
+      template: cluster-api-provider-aws-1-0-9
     - name: cluster-api-provider-openstack
       template: cluster-api-provider-openstack-1-0-11
     - name: cluster-api-provider-docker

--- a/templates/provider/kcm-templates/files/templates/aws-eks-1-0-4.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-1-0-4.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-eks-1-0-3
+  name: aws-eks-1-0-4
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: aws-eks
-      version: 1.0.3
+      version: 1.0.4
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-21.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-21.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-20
+  name: aws-hosted-cp-1-0-21
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: aws-hosted-cp
-      version: 1.0.20
+      version: 1.0.21
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-20.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-20.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-19
+  name: aws-standalone-cp-1-0-20
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: aws-standalone-cp
-      version: 1.0.19
+      version: 1.0.20
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-aws-1-0-8
+  name: cluster-api-provider-aws-1-0-9
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-aws
-      version: 1.0.8
+      version: 1.0.9
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:

Unlock the possibility to create EKS clusters.

The upgrade procedure from the `v1beta1` CAPI for already existing EKS clusters works as expected.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #2091 