### PR TITLE
feat: add e2e tests for pausing of service set reconciliation

### DIFF
--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -896,7 +896,7 @@ func helmChartFromSpecOrRef(
 			return svc.Name
 		}(),
 		RegistryCredentialsConfig: registryCredentialsConfig,
-		Options:                   convertHelmOptions(*helmOptions),
+		Options:                   convertHelmOptions(helmOptions),
 	}
 	return helmChart, nil
 }
@@ -1011,7 +1011,7 @@ func helmChartFromFluxSource(
 		ReleaseNamespace: svc.Namespace,
 		Values:           svc.Values,
 		ValuesFrom:       convertValuesFrom(svc.ValuesFrom, namespace),
-		Options:          convertHelmOptions(*helmOptions),
+		Options:          convertHelmOptions(helmOptions),
 	}
 
 	return helmChart, nil
@@ -1141,7 +1141,10 @@ func convertValuesFrom(src []kcmv1.ValuesFrom, namespace string) []addoncontroll
 	return valueFrom
 }
 
-func convertHelmOptions(options kcmv1.ServiceHelmOptions) *addoncontrollerv1beta1.HelmOptions {
+func convertHelmOptions(options *kcmv1.ServiceHelmOptions) *addoncontrollerv1beta1.HelmOptions {
+	if options == nil {
+		return nil
+	}
 	toReturn := addoncontrollerv1beta1.HelmOptions{
 		Timeout: options.Timeout,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds pause / unpause e2e tests to the test suite
**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
#1990 