### PR TITLE
chore(make): align regional with the main chart version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,19 +83,19 @@ generate-release: yq
 	@release_file="$(PROVIDER_TEMPLATES_DIR)/kcm-templates/files/release.yaml"; \
 	if [ -n "$$OUTPUT" ]; then \
 		$(YQ) eval \
-			'.spec.version = "$(VERSION)" | .metadata.name = "kcm-$(FQDN_VERSION)" | .spec.kcm.template = "kcm-$(FQDN_VERSION)"' \
+			'.spec.version = "$(VERSION)" | .metadata.name = "kcm-$(FQDN_VERSION)" | .spec.kcm.template = "kcm-$(FQDN_VERSION)" | .spec.regional.template = "kcm-regional-$(FQDN_VERSION)"' \
 			"$$release_file" > "$$OUTPUT"; \
 	else \
 		$(YQ) eval -i \
-			'.spec.version = "$(VERSION)" | .metadata.name = "kcm-$(FQDN_VERSION)" | .spec.kcm.template = "kcm-$(FQDN_VERSION)"' \
+			'.spec.version = "$(VERSION)" | .metadata.name = "kcm-$(FQDN_VERSION)" | .spec.kcm.template = "kcm-$(FQDN_VERSION)" | .spec.regional.template = "kcm-regional-$(FQDN_VERSION)"' \
 			"$$release_file"; \
 	fi
 
 .PHONY: set-kcm-version
 set-kcm-version: yq
-	$(eval KCM_REGIONAL_VERSION := $(shell $(YQ) -r '.version' $(PROVIDER_TEMPLATES_DIR)/kcm-regional/Chart.yaml))
+	$(YQ) eval '.version = "$(VERSION)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm-regional/Chart.yaml
 	$(YQ) eval -i \
-		'.version = "$(VERSION)" | (.dependencies[] | select(.name == "kcm-regional") | .version) = "$(KCM_REGIONAL_VERSION)"' \
+		'.version = "$(VERSION)" | (.dependencies[] | select(.name == "kcm-regional") | .version) = "$(VERSION)"' \
 		$(PROVIDER_TEMPLATES_DIR)/kcm/Chart.yaml
 	$(YQ) eval '.version = "$(VERSION)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm-templates/Chart.yaml
 	$(YQ) eval '.image.tag = "$(VERSION)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm/values.yaml

--- a/hack/chart-version.bash
+++ b/hack/chart-version.bash
@@ -19,14 +19,15 @@ set -eu
 BASE_COMMIT="${BASE_COMMIT:-origin/main}"
 HEAD_COMMIT="${HEAD_COMMIT:-HEAD}"
 
-COMMITTED_CHANGED=$(git diff --name-only "$BASE_COMMIT"...$HEAD_COMMIT)
+COMMITTED_CHANGED=$(git diff --name-only "$BASE_COMMIT"..."$HEAD_COMMIT")
 TRACKED_CHANGED=$(git diff --name-only)
 UNTRACKED_CHANGED=$(git ls-files --others --exclude-standard)
-ALL_CHANGED_FILES=$(echo -e "$COMMITTED_CHANGED\n$TRACKED_CHANGED\n$UNTRACKED_CHANGED" \
-  | sort -u \
-  | grep -E '^templates/(provider|cluster)/' \
-  | grep -v '^templates/provider/kcm-templates/' \
-  | grep -v '^templates/provider/kcm/' || true)
+ALL_CHANGED_FILES=$(echo -e "$COMMITTED_CHANGED\n$TRACKED_CHANGED\n$UNTRACKED_CHANGED" |
+  sort -u |
+  grep -E '^templates/(provider|cluster)/' |
+  grep -v '^templates/provider/kcm-templates/' |
+  grep -v '^templates/provider/kcm-regional/' |
+  grep -v '^templates/provider/kcm/' || true)
 
 declare -A UPDATED_CHARTS
 

--- a/hack/update-dev-configs.bash
+++ b/hack/update-dev-configs.bash
@@ -21,11 +21,11 @@ CONFIG_DEV_DIR=${CONFIG_DEV_DIR:-config/dev}
 BASE_COMMIT=${BASE_COMMIT:-origin/main}
 HEAD_COMMIT=${HEAD_COMMIT:-HEAD}
 
