### PR TITLE
ci: Set staging chart defaults properly

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -70,7 +70,7 @@ jobs:
           IMG_TELEMETRY: ghcr.io/k0rdent/kcm/staging/telemetry:${{ steps.version.outputs.version }}
         run: |
           make set-kcm-repo
-          make set-telemetry-repo
+          make set-regional-telemetry-repo
           make set-templates-repo
           make kcm-chart-release
           make helm-push

--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,9 @@ set-kcm-version: yq
 set-kcm-repo: yq
 	$(YQ) eval '.image.repository = "$(IMG_REPO)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm/values.yaml
 
-.PHONY: set-telemetry-repo
-set-telemetry-repo: yq
-	$(YQ) eval '.regional.telemetry.controller.image.repository = "$(IMG_TELEMETRY_REPO)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm/values.yaml
+.PHONY: set-regional-telemetry-repo
+set-regional-telemetry-repo: yq
+	$(YQ) eval '.telemetry.controller.image.repository = "$(IMG_TELEMETRY_REPO)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm-regional/values.yaml
 
 .PHONY: set-templates-repo
 set-templates-repo: yq


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces configuration abilities for telemetry image repo and templates repo using Makefile to make corresponding charts (in that case - staging one) use valid defaults.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
related k0rdent/kcm#2094
