### PR TITLE
fix(tests): skip provider config overwrite when empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,10 @@ test-e2e: ## Run the e2e tests using a Kind k8s instance as the management clust
 
 .PHONY: load-e2e-config
 load-e2e-config: yq
+	@if [ -z "$(E2E_CONFIG_B64)" ]; then \
+		echo "E2E_CONFIG_B64 is empty, the default configuration from test/e2e/config/config.yaml will be used"; \
+		exit 0; \
+	fi; \
 	@config_content="$$(echo -n "$(E2E_CONFIG_B64)" | base64 -d)"; \
 	echo "Validating provided configuration..."; \
 	if ! echo "$$config_content" | $(YQ) eval > /dev/null 2>&1; then \


### PR DESCRIPTION
**What this PR does / why we need it**:
When the `E2E_CONFIG_B64` env variable is empty, the config should not overwrite the defaults from test/e2e/config/config.yaml.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
