### PR TITLE
fix: only set the service to failed if it's not in deployed state

### DIFF
--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -1520,7 +1520,7 @@ func servicesStateFromSummary(
 			if deployed {
 				newState.State = kcmv1.ServiceStateDeployed
 			}
-			if helmChartsFailureMessage != "" {
+			if !deployed && helmChartsFailureMessage != "" {
 				newState.State = kcmv1.ServiceStateFailed
 				newState.FailureMessage = helmChartsFailureMessage
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where a service's status will be set to failed if a single service fails to deploy with a conflict error. 
**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2224 