### PR TITLE
fix: remove self-management cluster selector labels

### DIFF
--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -526,14 +526,6 @@ func (r *ServiceSetReconciler) profileSpec(ctx context.Context, rgnClient client
 		err                         error
 	)
 	if serviceSet.Spec.Provider.SelfManagement {
-		clusterSelector = libsveltosv1beta1.Selector{
-			LabelSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					kcmv1.K0rdentManagementClusterLabelKey: kcmv1.K0rdentManagementClusterLabelValue,
-					"sveltos-agent":                        "present",
-				},
-			},
-		}
 		clusterRef = corev1.ObjectReference{
 			Kind:       libsveltosv1beta1.SveltosClusterKind,
 			Namespace:  managementSveltosCluster,

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -194,10 +194,10 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 
 			mcs := multiclusterservice.BuildMultiClusterService(sd, multiClusterServiceTemplate, multiClusterServiceMatchLabel, multiClusterServiceName)
 			multiclusterservice.CreateMultiClusterService(ctx, kc.CrClient, mcs)
-			multiclusterservice.ValidateMultiClusterService(kc, multiClusterServiceName, 1)
+			multiclusterservice.ValidateMultiClusterService(ctx, kc, multiClusterServiceName, 1)
 
 			updateClusterDeploymentLabel(ctx, kc.CrClient, sd, multiClusterServiceMatchLabel, "not-matched")
-			multiclusterservice.ValidateMultiClusterService(kc, multiClusterServiceName, 0)
+			multiclusterservice.ValidateMultiClusterService(ctx, kc, multiClusterServiceName, 0)
 
 			multiclusterservice.DeleteMultiClusterService(ctx, kc.CrClient, mcs)
 			Expect(clusterDeleteFunc()).Error().NotTo(HaveOccurred(), "failed to delete cluster")

--- a/test/e2e/mothership_test.go
+++ b/test/e2e/mothership_test.go
@@ -130,7 +130,7 @@ var _ = Context("Mothership Cluster", Label("mothership"), func() {
 			// This is skipped because sometimes the following validation fails.
 			// It seems to happen intermittently which suggests there is some
 			// fine tuning to be done in the reconcile loop.
-			mcse2e.ValidateMultiClusterService(kc, mcs.GetName(), 1)
+			mcse2e.ValidateMultiClusterService(ctx, kc, mcs.GetName(), 1)
 		})
 
 		It("deploy MCS with a service", func() {
@@ -149,7 +149,7 @@ var _ = Context("Mothership Cluster", Label("mothership"), func() {
 			)
 			fn := mcse2e.CreateMultiClusterServiceWithDelete(ctx, kc.CrClient, mcs)
 			afterEachDeleteFuncs = append(afterEachDeleteFuncs, fn)
-			mcse2e.ValidateMultiClusterService(kc, mcs.GetName(), 1)
+			mcse2e.ValidateMultiClusterService(ctx, kc, mcs.GetName(), 1)
 			mcse2e.ValidateServiceSet(ctx, kc.CrClient, kubeutil.CurrentNamespace(), nil, mcs)
 		})
 
@@ -189,11 +189,11 @@ var _ = Context("Mothership Cluster", Label("mothership"), func() {
 				},
 			)
 			_ = mcse2e.CreateMultiClusterServiceWithDelete(ctx, kc.CrClient, mcs1)
-			mcse2e.ValidateMultiClusterService(kc, mcs1.GetName(), 1)
+			mcse2e.ValidateMultiClusterService(ctx, kc, mcs1.GetName(), 1)
 			mcse2e.ValidateServiceSet(ctx, kc.CrClient, kubeutil.CurrentNamespace(), nil, mcs1)
 
 			// Validate mcs2 now that all services of mcs1 have been deployed.
-			mcse2e.ValidateMultiClusterService(kc, mcs2.GetName(), 1)
+			mcse2e.ValidateMultiClusterService(ctx, kc, mcs2.GetName(), 1)
 			mcse2e.ValidateServiceSet(ctx, kc.CrClient, kubeutil.CurrentNamespace(), nil, mcs2)
 
 			// Delete mcs1.
@@ -254,7 +254,7 @@ var _ = Context("Mothership Cluster", Label("mothership"), func() {
 				},
 			)
 			_ = mcse2e.CreateMultiClusterServiceWithDelete(ctx, kc.CrClient, mcs1)
-			mcse2e.ValidateMultiClusterService(kc, mcs1.GetName(), 1)
+			mcse2e.ValidateMultiClusterService(ctx, kc, mcs1.GetName(), 1)
 			mcse2e.ValidateServiceSet(ctx, kc.CrClient, kubeutil.CurrentNamespace(), nil, mcs1)
 
 			mcs2 := buildSelfManagementMCS("mcs2", nil,
@@ -269,11 +269,11 @@ var _ = Context("Mothership Cluster", Label("mothership"), func() {
 				},
 			)
 			_ = mcse2e.CreateMultiClusterServiceWithDelete(ctx, kc.CrClient, mcs2)
-			mcse2e.ValidateMultiClusterService(kc, mcs2.GetName(), 1)
+			mcse2e.ValidateMultiClusterService(ctx, kc, mcs2.GetName(), 1)
 			mcse2e.ValidateServiceSet(ctx, kc.CrClient, kubeutil.CurrentNamespace(), nil, mcs2)
 
 			// Validate mcs3 now that all services of mcs1 & mcs2 have been deployed.
-			mcse2e.ValidateMultiClusterService(kc, mcs3.GetName(), 1)
+			mcse2e.ValidateMultiClusterService(ctx, kc, mcs3.GetName(), 1)
 			mcse2e.ValidateServiceSet(ctx, kc.CrClient, kubeutil.CurrentNamespace(), nil, mcs3)
 
 			// Delete mcs1.
@@ -374,15 +374,15 @@ var _ = Context("Mothership Cluster", Label("mothership"), func() {
 				},
 			)
 			_ = mcse2e.CreateMultiClusterServiceWithDelete(ctx, kc.CrClient, mcs3)
-			mcse2e.ValidateMultiClusterService(kc, mcs3.GetName(), 1)
+			mcse2e.ValidateMultiClusterService(ctx, kc, mcs3.GetName(), 1)
 			mcse2e.ValidateServiceSet(ctx, kc.CrClient, kubeutil.CurrentNamespace(), nil, mcs3)
 
 			// Validate mcs1 now that all services of mcs3 have been deployed.
-			mcse2e.ValidateMultiClusterService(kc, mcs1.GetName(), 1)
+			mcse2e.ValidateMultiClusterService(ctx, kc, mcs1.GetName(), 1)
 			mcse2e.ValidateServiceSet(ctx, kc.CrClient, kubeutil.CurrentNamespace(), nil, mcs1)
 
 			// Validate mcs2 now that all services of mcs3 have been deployed.
-			mcse2e.ValidateMultiClusterService(kc, mcs2.GetName(), 1)
+			mcse2e.ValidateMultiClusterService(ctx, kc, mcs2.GetName(), 1)
 			mcse2e.ValidateServiceSet(ctx, kc.CrClient, kubeutil.CurrentNamespace(), nil, mcs2)
 
 			// Delete mcs3.
@@ -413,7 +413,6 @@ var _ = Context("Mothership Cluster", Label("mothership"), func() {
 func buildSelfManagementMCS(name string, dependsOn []string, serviceSpec kcmv1.ServiceSpec) *kcmv1.MultiClusterService {
 	mcs := buildMCS(name, map[string]string{
 		kcmv1.K0rdentManagementClusterLabelKey: kcmv1.K0rdentManagementClusterLabelValue,
-		"sveltos-agent":                        "present",
 	}, dependsOn, serviceSpec)
 	mcs.Spec.ServiceSpec.Provider.SelfManagement = true
 	return mcs

--- a/test/e2e/provider_aws_test.go
+++ b/test/e2e/provider_aws_test.go
@@ -230,9 +230,9 @@ var _ = Describe("AWS Templates", Label("provider:cloud", "provider:aws"), Order
 
 			mcs := multiclusterservice.BuildMultiClusterService(sd, multiClusterServiceTemplate, multiClusterServiceMatchLabel, multiClusterServiceName)
 			multiclusterservice.CreateMultiClusterService(context.Background(), kc.CrClient, mcs)
-			multiclusterservice.ValidateMultiClusterService(kc, multiClusterServiceName, 1)
+			multiclusterservice.ValidateMultiClusterService(context.Background(), kc, multiClusterServiceName, 1)
 			updateClusterDeploymentLabel(context.Background(), kc.CrClient, sd, multiClusterServiceMatchLabel, "not-matched")
-			multiclusterservice.ValidateMultiClusterService(kc, multiClusterServiceName, 0)
+			multiclusterservice.ValidateMultiClusterService(context.Background(), kc, multiClusterServiceName, 0)
 
 			if !testingConfig.Upgrade && testingConfig.Hosted == nil {
 				return


### PR DESCRIPTION
# Description

We now reference the management cluster directly via ClusterRef in the default Sveltos adapter for KSM when `.spec.serviceSpec.Provider.SelfManagement=true`. Therefore we do not need to to match to any labels when self-managing the management cluster.

# Sanity Testing

- Created the following MCS with self-management enabled:

```sh
apiVersion: k0rdent.mirantis.com/v1beta1
kind: MultiClusterService
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"k0rdent.mirantis.com/v1beta1","kind":"MultiClusterService","metadata":{"annotations":{},"name":"mcs1"},"spec":{"serviceSpec":{"provider":{"config":{"continueOnError":true,"priority":1000,"stopOnConflict":false},"name":"ksm-projectsveltos","selfManagement":true},"services":[{"name":"ingress-nginx","namespace":"ingress-nginx","template":"ingress-nginx-4-13-0"}]}}}
  creationTimestamp: "2026-01-05T04:57:11Z"
  finalizers:
  - k0rdent.mirantis.com/multicluster-service
  generation: 2
  labels:
    k0rdent.mirantis.com/component: kcm
  name: mcs1
  resourceVersion: "10896"
  uid: 6b515fa7-c9fc-451d-9b4a-f956e4c1bace
spec:
  clusterSelector: {}
  serviceSpec:
    continueOnError: false
    priority: 100
    provider:
      config:
        continueOnError: true
        priority: 1000
        stopOnConflict: false
      name: ksm-projectsveltos
      selfManagement: true
    services:
    - name: ingress-nginx
      namespace: ingress-nginx
      template: ingress-nginx-4-13-0
    stopOnConflict: false
    syncMode: Continuous
status:
  conditions:
  - lastTransitionTime: "2026-01-05T04:57:21Z"
    message: ""
    observedGeneration: 2
    reason: Succeeded
    status: "True"
    type: ServicesReferencesValidation
  - lastTransitionTime: "2026-01-05T04:57:21Z"
    message: ""
    observedGeneration: 2
    reason: Succeeded
    status: "True"
    type: ServicesDependencyValidation
  - lastTransitionTime: "2026-01-05T04:57:21Z"
    message: ""
    observedGeneration: 2
    reason: Succeeded
    status: "True"
    type: MultiClusterServiceDependencyValidation
  - lastTransitionTime: "2026-01-05T04:57:30Z"
    message: 1/1
    reason: Succeeded
    status: "True"
    type: ClusterInReadyState
  - lastTransitionTime: "2026-01-05T04:57:30Z"
    message: Object is ready
    reason: Succeeded
    status: "True"
    type: Ready
  matchingClusters:
  - apiVersion: lib.projectsveltos.io/v1beta1
    deployed: true
    kind: SveltosCluster
    lastTransitionTime: "2026-01-05T04:57:30Z"
    name: mgmt
    namespace: mgmt
    regional: false
  observedGeneration: 2
  servicesUpgradePaths:
  - availableUpgrades:
    - versions:
      - name: ingress-nginx-4-13-0
        version: ingress-nginx-4-13-0
    name: ingress-nginx
    namespace: ingress-nginx
    template: ingress-nginx-4-13-0
```

Verified that nginx was successfully deployed on the mothership cluster:
```sh
➜  ~ kubectl -n ingress-nginx get pod
NAME                                        READY   STATUS    RESTARTS   AGE
ingress-nginx-controller-78d57d8578-ln9p6   1/1     Running   0          87s
```

- Also tested mcs2<-mcs1 (mcs2 dependsOn mcs1). Created mcs2 which failed validation with `message: 'failed MCS dependency validation: dependency /mcs1 of /mcs2 is not defined'` because mcs1 didn't exist yet. Once mcs1 was created, services of both mcs1 and mcs2 were eventually deployed on the mothership.