### PR TITLE
feat: add CAPK provider template

### DIFF
--- a/templates/provider/cluster-api-provider-kubevirt/.helmignore
+++ b/templates/provider/cluster-api-provider-kubevirt/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/templates/provider/cluster-api-provider-kubevirt/Chart.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: cluster-api-provider-kubevirt
+description: A Helm chart for Cluster API provider KubeVirt
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.11.0"
+annotations:
+  cluster.x-k8s.io/provider: infrastructure-kubevirt
+  cluster.x-k8s.io/v1beta1: v1alpha1

--- a/templates/provider/cluster-api-provider-kubevirt/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-kubevirt/templates/_helpers.tpl
@@ -1,0 +1,88 @@
+{{/*
+Build proxy env vars if global.proxy is set
+*/}}
+{{- define "infrastructureProvider.proxyEnv" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $proxy := $global.proxy | default dict -}}
+{{- $localProxy := .Values.proxy | default dict -}}
+{{- if and $localProxy.enabled $proxy.secretName }}
+env:
+  - name: HTTP_PROXY
+    valueFrom:
+      secretKeyRef:
+        name: {{ $proxy.secretName }}
+        key: HTTP_PROXY
+        optional: true
+  - name: http_proxy
+    valueFrom:
+      secretKeyRef:
+        name: {{ $proxy.secretName }}
+        key: HTTP_PROXY
+        optional: true
+  - name: HTTPS_PROXY
+    valueFrom:
+      secretKeyRef:
+        name: {{ $proxy.secretName }}
+        key: HTTPS_PROXY
+        optional: true
+  - name: https_proxy
+    valueFrom:
+      secretKeyRef:
+        name: {{ $proxy.secretName }}
+        key: HTTPS_PROXY
+        optional: true
+  - name: NO_PROXY
+    valueFrom:
+      secretKeyRef:
+        name: {{ $proxy.secretName }}
+        key: NO_PROXY
+        optional: true
+  - name: no_proxy
+    valueFrom:
+      secretKeyRef:
+        name: {{ $proxy.secretName }}
+        key: NO_PROXY
+        optional: true
+{{- end }}
+{{- end }}
+
+{{/*
+Build the default deployment settings
+*/}}
+{{- define "infrastructureProvider.deployment.default" -}}
+{{- $global := .Values.global | default dict -}}
+{{- $version := .Chart.AppVersion -}}
+
+{{- $deployment := dict -}}
+{{- $container := dict "name" "manager" -}}
+
+{{- /* Image */ -}}
+{{- if $global.registry }}
+{{- $_ := set $container "imageUrl" (printf "%s/capi/capk-manager:%s" $global.registry $version) -}}
+{{- end }}
+
+{{- /* Proxy env vars */ -}}
+{{- $proxyEnv := include "infrastructureProvider.proxyEnv" . | fromYaml -}}
+{{- if $proxyEnv }}
+{{- $_ := set $container "env" $proxyEnv.env -}}
+{{- end }}
+
+{{- /* Add container only if something was configured */ -}}
+{{- if gt (len $container) 1 }}
+{{- $_ := set $deployment "containers" (list $container) -}}
+{{- end }}
+
+{{- /* Image pull secrets */ -}}
+{{- if $global.imagePullSecrets }}
+{{- $_ := set $deployment "imagePullSecrets" $global.imagePullSecrets -}}
+{{- end }}
+
+{{- toYaml $deployment -}}
+{{- end }}
+
+{{/*
+Merge default deployment settings with user-provided overrides
+*/}}
+{{- define "infrastructureProvider.deployment" -}}
+{{ toYaml (merge (.Values.deployment | default dict) (include "infrastructureProvider.deployment.default" . | fromYaml | default dict)) }}
+{{- end }}

--- a/templates/provider/cluster-api-provider-kubevirt/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/templates/interface.yaml
@@ -1,0 +1,16 @@
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ProviderInterface
+metadata:
+  name: cluster-api-provider-kubevirt
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  clusterGVKs:
+    - group: infrastructure.cluster.x-k8s.io
+      version: v1alpha1
+      kind: KubevirtCluster
+  clusterIdentities:
+    - group: ""
+      version: v1
+      kind: Secret
+  description: "KubeVirt infrastructure provider for Cluster API"