-COMMITTED_CHANGED=$(git diff --name-only "$BASE_COMMIT"...$HEAD_COMMIT -- "$TEMPLATE_DIR")
+COMMITTED_CHANGED=$(git diff --name-only "$BASE_COMMIT"..."$HEAD_COMMIT" -- "$TEMPLATE_DIR")
 TRACKED_CHANGED=$(git diff --name-only -- "$TEMPLATE_DIR")
 UNTRACKED_CHANGED=$(git ls-files --others --exclude-standard "$TEMPLATE_DIR")
-ALL_CHANGED=$(echo -e "$COMMITTED_CHANGED\n$TRACKED_CHANGED\n$UNTRACKED_CHANGED" \
-  | sort -u | grep -E '\.ya?ml$' || true)
+ALL_CHANGED=$(echo -e "$COMMITTED_CHANGED\n$TRACKED_CHANGED\n$UNTRACKED_CHANGED" |
+  sort -u | grep -E '\.ya?ml$' || true)
 
 for file in $ALL_CHANGED; do
   [[ -f "$file" ]] || continue

--- a/hack/update-release.bash
+++ b/hack/update-release.bash
@@ -21,11 +21,11 @@ TEMPLATE_DIR=${TEMPLATE_DIR:-templates/provider/kcm-templates/files/templates}
 BASE_COMMIT=${BASE_COMMIT:-origin/main}
 HEAD_COMMIT=${HEAD_COMMIT:-HEAD}
 
-COMMITTED_CHANGED=$(git diff --name-only "$BASE_COMMIT"...$HEAD_COMMIT -- "$TEMPLATE_DIR")
+COMMITTED_CHANGED=$(git diff --name-only "$BASE_COMMIT"..."$HEAD_COMMIT" -- "$TEMPLATE_DIR")
 TRACKED_CHANGED=$(git diff --name-only -- "$TEMPLATE_DIR")
 UNTRACKED_CHANGED=$(git ls-files --others --exclude-standard "$TEMPLATE_DIR")
-ALL_CHANGED=$(echo -e "$COMMITTED_CHANGED\n$TRACKED_CHANGED\n$UNTRACKED_CHANGED" \
-  | sort -u | grep -E '\.ya?ml$' || true)
+ALL_CHANGED=$(echo -e "$COMMITTED_CHANGED\n$TRACKED_CHANGED\n$UNTRACKED_CHANGED" |
+  sort -u | grep -E '\.ya?ml$' || true)
 
 for file in $ALL_CHANGED; do
   [[ -f "$file" ]] || continue
@@ -67,4 +67,3 @@ for file in $ALL_CHANGED; do
     fi
   fi
 done
-

--- a/templates/provider/kcm-regional/Chart.yaml
+++ b/templates/provider/kcm-regional/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.5.0
 dependencies:
   - name: cert-manager
     version: 1.19.1

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -9,7 +9,7 @@ spec:
   kcm:
     template: kcm-1-5-0
   regional:
-    template: kcm-regional-1-0-7
+    template: kcm-regional-1-5-0
   capi:
     template: cluster-api-1-0-8
   providers:

--- a/templates/provider/kcm-templates/files/templates/kcm-regional.yaml
+++ b/templates/provider/kcm-templates/files/templates/kcm-regional.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: kcm-regional-1-0-7
+  name: kcm-regional-1-5-0
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kcm-regional
-      version: 1.0.7
+      version: 1.5.0
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/Chart.lock
+++ b/templates/provider/kcm/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.21.2
 - name: kcm-regional
   repository: file://../kcm-regional
-  version: 1.0.7
-digest: sha256:eff059bc1e7cf437e15fe702d122fb20660b7b632e12a5ae50923f983d9ff39f
-generated: "2025-12-01T15:40:32.957113+04:00"
+  version: 1.5.0
+digest: sha256:4584182f1fc83f7e2bcd820d566fa8e529e8481103dbf1450264a3c3e19d9010
+generated: "2025-12-05T16:41:39.959192+01:00"

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -25,5 +25,5 @@ dependencies:
     condition: rbac-manager.enabled
   - name: kcm-regional
     alias: regional
-    version: 1.0.7
+    version: 1.5.0
     repository: "file://../kcm-regional"


### PR DESCRIPTION
**What this PR does / why we need it**:
Aligns `kcm-regional` chart version with the `kcm` chart version.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #2212 
