### PR TITLE
chore: drop `authURL` from dev openstack cluster config

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -24,7 +24,6 @@ spec:
     externalNetwork:
       filter:
         name: "public"
-    authURL: ${OS_AUTH_URL}
     identityRef:
       cloudName: "openstack"
       region: ${OS_REGION_NAME}


### PR DESCRIPTION
**What this PR does / why we need it**: This parameter is unused.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
