### PR TITLE
chore: deprecated and unused cleanup

### DIFF
--- a/internal/serviceset/builder.go
+++ b/internal/serviceset/builder.go
@@ -179,25 +179,17 @@ func ConvertServiceSpecToProviderConfig(serviceSpec kcmv1.ServiceSpec) (kcmv1.St
 		ContinueOnError      bool                                         `json:"continueOnError,omitempty"`
 	}
 
+	//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
 	cfg := config{
-		//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-		SyncMode: serviceSpec.SyncMode,
-		//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
+		SyncMode:             serviceSpec.SyncMode,
 		TemplateResourceRefs: serviceSpec.TemplateResourceRefs,
-		//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-		PolicyRefs: serviceSpec.PolicyRefs,
-		//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-		DriftIgnore: serviceSpec.DriftIgnore,
-		//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-		DriftExclusions: serviceSpec.DriftExclusions,
-		//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-		Priority: serviceSpec.Priority,
-		//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-		StopOnConflict: serviceSpec.StopOnConflict,
-		//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-		Reload: serviceSpec.Reload,
-		//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-		ContinueOnError: serviceSpec.ContinueOnError,
+		PolicyRefs:           serviceSpec.PolicyRefs,
+		DriftIgnore:          serviceSpec.DriftIgnore,
+		DriftExclusions:      serviceSpec.DriftExclusions,
+		Priority:             serviceSpec.Priority,
+		StopOnConflict:       serviceSpec.StopOnConflict,
+		Reload:               serviceSpec.Reload,
+		ContinueOnError:      serviceSpec.ContinueOnError,
 	}
 	raw, err := json.Marshal(cfg)
 	if err != nil {

--- a/internal/telemetry/collector/local.go
+++ b/internal/telemetry/collector/local.go
@@ -158,8 +158,6 @@ func (l *LocalCollector) Collect(ctx context.Context) error {
 			if dataScope.isMgmt() { // sanity
 				if cld, ok := cluster.(*kcmv1.ClusterDeployment); ok {
 					entry.inc(bucketTemplate(cld.Spec.Template))
-					//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-					entry.inc(bucketSyncMode(cld.Spec.ServiceSpec.SyncMode))
 					entry.label(labelCldID, string(cld.UID))
 				}
 			}

--- a/internal/telemetry/collector/local_buckets.go
+++ b/internal/telemetry/collector/local_buckets.go
@@ -132,10 +132,6 @@ func bucketOperatorInstalled(typ string, v bool) string {
 	return "gpu.operator_installed." + typ + ":" + strconv.FormatBool(v)
 }
 
-func bucketSyncMode(mode string) string {
-	return "syncMode:" + strings.ToLower(mode)
-}
-
 func bucketTemplate(name string) string {
 	return "template:" + name
 }

--- a/internal/telemetry/collector/local_buckets_test.go
+++ b/internal/telemetry/collector/local_buckets_test.go
@@ -132,6 +132,5 @@ func Test_buckets(t *testing.T) {
 	reqs.Equal("node.info.arch:arm64", bucketArch("arm64"))
 	reqs.Equal("node.info.arch:other", bucketArch("loongarch64"))
 	reqs.Equal("gpu.operator_installed.nvidia:true", bucketOperatorInstalled("nvidia", true))
-	reqs.Equal("syncMode:continuous", bucketSyncMode("CoNtInUoUs"))
 	reqs.Equal("template:aws-foo", bucketTemplate("aws-foo"))
 }

--- a/internal/telemetry/collector/local_test.go
+++ b/internal/telemetry/collector/local_test.go
@@ -248,7 +248,7 @@ func Test_localCollector_Collect(t *testing.T) {
 			name: "single cluster happy path",
 			mgmt: mgmtSeed{
 				clusterDeployments: []*kcmv1.ClusterDeployment{
-					makeCLD(t, nsOne, cldOne, "tpl-1", "OneTime", 10),
+					makeCLD(t, nsOne, cldOne, "tpl-1", 10),
 				},
 				capiClusters: []*clusterapiv1.Cluster{
 					makeCAPICluster(t, nsOne, cldOne, "kube-system:abcd-1234"),
@@ -310,8 +310,8 @@ func Test_localCollector_Collect(t *testing.T) {
 			name: "one ok cluster, another failed, expect failures counter",
 			mgmt: mgmtSeed{
 				clusterDeployments: []*kcmv1.ClusterDeployment{
-					makeCLD(t, nsSome, cldSome, "tpl", "OneTime", 2),
-					makeCLD(t, nsSome, cldErr, "tpl", "continuous", 0),
+					makeCLD(t, nsSome, cldSome, "tpl", 2),
+					makeCLD(t, nsSome, cldErr, "tpl", 0),
 				},
 				secrets: []*corev1.Secret{
 					makeKubeconfigSecret(t, nsSome, cldSome, "child:"+nsName(nsSome, cldSome)),
@@ -373,7 +373,7 @@ func Test_localCollector_Collect(t *testing.T) {
 			name: "no secret expect nothing",
 			mgmt: mgmtSeed{
 				clusterDeployments: []*kcmv1.ClusterDeployment{
-					makeCLD(t, nsSome, "no-secret", "tpl", "continuous", 0),
+					makeCLD(t, nsSome, "no-secret", "tpl", 0),
 				},
 			},
 			children:  nil,
@@ -520,7 +520,7 @@ func makeKubeconfigSecret(t *testing.T, ns, name, kubeconfigTag string) *corev1.
 	}
 }
 
-func makeCLD(t *testing.T, ns, name, tpl, syncMode string, services int) *kcmv1.ClusterDeployment {
+func makeCLD(t *testing.T, ns, name, tpl string, services int) *kcmv1.ClusterDeployment {
 	t.Helper()
 
 	cd := &kcmv1.ClusterDeployment{
@@ -532,8 +532,6 @@ func makeCLD(t *testing.T, ns, name, tpl, syncMode string, services int) *kcmv1.
 	}
 
 	cd.Spec.Template = tpl
-	//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-	cd.Spec.ServiceSpec.SyncMode = syncMode
 	if services > 0 {
 		cd.Spec.ServiceSpec.Services = make([]kcmv1.Service, services)
 	}

--- a/internal/telemetry/collector/segmentio.go
+++ b/internal/telemetry/collector/segmentio.go
@@ -139,8 +139,6 @@ func (t *SegmentIO) Collect(ctx context.Context) error {
 				if cld, ok := cluster.(*kcmv1.ClusterDeployment); ok {
 					props["clusterDeploymentID"] = string(cld.UID)
 					props["template"] = cld.Spec.Template
-					//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-					props["syncMode"] = cld.Spec.ServiceSpec.SyncMode
 
 					// NOTE: it's okay to read concurrently here since NO writes occur; checked with -race flag
 					if template, ok := parentData.mgmtTemplateName2Template[client.ObjectKey{Namespace: cld.Namespace, Name: cld.Spec.Template}]; ok {

--- a/internal/telemetry/collector/segmentio_test.go
+++ b/internal/telemetry/collector/segmentio_test.go
@@ -420,8 +420,6 @@ func Test_SegmentIO_Collect(t *testing.T) {
 		reqs.Equal(tpl.Status.Providers, props["providers"])
 		reqs.Equal(tpl.Status.ChartVersion, props["templateHelmChartVersion"])
 		reqs.Equal(clds[i].Spec.Template, props["template"])
-		//nolint:staticcheck // SA1019: Deprecated but used for legacy support.
-		reqs.Equal(clds[i].Spec.ServiceSpec.SyncMode, props["syncMode"])
 		reqs.Equal(0, props["userServiceCount"])
 
 		reqs.Equal(false, props["gpu.operator_installed.amd"])

--- a/test/e2e/clusterdeployment/clusterdeployment.go
+++ b/test/e2e/clusterdeployment/clusterdeployment.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	clusterapiv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -88,20 +87,6 @@ var adoptedClusterDeploymentTemplateBytes []byte
 
 //go:embed resources/remote-cluster.yaml.tpl
 var remoteClusterDeploymentTemplateBytes []byte
-
-func FilterAllProviders() []string {
-	return []string{
-		KCMControllerLabel,
-		GetProviderLabel(ProviderAWS),
-		GetProviderLabel(ProviderAzure),
-		GetProviderLabel(ProviderCAPI),
-		GetProviderLabel(ProviderVSphere),
-	}
-}
-
-func GetProviderLabel(provider ProviderType) string {
-	return fmt.Sprintf("%s=%s", clusterapiv1.ProviderNameLabel, provider)
-}
 
 func GenerateClusterName(postfix string) string {
 	mcPrefix := os.Getenv(EnvVarClusterDeploymentPrefix)

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -121,13 +121,6 @@ func applyDefaultConfiguration() {
 	}
 }
 
-func Show() string {
-	prettyConfig, err := yaml.Marshal(Config)
-	Expect(err).NotTo(HaveOccurred())
-
-	return string(prettyConfig)
-}
-
 func UpgradeRequired() bool {
 	for _, configs := range Config {
 		for _, config := range configs {

--- a/test/e2e/credential/credential.go
+++ b/test/e2e/credential/credential.go
@@ -22,9 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	executil "github.com/K0rdent/kcm/test/util/exec"
 )
 
@@ -43,18 +41,4 @@ func Apply(kubeconfigPath string, providers ...string) {
 			return err
 		}).WithTimeout(5 * time.Minute).WithPolling(time.Minute).Should(Succeed())
 	}
-}
-
-func Validate(ctx context.Context, cl crclient.Client, namespace, name string) {
-	Eventually(func() error {
-		cred := &kcmv1.Credential{}
-		err := cl.Get(ctx, crclient.ObjectKey{Namespace: namespace, Name: name}, cred)
-		if err != nil {
-			return err
-		}
-		if !cred.Status.Ready {
-			return fmt.Errorf("credential %s is not ready yet", crclient.ObjectKeyFromObject(cred))
-		}
-		return nil
-	}).WithTimeout(5 * time.Minute).WithPolling(time.Minute).Should(Succeed())
 }

--- a/test/e2e/multiclusterservice/multiclusterservice.go
+++ b/test/e2e/multiclusterservice/multiclusterservice.go
@@ -87,23 +87,21 @@ func CreateMultiClusterServiceWithDelete(
 	CreateMultiClusterService(ctx, cl, mcs)
 	mcsKey := client.ObjectKeyFromObject(mcs)
 	return func() error {
+		fmt.Fprintf(GinkgoWriter, "Deleting MultiClusterService [%s]\n", mcsKey)
+
 		if err := cl.Delete(ctx, mcs); client.IgnoreNotFound(err) != nil {
 			return err
 		}
+
 		Eventually(func() bool {
 			err := cl.Get(ctx, mcsKey, &kcmv1.MultiClusterService{})
 			return apierrors.IsNotFound(err)
 		}).WithTimeout(30 * time.Minute).WithPolling(5 * time.Minute).Should(BeTrue())
-		_, _ = fmt.Fprintf(GinkgoWriter, "Deleted MultiClusterService %s\n", mcsKey)
+
+		fmt.Fprintf(GinkgoWriter, "Deleted MultiClusterService [%s]\n", mcsKey)
+
 		return nil
 	}
-}
-
-func DeleteMultiClusterService(ctx context.Context, cl client.Client, mcs *kcmv1.MultiClusterService) error {
-	if err := cl.Delete(ctx, mcs); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-	return nil
 }
 
 func checkMultiClusterServiceConditions(ctx context.Context, kc *kubeclient.KubeClient, multiclusterServiceName string, expectedCount int) error {
@@ -152,8 +150,7 @@ func ValidateMCSConditions(ctx context.Context, cl client.Client, mcsKey client.
 	Eventually(func() (err error) {
 		defer func() {
 			if err != nil {
-				err = fmt.Errorf("[%s] failed validation of conditions: %v", mcsKey.String(), err)
-				_, _ = fmt.Fprintf(GinkgoWriter, "%v\n", err.Error())
+				fmt.Fprintf(GinkgoWriter, "[%s] failed validation of conditions: %v\n", mcsKey, err)
 			}
 		}()
 
@@ -183,6 +180,8 @@ func ValidateMCSConditions(ctx context.Context, cl client.Client, mcsKey client.
 
 		return nil
 	}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+	fmt.Fprintf(GinkgoWriter, "[%s] MultiClusterService successfully passed\n", mcsKey)
 }
 
 // ValidateServiceSet validates the ServiceSet associated with the provided CD and MCS.

--- a/test/objects/datasource/datasource.go
+++ b/test/objects/datasource/datasource.go
@@ -68,24 +68,6 @@ func WithNamespace(namespace string) Opt {
 	}
 }
 
-func WithEndpoints(eps []string) Opt {
-	return func(ds *kcmv1.DataSource) {
-		ds.Spec.Endpoints = eps
-	}
-}
-
-func WithAuth(auth kcmv1.DataSourceAuth) Opt {
-	return func(ds *kcmv1.DataSource) {
-		ds.Spec.Auth = auth
-	}
-}
-
-func WithCertificateAuthority(reference *kcmv1.SecretKeyReference) Opt {
-	return func(ds *kcmv1.DataSource) {
-		ds.Spec.CertificateAuthority = reference
-	}
-}
-
 func WithLabels(kvs ...string) Opt {
 	return func(ds *kcmv1.DataSource) {
 		if ds.Labels == nil {

--- a/test/objects/providerinterface/providerinterface.go
+++ b/test/objects/providerinterface/providerinterface.go
@@ -46,13 +46,6 @@ func WithName(name string) Opt {
 	}
 }
 
-func WithClusterIdentityKinds(vals ...string) Opt {
-	return func(p *kcmv1.ProviderInterface) {
-		//nolint:staticcheck // SA1019: ClusterIdentityKinds is deprecated but used for legacy support
-		p.Spec.ClusterIdentityKinds = vals
-	}
-}
-
 func WithClusterIdentities(cis []kcmv1.ClusterIdentity) Opt {
 	return func(p *kcmv1.ProviderInterface) {
 		p.Spec.ClusterIdentities = cis

--- a/test/objects/template/template.go
+++ b/test/objects/template/template.go
@@ -110,27 +110,9 @@ func WithNamespace(namespace string) Opt {
 	}
 }
 
-func WithLabels(labels map[string]string) Opt {
-	return func(t Template) {
-		t.SetLabels(labels)
-	}
-}
-
 func WithOwnerReference(ownerRef []metav1.OwnerReference) Opt {
 	return func(t Template) {
 		t.SetOwnerReferences(ownerRef)
-	}
-}
-
-func ManagedByKCM() Opt {
-	return func(template Template) {
-		labels := template.GetLabels()
-		if labels == nil {
-			labels = make(map[string]string)
-		}
-		labels[kcmv1.KCMManagedLabelKey] = kcmv1.KCMManagedLabelValue
-
-		template.SetLabels(labels)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes some of the deprecated and most of the unused code.

Slightly improves MCS E2E tests logs and output.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
