### PR TITLE
ci: build and push staging images for every push and tagged versions

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -54,6 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REGISTRY: ghcr.io/k0rdent/kcm/staging
           IMAGE_NAME: controller
+          TELEMETRY_IMAGE_NAME: telemetry
           VERSION: ${{ steps.version.outputs.version }}
           SKIP_SCM_RELEASE: true
         with:
@@ -66,6 +67,7 @@ jobs:
           REGISTRY_REPO: oci://ghcr.io/k0rdent/kcm/staging
           VERSION: ${{ steps.version.outputs.version }}
           IMG: ghcr.io/k0rdent/kcm/staging/controller:${{ steps.version.outputs.version }}
+          IMG_TELEMETRY: ghcr.io/k0rdent/kcm/staging/telemetry:${{ steps.version.outputs.version }}
         run: |
           make set-kcm-repo
           make kcm-chart-release


### PR DESCRIPTION
**What this PR does / why we need it**:
Builds and pushes images and charts to staging repo to enable [#2094](https://github.com/k0rdent/kcm/issues/2094) It is needed to KSI can smoothly test upgrades from released versions to non-released versions of KCM since both versions of KCM must be in the same repo to upgrade.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes [#2094](https://github.com/k0rdent/kcm/issues/2094) 