### PR TITLE
ci: fix push triggers hierarchy for staging artifacts

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -1,10 +1,11 @@
 name: Build staging binaries
 on:
   push:
-    tags:
-      - "v*.*.*" # only the v-prefixed tags
     branches:
       - main
+      - '*-release'
+    tags:
+      - "v*.*.*" # only the v-prefixed tags
 
 jobs:
   build-and-push:


### PR DESCRIPTION
**What this PR does / why we need it**:

The WF for building staging artifacts actually is intended to be triggered on tags also. This PR fixes hierarchy of trigger events and make WF operable on tags pushes and commits to *-release branches.

