### PR TITLE
fix: add namespace validation for services

### DIFF
--- a/internal/util/validation/services.go
+++ b/internal/util/validation/services.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,8 +38,14 @@ func ServicesHaveValidTemplates(ctx context.Context, cl client.Client, services 
 	var errs error
 	for _, svc := range services {
 		if svc.Namespace != "" {
-			for _, msg := range validation.IsDNS1123Label(svc.Namespace) {
+			for _, msg := range validation.ValidateNamespaceName(svc.Namespace, false) {
 				errs = errors.Join(errs, field.Invalid(field.NewPath("namespace"), svc.Namespace, msg))
+			}
+		}
+
+		if svc.Name != "" {
+			for _, msg := range validation.ValidateNamespaceName(svc.Name, false) {
+				errs = errors.Join(errs, field.Invalid(field.NewPath("name"), svc.Name, msg))
 			}
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Simple fix to add namespace validation on services within the webhook.
**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
#2278 