### PR TITLE
fix: multicluster service value updates not reflected in service depl…

### DIFF
--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -395,7 +395,7 @@ func ServicesToDeploy(
 				return svc.Name == s.Name && effectiveNamespace(svc.Namespace) == key.Namespace
 			})
 			if idx >= 0 {
-				services = append(services, serviceSet.Spec.Services[idx])
+				services = append(services, makeService(s, s.Version, s.Template))
 			}
 			continue
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes an issue where updating a multiclusterservice with service values doesn't get reflected in the deployed services (serviceset).
**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2252