### PR TITLE
fix: dataSource values propagation

### DIFF
--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -630,6 +630,7 @@ func (r *ClusterDeploymentReconciler) ensureDataSourceReferences(ctx context.Con
 
 			return true, nil // updated the CDS, wait for the object to be reconciled
 		}
+		scope.kine.clusterDataSource = clusterdatasource
 
 		return r.ensureClusterDataSourceRegionalSecrets(ctx, clusterdatasource, scope)
 	}
@@ -737,9 +738,6 @@ func (r *ClusterDeploymentReconciler) ensureClusterDataSourceRegionalSecrets(ctx
 			r.eventf(cd, "KineSecretUpdated", "Successfully updated Secret %s/%s for kine data source", cd.Namespace, secretName)
 		}
 	}
-
-	scope.kine.clusterDataSource = cds
-
 	return false, nil // we had both CDS and its secret data
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the `dataSource` values propagation for non-regional ClusterDeployments.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2218