--- a/templates/provider/cluster-api-provider-kubevirt/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/templates/provider.yaml
@@ -1,0 +1,22 @@
+{{- $global := .Values.global | default dict }}
+{{- $version := .Chart.AppVersion }}
+apiVersion: operator.cluster.x-k8s.io/v1alpha2
+kind: InfrastructureProvider
+metadata:
+  name: kubevirt
+spec:
+  version: {{ $version }}
+  {{- if .Values.configSecret.name }}
+  configSecret:
+    name: {{ .Values.configSecret.name }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  {{- end }}
+  manager: {{- toYaml .Values.manager | nindent 4 }}
+  {{- if $global.registry }}
+  fetchConfig:
+    oci: {{ $global.registry }}/capi/cluster-api-provider-kubevirt-components:{{ $version }}
+  {{- end }}
+  {{- with (include "infrastructureProvider.deployment" . | fromYaml) }}
+  deployment: {{ toYaml . | nindent 4 }}
+  {{- end }}
+

--- a/templates/provider/cluster-api-provider-kubevirt/templates/rbac.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/templates/rbac.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: provider-interface-kubevirt
+  labels:
+    k0rdent.mirantis.com/aggregate-to-manager: "true"
+rules:
+  - apiGroups:
+      - infrastructure.cluster.x-k8s.io
+    resources:
+      - kubevirtclusters
+    verbs:
+      - get
+      - list
+      - patch
+      - watch

--- a/templates/provider/cluster-api-provider-kubevirt/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.configSecret.create .Values.configSecret.name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.configSecret.name }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+stringData:
+{{ toYaml .Values.config | indent 2 }}
+{{- end }}

--- a/templates/provider/cluster-api-provider-kubevirt/values.schema.json
+++ b/templates/provider/cluster-api-provider-kubevirt/values.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A KCM provider cluster-api-provider-kubevirt template",
+  "type": "object",
+  "properties": {
+    "config": {
+      "description": "Key-value configuration data stored in the configuration Secret. Only used when configSecret.create is true",
+      "type": "object"
+    },
+    "configSecret": {
+      "description": "Configuration for the Secret that provides controller configuration variables",
+      "type": "object",
+      "properties": {
+        "create": {
+          "description": "Specifies whether the configuration Secret should be created by this chart",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Name of the configuration Secret",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace of the configuration Secret",
+          "type": "string"
+        }
+      }
+    },
+    "deployment": {
+      "description": "Deployment-level overrides for the provider controller, including replicas, containers, and scheduling settings",
+      "type": "object"
+    },
+    "manager": {
+      "description": "Controller manager settings, such as feature gates, verbosity and other options",
+      "type": "object"
+    },
+    "proxy": {
+      "description": "Proxy settings of the controller",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable proxy",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/templates/provider/cluster-api-provider-kubevirt/values.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/values.yaml
@@ -1,0 +1,13 @@
+configSecret: # @schema type: object; description: Configuration for the Secret that provides controller configuration variables
+  create: false # @schema type: boolean; description: Specifies whether the configuration Secret should be created by this chart
+  name: "" # @schema type: string; description: Name of the configuration Secret
+  namespace: "" # @schema type: string; description: Namespace of the configuration Secret
+
+config: {} # @schema type: object; description: Key-value configuration data stored in the configuration Secret. Only used when configSecret.create is true
+
+manager: {} # @schema type: object; description: Controller manager settings, such as feature gates, verbosity and other options
+
+deployment: {} # @schema type: object; description: Deployment-level overrides for the provider controller, including replicas, containers, and scheduling settings
+
+proxy: # @schema type: object; description: Proxy settings of the controller; additionalProperties: false
+  enabled: true # @schema type: boolean; description: Enable proxy

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -31,5 +31,7 @@ spec:
       template: cluster-api-provider-ipam-1-0-6
     - name: cluster-api-provider-infoblox
       template: cluster-api-provider-infoblox-1-0-5
+    - name: cluster-api-provider-kubevirt
+      template: cluster-api-provider-kubevirt-1-0-0
     - name: projectsveltos
       template: projectsveltos-1-1-1

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
@@ -1,0 +1,15 @@
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ProviderTemplate
+metadata:
+  name: cluster-api-provider-kubevirt-1-0-0
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  helm:
+    chartSpec:
+      chart: cluster-api-provider-kubevirt
+      version: 1.0.0
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: kcm-templates


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new ProviderTemplate for the kubevirt provider.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2306