### PR TITLE
fix: mark CRDs with helm-keep annotation where possible

### DIFF
--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/templates/orc.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/orc.yaml
@@ -13,6 +13,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
+    helm.sh/resource-policy: keep
   name: flavors.openstack.k-orc.cloud
 spec:
   group: openstack.k-orc.cloud
@@ -386,6 +387,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
+    helm.sh/resource-policy: keep
   name: images.openstack.k-orc.cloud
 spec:
   group: openstack.k-orc.cloud
@@ -1113,6 +1115,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
+    helm.sh/resource-policy: keep
   name: networks.openstack.k-orc.cloud
 spec:
   group: openstack.k-orc.cloud
@@ -1640,6 +1643,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
+    helm.sh/resource-policy: keep
   name: ports.openstack.k-orc.cloud
 spec:
   group: openstack.k-orc.cloud
@@ -2228,6 +2232,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
+    helm.sh/resource-policy: keep
   name: projects.openstack.k-orc.cloud
 spec:
   group: openstack.k-orc.cloud
@@ -2581,6 +2586,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
+    helm.sh/resource-policy: keep
   name: routerinterfaces.openstack.k-orc.cloud
 spec:
   group: openstack.k-orc.cloud
@@ -2750,6 +2756,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
+    helm.sh/resource-policy: keep
   name: routers.openstack.k-orc.cloud
 spec:
   group: openstack.k-orc.cloud
@@ -3191,6 +3198,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
+    helm.sh/resource-policy: keep
   name: securitygroups.openstack.k-orc.cloud
 spec:
   group: openstack.k-orc.cloud
@@ -3778,6 +3786,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
+    helm.sh/resource-policy: keep
   name: servers.openstack.k-orc.cloud
 spec:
   group: openstack.k-orc.cloud
@@ -4179,6 +4188,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.1
+    helm.sh/resource-policy: keep
   name: subnets.openstack.k-orc.cloud
 spec:
   group: openstack.k-orc.cloud

--- a/templates/provider/kcm-regional/templates/crds/k0rdent.mirantis.com_providerinterfaces.yaml
+++ b/templates/provider/kcm-regional/templates/crds/k0rdent.mirantis.com_providerinterfaces.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: providerinterfaces.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,131 +13,128 @@ spec:
     listKind: ProviderInterfaceList
     plural: providerinterfaces
     shortNames:
-    - pi
+      - pi
     singular: providerinterface
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.description
-      name: Description
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ProviderInterface is the Schema for the ProviderInterface API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ProviderInterfaceSpec defines the desired state of ProviderInterface
-            properties:
-              clusterGVKs:
-                description: ClusterGVKs defines the Group-Version-Kind resources
-                  this provider can manage
-                items:
-                  description: |-
-                    GroupVersionKind unambiguously identifies a kind. It doesn't anonymously include GroupVersion
-                    to avoid automatic coercion. It doesn't use a GroupVersion to avoid custom marshalling
-                    Note: mirror of https://github.com/kubernetes/apimachinery/blob/v0.32.3/pkg/runtime/schema/group_version.go#L140-L146
-                  properties:
-                    group:
-                      type: string
-                    kind:
-                      type: string
-                    version:
-                      type: string
-                  required:
-                  - group
-                  - kind
-                  - version
-                  type: object
-                type: array
-              clusterIdentities:
-                description: ClusterIdentities defines the cluster identity objects
-                  supported by this provider
-                items:
-                  description: |-
-                    ClusterIdentity defines a Cluster API provider's ClusterIdentity object with its references.
-                    It represents a unique identity used by infrastructure providers to access and manage resources
-                  properties:
-                    group:
-                      type: string
-                    kind:
-                      type: string
-                    references:
-                      description: |-
-                        References lists the objects associated with this identity. These may include transitive dependencies
-                        such as referenced Secrets required by the identity
-                      items:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.description
+          name: Description
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ProviderInterface is the Schema for the ProviderInterface API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ProviderInterfaceSpec defines the desired state of ProviderInterface
+              properties:
+                clusterGVKs:
+                  description: ClusterGVKs defines the Group-Version-Kind resources this provider can manage
+                  items:
+                    description: |-
+                      GroupVersionKind unambiguously identifies a kind. It doesn't anonymously include GroupVersion
+                      to avoid automatic coercion. It doesn't use a GroupVersion to avoid custom marshalling
+                      Note: mirror of https://github.com/kubernetes/apimachinery/blob/v0.32.3/pkg/runtime/schema/group_version.go#L140-L146
+                    properties:
+                      group:
+                        type: string
+                      kind:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - group
+                      - kind
+                      - version
+                    type: object
+                  type: array
+                clusterIdentities:
+                  description: ClusterIdentities defines the cluster identity objects supported by this provider
+                  items:
+                    description: |-
+                      ClusterIdentity defines a Cluster API provider's ClusterIdentity object with its references.
+                      It represents a unique identity used by infrastructure providers to access and manage resources
+                    properties:
+                      group:
+                        type: string
+                      kind:
+                        type: string
+                      references:
                         description: |-
-                          ClusterIdentityReference defines how to locate and resolve a referenced object
-                          associated with a ClusterIdentity
-                        properties:
-                          group:
-                            type: string
-                          kind:
-                            type: string
-                          nameFieldPath:
-                            description: |-
-                              NameFieldPath specifies the field path in the ClusterIdentity object where the name of
-                              the referenced object can be found. Cannot start with a dot ('.')
-                            example: spec.clientSecret.name
-                            pattern: ^[^.].*$
-                            type: string
-                          namespaceFieldPath:
-                            description: |-
-                              NamespaceFieldPath specifies the field path in the ClusterIdentity object where the namespace of
-                              the referenced object can be found. Cannot start with a dot ('.'). Defaults to the system namespace
-                            example: spec.clientSecret.namespace
-                            pattern: ^[^.].*$
-                            type: string
-                          version:
-                            type: string
-                        required:
-                        - group
-                        - kind
-                        - nameFieldPath
-                        - version
-                        type: object
-                      type: array
-                    version:
-                      type: string
-                  required:
-                  - group
-                  - kind
-                  - version
-                  type: object
-                type: array
-              clusterIdentityKinds:
-                description: |-
-                  ClusterIdentityKinds defines the Kind of identity objects supported by this provider
+                          References lists the objects associated with this identity. These may include transitive dependencies
+                          such as referenced Secrets required by the identity
+                        items:
+                          description: |-
+                            ClusterIdentityReference defines how to locate and resolve a referenced object
+                            associated with a ClusterIdentity
+                          properties:
+                            group:
+                              type: string
+                            kind:
+                              type: string
+                            nameFieldPath:
+                              description: |-
+                                NameFieldPath specifies the field path in the ClusterIdentity object where the name of
+                                the referenced object can be found. Cannot start with a dot ('.')
+                              example: spec.clientSecret.name
+                              pattern: ^[^.].*$
+                              type: string
+                            namespaceFieldPath:
+                              description: |-
+                                NamespaceFieldPath specifies the field path in the ClusterIdentity object where the namespace of
+                                the referenced object can be found. Cannot start with a dot ('.'). Defaults to the system namespace
+                              example: spec.clientSecret.namespace
+                              pattern: ^[^.].*$
+                              type: string
+                            version:
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - nameFieldPath
+                            - version
+                          type: object
+                        type: array
+                      version:
+                        type: string
+                    required:
+                      - group
+                      - kind
+                      - version
+                    type: object
+                  type: array
+                clusterIdentityKinds:
+                  description: |-
+                    ClusterIdentityKinds defines the Kind of identity objects supported by this provider
 
-                  Deprecated: Use ClusterIdentities instead
-                items:
+                    Deprecated: Use ClusterIdentities instead
+                  items:
+                    type: string
+                  type: array
+                description:
+                  description: Description provides a human-readable explanation of what this provider does
                   type: string
-                type: array
-              description:
-                description: Description provides a human-readable explanation of
-                  what this provider does
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm-regional/values.schema.json
+++ b/templates/provider/kcm-regional/values.schema.json
@@ -11,9 +11,6 @@
           "properties": {
             "enabled": {
               "type": "boolean"
-            },
-            "keep": {
-              "type": "boolean"
             }
           }
         },

--- a/templates/provider/kcm-regional/values.yaml
+++ b/templates/provider/kcm-regional/values.yaml
@@ -65,7 +65,6 @@ cert-manager:
   enabled: true
   crds:
     enabled: true
-    keep: false
 
 cluster-api-operator:
   enabled: false

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -22,7 +22,7 @@ spec:
     - name: cluster-api-provider-aws
       template: cluster-api-provider-aws-1-0-11
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-1-0-13
+      template: cluster-api-provider-openstack-1-0-14
     - name: cluster-api-provider-docker
       template: cluster-api-provider-docker-1-0-8
     - name: cluster-api-provider-gcp

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-1-0-13
+  name: cluster-api-provider-openstack-1-0-14
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 1.0.13
+      version: 1.0.14
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_accessmanagements.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_accessmanagements.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: accessmanagements.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,282 +13,273 @@ spec:
     listKind: AccessManagementList
     plural: accessmanagements
     shortNames:
-    - am
+      - am
     singular: accessmanagement
   scope: Cluster
   versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: AccessManagement is the Schema for the AccessManagements API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AccessManagementSpec defines the desired state of AccessManagement
-            properties:
-              accessRules:
-                description: |-
-                  AccessRules is the list of access rules. Each AccessRule enforces
-                  objects distribution to the TargetNamespaces.
-                items:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: AccessManagement is the Schema for the AccessManagements API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AccessManagementSpec defines the desired state of AccessManagement
+              properties:
+                accessRules:
                   description: |-
-                    AccessRule is the definition of the AccessManagement access rule. Each AccessRule enforces
-                    Templates and Credentials distribution to the TargetNamespaces
-                  properties:
-                    clusterAuthentications:
-                      description: |-
-                        ClusterAuthentications is the list of [ClusterAuthentication] names that will be distributed to all the
-                        namespaces specified in TargetNamespaces.
-                      items:
-                        type: string
-                      type: array
-                    clusterTemplateChains:
-                      description: |-
-                        ClusterTemplateChains is the list of [ClusterTemplateChain] names whose ClusterTemplates
-                        will be distributed to all namespaces specified in TargetNamespaces.
-                      items:
-                        type: string
-                      type: array
-                    credentials:
-                      description: |-
-                        Credentials is the list of [Credential] names that will be distributed to all the
-                        namespaces specified in TargetNamespaces.
-                      items:
-                        type: string
-                      type: array
-                    dataSources:
-                      description: |-
-                        DataSources is the list of [DataSource] names that will be distributed to all the
-                        namespaces specified in TargetNamespaces.
-                      items:
-                        type: string
-                      type: array
-                    serviceTemplateChains:
-                      description: |-
-                        ServiceTemplateChains is the list of [ServiceTemplateChain] names whose ServiceTemplates
-                        will be distributed to all namespaces specified in TargetNamespaces.
-                      items:
-                        type: string
-                      type: array
-                    targetNamespaces:
-                      description: |-
-                        TargetNamespaces defines the namespaces where selected objects will be distributed.
-                        Templates and Credentials will be distributed to all namespaces if unset.
-                      properties:
-                        list:
-                          description: |-
-                            List is the list of namespaces to select.
-                            Mutually exclusive with StringSelector and Selector.
-                          items:
-                            type: string
-                          type: array
-                        selector:
-                          description: |-
-                            Selector is a structured label query to select namespaces.
-                            Mutually exclusive with StringSelector and List.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        stringSelector:
-                          description: |-
-                            StringSelector is a label query to select namespaces.
-                            Mutually exclusive with Selector and List.
+                    AccessRules is the list of access rules. Each AccessRule enforces
+                    objects distribution to the TargetNamespaces.
+                  items:
+                    description: |-
+                      AccessRule is the definition of the AccessManagement access rule. Each AccessRule enforces
+                      Templates and Credentials distribution to the TargetNamespaces
+                    properties:
+                      clusterAuthentications:
+                        description: |-
+                          ClusterAuthentications is the list of [ClusterAuthentication] names that will be distributed to all the
+                          namespaces specified in TargetNamespaces.
+                        items:
                           type: string
-                      type: object
-                      x-kubernetes-validations:
-                      - message: only one of spec.targetNamespaces.selector or spec.targetNamespaces.stringSelector
-                          or spec.targetNamespaces.list can be specified
-                        rule: '((has(self.stringSelector) ? 1 : 0) + (has(self.selector)
-                          ? 1 : 0) + (has(self.list) ? 1 : 0)) <= 1'
-                  type: object
-                type: array
-            type: object
-          status:
-            description: AccessManagementStatus defines the observed state of AccessManagement
-            properties:
-              current:
-                description: Current reflects the applied access rules configuration.
-                items:
-                  description: |-
-                    AccessRule is the definition of the AccessManagement access rule. Each AccessRule enforces
-                    Templates and Credentials distribution to the TargetNamespaces
-                  properties:
-                    clusterAuthentications:
-                      description: |-
-                        ClusterAuthentications is the list of [ClusterAuthentication] names that will be distributed to all the
-                        namespaces specified in TargetNamespaces.
-                      items:
-                        type: string
-                      type: array
-                    clusterTemplateChains:
-                      description: |-
-                        ClusterTemplateChains is the list of [ClusterTemplateChain] names whose ClusterTemplates
-                        will be distributed to all namespaces specified in TargetNamespaces.
-                      items:
-                        type: string
-                      type: array
-                    credentials:
-                      description: |-
-                        Credentials is the list of [Credential] names that will be distributed to all the
-                        namespaces specified in TargetNamespaces.
-                      items:
-                        type: string
-                      type: array
-                    dataSources:
-                      description: |-
-                        DataSources is the list of [DataSource] names that will be distributed to all the
-                        namespaces specified in TargetNamespaces.
-                      items:
-                        type: string
-                      type: array
-                    serviceTemplateChains:
-                      description: |-
-                        ServiceTemplateChains is the list of [ServiceTemplateChain] names whose ServiceTemplates
-                        will be distributed to all namespaces specified in TargetNamespaces.
-                      items:
-                        type: string
-                      type: array
-                    targetNamespaces:
-                      description: |-
-                        TargetNamespaces defines the namespaces where selected objects will be distributed.
-                        Templates and Credentials will be distributed to all namespaces if unset.
-                      properties:
-                        list:
-                          description: |-
-                            List is the list of namespaces to select.
-                            Mutually exclusive with StringSelector and Selector.
-                          items:
-                            type: string
-                          type: array
-                        selector:
-                          description: |-
-                            Selector is a structured label query to select namespaces.
-                            Mutually exclusive with StringSelector and List.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: |-
-                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: |-
-                                      operator represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: |-
-                                      values is an array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. This array is replaced during a strategic
-                                      merge patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                    x-kubernetes-list-type: atomic
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: |-
-                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                operator is "In", and the values array contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        stringSelector:
-                          description: |-
-                            StringSelector is a label query to select namespaces.
-                            Mutually exclusive with Selector and List.
+                        type: array
+                      clusterTemplateChains:
+                        description: |-
+                          ClusterTemplateChains is the list of [ClusterTemplateChain] names whose ClusterTemplates
+                          will be distributed to all namespaces specified in TargetNamespaces.
+                        items:
                           type: string
-                      type: object
-                      x-kubernetes-validations:
-                      - message: only one of spec.targetNamespaces.selector or spec.targetNamespaces.stringSelector
-                          or spec.targetNamespaces.list can be specified
-                        rule: '((has(self.stringSelector) ? 1 : 0) + (has(self.selector)
-                          ? 1 : 0) + (has(self.list) ? 1 : 0)) <= 1'
-                  type: object
-                type: array
-              error:
-                description: Error is the error message occurred during the reconciliation
-                  (if any)
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                        type: array
+                      credentials:
+                        description: |-
+                          Credentials is the list of [Credential] names that will be distributed to all the
+                          namespaces specified in TargetNamespaces.
+                        items:
+                          type: string
+                        type: array
+                      dataSources:
+                        description: |-
+                          DataSources is the list of [DataSource] names that will be distributed to all the
+                          namespaces specified in TargetNamespaces.
+                        items:
+                          type: string
+                        type: array
+                      serviceTemplateChains:
+                        description: |-
+                          ServiceTemplateChains is the list of [ServiceTemplateChain] names whose ServiceTemplates
+                          will be distributed to all namespaces specified in TargetNamespaces.
+                        items:
+                          type: string
+                        type: array
+                      targetNamespaces:
+                        description: |-
+                          TargetNamespaces defines the namespaces where selected objects will be distributed.
+                          Templates and Credentials will be distributed to all namespaces if unset.
+                        properties:
+                          list:
+                            description: |-
+                              List is the list of namespaces to select.
+                              Mutually exclusive with StringSelector and Selector.
+                            items:
+                              type: string
+                            type: array
+                          selector:
+                            description: |-
+                              Selector is a structured label query to select namespaces.
+                              Mutually exclusive with StringSelector and List.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          stringSelector:
+                            description: |-
+                              StringSelector is a label query to select namespaces.
+                              Mutually exclusive with Selector and List.
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: only one of spec.targetNamespaces.selector or spec.targetNamespaces.stringSelector or spec.targetNamespaces.list can be specified
+                            rule: '((has(self.stringSelector) ? 1 : 0) + (has(self.selector) ? 1 : 0) + (has(self.list) ? 1 : 0)) <= 1'
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: AccessManagementStatus defines the observed state of AccessManagement
+              properties:
+                current:
+                  description: Current reflects the applied access rules configuration.
+                  items:
+                    description: |-
+                      AccessRule is the definition of the AccessManagement access rule. Each AccessRule enforces
+                      Templates and Credentials distribution to the TargetNamespaces
+                    properties:
+                      clusterAuthentications:
+                        description: |-
+                          ClusterAuthentications is the list of [ClusterAuthentication] names that will be distributed to all the
+                          namespaces specified in TargetNamespaces.
+                        items:
+                          type: string
+                        type: array
+                      clusterTemplateChains:
+                        description: |-
+                          ClusterTemplateChains is the list of [ClusterTemplateChain] names whose ClusterTemplates
+                          will be distributed to all namespaces specified in TargetNamespaces.
+                        items:
+                          type: string
+                        type: array
+                      credentials:
+                        description: |-
+                          Credentials is the list of [Credential] names that will be distributed to all the
+                          namespaces specified in TargetNamespaces.
+                        items:
+                          type: string
+                        type: array
+                      dataSources:
+                        description: |-
+                          DataSources is the list of [DataSource] names that will be distributed to all the
+                          namespaces specified in TargetNamespaces.
+                        items:
+                          type: string
+                        type: array
+                      serviceTemplateChains:
+                        description: |-
+                          ServiceTemplateChains is the list of [ServiceTemplateChain] names whose ServiceTemplates
+                          will be distributed to all namespaces specified in TargetNamespaces.
+                        items:
+                          type: string
+                        type: array
+                      targetNamespaces:
+                        description: |-
+                          TargetNamespaces defines the namespaces where selected objects will be distributed.
+                          Templates and Credentials will be distributed to all namespaces if unset.
+                        properties:
+                          list:
+                            description: |-
+                              List is the list of namespaces to select.
+                              Mutually exclusive with StringSelector and Selector.
+                            items:
+                              type: string
+                            type: array
+                          selector:
+                            description: |-
+                              Selector is a structured label query to select namespaces.
+                              Mutually exclusive with StringSelector and List.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          stringSelector:
+                            description: |-
+                              StringSelector is a label query to select namespaces.
+                              Mutually exclusive with Selector and List.
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: only one of spec.targetNamespaces.selector or spec.targetNamespaces.stringSelector or spec.targetNamespaces.list can be specified
+                            rule: '((has(self.stringSelector) ? 1 : 0) + (has(self.selector) ? 1 : 0) + (has(self.list) ? 1 : 0)) <= 1'
+                    type: object
+                  type: array
+                error:
+                  description: Error is the error message occurred during the reconciliation (if any)
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterauthentications.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterauthentications.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: clusterauthentications.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,140 +13,150 @@ spec:
     listKind: ClusterAuthenticationList
     plural: clusterauthentications
     shortNames:
-    - clauth
+      - clauth
     singular: clusterauthentication
   scope: Namespaced
   versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ClusterAuthentication is the Schema for the cluster authentication
-          configuration API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ClusterAuthenticationSpec defines the desired state of ClusterAuthentication
-            properties:
-              authenticationConfiguration:
-                description: |-
-                  AuthenticationConfiguration contains the full content of an [AuthenticationConfiguration] object,
-                  which defines how the API server should perform request authentication.
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ClusterAuthentication is the Schema for the cluster authentication configuration API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterAuthenticationSpec defines the desired state of ClusterAuthentication
+              properties:
+                authenticationConfiguration:
+                  description: |-
+                    AuthenticationConfiguration contains the full content of an [AuthenticationConfiguration] object,
+                    which defines how the API server should perform request authentication.
 
-                  For more details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration
-                properties:
-                  anonymous:
-                    description: If present --anonymous-auth must not be set
-                    properties:
-                      conditions:
-                        description: |-
-                          If set, anonymous auth is only allowed if the request meets one of the
-                          conditions.
-                        items:
-                          description: |-
-                            AnonymousAuthCondition describes the condition under which anonymous auth
-                            should be enabled.
-                          properties:
-                            path:
-                              description: Path for which anonymous auth is enabled.
-                              type: string
-                          required:
-                          - path
-                          type: object
-                        type: array
-                      enabled:
-                        type: boolean
-                    required:
-                    - enabled
-                    type: object
-                  apiVersion:
-                    description: |-
-                      APIVersion defines the versioned schema of this representation of an object.
-                      Servers should convert recognized schemas to the latest internal value, and
-                      may reject unrecognized values.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-                    type: string
-                  jwt:
-                    description: "jwt is a list of authenticator to authenticate Kubernetes
-                      users using\nJWT compliant tokens. The authenticator will attempt
-                      to parse a raw ID token,\nverify it's been signed by the configured
-                      issuer. The public key to verify the\nsignature is discovered
-                      from the issuer's public endpoint using OIDC discovery.\nFor
-                      an incoming token, each JWT authenticator will be attempted
-                      in\nthe order in which it is specified in this list.  Note however
-                      that\nother authenticators may run before or after the JWT authenticators.\nThe
-                      specific position of JWT authenticators in relation to other\nauthenticators
-                      is neither defined nor stable across releases.  Since\neach
-                      JWT authenticator must have a unique issuer URL, at most one\nJWT
-                      authenticator will attempt to cryptographically validate the
-                      token.\n\nThe minimum valid JWT payload must contain the following
-                      claims:\n{\n\t\t\"iss\": \"https://issuer.example.com\",\n\t\t\"aud\":
-                      [\"audience\"],\n\t\t\"exp\": 1234567890,\n\t\t\"<username claim>\":
-                      \"username\"\n}"
-                    items:
-                      description: JWTAuthenticator provides the configuration for
-                        a single JWT authenticator.
+                    For more details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-authentication-configuration
+                  properties:
+                    anonymous:
+                      description: If present --anonymous-auth must not be set
                       properties:
-                        claimMappings:
-                          description: claimMappings points claims of a token to be
-                            treated as user attributes.
-                          properties:
-                            extra:
-                              description: |-
-                                extra represents an option for the extra attribute.
-                                expression must produce a string or string array value.
-                                If the value is empty, the extra mapping will not be present.
+                        conditions:
+                          description: |-
+                            If set, anonymous auth is only allowed if the request meets one of the
+                            conditions.
+                          items:
+                            description: |-
+                              AnonymousAuthCondition describes the condition under which anonymous auth
+                              should be enabled.
+                            properties:
+                              path:
+                                description: Path for which anonymous auth is enabled.
+                                type: string
+                            required:
+                              - path
+                            type: object
+                          type: array
+                        enabled:
+                          type: boolean
+                      required:
+                        - enabled
+                      type: object
+                    apiVersion:
+                      description: |-
+                        APIVersion defines the versioned schema of this representation of an object.
+                        Servers should convert recognized schemas to the latest internal value, and
+                        may reject unrecognized values.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                      type: string
+                    jwt:
+                      description: "jwt is a list of authenticator to authenticate Kubernetes users using\nJWT compliant tokens. The authenticator will attempt to parse a raw ID token,\nverify it's been signed by the configured issuer. The public key to verify the\nsignature is discovered from the issuer's public endpoint using OIDC discovery.\nFor an incoming token, each JWT authenticator will be attempted in\nthe order in which it is specified in this list.  Note however that\nother authenticators may run before or after the JWT authenticators.\nThe specific position of JWT authenticators in relation to other\nauthenticators is neither defined nor stable across releases.  Since\neach JWT authenticator must have a unique issuer URL, at most one\nJWT authenticator will attempt to cryptographically validate the token.\n\nThe minimum valid JWT payload must contain the following claims:\n{\n\t\t\"iss\": \"https://issuer.example.com\",\n\t\t\"aud\": [\"audience\"],\n\t\t\"exp\": 1234567890,\n\t\t\"<username claim>\": \"username\"\n}"
+                      items:
+                        description: JWTAuthenticator provides the configuration for a single JWT authenticator.
+                        properties:
+                          claimMappings:
+                            description: claimMappings points claims of a token to be treated as user attributes.
+                            properties:
+                              extra:
+                                description: |-
+                                  extra represents an option for the extra attribute.
+                                  expression must produce a string or string array value.
+                                  If the value is empty, the extra mapping will not be present.
 
-                                hard-coded extra key/value
-                                - key: "foo"
-                                  valueExpression: "'bar'"
-                                This will result in an extra attribute - foo: ["bar"]
+                                  hard-coded extra key/value
+                                  - key: "foo"
+                                    valueExpression: "'bar'"
+                                  This will result in an extra attribute - foo: ["bar"]
 
-                                hard-coded key, value copying claim value
-                                - key: "foo"
-                                  valueExpression: "claims.some_claim"
-                                This will result in an extra attribute - foo: [value of some_claim]
+                                  hard-coded key, value copying claim value
+                                  - key: "foo"
+                                    valueExpression: "claims.some_claim"
+                                  This will result in an extra attribute - foo: [value of some_claim]
 
-                                hard-coded key, value derived from claim value
-                                - key: "admin"
-                                  valueExpression: '(has(claims.is_admin) && claims.is_admin) ? "true":""'
-                                This will result in:
-                                 - if is_admin claim is present and true, extra attribute - admin: ["true"]
-                                 - if is_admin claim is present and false or is_admin claim is not present, no extra attribute will be added
-                              items:
-                                description: ExtraMapping provides the configuration
-                                  for a single extra mapping.
+                                  hard-coded key, value derived from claim value
+                                  - key: "admin"
+                                    valueExpression: '(has(claims.is_admin) && claims.is_admin) ? "true":""'
+                                  This will result in:
+                                   - if is_admin claim is present and true, extra attribute - admin: ["true"]
+                                   - if is_admin claim is present and false or is_admin claim is not present, no extra attribute will be added
+                                items:
+                                  description: ExtraMapping provides the configuration for a single extra mapping.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        key is a string to use as the extra attribute key.
+                                        key must be a domain-prefix path (e.g. example.org/foo). All characters before the first "/" must be a valid
+                                        subdomain as defined by RFC 1123. All characters trailing the first "/" must
+                                        be valid HTTP Path characters as defined by RFC 3986.
+                                        key must be lowercase.
+                                        Required to be unique.
+                                      type: string
+                                    valueExpression:
+                                      description: |-
+                                        valueExpression is a CEL expression to extract extra attribute value.
+                                        valueExpression must produce a string or string array value.
+                                        "", [], and null values are treated as the extra mapping not being present.
+                                        Empty string values contained within a string array are filtered out.
+
+                                        CEL expressions have access to the contents of the token claims, organized into CEL variable:
+                                        - 'claims' is a map of claim names to claim values.
+                                          For example, a variable named 'sub' can be accessed as 'claims.sub'.
+                                          Nested claims can be accessed using dot notation, e.g. 'claims.foo.bar'.
+
+                                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+                                      type: string
+                                  required:
+                                    - key
+                                    - valueExpression
+                                  type: object
+                                type: array
+                              groups:
+                                description: |-
+                                  groups represents an option for the groups attribute.
+                                  The claim's value must be a string or string array claim.
+                                  If groups.claim is set, the prefix must be specified (and can be the empty string).
+                                  If groups.expression is set, the expression must produce a string or string array value.
+                                   "", [], and null values are treated as the group mapping not being present.
                                 properties:
-                                  key:
+                                  claim:
                                     description: |-
-                                      key is a string to use as the extra attribute key.
-                                      key must be a domain-prefix path (e.g. example.org/foo). All characters before the first "/" must be a valid
-                                      subdomain as defined by RFC 1123. All characters trailing the first "/" must
-                                      be valid HTTP Path characters as defined by RFC 3986.
-                                      key must be lowercase.
-                                      Required to be unique.
+                                      claim is the JWT claim to use.
+                                      Mutually exclusive with expression.
                                     type: string
-                                  valueExpression:
+                                  expression:
                                     description: |-
-                                      valueExpression is a CEL expression to extract extra attribute value.
-                                      valueExpression must produce a string or string array value.
-                                      "", [], and null values are treated as the extra mapping not being present.
-                                      Empty string values contained within a string array are filtered out.
+                                      expression represents the expression which will be evaluated by CEL.
 
                                       CEL expressions have access to the contents of the token claims, organized into CEL variable:
                                       - 'claims' is a map of claim names to claim values.
@@ -153,326 +164,290 @@ spec:
                                         Nested claims can be accessed using dot notation, e.g. 'claims.foo.bar'.
 
                                       Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Mutually exclusive with claim and prefix.
                                     type: string
-                                required:
-                                - key
-                                - valueExpression
+                                  prefix:
+                                    description: |-
+                                      prefix is prepended to claim's value to prevent clashes with existing names.
+                                      prefix needs to be set if claim is set and can be the empty string.
+                                      Mutually exclusive with expression.
+                                    type: string
                                 type: object
-                              type: array
-                            groups:
-                              description: |-
-                                groups represents an option for the groups attribute.
-                                The claim's value must be a string or string array claim.
-                                If groups.claim is set, the prefix must be specified (and can be the empty string).
-                                If groups.expression is set, the expression must produce a string or string array value.
-                                 "", [], and null values are treated as the group mapping not being present.
-                              properties:
-                                claim:
-                                  description: |-
-                                    claim is the JWT claim to use.
-                                    Mutually exclusive with expression.
-                                  type: string
-                                expression:
-                                  description: |-
-                                    expression represents the expression which will be evaluated by CEL.
-
-                                    CEL expressions have access to the contents of the token claims, organized into CEL variable:
-                                    - 'claims' is a map of claim names to claim values.
-                                      For example, a variable named 'sub' can be accessed as 'claims.sub'.
-                                      Nested claims can be accessed using dot notation, e.g. 'claims.foo.bar'.
-
-                                    Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
-
-                                    Mutually exclusive with claim and prefix.
-                                  type: string
-                                prefix:
-                                  description: |-
-                                    prefix is prepended to claim's value to prevent clashes with existing names.
-                                    prefix needs to be set if claim is set and can be the empty string.
-                                    Mutually exclusive with expression.
-                                  type: string
-                              type: object
-                            uid:
-                              description: |-
-                                uid represents an option for the uid attribute.
-                                Claim must be a singular string claim.
-                                If uid.expression is set, the expression must produce a string value.
-                              properties:
-                                claim:
-                                  description: |-
-                                    claim is the JWT claim to use.
-                                    Either claim or expression must be set.
-                                    Mutually exclusive with expression.
-                                  type: string
-                                expression:
-                                  description: |-
-                                    expression represents the expression which will be evaluated by CEL.
-
-                                    CEL expressions have access to the contents of the token claims, organized into CEL variable:
-                                    - 'claims' is a map of claim names to claim values.
-                                      For example, a variable named 'sub' can be accessed as 'claims.sub'.
-                                      Nested claims can be accessed using dot notation, e.g. 'claims.foo.bar'.
-
-                                    Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
-
-                                    Mutually exclusive with claim.
-                                  type: string
-                              type: object
-                            username:
-                              description: |-
-                                username represents an option for the username attribute.
-                                The claim's value must be a singular string.
-                                Same as the --oidc-username-claim and --oidc-username-prefix flags.
-                                If username.expression is set, the expression must produce a string value.
-                                If username.expression uses 'claims.email', then 'claims.email_verified' must be used in
-                                username.expression or extra[*].valueExpression or claimValidationRules[*].expression.
-                                An example claim validation rule expression that matches the validation automatically
-                                applied when username.claim is set to 'email' is 'claims.?email_verified.orValue(true) == true'. By explicitly comparing
-                                the value to true, we let type-checking see the result will be a boolean, and to make sure a non-boolean email_verified
-                                claim will be caught at runtime.
-
-                                In the flag based approach, the --oidc-username-claim and --oidc-username-prefix are optional. If --oidc-username-claim is not set,
-                                the default value is "sub". For the authentication config, there is no defaulting for claim or prefix. The claim and prefix must be set explicitly.
-                                For claim, if --oidc-username-claim was not set with legacy flag approach, configure username.claim="sub" in the authentication config.
-                                For prefix:
-                                    (1) --oidc-username-prefix="-", no prefix was added to the username. For the same behavior using authentication config,
-                                        set username.prefix=""
-                                    (2) --oidc-username-prefix="" and  --oidc-username-claim != "email", prefix was "<value of --oidc-issuer-url>#". For the same
-                                        behavior using authentication config, set username.prefix="<value of issuer.url>#"
-                                    (3) --oidc-username-prefix="<value>". For the same behavior using authentication config, set username.prefix="<value>"
-                              properties:
-                                claim:
-                                  description: |-
-                                    claim is the JWT claim to use.
-                                    Mutually exclusive with expression.
-                                  type: string
-                                expression:
-                                  description: |-
-                                    expression represents the expression which will be evaluated by CEL.
-
-                                    CEL expressions have access to the contents of the token claims, organized into CEL variable:
-                                    - 'claims' is a map of claim names to claim values.
-                                      For example, a variable named 'sub' can be accessed as 'claims.sub'.
-                                      Nested claims can be accessed using dot notation, e.g. 'claims.foo.bar'.
-
-                                    Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
-
-                                    Mutually exclusive with claim and prefix.
-                                  type: string
-                                prefix:
-                                  description: |-
-                                    prefix is prepended to claim's value to prevent clashes with existing names.
-                                    prefix needs to be set if claim is set and can be the empty string.
-                                    Mutually exclusive with expression.
-                                  type: string
-                              type: object
-                          required:
-                          - username
-                          type: object
-                        claimValidationRules:
-                          description: claimValidationRules are rules that are applied
-                            to validate token claims to authenticate users.
-                          items:
-                            description: ClaimValidationRule provides the configuration
-                              for a single claim validation rule.
-                            properties:
-                              claim:
+                              uid:
                                 description: |-
-                                  claim is the name of a required claim.
-                                  Same as --oidc-required-claim flag.
-                                  Only string claim keys are supported.
-                                  Mutually exclusive with expression and message.
-                                type: string
-                              expression:
-                                description: |-
-                                  expression represents the expression which will be evaluated by CEL.
-                                  Must produce a boolean.
+                                  uid represents an option for the uid attribute.
+                                  Claim must be a singular string claim.
+                                  If uid.expression is set, the expression must produce a string value.
+                                properties:
+                                  claim:
+                                    description: |-
+                                      claim is the JWT claim to use.
+                                      Either claim or expression must be set.
+                                      Mutually exclusive with expression.
+                                    type: string
+                                  expression:
+                                    description: |-
+                                      expression represents the expression which will be evaluated by CEL.
 
-                                  CEL expressions have access to the contents of the token claims, organized into CEL variable:
-                                  - 'claims' is a map of claim names to claim values.
-                                    For example, a variable named 'sub' can be accessed as 'claims.sub'.
-                                    Nested claims can be accessed using dot notation, e.g. 'claims.foo.bar'.
-                                  Must return true for the validation to pass.
+                                      CEL expressions have access to the contents of the token claims, organized into CEL variable:
+                                      - 'claims' is a map of claim names to claim values.
+                                        For example, a variable named 'sub' can be accessed as 'claims.sub'.
+                                        Nested claims can be accessed using dot notation, e.g. 'claims.foo.bar'.
 
-                                  Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
 
-                                  Mutually exclusive with claim and requiredValue.
-                                type: string
-                              message:
+                                      Mutually exclusive with claim.
+                                    type: string
+                                type: object
+                              username:
                                 description: |-
-                                  message customizes the returned error message when expression returns false.
-                                  message is a literal string.
-                                  Mutually exclusive with claim and requiredValue.
-                                type: string
-                              requiredValue:
-                                description: |-
-                                  requiredValue is the value of a required claim.
-                                  Same as --oidc-required-claim flag.
-                                  Only string claim values are supported.
-                                  If claim is set and requiredValue is not set, the claim must be present with a value set to the empty string.
-                                  Mutually exclusive with expression and message.
-                                type: string
+                                  username represents an option for the username attribute.
+                                  The claim's value must be a singular string.
+                                  Same as the --oidc-username-claim and --oidc-username-prefix flags.
+                                  If username.expression is set, the expression must produce a string value.
+                                  If username.expression uses 'claims.email', then 'claims.email_verified' must be used in
+                                  username.expression or extra[*].valueExpression or claimValidationRules[*].expression.
+                                  An example claim validation rule expression that matches the validation automatically
+                                  applied when username.claim is set to 'email' is 'claims.?email_verified.orValue(true) == true'. By explicitly comparing
+                                  the value to true, we let type-checking see the result will be a boolean, and to make sure a non-boolean email_verified
+                                  claim will be caught at runtime.
+
+                                  In the flag based approach, the --oidc-username-claim and --oidc-username-prefix are optional. If --oidc-username-claim is not set,
+                                  the default value is "sub". For the authentication config, there is no defaulting for claim or prefix. The claim and prefix must be set explicitly.
+                                  For claim, if --oidc-username-claim was not set with legacy flag approach, configure username.claim="sub" in the authentication config.
+                                  For prefix:
+                                      (1) --oidc-username-prefix="-", no prefix was added to the username. For the same behavior using authentication config,
+                                          set username.prefix=""
+                                      (2) --oidc-username-prefix="" and  --oidc-username-claim != "email", prefix was "<value of --oidc-issuer-url>#". For the same
+                                          behavior using authentication config, set username.prefix="<value of issuer.url>#"
+                                      (3) --oidc-username-prefix="<value>". For the same behavior using authentication config, set username.prefix="<value>"
+                                properties:
+                                  claim:
+                                    description: |-
+                                      claim is the JWT claim to use.
+                                      Mutually exclusive with expression.
+                                    type: string
+                                  expression:
+                                    description: |-
+                                      expression represents the expression which will be evaluated by CEL.
+
+                                      CEL expressions have access to the contents of the token claims, organized into CEL variable:
+                                      - 'claims' is a map of claim names to claim values.
+                                        For example, a variable named 'sub' can be accessed as 'claims.sub'.
+                                        Nested claims can be accessed using dot notation, e.g. 'claims.foo.bar'.
+
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Mutually exclusive with claim and prefix.
+                                    type: string
+                                  prefix:
+                                    description: |-
+                                      prefix is prepended to claim's value to prevent clashes with existing names.
+                                      prefix needs to be set if claim is set and can be the empty string.
+                                      Mutually exclusive with expression.
+                                    type: string
+                                type: object
+                            required:
+                              - username
                             type: object
-                          type: array
-                        issuer:
-                          description: issuer contains the basic OIDC provider connection
-                            options.
-                          properties:
-                            audienceMatchPolicy:
-                              description: |-
-                                audienceMatchPolicy defines how the "audiences" field is used to match the "aud" claim in the presented JWT.
-                                Allowed values are:
-                                1. "MatchAny" when multiple audiences are specified and
-                                2. empty (or unset) or "MatchAny" when a single audience is specified.
+                          claimValidationRules:
+                            description: claimValidationRules are rules that are applied to validate token claims to authenticate users.
+                            items:
+                              description: ClaimValidationRule provides the configuration for a single claim validation rule.
+                              properties:
+                                claim:
+                                  description: |-
+                                    claim is the name of a required claim.
+                                    Same as --oidc-required-claim flag.
+                                    Only string claim keys are supported.
+                                    Mutually exclusive with expression and message.
+                                  type: string
+                                expression:
+                                  description: |-
+                                    expression represents the expression which will be evaluated by CEL.
+                                    Must produce a boolean.
 
-                                - MatchAny: the "aud" claim in the presented JWT must match at least one of the entries in the "audiences" field.
-                                For example, if "audiences" is ["foo", "bar"], the "aud" claim in the presented JWT must contain either "foo" or "bar" (and may contain both).
+                                    CEL expressions have access to the contents of the token claims, organized into CEL variable:
+                                    - 'claims' is a map of claim names to claim values.
+                                      For example, a variable named 'sub' can be accessed as 'claims.sub'.
+                                      Nested claims can be accessed using dot notation, e.g. 'claims.foo.bar'.
+                                    Must return true for the validation to pass.
 
-                                - "": The match policy can be empty (or unset) when a single audience is specified in the "audiences" field. The "aud" claim in the presented JWT must contain the single audience (and may contain others).
+                                    Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
 
-                                For more nuanced audience validation, use claimValidationRules.
-                                  example: claimValidationRule[].expression: 'sets.equivalent(claims.aud, ["bar", "foo", "baz"])' to require an exact match.
-                              type: string
-                            audiences:
-                              description: |-
-                                audiences is the set of acceptable audiences the JWT must be issued to.
-                                At least one of the entries must match the "aud" claim in presented JWTs.
-                                Same value as the --oidc-client-id flag (though this field supports an array).
-                                Required to be non-empty.
-                              items:
-                                type: string
-                              type: array
-                            certificateAuthority:
-                              description: |-
-                                certificateAuthority contains PEM-encoded certificate authority certificates
-                                used to validate the connection when fetching discovery information.
-                                If unset, the system verifier is used.
-                                Same value as the content of the file referenced by the --oidc-ca-file flag.
-                              type: string
-                            discoveryURL:
-                              description: |-
-                                discoveryURL, if specified, overrides the URL used to fetch discovery
-                                information instead of using "{url}/.well-known/openid-configuration".
-                                The exact value specified is used, so "/.well-known/openid-configuration"
-                                must be included in discoveryURL if needed.
-
-                                The "issuer" field in the fetched discovery information must match the "issuer.url" field
-                                in the AuthenticationConfiguration and will be used to validate the "iss" claim in the presented JWT.
-                                This is for scenarios where the well-known and jwks endpoints are hosted at a different
-                                location than the issuer (such as locally in the cluster).
-
-                                Example:
-                                A discovery url that is exposed using kubernetes service 'oidc' in namespace 'oidc-namespace'
-                                and discovery information is available at '/.well-known/openid-configuration'.
-                                discoveryURL: "https://oidc.oidc-namespace/.well-known/openid-configuration"
-                                certificateAuthority is used to verify the TLS connection and the hostname on the leaf certificate
-                                must be set to 'oidc.oidc-namespace'.
-
-                                curl https://oidc.oidc-namespace/.well-known/openid-configuration (.discoveryURL field)
-                                {
-                                    issuer: "https://oidc.example.com" (.url field)
-                                }
-
-                                discoveryURL must be different from url.
-                                Required to be unique across all JWT authenticators.
-                                Note that egress selection configuration is not used for this network connection.
-                              type: string
-                            egressSelectorType:
-                              description: |-
-                                egressSelectorType is an indicator of which egress selection should be used for sending all traffic related
-                                to this issuer (discovery, JWKS, distributed claims, etc).  If unspecified, no custom dialer is used.
-                                When specified, the valid choices are "controlplane" and "cluster".  These correspond to the associated
-                                values in the --egress-selector-config-file.
-
-                                - controlplane: for traffic intended to go to the control plane.
-
-                                - cluster: for traffic intended to go to the system being managed by Kubernetes.
-                              type: string
-                            url:
-                              description: |-
-                                url points to the issuer URL in a format https://url or https://url/path.
-                                This must match the "iss" claim in the presented JWT, and the issuer returned from discovery.
-                                Same value as the --oidc-issuer-url flag.
-                                Discovery information is fetched from "{url}/.well-known/openid-configuration" unless overridden by discoveryURL.
-                                Required to be unique across all JWT authenticators.
-                                Note that egress selection configuration is not used for this network connection.
-                              type: string
-                          required:
-                          - audiences
-                          - url
-                          type: object
-                        userValidationRules:
-                          description: |-
-                            userValidationRules are rules that are applied to final user before completing authentication.
-                            These allow invariants to be applied to incoming identities such as preventing the
-                            use of the system: prefix that is commonly used by Kubernetes components.
-                            The validation rules are logically ANDed together and must all return true for the validation to pass.
-                          items:
-                            description: UserValidationRule provides the configuration
-                              for a single user info validation rule.
+                                    Mutually exclusive with claim and requiredValue.
+                                  type: string
+                                message:
+                                  description: |-
+                                    message customizes the returned error message when expression returns false.
+                                    message is a literal string.
+                                    Mutually exclusive with claim and requiredValue.
+                                  type: string
+                                requiredValue:
+                                  description: |-
+                                    requiredValue is the value of a required claim.
+                                    Same as --oidc-required-claim flag.
+                                    Only string claim values are supported.
+                                    If claim is set and requiredValue is not set, the claim must be present with a value set to the empty string.
+                                    Mutually exclusive with expression and message.
+                                  type: string
+                              type: object
+                            type: array
+                          issuer:
+                            description: issuer contains the basic OIDC provider connection options.
                             properties:
-                              expression:
+                              audienceMatchPolicy:
                                 description: |-
-                                  expression represents the expression which will be evaluated by CEL.
-                                  Must return true for the validation to pass.
+                                  audienceMatchPolicy defines how the "audiences" field is used to match the "aud" claim in the presented JWT.
+                                  Allowed values are:
+                                  1. "MatchAny" when multiple audiences are specified and
+                                  2. empty (or unset) or "MatchAny" when a single audience is specified.
 
-                                  CEL expressions have access to the contents of UserInfo, organized into CEL variable:
-                                  - 'user' - authentication.k8s.io/v1, Kind=UserInfo object
-                                     Refer to https://github.com/kubernetes/api/blob/release-1.28/authentication/v1/types.go#L105-L122 for the definition.
-                                     API documentation: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#userinfo-v1-authentication-k8s-io
+                                  - MatchAny: the "aud" claim in the presented JWT must match at least one of the entries in the "audiences" field.
+                                  For example, if "audiences" is ["foo", "bar"], the "aud" claim in the presented JWT must contain either "foo" or "bar" (and may contain both).
 
-                                  Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+                                  - "": The match policy can be empty (or unset) when a single audience is specified in the "audiences" field. The "aud" claim in the presented JWT must contain the single audience (and may contain others).
+
+                                  For more nuanced audience validation, use claimValidationRules.
+                                    example: claimValidationRule[].expression: 'sets.equivalent(claims.aud, ["bar", "foo", "baz"])' to require an exact match.
                                 type: string
-                              message:
+                              audiences:
                                 description: |-
-                                  message customizes the returned error message when rule returns false.
-                                  message is a literal string.
+                                  audiences is the set of acceptable audiences the JWT must be issued to.
+                                  At least one of the entries must match the "aud" claim in presented JWTs.
+                                  Same value as the --oidc-client-id flag (though this field supports an array).
+                                  Required to be non-empty.
+                                items:
+                                  type: string
+                                type: array
+                              certificateAuthority:
+                                description: |-
+                                  certificateAuthority contains PEM-encoded certificate authority certificates
+                                  used to validate the connection when fetching discovery information.
+                                  If unset, the system verifier is used.
+                                  Same value as the content of the file referenced by the --oidc-ca-file flag.
+                                type: string
+                              discoveryURL:
+                                description: |-
+                                  discoveryURL, if specified, overrides the URL used to fetch discovery
+                                  information instead of using "{url}/.well-known/openid-configuration".
+                                  The exact value specified is used, so "/.well-known/openid-configuration"
+                                  must be included in discoveryURL if needed.
+
+                                  The "issuer" field in the fetched discovery information must match the "issuer.url" field
+                                  in the AuthenticationConfiguration and will be used to validate the "iss" claim in the presented JWT.
+                                  This is for scenarios where the well-known and jwks endpoints are hosted at a different
+                                  location than the issuer (such as locally in the cluster).
+
+                                  Example:
+                                  A discovery url that is exposed using kubernetes service 'oidc' in namespace 'oidc-namespace'
+                                  and discovery information is available at '/.well-known/openid-configuration'.
+                                  discoveryURL: "https://oidc.oidc-namespace/.well-known/openid-configuration"
+                                  certificateAuthority is used to verify the TLS connection and the hostname on the leaf certificate
+                                  must be set to 'oidc.oidc-namespace'.
+
+                                  curl https://oidc.oidc-namespace/.well-known/openid-configuration (.discoveryURL field)
+                                  {
+                                      issuer: "https://oidc.example.com" (.url field)
+                                  }
+
+                                  discoveryURL must be different from url.
+                                  Required to be unique across all JWT authenticators.
+                                  Note that egress selection configuration is not used for this network connection.
+                                type: string
+                              egressSelectorType:
+                                description: |-
+                                  egressSelectorType is an indicator of which egress selection should be used for sending all traffic related
+                                  to this issuer (discovery, JWKS, distributed claims, etc).  If unspecified, no custom dialer is used.
+                                  When specified, the valid choices are "controlplane" and "cluster".  These correspond to the associated
+                                  values in the --egress-selector-config-file.
+
+                                  - controlplane: for traffic intended to go to the control plane.
+
+                                  - cluster: for traffic intended to go to the system being managed by Kubernetes.
+                                type: string
+                              url:
+                                description: |-
+                                  url points to the issuer URL in a format https://url or https://url/path.
+                                  This must match the "iss" claim in the presented JWT, and the issuer returned from discovery.
+                                  Same value as the --oidc-issuer-url flag.
+                                  Discovery information is fetched from "{url}/.well-known/openid-configuration" unless overridden by discoveryURL.
+                                  Required to be unique across all JWT authenticators.
+                                  Note that egress selection configuration is not used for this network connection.
                                 type: string
                             required:
-                            - expression
+                              - audiences
+                              - url
                             type: object
-                          type: array
-                      required:
-                      - claimMappings
-                      - issuer
-                      type: object
-                    type: array
-                  kind:
-                    description: |-
-                      Kind is a string value representing the REST resource this object represents.
-                      Servers may infer this from the endpoint the client submits requests to.
-                      Cannot be updated.
-                      In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                    type: string
-                required:
-                - jwt
-                type: object
-              caSecret:
-                description: |-
-                  CASecret is the reference to the secret containing the CA certificates used to validate the connection
-                  to the issuers endpoints.
-                properties:
-                  key:
-                    description: Key is the name of the key for the given Secret reference
-                      where the value is stored.
-                    minLength: 1
-                    type: string
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                required:
-                - key
-                type: object
-                x-kubernetes-map-type: atomic
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                          userValidationRules:
+                            description: |-
+                              userValidationRules are rules that are applied to final user before completing authentication.
+                              These allow invariants to be applied to incoming identities such as preventing the
+                              use of the system: prefix that is commonly used by Kubernetes components.
+                              The validation rules are logically ANDed together and must all return true for the validation to pass.
+                            items:
+                              description: UserValidationRule provides the configuration for a single user info validation rule.
+                              properties:
+                                expression:
+                                  description: |-
+                                    expression represents the expression which will be evaluated by CEL.
+                                    Must return true for the validation to pass.
+
+                                    CEL expressions have access to the contents of UserInfo, organized into CEL variable:
+                                    - 'user' - authentication.k8s.io/v1, Kind=UserInfo object
+                                       Refer to https://github.com/kubernetes/api/blob/release-1.28/authentication/v1/types.go#L105-L122 for the definition.
+                                       API documentation: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#userinfo-v1-authentication-k8s-io
+
+                                    Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+                                  type: string
+                                message:
+                                  description: |-
+                                    message customizes the returned error message when rule returns false.
+                                    message is a literal string.
+                                  type: string
+                              required:
+                                - expression
+                              type: object
+                            type: array
+                        required:
+                          - claimMappings
+                          - issuer
+                        type: object
+                      type: array
+                    kind:
+                      description: |-
+                        Kind is a string value representing the REST resource this object represents.
+                        Servers may infer this from the endpoint the client submits requests to.
+                        Cannot be updated.
+                        In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                  required:
+                    - jwt
+                  type: object
+                caSecret:
+                  description: |-
+                    CASecret is the reference to the secret containing the CA certificates used to validate the connection
+                    to the issuers endpoints.
+                  properties:
+                    key:
+                      description: Key is the name of the key for the given Secret reference where the value is stored.
+                      minLength: 1
+                      type: string
+                    name:
+                      description: name is unique within a namespace to reference a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret name must be unique.
+                      type: string
+                  required:
+                    - key
+                  type: object
+                  x-kubernetes-map-type: atomic
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdatasources.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdatasources.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: clusterdatasources.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,107 +13,104 @@ spec:
     listKind: ClusterDataSourceList
     plural: clusterdatasources
     shortNames:
-    - clds
+      - clds
     singular: clusterdatasource
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Referenced DataSource object
-      jsonPath: .spec.dataSource
-      name: DataSource
-      type: string
-    - description: The name of the schema created
-      jsonPath: .spec.schema
-      name: Schema
-      type: string
-    - description: Readiness
-      jsonPath: .status.ready
-      name: Ready
-      type: string
-    - description: An error occurred
-      jsonPath: .status.error
-      name: Error
-      priority: 1
-      type: string
-    - description: Age
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ClusterDataSource is the Schema for the clusterdatasources API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ClusterDataSourceSpec defines the desired state of ClusterDataSource
-            properties:
-              dataSource:
-                description: |-
-                  DataSource references the [DataSource] object (in the same namespace) that provides database connection
-                  information and credentials.
-                type: string
-              schema:
-                description: |-
-                  Schema is the name of the database for the Cluster. This value is immutable.
-                  The value defaults to the namespace and name of the [ClusterDeployment] with some short random suffix.
-                type: string
-                x-kubernetes-validations:
-                - message: changing the schema is not supported
-                  rule: self == oldSelf
-            required:
-            - dataSource
-            - schema
-            type: object
-          status:
-            description: ClusterDataSourceStatus defines the observed state of ClusterDataSource
-            properties:
-              caSecret:
-                description: |-
-                  CASecret is the name of the Secret containing the CA certificate used to establish a TLS-secured
-                  connection to the datastore, if applicable.
-                type: string
-              error:
-                description: Error contains a description of any errors that occurred,
-                  if applicable. It is omitted if no errors are present.
-                type: string
-              kineDataSourceSecret:
-                description: |-
-                  KineDataSourceSecret is the name of the Secret containing credentials for the Kine datastore connection.
-                  Created and managed by the controller.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the latest source generation observed
-                  by the controller.
-                format: int64
-                type: integer
-              ready:
-                description: Ready indicates whether the object is fully initialized
-                  and operational.
-                type: boolean
-            required:
-            - ready
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Referenced DataSource object
+          jsonPath: .spec.dataSource
+          name: DataSource
+          type: string
+        - description: The name of the schema created
+          jsonPath: .spec.schema
+          name: Schema
+          type: string
+        - description: Readiness
+          jsonPath: .status.ready
+          name: Ready
+          type: string
+        - description: An error occurred
+          jsonPath: .status.error
+          name: Error
+          priority: 1
+          type: string
+        - description: Age
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ClusterDataSource is the Schema for the clusterdatasources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterDataSourceSpec defines the desired state of ClusterDataSource
+              properties:
+                dataSource:
+                  description: |-
+                    DataSource references the [DataSource] object (in the same namespace) that provides database connection
+                    information and credentials.
+                  type: string
+                schema:
+                  description: |-
+                    Schema is the name of the database for the Cluster. This value is immutable.
+                    The value defaults to the namespace and name of the [ClusterDeployment] with some short random suffix.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: changing the schema is not supported
+                      rule: self == oldSelf
+              required:
+                - dataSource
+                - schema
+              type: object
+            status:
+              description: ClusterDataSourceStatus defines the observed state of ClusterDataSource
+              properties:
+                caSecret:
+                  description: |-
+                    CASecret is the name of the Secret containing the CA certificate used to establish a TLS-secured
+                    connection to the datastore, if applicable.
+                  type: string
+                error:
+                  description: Error contains a description of any errors that occurred, if applicable. It is omitted if no errors are present.
+                  type: string
+                kineDataSourceSecret:
+                  description: |-
+                    KineDataSourceSecret is the name of the Secret containing credentials for the Kine datastore connection.
+                    Created and managed by the controller.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the latest source generation observed by the controller.
+                  format: int64
+                  type: integer
+                ready:
+                  description: Ready indicates whether the object is fully initialized and operational.
+                  type: boolean
+              required:
+                - ready
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: clusterdeployments.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,935 +13,885 @@ spec:
     listKind: ClusterDeploymentList
     plural: clusterdeployments
     shortNames:
-    - clusterd
-    - cld
+      - clusterd
+      - cld
     singular: clusterdeployment
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Shows readiness of the ClusterDeployment
-      jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - description: Number of ready out of total services
-      jsonPath: .status.conditions[?(@.type=="ServicesInReadyState")].message
-      name: Services
-      type: string
-    - description: ClusterTemplate used for the ClusterDeployment
-      jsonPath: .spec.template
-      name: Template
-      type: string
-    - description: Shows either readiness or error messages from child objects
-      jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Messages
-      type: string
-    - description: Time elapsed since object creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Dry Run
-      jsonPath: .spec.dryRun
-      name: DryRun
-      priority: 1
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ClusterDeployment is the Schema for the ClusterDeployments API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ClusterDeploymentSpec defines the desired state of ClusterDeployment
-            properties:
-              cleanupOnDeletion:
-                description: |-
-                  CleanupOnDeletion specifies whether potentially orphaned Services and PVCs
-                  should be removed during the object deletion.
-                  This is a best-effort cleanup, if there is no possibility to acquire
-                  a managed cluster's kubeconfig, the cleanup will NOT happen.
-                type: boolean
-              clusterAuth:
-                description: Name reference to the related [ClusterAuthentication]
-                  object.
-                type: string
-              config:
-                description: |-
-                  Config allows to provide parameters for template customization.
-                  If no Config provided, the field will be populated with the default values for
-                  the template and DryRun will be enabled.
-                x-kubernetes-preserve-unknown-fields: true
-              credential:
-                description: Name reference to the related [Credential] object located
-                  in the same namespace.
-                type: string
-              dataSource:
-                description: DataSource is the name reference to the related [DataSource]
-                  object located in the same namespace.
-                type: string
-              dryRun:
-                description: DryRun specifies whether the template should be applied
-                  after validation or only validated.
-                type: boolean
-              ipamClaim:
-                description: |-
-                  IPAMClaim defines IP Address Management (IPAM) requirements for the cluster.
-                  It can either reference an existing IPAM claim or specify an inline claim.
-                properties:
-                  ref:
-                    description: ClusterIPAMClaimRef is the name of an existing ClusterIPAMClaim
-                      resource to use.
-                    type: string
-                  spec:
-                    description: |-
-                      ClusterIPAMClaimSpec defines the inline IPAM claim specification if no reference is provided.
-                      This allows for dynamic IP address allocation during cluster provisioning.
-                    properties:
-                      cluster:
-                        description: Cluster is the reference to the [ClusterDeployment]
-                          that this claim is for
-                        type: string
-                        x-kubernetes-validations:
-                        - message: Cluster reference is immutable once set
-                          rule: oldSelf == '' || self == oldSelf
-                      clusterIPAMRef:
-                        description: ClusterIPAMRef is the reference to the [ClusterIPAM]
-                          resource that this claim is for
-                        type: string
-                        x-kubernetes-validations:
-                        - message: ClusterIPAM reference is immutable once set
-                          rule: oldSelf == '' || self == oldSelf
-                      clusterNetwork:
-                        description: ClusterNetwork defines the allocation for requisitioning
-                          ip addresses for use by the k8s cluster itself
-                        properties:
-                          cidr:
-                            description: CIDR notation of the allocated address space
-                            type: string
-                          gateway:
-                            description: Gateway to be used for the address space
-                            type: string
-                          ipAddresses:
-                            description: IPAddresses to be allocated
-                            items:
-                              type: string
-                            type: array
-                          prefix:
-                            description: Prefix is the network prefix to use.
-                            type: integer
-                        type: object
-                      externalNetwork:
-                        description: ExternalNetwork defines the allocation for requisitioning
-                          ip addresses for use by services such as load balancers
-                        properties:
-                          cidr:
-                            description: CIDR notation of the allocated address space
-                            type: string
-                          gateway:
-                            description: Gateway to be used for the address space
-                            type: string
-                          ipAddresses:
-                            description: IPAddresses to be allocated
-                            items:
-                              type: string
-                            type: array
-                          prefix:
-                            description: Prefix is the network prefix to use.
-                            type: integer
-                        type: object
-                      nodeNetwork:
-                        description: NodeNetwork defines the allocation requisitioning
-                          ip addresses for cluster nodes
-                        properties:
-                          cidr:
-                            description: CIDR notation of the allocated address space
-                            type: string
-                          gateway:
-                            description: Gateway to be used for the address space
-                            type: string
-                          ipAddresses:
-                            description: IPAddresses to be allocated
-                            items:
-                              type: string
-                            type: array
-                          prefix:
-                            description: Prefix is the network prefix to use.
-                            type: integer
-                        type: object
-                      provider:
-                        description: Provider is the name of the provider that this
-                          claim will be consumed by
-                        enum:
-                        - in-cluster
-                        - ipam-infoblox
-                        type: string
-                    required:
-                    - provider
-                    type: object
-                type: object
-              propagateCredentials:
-                default: true
-                description: |-
-                  PropagateCredentials indicates whether credentials should be propagated
-                  for use by CCM (Cloud Controller Manager).
-                type: boolean
-              serviceSpec:
-                description: ServiceSpec is spec related to deployment of services.
-                properties:
-                  continueOnError:
-                    default: false
-                    description: |-
-                      ContinueOnError specifies if the services deployment should continue if an error occurs.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    type: boolean
-                  driftExclusions:
-                    description: |-
-                      DriftExclusions specifies specific configurations of resources to ignore for drift detection.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    items:
+    - additionalPrinterColumns:
+        - description: Shows readiness of the ClusterDeployment
+          jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - description: Number of ready out of total services
+          jsonPath: .status.conditions[?(@.type=="ServicesInReadyState")].message
+          name: Services
+          type: string
+        - description: ClusterTemplate used for the ClusterDeployment
+          jsonPath: .spec.template
+          name: Template
+          type: string
+        - description: Shows either readiness or error messages from child objects
+          jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Messages
+          type: string
+        - description: Time elapsed since object creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Dry Run
+          jsonPath: .spec.dryRun
+          name: DryRun
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ClusterDeployment is the Schema for the ClusterDeployments API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterDeploymentSpec defines the desired state of ClusterDeployment
+              properties:
+                cleanupOnDeletion:
+                  description: |-
+                    CleanupOnDeletion specifies whether potentially orphaned Services and PVCs
+                    should be removed during the object deletion.
+                    This is a best-effort cleanup, if there is no possibility to acquire
+                    a managed cluster's kubeconfig, the cleanup will NOT happen.
+                  type: boolean
+                clusterAuth:
+                  description: Name reference to the related [ClusterAuthentication] object.
+                  type: string
+                config:
+                  description: |-
+                    Config allows to provide parameters for template customization.
+                    If no Config provided, the field will be populated with the default values for
+                    the template and DryRun will be enabled.
+                  x-kubernetes-preserve-unknown-fields: true
+                credential:
+                  description: Name reference to the related [Credential] object located in the same namespace.
+                  type: string
+                dataSource:
+                  description: DataSource is the name reference to the related [DataSource] object located in the same namespace.
+                  type: string
+                dryRun:
+                  description: DryRun specifies whether the template should be applied after validation or only validated.
+                  type: boolean
+                ipamClaim:
+                  description: |-
+                    IPAMClaim defines IP Address Management (IPAM) requirements for the cluster.
+                    It can either reference an existing IPAM claim or specify an inline claim.
+                  properties:
+                    ref:
+                      description: ClusterIPAMClaimRef is the name of an existing ClusterIPAMClaim resource to use.
+                      type: string
+                    spec:
+                      description: |-
+                        ClusterIPAMClaimSpec defines the inline IPAM claim specification if no reference is provided.
+                        This allows for dynamic IP address allocation during cluster provisioning.
                       properties:
-                        paths:
-                          description: Paths is a slice of JSON6902 paths to exclude
-                            from configuration drift evaluation.
-                          items:
-                            type: string
-                          type: array
-                        target:
-                          description: Target points to the resources that the paths
-                            refers to.
+                        cluster:
+                          description: Cluster is the reference to the [ClusterDeployment] that this claim is for
+                          type: string
+                          x-kubernetes-validations:
+                            - message: Cluster reference is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        clusterIPAMRef:
+                          description: ClusterIPAMRef is the reference to the [ClusterIPAM] resource that this claim is for
+                          type: string
+                          x-kubernetes-validations:
+                            - message: ClusterIPAM reference is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        clusterNetwork:
+                          description: ClusterNetwork defines the allocation for requisitioning ip addresses for use by the k8s cluster itself
                           properties:
-                            annotationSelector:
-                              description: |-
-                                AnnotationSelector is a string that follows the label selection expression
-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                It matches with the resource annotations.
+                            cidr:
+                              description: CIDR notation of the allocated address space
                               type: string
-                            group:
-                              description: |-
-                                Group is the API group to select resources from.
-                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            gateway:
+                              description: Gateway to be used for the address space
                               type: string
-                            kind:
-                              description: |-
-                                Kind of the API Group to select resources from.
-                                Together with Group and Version it is capable of unambiguously
-                                identifying and/or selecting resources.
-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                              type: string
-                            labelSelector:
-                              description: |-
-                                LabelSelector is a string that follows the label selection expression
-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                It matches with the resource labels.
-                              type: string
-                            name:
-                              description: Name to match resources with.
-                              type: string
-                            namespace:
-                              description: Namespace to select resources from.
-                              type: string
-                            version:
-                              description: |-
-                                Version of the API Group to select resources from.
-                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                              type: string
+                            ipAddresses:
+                              description: IPAddresses to be allocated
+                              items:
+                                type: string
+                              type: array
+                            prefix:
+                              description: Prefix is the network prefix to use.
+                              type: integer
                           type: object
-                      required:
-                      - paths
-                      type: object
-                    type: array
-                  driftIgnore:
-                    description: |-
-                      DriftIgnore specifies resources to ignore for drift detection.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    items:
-                      properties:
-                        annotationSelector:
-                          description: |-
-                            AnnotationSelector is a string that follows the label selection expression
-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                            It matches with the resource annotations.
-                          type: string
-                        group:
-                          description: |-
-                            Group is the API group to select resources from.
-                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                          type: string
-                        kind:
-                          description: |-
-                            Kind of the API Group to select resources from.
-                            Together with Group and Version it is capable of unambiguously
-                            identifying and/or selecting resources.
-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                          type: string
-                        labelSelector:
-                          description: |-
-                            LabelSelector is a string that follows the label selection expression
-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                            It matches with the resource labels.
-                          type: string
-                        name:
-                          description: Name to match resources with.
-                          type: string
-                        namespace:
-                          description: Namespace to select resources from.
-                          type: string
-                        version:
-                          description: |-
-                            Version of the API Group to select resources from.
-                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                          type: string
-                      type: object
-                    type: array
-                  policyRefs:
-                    description: |-
-                      PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
-                      that need to be deployed in the target clusters.
-                      The values contained in those resources can be static or leverage Go templates for dynamic customization.
-                      When expressed as templates, the values are filled in using information from
-                      resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    items:
-                      properties:
-                        deploymentType:
-                          default: Remote
-                          description: |-
-                            DeploymentType indicates whether resources need to be deployed
-                            into the management cluster (local) or the managed cluster (remote)
+                        externalNetwork:
+                          description: ExternalNetwork defines the allocation for requisitioning ip addresses for use by services such as load balancers
+                          properties:
+                            cidr:
+                              description: CIDR notation of the allocated address space
+                              type: string
+                            gateway:
+                              description: Gateway to be used for the address space
+                              type: string
+                            ipAddresses:
+                              description: IPAddresses to be allocated
+                              items:
+                                type: string
+                              type: array
+                            prefix:
+                              description: Prefix is the network prefix to use.
+                              type: integer
+                          type: object
+                        nodeNetwork:
+                          description: NodeNetwork defines the allocation requisitioning ip addresses for cluster nodes
+                          properties:
+                            cidr:
+                              description: CIDR notation of the allocated address space
+                              type: string
+                            gateway:
+                              description: Gateway to be used for the address space
+                              type: string
+                            ipAddresses:
+                              description: IPAddresses to be allocated
+                              items:
+                                type: string
+                              type: array
+                            prefix:
+                              description: Prefix is the network prefix to use.
+                              type: integer
+                          type: object
+                        provider:
+                          description: Provider is the name of the provider that this claim will be consumed by
                           enum:
-                          - Local
-                          - Remote
-                          type: string
-                        kind:
-                          description: |-
-                            Kind of the resource. Supported kinds are:
-                            - ConfigMap/Secret
-                            - flux GitRepository;OCIRepository;Bucket
-                          enum:
-                          - GitRepository
-                          - OCIRepository
-                          - Bucket
-                          - ConfigMap
-                          - Secret
-                          type: string
-                        name:
-                          description: |-
-                            Name of the referenced resource.
-                            Name can be expressed as a template and instantiate using any cluster field.
-                          minLength: 1
-                          type: string
-                        namespace:
-                          description: |-
-                            Namespace of the referenced resource.
-                            For ClusterProfile namespace can be left empty. In such a case, namespace will
-                            be implicit set to cluster's namespace.
-                            For Profile namespace must be left empty. Profile namespace will be used.
-                            Namespace can be expressed as a template and instantiate using any cluster field.
-                          type: string
-                        optional:
-                          default: false
-                          description: |-
-                            Optional indicates that the referenced resource is not mandatory.
-                            If set to true and the resource is not found, the error will be ignored,
-                            and Sveltos will continue processing other PolicyRefs.
-                          type: boolean
-                        path:
-                          description: |-
-                            Path to the directory containing the YAML files.
-                            Defaults to 'None', which translates to the root path of the SourceRef.
-                            Used only for GitRepository;OCIRepository;Bucket
+                            - in-cluster
+                            - ipam-infoblox
                           type: string
                       required:
-                      - kind
-                      - name
+                        - provider
                       type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  priority:
-                    default: 100
-                    description: |-
-                      Priority sets the priority for the services defined in this spec.
-                      Higher value means higher priority and lower means lower.
-                      In case of conflict with another object managing the service,
-                      the one with higher priority will get to deploy its services.
+                  type: object
+                propagateCredentials:
+                  default: true
+                  description: |-
+                    PropagateCredentials indicates whether credentials should be propagated
+                    for use by CCM (Cloud Controller Manager).
+                  type: boolean
+                serviceSpec:
+                  description: ServiceSpec is spec related to deployment of services.
+                  properties:
+                    continueOnError:
+                      default: false
+                      description: |-
+                        ContinueOnError specifies if the services deployment should continue if an error occurs.
 
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    format: int32
-                    maximum: 2147483646
-                    minimum: 1
-                    type: integer
-                  provider:
-                    description: Provider is the definition of the provider to use
-                      to deploy services.
-                    properties:
-                      config:
-                        description: Config is the provider-specific configuration
-                          applied to the produced objects.
-                        x-kubernetes-preserve-unknown-fields: true
-                      name:
-                        description: Name is the name of the [StateManagementProvider]
-                          object.
-                        type: string
-                        x-kubernetes-validations:
-                        - message: Provider name is immutable once set
-                          rule: oldSelf == '' || self == oldSelf
-                      selfManagement:
-                        description: |-
-                          SelfManagement flag defines whether resources must be deployed to the management cluster itself.
-                          This field is ignored if set for ClusterDeployment.
-                        type: boolean
-                    type: object
-                  reload:
-                    description: |-
-                      Reload instances via rolling upgrade when a ConfigMap/Secret mounted as volume is modified.
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      type: boolean
+                    driftExclusions:
+                      description: |-
+                        DriftExclusions specifies specific configurations of resources to ignore for drift detection.
 
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    type: boolean
-                  services:
-                    description: |-
-                      Services is a list of services created via ServiceTemplates
-                      that could be installed on the target cluster.
-                    items:
-                      description: Service represents a Service to be deployed.
-                      properties:
-                        dependsOn:
-                          description: DependsOn specifies a list of other services
-                            that this service depends on.
-                          items:
-                            description: ServiceDependsOn identifies a service by
-                              its release name and namespace.
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      items:
+                        properties:
+                          paths:
+                            description: Paths is a slice of JSON6902 paths to exclude from configuration drift evaluation.
+                            items:
+                              type: string
+                            type: array
+                          target:
+                            description: Target points to the resources that the paths refers to.
                             properties:
+                              annotationSelector:
+                                description: |-
+                                  AnnotationSelector is a string that follows the label selection expression
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                  It matches with the resource annotations.
+                                type: string
+                              group:
+                                description: |-
+                                  Group is the API group to select resources from.
+                                  Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the API Group to select resources from.
+                                  Together with Group and Version it is capable of unambiguously
+                                  identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                type: string
+                              labelSelector:
+                                description: |-
+                                  LabelSelector is a string that follows the label selection expression
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                  It matches with the resource labels.
+                                type: string
                               name:
-                                description: Name is the release name on target cluster.
-                                maxLength: 253
-                                minLength: 1
+                                description: Name to match resources with.
                                 type: string
                               namespace:
-                                description: Namespace is the release namespace on
-                                  target cluster.
+                                description: Namespace to select resources from.
                                 type: string
-                            required:
-                            - name
+                              version:
+                                description: |-
+                                  Version of the API Group to select resources from.
+                                  Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                type: string
                             type: object
-                          type: array
-                        disable:
-                          description: Disable can be set to disable handling of this
-                            service.
-                          type: boolean
-                        helmOptions:
-                          description: HelmOptions are the options to be passed to
-                            the provider for helm installation or updates
-                          properties:
-                            atomic:
-                              description: |-
-                                if set, the installation process deletes the installation/upgrades on failure.
-                                The --wait flag will be set automatically if --atomic is used
-                              type: boolean
-                            createNamespace:
-                              type: boolean
-                            dependencyUpdate:
-                              description: update dependencies if they are missing
-                                before installing the chart
-                              type: boolean
-                            description:
-                              description: Description is the description of an helm
-                                operation
-                              type: string
-                            disableHooks:
-                              description: prevent hooks from running during install/upgrade/uninstall
-                              type: boolean
-                            disableOpenAPIValidation:
-                              description: if set, the installation process will not
-                                validate rendered templates against the Kubernetes
-                                OpenAPI Schema
-                              type: boolean
-                            enableClientCache:
-                              description: EnableClientCache is a flag to enable Helm
-                                client cache. If it is not specified, it will be set
-                                to false.
-                              type: boolean
-                            labels:
-                              additionalProperties:
-                                type: string
-                              description: Labels that would be added to release metadata.
-                              type: object
-                            replace:
-                              description: Replaces if set indicates to replace an
-                                older release with this one
-                              type: boolean
-                            skipCRDs:
-                              description: |-
-                                SkipCRDs controls whether CRDs should be installed during install/upgrade operation.
-                                By default, CRDs are installed if not already present.
-                              type: boolean
-                            skipSchemaValidation:
-                              description: SkipSchemaValidation determines if JSON
-                                schema validation is disabled.
-                              type: boolean
-                            timeout:
-                              description: time to wait for any individual Kubernetes
-                                operation (like Jobs for hooks) (default 5m0s)
-                              type: string
-                            wait:
-                              description: |-
-                                if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet
-                                are in a ready state before marking the release as successful. It will wait for as long as --timeout
-                              type: boolean
-                            waitForJobs:
-                              description: |-
-                                if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful.
-                                It will wait for as long as --timeout
-                              type: boolean
-                          type: object
-                        name:
-                          description: Name is the chart release.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        namespace:
-                          default: default
-                          description: |-
-                            Namespace is the namespace the release will be installed in.
-                            It will default to "default" if not provided.
-                          type: string
-                        template:
-                          description: Template is a reference to a Template object
-                            located in the same namespace.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        templateChain:
-                          description: |-
-                            TemplateChain defines the ServiceTemplateChain object that will be used to deploy the service
-                            along with desired ServiceTemplate version.
-                          type: string
-                        values:
-                          description: |-
-                            Values is the helm values to be passed to the chart used by the template.
-                            The string type is used in order to allow for templating.
-                          type: string
-                        valuesFrom:
-                          description: ValuesFrom can reference a ConfigMap or Secret
-                            containing helm values.
-                          items:
-                            description: |-
-                              ValuesFrom is the source of the values to pass to the ServiceTemplate. The source
-                              can be a ConfigMap or a Secret located in the same namespace as the ServiceSet.
-                            properties:
-                              kind:
-                                description: Kind is the kind of the source.
-                                enum:
-                                - ConfigMap
-                                - Secret
-                                type: string
-                              name:
-                                description: Name is the name of the source.
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                          type: array
-                        version:
-                          description: Version is the version of the service template.
-                          type: string
-                      required:
-                      - name
-                      - template
-                      type: object
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - name
-                    - namespace
-                    x-kubernetes-list-type: map
-                  stopOnConflict:
-                    default: false
-                    description: |-
-                      StopOnConflict specifies what to do in case of a conflict.
-                      E.g. If another object is already managing a service.
-                      By default the remaining services will be deployed even if conflict is detected.
-                      If set to true, the deployment will stop after encountering the first conflict.
+                        required:
+                          - paths
+                        type: object
+                      type: array
+                    driftIgnore:
+                      description: |-
+                        DriftIgnore specifies resources to ignore for drift detection.
 
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    type: boolean
-                  syncMode:
-                    default: Continuous
-                    description: |-
-                      SyncMode specifies how services are synced in the target cluster.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    enum:
-                    - OneTime
-                    - Continuous
-                    - ContinuousWithDriftDetection
-                    - DryRun
-                    type: string
-                  templateResourceRefs:
-                    description: |-
-                      TemplateResourceRefs is a list of resources to collect from the management cluster,
-                      the values from which can be used in templates.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    items:
-                      properties:
-                        identifier:
-                          description: |-
-                            Identifier is how the resource will be referred to in the
-                            template
-                          type: string
-                        optional:
-                          default: false
-                          description: |-
-                            Optional indicates that the referenced resource is not mandatory.
-                            If set to true and the resource is not found, the error will be ignored,
-                            and Sveltos will continue processing other TemplateResourceRefs.
-                          type: boolean
-                        resource:
-                          description: |-
-                            Resource references a Kubernetes instance in the management
-                            cluster to fetch and use during template instantiation.
-                            For ClusterProfile namespace can be left empty. In such a case, namespace will
-                            be implicit set to cluster's namespace.
-                            Name and namespace can be expressed as a template and instantiate using any cluster field.
-                          properties:
-                            apiVersion:
-                              description: API version of the referent.
-                              type: string
-                            fieldPath:
-                              description: |-
-                                If referring to a piece of an object instead of an entire object, this string
-                                should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                                For example, if the object reference is to a container within a pod, this would take on a value like:
-                                "spec.containers{name}" (where "name" refers to the name of the container that triggered
-                                the event) or if no container name is specified "spec.containers[2]" (container with
-                                index 2 in this pod). This syntax is chosen only to have some well-defined way of
-                                referencing a part of an object.
-                              type: string
-                            kind:
-                              description: |-
-                                Kind of the referent.
-                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                              type: string
-                            name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            namespace:
-                              description: |-
-                                Namespace of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                              type: string
-                            resourceVersion:
-                              description: |-
-                                Specific resourceVersion to which this reference is made, if any.
-                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                              type: string
-                            uid:
-                              description: |-
-                                UID of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      required:
-                      - identifier
-                      - resource
-                      type: object
-                    type: array
-                type: object
-              template:
-                description: Template is a reference to a Template object located
-                  in the same namespace.
-                maxLength: 253
-                minLength: 1
-                type: string
-            required:
-            - template
-            type: object
-          status:
-            description: ClusterDeploymentStatus defines the observed state of ClusterDeployment
-            properties:
-              availableUpgrades:
-                description: |-
-                  AvailableUpgrades is the list of ClusterTemplate names to which
-                  this cluster can be upgraded. It can be an empty array, which means no upgrades are
-                  available.
-                items:
-                  type: string
-                type: array
-              conditions:
-                description: Conditions contains details for the current state of
-                  the ClusterDeployment.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              k8sVersion:
-                description: |-
-                  Currently compatible exact Kubernetes version of the cluster. Being set only if
-                  provided by the corresponding ClusterTemplate.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              region:
-                description: Region shows the region the [ClusterDeployment] targets.
-                type: string
-              services:
-                description: Services contains details for the state of services.
-                items:
-                  description: ServiceState is the state of a Service
-                  properties:
-                    conditions:
-                      description: Conditions is a list of conditions for the Service
+                        Deprecated: use .provider.config field to define provider-specific configuration.
                       items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
                         properties:
-                          lastTransitionTime:
+                          annotationSelector:
                             description: |-
-                              lastTransitionTime is the last time the condition transitioned from one status to another.
-                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                            format: date-time
+                              AnnotationSelector is a string that follows the label selection expression
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                              It matches with the resource annotations.
                             type: string
-                          message:
+                          group:
                             description: |-
-                              message is a human readable message indicating details about the transition.
-                              This may be an empty string.
-                            maxLength: 32768
+                              Group is the API group to select resources from.
+                              Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                             type: string
-                          observedGeneration:
+                          kind:
                             description: |-
-                              observedGeneration represents the .metadata.generation that the condition was set based upon.
-                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                              with respect to the current state of the instance.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          reason:
-                            description: |-
-                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                              Producers of specific condition types may define expected values and meanings for this field,
-                              and whether the values are considered a guaranteed API.
-                              The value should be a CamelCase string.
-                              This field may not be empty.
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              Kind of the API Group to select resources from.
+                              Together with Group and Version it is capable of unambiguously
+                              identifying and/or selecting resources.
+                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                             type: string
-                          status:
-                            description: status of the condition, one of True, False,
-                              Unknown.
+                          labelSelector:
+                            description: |-
+                              LabelSelector is a string that follows the label selection expression
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                              It matches with the resource labels.
+                            type: string
+                          name:
+                            description: Name to match resources with.
+                            type: string
+                          namespace:
+                            description: Namespace to select resources from.
+                            type: string
+                          version:
+                            description: |-
+                              Version of the API Group to select resources from.
+                              Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            type: string
+                        type: object
+                      type: array
+                    policyRefs:
+                      description: |-
+                        PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
+                        that need to be deployed in the target clusters.
+                        The values contained in those resources can be static or leverage Go templates for dynamic customization.
+                        When expressed as templates, the values are filled in using information from
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      items:
+                        properties:
+                          deploymentType:
+                            default: Remote
+                            description: |-
+                              DeploymentType indicates whether resources need to be deployed
+                              into the management cluster (local) or the managed cluster (remote)
                             enum:
-                            - "True"
-                            - "False"
-                            - Unknown
+                              - Local
+                              - Remote
                             type: string
-                          type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          kind:
+                            description: |-
+                              Kind of the resource. Supported kinds are:
+                              - ConfigMap/Secret
+                              - flux GitRepository;OCIRepository;Bucket
+                            enum:
+                              - GitRepository
+                              - OCIRepository
+                              - Bucket
+                              - ConfigMap
+                              - Secret
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referenced resource.
+                              Name can be expressed as a template and instantiate using any cluster field.
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referenced resource.
+                              For ClusterProfile namespace can be left empty. In such a case, namespace will
+                              be implicit set to cluster's namespace.
+                              For Profile namespace must be left empty. Profile namespace will be used.
+                              Namespace can be expressed as a template and instantiate using any cluster field.
+                            type: string
+                          optional:
+                            default: false
+                            description: |-
+                              Optional indicates that the referenced resource is not mandatory.
+                              If set to true and the resource is not found, the error will be ignored,
+                              and Sveltos will continue processing other PolicyRefs.
+                            type: boolean
+                          path:
+                            description: |-
+                              Path to the directory containing the YAML files.
+                              Defaults to 'None', which translates to the root path of the SourceRef.
+                              Used only for GitRepository;OCIRepository;Bucket
                             type: string
                         required:
-                        - lastTransitionTime
-                        - message
-                        - reason
-                        - status
-                        - type
+                          - kind
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    priority:
+                      default: 100
+                      description: |-
+                        Priority sets the priority for the services defined in this spec.
+                        Higher value means higher priority and lower means lower.
+                        In case of conflict with another object managing the service,
+                        the one with higher priority will get to deploy its services.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      format: int32
+                      maximum: 2147483646
+                      minimum: 1
+                      type: integer
+                    provider:
+                      description: Provider is the definition of the provider to use to deploy services.
+                      properties:
+                        config:
+                          description: Config is the provider-specific configuration applied to the produced objects.
+                          x-kubernetes-preserve-unknown-fields: true
+                        name:
+                          description: Name is the name of the [StateManagementProvider] object.
+                          type: string
+                          x-kubernetes-validations:
+                            - message: Provider name is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        selfManagement:
+                          description: |-
+                            SelfManagement flag defines whether resources must be deployed to the management cluster itself.
+                            This field is ignored if set for ClusterDeployment.
+                          type: boolean
+                      type: object
+                    reload:
+                      description: |-
+                        Reload instances via rolling upgrade when a ConfigMap/Secret mounted as volume is modified.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      type: boolean
+                    services:
+                      description: |-
+                        Services is a list of services created via ServiceTemplates
+                        that could be installed on the target cluster.
+                      items:
+                        description: Service represents a Service to be deployed.
+                        properties:
+                          dependsOn:
+                            description: DependsOn specifies a list of other services that this service depends on.
+                            items:
+                              description: ServiceDependsOn identifies a service by its release name and namespace.
+                              properties:
+                                name:
+                                  description: Name is the release name on target cluster.
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                namespace:
+                                  description: Namespace is the release namespace on target cluster.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            type: array
+                          disable:
+                            description: Disable can be set to disable handling of this service.
+                            type: boolean
+                          helmOptions:
+                            description: HelmOptions are the options to be passed to the provider for helm installation or updates
+                            properties:
+                              atomic:
+                                description: |-
+                                  if set, the installation process deletes the installation/upgrades on failure.
+                                  The --wait flag will be set automatically if --atomic is used
+                                type: boolean
+                              createNamespace:
+                                type: boolean
+                              dependencyUpdate:
+                                description: update dependencies if they are missing before installing the chart
+                                type: boolean
+                              description:
+                                description: Description is the description of an helm operation
+                                type: string
+                              disableHooks:
+                                description: prevent hooks from running during install/upgrade/uninstall
+                                type: boolean
+                              disableOpenAPIValidation:
+                                description: if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema
+                                type: boolean
+                              enableClientCache:
+                                description: EnableClientCache is a flag to enable Helm client cache. If it is not specified, it will be set to false.
+                                type: boolean
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels that would be added to release metadata.
+                                type: object
+                              replace:
+                                description: Replaces if set indicates to replace an older release with this one
+                                type: boolean
+                              skipCRDs:
+                                description: |-
+                                  SkipCRDs controls whether CRDs should be installed during install/upgrade operation.
+                                  By default, CRDs are installed if not already present.
+                                type: boolean
+                              skipSchemaValidation:
+                                description: SkipSchemaValidation determines if JSON schema validation is disabled.
+                                type: boolean
+                              timeout:
+                                description: time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
+                                type: string
+                              wait:
+                                description: |-
+                                  if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet
+                                  are in a ready state before marking the release as successful. It will wait for as long as --timeout
+                                type: boolean
+                              waitForJobs:
+                                description: |-
+                                  if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful.
+                                  It will wait for as long as --timeout
+                                type: boolean
+                            type: object
+                          name:
+                            description: Name is the chart release.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            default: default
+                            description: |-
+                              Namespace is the namespace the release will be installed in.
+                              It will default to "default" if not provided.
+                            type: string
+                          template:
+                            description: Template is a reference to a Template object located in the same namespace.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          templateChain:
+                            description: |-
+                              TemplateChain defines the ServiceTemplateChain object that will be used to deploy the service
+                              along with desired ServiceTemplate version.
+                            type: string
+                          values:
+                            description: |-
+                              Values is the helm values to be passed to the chart used by the template.
+                              The string type is used in order to allow for templating.
+                            type: string
+                          valuesFrom:
+                            description: ValuesFrom can reference a ConfigMap or Secret containing helm values.
+                            items:
+                              description: |-
+                                ValuesFrom is the source of the values to pass to the ServiceTemplate. The source
+                                can be a ConfigMap or a Secret located in the same namespace as the ServiceSet.
+                              properties:
+                                kind:
+                                  description: Kind is the kind of the source.
+                                  enum:
+                                    - ConfigMap
+                                    - Secret
+                                  type: string
+                                name:
+                                  description: Name is the name of the source.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            type: array
+                          version:
+                            description: Version is the version of the service template.
+                            type: string
+                        required:
+                          - name
+                          - template
                         type: object
                       type: array
                       x-kubernetes-list-map-keys:
-                      - type
+                        - name
+                        - namespace
                       x-kubernetes-list-type: map
-                    failureMessage:
-                      description: FailureMessage is the reason why the Service failed
-                        to deploy
-                      type: string
-                    lastStateTransitionTime:
-                      description: LastStateTransitionTime is the time the State was
-                        last transitioned
-                      format: date-time
-                      type: string
-                    name:
-                      description: Name is the name of the Service
-                      type: string
-                    namespace:
-                      description: Namespace is the namespace of the Service
-                      type: string
-                    state:
-                      description: State is the state of the Service
+                    stopOnConflict:
+                      default: false
+                      description: |-
+                        StopOnConflict specifies what to do in case of a conflict.
+                        E.g. If another object is already managing a service.
+                        By default the remaining services will be deployed even if conflict is detected.
+                        If set to true, the deployment will stop after encountering the first conflict.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      type: boolean
+                    syncMode:
+                      default: Continuous
+                      description: |-
+                        SyncMode specifies how services are synced in the target cluster.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
                       enum:
-                      - Deployed
-                      - Provisioning
-                      - Failed
-                      - Pending
-                      - Deleting
+                        - OneTime
+                        - Continuous
+                        - ContinuousWithDriftDetection
+                        - DryRun
                       type: string
-                    template:
-                      description: Template is the name of the ServiceTemplate used
-                        to deploy the Service
-                      type: string
-                    type:
-                      description: Type is the type of the deployment method for the
-                        Service
-                      enum:
-                      - Helm
-                      - Kustomize
-                      - Resource
-                      type: string
-                    version:
-                      description: Version is the version of the Service
-                      type: string
-                  required:
-                  - lastStateTransitionTime
-                  - name
-                  - namespace
-                  - state
-                  - template
-                  - type
-                  type: object
-                type: array
-              servicesUpgradePaths:
-                description: ServicesUpgradePaths contains details for the state of
-                  services upgrade paths.
-                items:
-                  description: ServiceUpgradePaths contains details for the state
-                    of service upgrade paths.
-                  properties:
-                    availableUpgrades:
-                      description: AvailableUpgrades contains details for the state
-                        of available upgrades.
+                    templateResourceRefs:
+                      description: |-
+                        TemplateResourceRefs is a list of resources to collect from the management cluster,
+                        the values from which can be used in templates.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
                       items:
-                        description: UpgradePath contains details for the state of
-                          service upgrade paths.
                         properties:
-                          upgradePaths:
-                            description: 'Deprecated: use Versions to define versions
-                              that service can be upgraded to.'
-                            items:
-                              type: string
-                            type: array
-                          versions:
-                            description: Versions contains the list of versions that
-                              service can be upgraded to.
-                            items:
-                              description: AvailableUpgrade is the definition of the
-                                available upgrade for the Template
-                              properties:
-                                name:
-                                  description: Name is the name of the Template to
-                                    which the upgrade is available.
-                                  type: string
-                                version:
-                                  description: Version is the version of the Template
-                                    to which the upgrade is available.
-                                  type: string
-                              required:
-                              - name
-                              - version
-                              type: object
-                            type: array
+                          identifier:
+                            description: |-
+                              Identifier is how the resource will be referred to in the
+                              template
+                            type: string
+                          optional:
+                            default: false
+                            description: |-
+                              Optional indicates that the referenced resource is not mandatory.
+                              If set to true and the resource is not found, the error will be ignored,
+                              and Sveltos will continue processing other TemplateResourceRefs.
+                            type: boolean
+                          resource:
+                            description: |-
+                              Resource references a Kubernetes instance in the management
+                              cluster to fetch and use during template instantiation.
+                              For ClusterProfile namespace can be left empty. In such a case, namespace will
+                              be implicit set to cluster's namespace.
+                              Name and namespace can be expressed as a template and instantiate using any cluster field.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - identifier
+                          - resource
                         type: object
                       type: array
-                    name:
-                      description: Name is the name of the service.
-                      type: string
-                    namespace:
-                      description: Namespace is the namespace of the service.
-                      type: string
-                    template:
-                      description: Template is the name of the current service template.
-                      type: string
-                  required:
-                  - name
-                  - namespace
-                  - template
                   type: object
-                type: array
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                template:
+                  description: Template is a reference to a Template object located in the same namespace.
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+              required:
+                - template
+              type: object
+            status:
+              description: ClusterDeploymentStatus defines the observed state of ClusterDeployment
+              properties:
+                availableUpgrades:
+                  description: |-
+                    AvailableUpgrades is the list of ClusterTemplate names to which
+                    this cluster can be upgraded. It can be an empty array, which means no upgrades are
+                    available.
+                  items:
+                    type: string
+                  type: array
+                conditions:
+                  description: Conditions contains details for the current state of the ClusterDeployment.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                k8sVersion:
+                  description: |-
+                    Currently compatible exact Kubernetes version of the cluster. Being set only if
+                    provided by the corresponding ClusterTemplate.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                region:
+                  description: Region shows the region the [ClusterDeployment] targets.
+                  type: string
+                services:
+                  description: Services contains details for the state of services.
+                  items:
+                    description: ServiceState is the state of a Service
+                    properties:
+                      conditions:
+                        description: Conditions is a list of conditions for the Service
+                        items:
+                          description: Condition contains details for one aspect of the current state of this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: |-
+                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              format: date-time
+                              type: string
+                            message:
+                              description: |-
+                                message is a human readable message indicating details about the transition.
+                                This may be an empty string.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: |-
+                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                with respect to the current state of the instance.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: |-
+                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                Producers of specific condition types may define expected values and meanings for this field,
+                                and whether the values are considered a guaranteed API.
+                                The value should be a CamelCase string.
+                                This field may not be empty.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      failureMessage:
+                        description: FailureMessage is the reason why the Service failed to deploy
+                        type: string
+                      lastStateTransitionTime:
+                        description: LastStateTransitionTime is the time the State was last transitioned
+                        format: date-time
+                        type: string
+                      name:
+                        description: Name is the name of the Service
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the Service
+                        type: string
+                      state:
+                        description: State is the state of the Service
+                        enum:
+                          - Deployed
+                          - Provisioning
+                          - Failed
+                          - Pending
+                          - Deleting
+                        type: string
+                      template:
+                        description: Template is the name of the ServiceTemplate used to deploy the Service
+                        type: string
+                      type:
+                        description: Type is the type of the deployment method for the Service
+                        enum:
+                          - Helm
+                          - Kustomize
+                          - Resource
+                        type: string
+                      version:
+                        description: Version is the version of the Service
+                        type: string
+                    required:
+                      - lastStateTransitionTime
+                      - name
+                      - namespace
+                      - state
+                      - template
+                      - type
+                    type: object
+                  type: array
+                servicesUpgradePaths:
+                  description: ServicesUpgradePaths contains details for the state of services upgrade paths.
+                  items:
+                    description: ServiceUpgradePaths contains details for the state of service upgrade paths.
+                    properties:
+                      availableUpgrades:
+                        description: AvailableUpgrades contains details for the state of available upgrades.
+                        items:
+                          description: UpgradePath contains details for the state of service upgrade paths.
+                          properties:
+                            upgradePaths:
+                              description: 'Deprecated: use Versions to define versions that service can be upgraded to.'
+                              items:
+                                type: string
+                              type: array
+                            versions:
+                              description: Versions contains the list of versions that service can be upgraded to.
+                              items:
+                                description: AvailableUpgrade is the definition of the available upgrade for the Template
+                                properties:
+                                  name:
+                                    description: Name is the name of the Template to which the upgrade is available.
+                                    type: string
+                                  version:
+                                    description: Version is the version of the Template to which the upgrade is available.
+                                    type: string
+                                required:
+                                  - name
+                                  - version
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                      name:
+                        description: Name is the name of the service.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the service.
+                        type: string
+                      template:
+                        description: Template is the name of the current service template.
+                        type: string
+                    required:
+                      - name
+                      - namespace
+                      - template
+                    type: object
+                  type: array
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusteripamclaims.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusteripamclaims.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: clusteripamclaims.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -14,195 +15,186 @@ spec:
     singular: clusteripamclaim
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Bound
-      jsonPath: .status.bound
-      name: bound
-      type: string
-    - description: Time elapsed since object creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ClusterIPAMClaim is the Schema for the clusteripamclaims API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ClusterIPAMClaimSpec defines the desired state of ClusterIPAMClaim
-            properties:
-              cluster:
-                description: Cluster is the reference to the [ClusterDeployment] that
-                  this claim is for
-                type: string
-                x-kubernetes-validations:
-                - message: Cluster reference is immutable once set
-                  rule: oldSelf == '' || self == oldSelf
-              clusterIPAMRef:
-                description: ClusterIPAMRef is the reference to the [ClusterIPAM]
-                  resource that this claim is for
-                type: string
-                x-kubernetes-validations:
-                - message: ClusterIPAM reference is immutable once set
-                  rule: oldSelf == '' || self == oldSelf
-              clusterNetwork:
-                description: ClusterNetwork defines the allocation for requisitioning
-                  ip addresses for use by the k8s cluster itself
-                properties:
-                  cidr:
-                    description: CIDR notation of the allocated address space
-                    type: string
-                  gateway:
-                    description: Gateway to be used for the address space
-                    type: string
-                  ipAddresses:
-                    description: IPAddresses to be allocated
-                    items:
-                      type: string
-                    type: array
-                  prefix:
-                    description: Prefix is the network prefix to use.
-                    type: integer
-                type: object
-              externalNetwork:
-                description: ExternalNetwork defines the allocation for requisitioning
-                  ip addresses for use by services such as load balancers
-                properties:
-                  cidr:
-                    description: CIDR notation of the allocated address space
-                    type: string
-                  gateway:
-                    description: Gateway to be used for the address space
-                    type: string
-                  ipAddresses:
-                    description: IPAddresses to be allocated
-                    items:
-                      type: string
-                    type: array
-                  prefix:
-                    description: Prefix is the network prefix to use.
-                    type: integer
-                type: object
-              nodeNetwork:
-                description: NodeNetwork defines the allocation requisitioning ip
-                  addresses for cluster nodes
-                properties:
-                  cidr:
-                    description: CIDR notation of the allocated address space
-                    type: string
-                  gateway:
-                    description: Gateway to be used for the address space
-                    type: string
-                  ipAddresses:
-                    description: IPAddresses to be allocated
-                    items:
-                      type: string
-                    type: array
-                  prefix:
-                    description: Prefix is the network prefix to use.
-                    type: integer
-                type: object
-              provider:
-                description: Provider is the name of the provider that this claim
-                  will be consumed by
-                enum:
-                - in-cluster
-                - ipam-infoblox
-                type: string
-            required:
-            - provider
-            type: object
-          status:
-            description: ClusterIPAMClaimStatus defines the observed state of ClusterIPAMClaim
-            properties:
-              bound:
-                default: false
-                description: Bound is a flag to indicate that the claim is bound because
-                  all ip addresses are allocated
-                type: boolean
-              conditions:
-                description: Conditions contains details for the current state of
-                  the [ClusterIPAMClaim]
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+    - additionalPrinterColumns:
+        - description: Bound
+          jsonPath: .status.bound
+          name: bound
+          type: string
+        - description: Time elapsed since object creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ClusterIPAMClaim is the Schema for the clusteripamclaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterIPAMClaimSpec defines the desired state of ClusterIPAMClaim
+              properties:
+                cluster:
+                  description: Cluster is the reference to the [ClusterDeployment] that this claim is for
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Cluster reference is immutable once set
+                      rule: oldSelf == '' || self == oldSelf
+                clusterIPAMRef:
+                  description: ClusterIPAMRef is the reference to the [ClusterIPAM] resource that this claim is for
+                  type: string
+                  x-kubernetes-validations:
+                    - message: ClusterIPAM reference is immutable once set
+                      rule: oldSelf == '' || self == oldSelf
+                clusterNetwork:
+                  description: ClusterNetwork defines the allocation for requisitioning ip addresses for use by the k8s cluster itself
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                    cidr:
+                      description: CIDR notation of the allocated address space
                       type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
+                    gateway:
+                      description: Gateway to be used for the address space
                       type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
+                    ipAddresses:
+                      description: IPAddresses to be allocated
+                      items:
+                        type: string
+                      type: array
+                    prefix:
+                      description: Prefix is the network prefix to use.
                       type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
                   type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-            required:
-            - bound
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                externalNetwork:
+                  description: ExternalNetwork defines the allocation for requisitioning ip addresses for use by services such as load balancers
+                  properties:
+                    cidr:
+                      description: CIDR notation of the allocated address space
+                      type: string
+                    gateway:
+                      description: Gateway to be used for the address space
+                      type: string
+                    ipAddresses:
+                      description: IPAddresses to be allocated
+                      items:
+                        type: string
+                      type: array
+                    prefix:
+                      description: Prefix is the network prefix to use.
+                      type: integer
+                  type: object
+                nodeNetwork:
+                  description: NodeNetwork defines the allocation requisitioning ip addresses for cluster nodes
+                  properties:
+                    cidr:
+                      description: CIDR notation of the allocated address space
+                      type: string
+                    gateway:
+                      description: Gateway to be used for the address space
+                      type: string
+                    ipAddresses:
+                      description: IPAddresses to be allocated
+                      items:
+                        type: string
+                      type: array
+                    prefix:
+                      description: Prefix is the network prefix to use.
+                      type: integer
+                  type: object
+                provider:
+                  description: Provider is the name of the provider that this claim will be consumed by
+                  enum:
+                    - in-cluster
+                    - ipam-infoblox
+                  type: string
+              required:
+                - provider
+              type: object
+            status:
+              description: ClusterIPAMClaimStatus defines the observed state of ClusterIPAMClaim
+              properties:
+                bound:
+                  default: false
+                  description: Bound is a flag to indicate that the claim is bound because all ip addresses are allocated
+                  type: boolean
+                conditions:
+                  description: Conditions contains details for the current state of the [ClusterIPAMClaim]
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              required:
+                - bound
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusteripams.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusteripams.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: clusteripams.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -14,87 +15,85 @@ spec:
     singular: clusteripam
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Phase
-      jsonPath: .status.phase
-      name: phase
-      type: string
-    - description: Time elapsed since object creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ClusterIPAM is the Schema for the clusteripams API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ClusterIPAMSpec defines the desired state of ClusterIPAM
-            properties:
-              clusterIPAMClaimRef:
-                description: ClusterIPAMClaimRef is a reference to the [ClusterIPAMClaim]
-                  that this [ClusterIPAM] is bound to.
-                type: string
-                x-kubernetes-validations:
-                - message: Claim reference is immutable once set
-                  rule: oldSelf == '' || self == oldSelf
-              provider:
-                description: The provider that this claim will be consumed by
-                enum:
-                - in-cluster
-                - ipam-infoblox
-                type: string
-            type: object
-          status:
-            description: ClusterIPAMStatus defines the observed state of ClusterIPAM
-            properties:
-              phase:
-                description: Phase is the current phase of the ClusterIPAM.
-                enum:
-                - Pending
-                - Bound
-                example: Pending
-                type: string
-              providerData:
-                description: |-
-                  ProviderData is the provider specific data produced for the ClusterIPAM.
-                  This field is represented as a list, because it will store multiple entries
-                  for different networks - nodes, cluster (pods, services), external - for
-                  the same provider.
-                items:
-                  properties:
-                    config:
-                      description: Data is the IPAM provider specific data
-                      x-kubernetes-preserve-unknown-fields: true
-                    name:
-                      description: Name of the IPAM provider data
-                      type: string
-                    ready:
-                      description: Ready indicates that the IPAM provider data is
-                        ready
-                      type: boolean
-                  type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Phase
+          jsonPath: .status.phase
+          name: phase
+          type: string
+        - description: Time elapsed since object creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ClusterIPAM is the Schema for the clusteripams API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterIPAMSpec defines the desired state of ClusterIPAM
+              properties:
+                clusterIPAMClaimRef:
+                  description: ClusterIPAMClaimRef is a reference to the [ClusterIPAMClaim] that this [ClusterIPAM] is bound to.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Claim reference is immutable once set
+                      rule: oldSelf == '' || self == oldSelf
+                provider:
+                  description: The provider that this claim will be consumed by
+                  enum:
+                    - in-cluster
+                    - ipam-infoblox
+                  type: string
+              type: object
+            status:
+              description: ClusterIPAMStatus defines the observed state of ClusterIPAM
+              properties:
+                phase:
+                  description: Phase is the current phase of the ClusterIPAM.
+                  enum:
+                    - Pending
+                    - Bound
+                  example: Pending
+                  type: string
+                providerData:
+                  description: |-
+                    ProviderData is the provider specific data produced for the ClusterIPAM.
+                    This field is represented as a list, because it will store multiple entries
+                    for different networks - nodes, cluster (pods, services), external - for
+                    the same provider.
+                  items:
+                    properties:
+                      config:
+                        description: Data is the IPAM provider specific data
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
+                        description: Name of the IPAM provider data
+                        type: string
+                      ready:
+                        description: Ready indicates that the IPAM provider data is ready
+                        type: boolean
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplatechains.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplatechains.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: clustertemplatechains.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -14,97 +15,89 @@ spec:
     singular: clustertemplatechain
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Is the chain valid
-      jsonPath: .status.valid
-      name: Valid
-      type: boolean
-    - description: Time elapsed since object creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ClusterTemplateChain is the Schema for the clustertemplatechains
-          API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: TemplateChainSpec defines the desired state of *TemplateChain
-            properties:
-              supportedTemplates:
-                description: SupportedTemplates is the list of supported Templates
-                  definitions and all available upgrade sequences for it.
-                items:
-                  description: SupportedTemplate is the supported Template definition
-                    and all available upgrade sequences for it
-                  properties:
-                    availableUpgrades:
-                      description: AvailableUpgrades is the list of available upgrades
-                        for the specified Template.
-                      items:
-                        description: AvailableUpgrade is the definition of the available
-                          upgrade for the Template
-                        properties:
-                          name:
-                            description: Name is the name of the Template to which
-                              the upgrade is available.
-                            type: string
-                          version:
-                            description: Version is the version of the Template to
-                              which the upgrade is available.
-                            type: string
-                        required:
-                        - name
-                        - version
-                        type: object
-                      type: array
-                    name:
-                      description: Name is the name of the Template.
-                      type: string
-                  required:
-                  - name
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - name
-                x-kubernetes-list-type: map
-            type: object
-            x-kubernetes-validations:
-            - message: Spec is immutable
-              rule: self == oldSelf
-          status:
-            description: TemplateChainStatus defines the observed state of *TemplateChain
-            properties:
-              valid:
-                description: |-
-                  Valid indicates whether the chain is valid and can be considered when calculating available
-                  upgrade paths.
-                type: boolean
-              validationError:
-                description: ValidationError provides information regarding issues
-                  encountered during templatechain validation.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Is the chain valid
+          jsonPath: .status.valid
+          name: Valid
+          type: boolean
+        - description: Time elapsed since object creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ClusterTemplateChain is the Schema for the clustertemplatechains API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TemplateChainSpec defines the desired state of *TemplateChain
+              properties:
+                supportedTemplates:
+                  description: SupportedTemplates is the list of supported Templates definitions and all available upgrade sequences for it.
+                  items:
+                    description: SupportedTemplate is the supported Template definition and all available upgrade sequences for it
+                    properties:
+                      availableUpgrades:
+                        description: AvailableUpgrades is the list of available upgrades for the specified Template.
+                        items:
+                          description: AvailableUpgrade is the definition of the available upgrade for the Template
+                          properties:
+                            name:
+                              description: Name is the name of the Template to which the upgrade is available.
+                              type: string
+                            version:
+                              description: Version is the version of the Template to which the upgrade is available.
+                              type: string
+                          required:
+                            - name
+                            - version
+                          type: object
+                        type: array
+                      name:
+                        description: Name is the name of the Template.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+              x-kubernetes-validations:
+                - message: Spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: TemplateChainStatus defines the observed state of *TemplateChain
+              properties:
+                valid:
+                  description: |-
+                    Valid indicates whether the chain is valid and can be considered when calculating available
+                    upgrade paths.
+                  type: boolean
+                validationError:
+                  description: ValidationError provides information regarding issues encountered during templatechain validation.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: clustertemplates.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,1030 +13,975 @@ spec:
     listKind: ClusterTemplateList
     plural: clustertemplates
     shortNames:
-    - clustertmpl
+      - clustertmpl
     singular: clustertemplate
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Valid
-      jsonPath: .status.valid
-      name: valid
-      type: boolean
-    - description: Validation Error
-      jsonPath: .status.validationError
-      name: validationError
-      priority: 1
-      type: string
-    - description: Description
-      jsonPath: .status.description
-      name: description
-      priority: 1
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ClusterTemplate is the Schema for the clustertemplates API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ClusterTemplateSpec defines the desired state of ClusterTemplate
-            properties:
-              helm:
-                description: HelmSpec references a Helm chart representing the KCM
-                  template
-                properties:
-                  chartRef:
-                    description: |-
-                      ChartRef is a reference to a source controller resource containing the
-                      Helm chart representing the template.
-                    properties:
-                      apiVersion:
-                        description: APIVersion of the referent.
-                        type: string
-                      kind:
-                        description: Kind of the referent.
-                        enum:
-                        - OCIRepository
-                        - HelmChart
-                        - ExternalArtifact
-                        type: string
-                      name:
-                        description: Name of the referent.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      namespace:
-                        description: |-
-                          Namespace of the referent, defaults to the namespace of the Kubernetes
-                          resource object that contains the reference.
-                        maxLength: 63
-                        minLength: 1
-                        type: string
-                    required:
-                    - kind
-                    - name
-                    type: object
-                  chartSource:
-                    description: ChartSource is a source of a Helm chart representing
-                      the template.
-                    properties:
-                      deploymentType:
-                        default: Remote
-                        description: |-
-                          DeploymentType is the type of the deployment. This field is ignored,
-                          when ResourceSpec is used as part of Helm chart configuration.
-                        enum:
-                        - Local
-                        - Remote
-                        type: string
-                      localSourceRef:
-                        description: LocalSourceRef is the local source of the kustomize
-                          manifest.
-                        properties:
-                          kind:
-                            description: Kind is the kind of the local source.
-                            enum:
-                            - ConfigMap
-                            - Secret
-                            - GitRepository
-                            - Bucket
+    - additionalPrinterColumns:
+        - description: Valid
+          jsonPath: .status.valid
+          name: valid
+          type: boolean
+        - description: Validation Error
+          jsonPath: .status.validationError
+          name: validationError
+          priority: 1
+          type: string
+        - description: Description
+          jsonPath: .status.description
+          name: description
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ClusterTemplate is the Schema for the clustertemplates API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterTemplateSpec defines the desired state of ClusterTemplate
+              properties:
+                helm:
+                  description: HelmSpec references a Helm chart representing the KCM template
+                  properties:
+                    chartRef:
+                      description: |-
+                        ChartRef is a reference to a source controller resource containing the
+                        Helm chart representing the template.
+                      properties:
+                        apiVersion:
+                          description: APIVersion of the referent.
+                          type: string
+                        kind:
+                          description: Kind of the referent.
+                          enum:
                             - OCIRepository
-                            type: string
-                          name:
-                            description: Name is the name of the local source.
-                            type: string
-                          namespace:
-                            description: |-
-                              Namespace is the namespace of the local source. Cross-namespace references
-                              are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
-                              If the Kind is ConfigMap or Secret, the namespace will be ignored.
-                            type: string
-                        required:
+                            - HelmChart
+                            - ExternalArtifact
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referent, defaults to the namespace of the Kubernetes
+                            resource object that contains the reference.
+                          maxLength: 63
+                          minLength: 1
+                          type: string
+                      required:
                         - kind
                         - name
-                        type: object
-                      path:
-                        description: Path to the directory containing the resource
-                          manifest.
-                        type: string
-                      remoteSourceSpec:
-                        description: RemoteSourceSpec is the remote source of the
-                          kustomize manifest.
-                        properties:
-                          bucket:
-                            description: Bucket is the definition of bucket source.
-                            properties:
-                              bucketName:
-                                description: BucketName is the name of the object
-                                  storage bucket.
-                                type: string
-                              certSecretRef:
-                                description: |-
-                                  CertSecretRef can be given the name of a Secret containing
-                                  either or both of
-
-                                  - a PEM-encoded client certificate (`tls.crt`) and private
-                                  key (`tls.key`);
-                                  - a PEM-encoded CA certificate (`ca.crt`)
-
-                                  and whichever are supplied, will be used for connecting to the
-                                  bucket. The client cert and key are useful if you are
-                                  authenticating with a certificate; the CA cert is useful if
-                                  you are using a self-signed server certificate. The Secret must
-                                  be of type `Opaque` or `kubernetes.io/tls`.
-
-                                  This field is only supported for the `generic` provider.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              endpoint:
-                                description: Endpoint is the object storage address
-                                  the BucketName is located at.
-                                type: string
-                              ignore:
-                                description: |-
-                                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                                  (which is the same as .gitignore). If not provided, a default will be used,
-                                  consult the documentation for your version to find out what those are.
-                                type: string
-                              insecure:
-                                description: Insecure allows connecting to a non-TLS
-                                  HTTP Endpoint.
-                                type: boolean
-                              interval:
-                                description: |-
-                                  Interval at which the Bucket Endpoint is checked for updates.
-                                  This interval is approximate and may be subject to jitter to ensure
-                                  efficient use of resources.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                                type: string
-                              prefix:
-                                description: Prefix to use for server-side filtering
-                                  of files in the Bucket.
-                                type: string
-                              provider:
-                                default: generic
-                                description: |-
-                                  Provider of the object storage bucket.
-                                  Defaults to 'generic', which expects an S3 (API) compatible object
-                                  storage.
-                                enum:
-                                - generic
-                                - aws
-                                - gcp
-                                - azure
-                                type: string
-                              proxySecretRef:
-                                description: |-
-                                  ProxySecretRef specifies the Secret containing the proxy configuration
-                                  to use while communicating with the Bucket server.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              region:
-                                description: Region of the Endpoint where the BucketName
-                                  is located in.
-                                type: string
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Secret containing authentication credentials
-                                  for the Bucket.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceAccountName:
-                                description: |-
-                                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                                  the bucket. This field is only supported for the 'gcp' and 'aws' providers.
-                                  For more information about workload identity:
-                                  https://fluxcd.io/flux/components/source/buckets/#workload-identity
-                                type: string
-                              sts:
-                                description: |-
-                                  STS specifies the required configuration to use a Security Token
-                                  Service for fetching temporary credentials to authenticate in a
-                                  Bucket provider.
-
-                                  This field is only supported for the `aws` and `generic` providers.
-                                properties:
-                                  certSecretRef:
-                                    description: |-
-                                      CertSecretRef can be given the name of a Secret containing
-                                      either or both of
-
-                                      - a PEM-encoded client certificate (`tls.crt`) and private
-                                      key (`tls.key`);
-                                      - a PEM-encoded CA certificate (`ca.crt`)
-
-                                      and whichever are supplied, will be used for connecting to the
-                                      STS endpoint. The client cert and key are useful if you are
-                                      authenticating with a certificate; the CA cert is useful if
-                                      you are using a self-signed server certificate. The Secret must
-                                      be of type `Opaque` or `kubernetes.io/tls`.
-
-                                      This field is only supported for the `ldap` provider.
-                                    properties:
-                                      name:
-                                        description: Name of the referent.
-                                        type: string
-                                    required:
-                                    - name
-                                    type: object
-                                  endpoint:
-                                    description: |-
-                                      Endpoint is the HTTP/S endpoint of the Security Token Service from
-                                      where temporary credentials will be fetched.
-                                    pattern: ^(http|https)://.*$
-                                    type: string
-                                  provider:
-                                    description: Provider of the Security Token Service.
-                                    enum:
-                                    - aws
-                                    - ldap
-                                    type: string
-                                  secretRef:
-                                    description: |-
-                                      SecretRef specifies the Secret containing authentication credentials
-                                      for the STS endpoint. This Secret must contain the fields `username`
-                                      and `password` and is supported only for the `ldap` provider.
-                                    properties:
-                                      name:
-                                        description: Name of the referent.
-                                        type: string
-                                    required:
-                                    - name
-                                    type: object
-                                required:
-                                - endpoint
-                                - provider
-                                type: object
-                              suspend:
-                                description: |-
-                                  Suspend tells the controller to suspend the reconciliation of this
-                                  Bucket.
-                                type: boolean
-                              timeout:
-                                default: 60s
-                                description: Timeout for fetch operations, defaults
-                                  to 60s.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                                type: string
-                            required:
-                            - bucketName
-                            - endpoint
-                            - interval
-                            type: object
-                            x-kubernetes-validations:
-                            - message: STS configuration is only supported for the
-                                'aws' and 'generic' Bucket providers
-                              rule: self.provider == 'aws' || self.provider == 'generic'
-                                || !has(self.sts)
-                            - message: '''aws'' is the only supported STS provider
-                                for the ''aws'' Bucket provider'
-                              rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider
-                                == 'aws'
-                            - message: '''ldap'' is the only supported STS provider
-                                for the ''generic'' Bucket provider'
-                              rule: self.provider != 'generic' || !has(self.sts) ||
-                                self.sts.provider == 'ldap'
-                            - message: spec.sts.secretRef is not required for the
-                                'aws' STS provider
-                              rule: '!has(self.sts) || self.sts.provider != ''aws''
-                                || !has(self.sts.secretRef)'
-                            - message: spec.sts.certSecretRef is not required for
-                                the 'aws' STS provider
-                              rule: '!has(self.sts) || self.sts.provider != ''aws''
-                                || !has(self.sts.certSecretRef)'
-                            - message: ServiceAccountName is not supported for the
-                                'generic' Bucket provider
-                              rule: self.provider != 'generic' || !has(self.serviceAccountName)
-                            - message: cannot set both .spec.secretRef and .spec.serviceAccountName
-                              rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
-                          git:
-                            description: Git is the definition of git repository source.
-                            properties:
-                              ignore:
-                                description: |-
-                                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                                  (which is the same as .gitignore). If not provided, a default will be used,
-                                  consult the documentation for your version to find out what those are.
-                                type: string
-                              include:
-                                description: |-
-                                  Include specifies a list of GitRepository resources which Artifacts
-                                  should be included in the Artifact produced for this GitRepository.
-                                items:
+                      type: object
+                    chartSource:
+                      description: ChartSource is a source of a Helm chart representing the template.
+                      properties:
+                        deploymentType:
+                          default: Remote
+                          description: |-
+                            DeploymentType is the type of the deployment. This field is ignored,
+                            when ResourceSpec is used as part of Helm chart configuration.
+                          enum:
+                            - Local
+                            - Remote
+                          type: string
+                        localSourceRef:
+                          description: LocalSourceRef is the local source of the kustomize manifest.
+                          properties:
+                            kind:
+                              description: Kind is the kind of the local source.
+                              enum:
+                                - ConfigMap
+                                - Secret
+                                - GitRepository
+                                - Bucket
+                                - OCIRepository
+                              type: string
+                            name:
+                              description: Name is the name of the local source.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of the local source. Cross-namespace references
+                                are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
+                                [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
+                                If the Kind is ConfigMap or Secret, the namespace will be ignored.
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                        path:
+                          description: Path to the directory containing the resource manifest.
+                          type: string
+                        remoteSourceSpec:
+                          description: RemoteSourceSpec is the remote source of the kustomize manifest.
+                          properties:
+                            bucket:
+                              description: Bucket is the definition of bucket source.
+                              properties:
+                                bucketName:
+                                  description: BucketName is the name of the object storage bucket.
+                                  type: string
+                                certSecretRef:
                                   description: |-
-                                    GitRepositoryInclude specifies a local reference to a GitRepository which
-                                    Artifact (sub-)contents must be included, and where they should be placed.
+                                    CertSecretRef can be given the name of a Secret containing
+                                    either or both of
+
+                                    - a PEM-encoded client certificate (`tls.crt`) and private
+                                    key (`tls.key`);
+                                    - a PEM-encoded CA certificate (`ca.crt`)
+
+                                    and whichever are supplied, will be used for connecting to the
+                                    bucket. The client cert and key are useful if you are
+                                    authenticating with a certificate; the CA cert is useful if
+                                    you are using a self-signed server certificate. The Secret must
+                                    be of type `Opaque` or `kubernetes.io/tls`.
+
+                                    This field is only supported for the `generic` provider.
                                   properties:
-                                    fromPath:
-                                      description: |-
-                                        FromPath specifies the path to copy contents from, defaults to the root
-                                        of the Artifact.
+                                    name:
+                                      description: Name of the referent.
                                       type: string
-                                    repository:
+                                  required:
+                                    - name
+                                  type: object
+                                endpoint:
+                                  description: Endpoint is the object storage address the BucketName is located at.
+                                  type: string
+                                ignore:
+                                  description: |-
+                                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                                    (which is the same as .gitignore). If not provided, a default will be used,
+                                    consult the documentation for your version to find out what those are.
+                                  type: string
+                                insecure:
+                                  description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+                                  type: boolean
+                                interval:
+                                  description: |-
+                                    Interval at which the Bucket Endpoint is checked for updates.
+                                    This interval is approximate and may be subject to jitter to ensure
+                                    efficient use of resources.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                                  type: string
+                                prefix:
+                                  description: Prefix to use for server-side filtering of files in the Bucket.
+                                  type: string
+                                provider:
+                                  default: generic
+                                  description: |-
+                                    Provider of the object storage bucket.
+                                    Defaults to 'generic', which expects an S3 (API) compatible object
+                                    storage.
+                                  enum:
+                                    - generic
+                                    - aws
+                                    - gcp
+                                    - azure
+                                  type: string
+                                proxySecretRef:
+                                  description: |-
+                                    ProxySecretRef specifies the Secret containing the proxy configuration
+                                    to use while communicating with the Bucket server.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                region:
+                                  description: Region of the Endpoint where the BucketName is located in.
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Secret containing authentication credentials
+                                    for the Bucket.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceAccountName:
+                                  description: |-
+                                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                                    the bucket. This field is only supported for the 'gcp' and 'aws' providers.
+                                    For more information about workload identity:
+                                    https://fluxcd.io/flux/components/source/buckets/#workload-identity
+                                  type: string
+                                sts:
+                                  description: |-
+                                    STS specifies the required configuration to use a Security Token
+                                    Service for fetching temporary credentials to authenticate in a
+                                    Bucket provider.
+
+                                    This field is only supported for the `aws` and `generic` providers.
+                                  properties:
+                                    certSecretRef:
                                       description: |-
-                                        GitRepositoryRef specifies the GitRepository which Artifact contents
-                                        must be included.
+                                        CertSecretRef can be given the name of a Secret containing
+                                        either or both of
+
+                                        - a PEM-encoded client certificate (`tls.crt`) and private
+                                        key (`tls.key`);
+                                        - a PEM-encoded CA certificate (`ca.crt`)
+
+                                        and whichever are supplied, will be used for connecting to the
+                                        STS endpoint. The client cert and key are useful if you are
+                                        authenticating with a certificate; the CA cert is useful if
+                                        you are using a self-signed server certificate. The Secret must
+                                        be of type `Opaque` or `kubernetes.io/tls`.
+
+                                        This field is only supported for the `ldap` provider.
                                       properties:
                                         name:
                                           description: Name of the referent.
                                           type: string
                                       required:
-                                      - name
+                                        - name
                                       type: object
-                                    toPath:
+                                    endpoint:
                                       description: |-
-                                        ToPath specifies the path to copy contents to, defaults to the name of
-                                        the GitRepositoryRef.
+                                        Endpoint is the HTTP/S endpoint of the Security Token Service from
+                                        where temporary credentials will be fetched.
+                                      pattern: ^(http|https)://.*$
                                       type: string
-                                  required:
-                                  - repository
-                                  type: object
-                                type: array
-                              interval:
-                                description: |-
-                                  Interval at which the GitRepository URL is checked for updates.
-                                  This interval is approximate and may be subject to jitter to ensure
-                                  efficient use of resources.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                                type: string
-                              provider:
-                                description: |-
-                                  Provider used for authentication, can be 'azure', 'github', 'generic'.
-                                  When not specified, defaults to 'generic'.
-                                enum:
-                                - generic
-                                - azure
-                                - github
-                                type: string
-                              proxySecretRef:
-                                description: |-
-                                  ProxySecretRef specifies the Secret containing the proxy configuration
-                                  to use while communicating with the Git server.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              recurseSubmodules:
-                                description: |-
-                                  RecurseSubmodules enables the initialization of all submodules within
-                                  the GitRepository as cloned from the URL, using their default settings.
-                                type: boolean
-                              ref:
-                                description: |-
-                                  Reference specifies the Git reference to resolve and monitor for
-                                  changes, defaults to the 'master' branch.
-                                properties:
-                                  branch:
-                                    description: Branch to check out, defaults to
-                                      'master' if no other field is defined.
-                                    type: string
-                                  commit:
-                                    description: |-
-                                      Commit SHA to check out, takes precedence over all reference fields.
-
-                                      This can be combined with Branch to shallow clone the branch, in which
-                                      the commit is expected to exist.
-                                    type: string
-                                  name:
-                                    description: |-
-                                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
-
-                                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
-                                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
-                                    type: string
-                                  semver:
-                                    description: SemVer tag expression to check out,
-                                      takes precedence over Tag.
-                                    type: string
-                                  tag:
-                                    description: Tag to check out, takes precedence
-                                      over Branch.
-                                    type: string
-                                type: object
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Secret containing authentication credentials for
-                                  the GitRepository.
-                                  For HTTPS repositories the Secret must contain 'username' and 'password'
-                                  fields for basic auth or 'bearerToken' field for token auth.
-                                  For SSH repositories the Secret must contain 'identity'
-                                  and 'known_hosts' fields.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceAccountName:
-                                description: |-
-                                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to
-                                  authenticate to the GitRepository. This field is only supported for 'azure' provider.
-                                type: string
-                              sparseCheckout:
-                                description: |-
-                                  SparseCheckout specifies a list of directories to checkout when cloning
-                                  the repository. If specified, only these directories are included in the
-                                  Artifact produced for this GitRepository.
-                                items:
-                                  type: string
-                                type: array
-                              suspend:
-                                description: |-
-                                  Suspend tells the controller to suspend the reconciliation of this
-                                  GitRepository.
-                                type: boolean
-                              timeout:
-                                default: 60s
-                                description: Timeout for Git operations like cloning,
-                                  defaults to 60s.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                                type: string
-                              url:
-                                description: URL specifies the Git repository URL,
-                                  it can be an HTTP/S or SSH address.
-                                pattern: ^(http|https|ssh)://.*$
-                                type: string
-                              verify:
-                                description: |-
-                                  Verification specifies the configuration to verify the Git commit
-                                  signature(s).
-                                properties:
-                                  mode:
-                                    default: HEAD
-                                    description: |-
-                                      Mode specifies which Git object(s) should be verified.
-
-                                      The variants "head" and "HEAD" both imply the same thing, i.e. verify
-                                      the commit that the HEAD of the Git repository points to. The variant
-                                      "head" solely exists to ensure backwards compatibility.
-                                    enum:
-                                    - head
-                                    - HEAD
-                                    - Tag
-                                    - TagAndHEAD
-                                    type: string
-                                  secretRef:
-                                    description: |-
-                                      SecretRef specifies the Secret containing the public keys of trusted Git
-                                      authors.
-                                    properties:
-                                      name:
-                                        description: Name of the referent.
-                                        type: string
-                                    required:
-                                    - name
-                                    type: object
-                                required:
-                                - secretRef
-                                type: object
-                            required:
-                            - interval
-                            - url
-                            type: object
-                            x-kubernetes-validations:
-                            - message: serviceAccountName can only be set when provider
-                                is 'azure'
-                              rule: '!has(self.serviceAccountName) || (has(self.provider)
-                                && self.provider == ''azure'')'
-                          oci:
-                            description: OCI is the definition of OCI repository source.
-                            properties:
-                              certSecretRef:
-                                description: |-
-                                  CertSecretRef can be given the name of a Secret containing
-                                  either or both of
-
-                                  - a PEM-encoded client certificate (`tls.crt`) and private
-                                  key (`tls.key`);
-                                  - a PEM-encoded CA certificate (`ca.crt`)
-
-                                  and whichever are supplied, will be used for connecting to the
-                                  registry. The client cert and key are useful if you are
-                                  authenticating with a certificate; the CA cert is useful if
-                                  you are using a self-signed server certificate. The Secret must
-                                  be of type `Opaque` or `kubernetes.io/tls`.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              ignore:
-                                description: |-
-                                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                                  (which is the same as .gitignore). If not provided, a default will be used,
-                                  consult the documentation for your version to find out what those are.
-                                type: string
-                              insecure:
-                                description: Insecure allows connecting to a non-TLS
-                                  HTTP container registry.
-                                type: boolean
-                              interval:
-                                description: |-
-                                  Interval at which the OCIRepository URL is checked for updates.
-                                  This interval is approximate and may be subject to jitter to ensure
-                                  efficient use of resources.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                                type: string
-                              layerSelector:
-                                description: |-
-                                  LayerSelector specifies which layer should be extracted from the OCI artifact.
-                                  When not specified, the first layer found in the artifact is selected.
-                                properties:
-                                  mediaType:
-                                    description: |-
-                                      MediaType specifies the OCI media type of the layer
-                                      which should be extracted from the OCI Artifact. The
-                                      first layer matching this type is selected.
-                                    type: string
-                                  operation:
-                                    description: |-
-                                      Operation specifies how the selected layer should be processed.
-                                      By default, the layer compressed content is extracted to storage.
-                                      When the operation is set to 'copy', the layer compressed content
-                                      is persisted to storage as it is.
-                                    enum:
-                                    - extract
-                                    - copy
-                                    type: string
-                                type: object
-                              provider:
-                                default: generic
-                                description: |-
-                                  The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
-                                  When not specified, defaults to 'generic'.
-                                enum:
-                                - generic
-                                - aws
-                                - azure
-                                - gcp
-                                type: string
-                              proxySecretRef:
-                                description: |-
-                                  ProxySecretRef specifies the Secret containing the proxy configuration
-                                  to use while communicating with the container registry.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              ref:
-                                description: |-
-                                  The OCI reference to pull and monitor for changes,
-                                  defaults to the latest tag.
-                                properties:
-                                  digest:
-                                    description: |-
-                                      Digest is the image digest to pull, takes precedence over SemVer.
-                                      The value should be in the format 'sha256:<HASH>'.
-                                    type: string
-                                  semver:
-                                    description: |-
-                                      SemVer is the range of tags to pull selecting the latest within
-                                      the range, takes precedence over Tag.
-                                    type: string
-                                  semverFilter:
-                                    description: SemverFilter is a regex pattern to
-                                      filter the tags within the SemVer range.
-                                    type: string
-                                  tag:
-                                    description: Tag is the image tag to pull, defaults
-                                      to latest.
-                                    type: string
-                                type: object
-                              secretRef:
-                                description: |-
-                                  SecretRef contains the secret name containing the registry login
-                                  credentials to resolve image metadata.
-                                  The secret must be of type kubernetes.io/dockerconfigjson.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceAccountName:
-                                description: |-
-                                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                                  the image pull if the service account has attached pull secrets. For more information:
-                                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
-                                type: string
-                              suspend:
-                                description: This flag tells the controller to suspend
-                                  the reconciliation of this source.
-                                type: boolean
-                              timeout:
-                                default: 60s
-                                description: The timeout for remote OCI Repository
-                                  operations like pulling, defaults to 60s.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                                type: string
-                              url:
-                                description: |-
-                                  URL is a reference to an OCI artifact repository hosted
-                                  on a remote container registry.
-                                pattern: ^oci://.*$
-                                type: string
-                              verify:
-                                description: |-
-                                  Verify contains the secret name containing the trusted public keys
-                                  used to verify the signature and specifies which provider to use to check
-                                  whether OCI image is authentic.
-                                properties:
-                                  matchOIDCIdentity:
-                                    description: |-
-                                      MatchOIDCIdentity specifies the identity matching criteria to use
-                                      while verifying an OCI artifact which was signed using Cosign keyless
-                                      signing. The artifact's identity is deemed to be verified if any of the
-                                      specified matchers match against the identity.
-                                    items:
+                                    provider:
+                                      description: Provider of the Security Token Service.
+                                      enum:
+                                        - aws
+                                        - ldap
+                                      type: string
+                                    secretRef:
                                       description: |-
-                                        OIDCIdentityMatch specifies options for verifying the certificate identity,
-                                        i.e. the issuer and the subject of the certificate.
+                                        SecretRef specifies the Secret containing authentication credentials
+                                        for the STS endpoint. This Secret must contain the fields `username`
+                                        and `password` and is supported only for the `ldap` provider.
                                       properties:
-                                        issuer:
-                                          description: |-
-                                            Issuer specifies the regex pattern to match against to verify
-                                            the OIDC issuer in the Fulcio certificate. The pattern must be a
-                                            valid Go regular expression.
-                                          type: string
-                                        subject:
-                                          description: |-
-                                            Subject specifies the regex pattern to match against to verify
-                                            the identity subject in the Fulcio certificate. The pattern must
-                                            be a valid Go regular expression.
+                                        name:
+                                          description: Name of the referent.
                                           type: string
                                       required:
-                                      - issuer
-                                      - subject
+                                        - name
                                       type: object
-                                    type: array
-                                  provider:
-                                    default: cosign
-                                    description: Provider specifies the technology
-                                      used to sign the OCI Artifact.
-                                    enum:
-                                    - cosign
-                                    - notation
-                                    type: string
-                                  secretRef:
-                                    description: |-
-                                      SecretRef specifies the Kubernetes Secret containing the
-                                      trusted public keys.
-                                    properties:
-                                      name:
-                                        description: Name of the referent.
-                                        type: string
-                                    required:
-                                    - name
-                                    type: object
-                                required:
-                                - provider
-                                type: object
-                            required:
-                            - interval
-                            - url
-                            type: object
-                        type: object
-                        x-kubernetes-validations:
-                        - message: Git, Bucket and OCI are mutually exclusive.
-                          rule: 'has(self.git) ? (!has(self.bucket) && !has(self.oci))
-                            : true'
-                        - message: Git, Bucket and OCI are mutually exclusive.
-                          rule: 'has(self.bucket) ? (!has(self.git) && !has(self.oci))
-                            : true'
-                        - message: Git, Bucket and OCI are mutually exclusive.
-                          rule: 'has(self.oci) ? (!has(self.git) && !has(self.bucket))
-                            : true'
-                        - message: One of Git, Bucket or OCI must be specified.
-                          rule: has(self.git) || has(self.bucket) || has(self.oci)
-                    required:
-                    - deploymentType
-                    - path
-                    type: object
-                    x-kubernetes-validations:
-                    - message: Secret and ConfigMap are not supported as Helm chart
-                        sources
-                      rule: 'has(self.localSourceRef) ? (self.localSourceRef.kind
-                        != ''Secret'' && self.localSourceRef.kind != ''ConfigMap''):
-                        true'
-                    - message: LocalSource and RemoteSource are mutually exclusive.
-                      rule: 'has(self.localSourceRef) ? !has(self.remoteSourceSpec):
-                        true'
-                    - message: LocalSource and RemoteSource are mutually exclusive.
-                      rule: 'has(self.remoteSourceSpec) ? !has(self.localSourceRef):
-                        true'
-                    - message: One of LocalSource or RemoteSource must be specified.
-                      rule: has(self.localSourceRef) || has(self.remoteSourceSpec)
-                  chartSpec:
-                    description: ChartSpec defines the desired state of the HelmChart
-                      to be created by the controller
-                    properties:
-                      chart:
-                        description: |-
-                          Chart is the name or path the Helm chart is available at in the
-                          SourceRef.
-                        type: string
-                      ignoreMissingValuesFiles:
-                        description: |-
-                          IgnoreMissingValuesFiles controls whether to silently ignore missing values
-                          files rather than failing.
-                        type: boolean
-                      interval:
-                        description: |-
-                          Interval at which the HelmChart SourceRef is checked for updates.
-                          This interval is approximate and may be subject to jitter to ensure
-                          efficient use of resources.
-                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                        type: string
-                      reconcileStrategy:
-                        default: ChartVersion
-                        description: |-
-                          ReconcileStrategy determines what enables the creation of a new artifact.
-                          Valid values are ('ChartVersion', 'Revision').
-                          See the documentation of the values for an explanation on their behavior.
-                          Defaults to ChartVersion when omitted.
-                        enum:
-                        - ChartVersion
-                        - Revision
-                        type: string
-                      sourceRef:
-                        description: SourceRef is the reference to the Source the
-                          chart is available at.
-                        properties:
-                          apiVersion:
-                            description: APIVersion of the referent.
-                            type: string
-                          kind:
-                            description: |-
-                              Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
-                              'Bucket').
-                            enum:
-                            - HelmRepository
-                            - GitRepository
-                            - Bucket
-                            type: string
-                          name:
-                            description: Name of the referent.
-                            type: string
-                        required:
-                        - kind
-                        - name
-                        type: object
-                      suspend:
-                        description: |-
-                          Suspend tells the controller to suspend the reconciliation of this
-                          source.
-                        type: boolean
-                      valuesFiles:
-                        description: |-
-                          ValuesFiles is an alternative list of values files to use as the chart
-                          values (values.yaml is not included by default), expected to be a
-                          relative path in the SourceRef.
-                          Values files are merged in the order of this list with the last file
-                          overriding the first. Ignored when omitted.
-                        items:
-                          type: string
-                        type: array
-                      verify:
-                        description: |-
-                          Verify contains the secret name containing the trusted public keys
-                          used to verify the signature and specifies which provider to use to check
-                          whether OCI image is authentic.
-                          This field is only supported when using HelmRepository source with spec.type 'oci'.
-                          Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
-                        properties:
-                          matchOIDCIdentity:
-                            description: |-
-                              MatchOIDCIdentity specifies the identity matching criteria to use
-                              while verifying an OCI artifact which was signed using Cosign keyless
-                              signing. The artifact's identity is deemed to be verified if any of the
-                              specified matchers match against the identity.
-                            items:
-                              description: |-
-                                OIDCIdentityMatch specifies options for verifying the certificate identity,
-                                i.e. the issuer and the subject of the certificate.
-                              properties:
-                                issuer:
+                                  required:
+                                    - endpoint
+                                    - provider
+                                  type: object
+                                suspend:
                                   description: |-
-                                    Issuer specifies the regex pattern to match against to verify
-                                    the OIDC issuer in the Fulcio certificate. The pattern must be a
-                                    valid Go regular expression.
-                                  type: string
-                                subject:
-                                  description: |-
-                                    Subject specifies the regex pattern to match against to verify
-                                    the identity subject in the Fulcio certificate. The pattern must
-                                    be a valid Go regular expression.
+                                    Suspend tells the controller to suspend the reconciliation of this
+                                    Bucket.
+                                  type: boolean
+                                timeout:
+                                  default: 60s
+                                  description: Timeout for fetch operations, defaults to 60s.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                                   type: string
                               required:
-                              - issuer
-                              - subject
+                                - bucketName
+                                - endpoint
+                                - interval
                               type: object
-                            type: array
-                          provider:
-                            default: cosign
-                            description: Provider specifies the technology used to
-                              sign the OCI Artifact.
-                            enum:
-                            - cosign
-                            - notation
-                            type: string
-                          secretRef:
-                            description: |-
-                              SecretRef specifies the Kubernetes Secret containing the
-                              trusted public keys.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
+                              x-kubernetes-validations:
+                                - message: STS configuration is only supported for the 'aws' and 'generic' Bucket providers
+                                  rule: self.provider == 'aws' || self.provider == 'generic' || !has(self.sts)
+                                - message: '''aws'' is the only supported STS provider for the ''aws'' Bucket provider'
+                                  rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider == 'aws'
+                                - message: '''ldap'' is the only supported STS provider for the ''generic'' Bucket provider'
+                                  rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider == 'ldap'
+                                - message: spec.sts.secretRef is not required for the 'aws' STS provider
+                                  rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
+                                - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
+                                  rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
+                                - message: ServiceAccountName is not supported for the 'generic' Bucket provider
+                                  rule: self.provider != 'generic' || !has(self.serviceAccountName)
+                                - message: cannot set both .spec.secretRef and .spec.serviceAccountName
+                                  rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
+                            git:
+                              description: Git is the definition of git repository source.
+                              properties:
+                                ignore:
+                                  description: |-
+                                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                                    (which is the same as .gitignore). If not provided, a default will be used,
+                                    consult the documentation for your version to find out what those are.
+                                  type: string
+                                include:
+                                  description: |-
+                                    Include specifies a list of GitRepository resources which Artifacts
+                                    should be included in the Artifact produced for this GitRepository.
+                                  items:
+                                    description: |-
+                                      GitRepositoryInclude specifies a local reference to a GitRepository which
+                                      Artifact (sub-)contents must be included, and where they should be placed.
+                                    properties:
+                                      fromPath:
+                                        description: |-
+                                          FromPath specifies the path to copy contents from, defaults to the root
+                                          of the Artifact.
+                                        type: string
+                                      repository:
+                                        description: |-
+                                          GitRepositoryRef specifies the GitRepository which Artifact contents
+                                          must be included.
+                                        properties:
+                                          name:
+                                            description: Name of the referent.
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
+                                      toPath:
+                                        description: |-
+                                          ToPath specifies the path to copy contents to, defaults to the name of
+                                          the GitRepositoryRef.
+                                        type: string
+                                    required:
+                                      - repository
+                                    type: object
+                                  type: array
+                                interval:
+                                  description: |-
+                                    Interval at which the GitRepository URL is checked for updates.
+                                    This interval is approximate and may be subject to jitter to ensure
+                                    efficient use of resources.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                                  type: string
+                                provider:
+                                  description: |-
+                                    Provider used for authentication, can be 'azure', 'github', 'generic'.
+                                    When not specified, defaults to 'generic'.
+                                  enum:
+                                    - generic
+                                    - azure
+                                    - github
+                                  type: string
+                                proxySecretRef:
+                                  description: |-
+                                    ProxySecretRef specifies the Secret containing the proxy configuration
+                                    to use while communicating with the Git server.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                recurseSubmodules:
+                                  description: |-
+                                    RecurseSubmodules enables the initialization of all submodules within
+                                    the GitRepository as cloned from the URL, using their default settings.
+                                  type: boolean
+                                ref:
+                                  description: |-
+                                    Reference specifies the Git reference to resolve and monitor for
+                                    changes, defaults to the 'master' branch.
+                                  properties:
+                                    branch:
+                                      description: Branch to check out, defaults to 'master' if no other field is defined.
+                                      type: string
+                                    commit:
+                                      description: |-
+                                        Commit SHA to check out, takes precedence over all reference fields.
+
+                                        This can be combined with Branch to shallow clone the branch, in which
+                                        the commit is expected to exist.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+                                        It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                                        Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                                      type: string
+                                    semver:
+                                      description: SemVer tag expression to check out, takes precedence over Tag.
+                                      type: string
+                                    tag:
+                                      description: Tag to check out, takes precedence over Branch.
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Secret containing authentication credentials for
+                                    the GitRepository.
+                                    For HTTPS repositories the Secret must contain 'username' and 'password'
+                                    fields for basic auth or 'bearerToken' field for token auth.
+                                    For SSH repositories the Secret must contain 'identity'
+                                    and 'known_hosts' fields.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceAccountName:
+                                  description: |-
+                                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+                                    authenticate to the GitRepository. This field is only supported for 'azure' provider.
+                                  type: string
+                                sparseCheckout:
+                                  description: |-
+                                    SparseCheckout specifies a list of directories to checkout when cloning
+                                    the repository. If specified, only these directories are included in the
+                                    Artifact produced for this GitRepository.
+                                  items:
+                                    type: string
+                                  type: array
+                                suspend:
+                                  description: |-
+                                    Suspend tells the controller to suspend the reconciliation of this
+                                    GitRepository.
+                                  type: boolean
+                                timeout:
+                                  default: 60s
+                                  description: Timeout for Git operations like cloning, defaults to 60s.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                                  type: string
+                                url:
+                                  description: URL specifies the Git repository URL, it can be an HTTP/S or SSH address.
+                                  pattern: ^(http|https|ssh)://.*$
+                                  type: string
+                                verify:
+                                  description: |-
+                                    Verification specifies the configuration to verify the Git commit
+                                    signature(s).
+                                  properties:
+                                    mode:
+                                      default: HEAD
+                                      description: |-
+                                        Mode specifies which Git object(s) should be verified.
+
+                                        The variants "head" and "HEAD" both imply the same thing, i.e. verify
+                                        the commit that the HEAD of the Git repository points to. The variant
+                                        "head" solely exists to ensure backwards compatibility.
+                                      enum:
+                                        - head
+                                        - HEAD
+                                        - Tag
+                                        - TagAndHEAD
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        SecretRef specifies the Secret containing the public keys of trusted Git
+                                        authors.
+                                      properties:
+                                        name:
+                                          description: Name of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - secretRef
+                                  type: object
+                              required:
+                                - interval
+                                - url
+                              type: object
+                              x-kubernetes-validations:
+                                - message: serviceAccountName can only be set when provider is 'azure'
+                                  rule: '!has(self.serviceAccountName) || (has(self.provider) && self.provider == ''azure'')'
+                            oci:
+                              description: OCI is the definition of OCI repository source.
+                              properties:
+                                certSecretRef:
+                                  description: |-
+                                    CertSecretRef can be given the name of a Secret containing
+                                    either or both of
+
+                                    - a PEM-encoded client certificate (`tls.crt`) and private
+                                    key (`tls.key`);
+                                    - a PEM-encoded CA certificate (`ca.crt`)
+
+                                    and whichever are supplied, will be used for connecting to the
+                                    registry. The client cert and key are useful if you are
+                                    authenticating with a certificate; the CA cert is useful if
+                                    you are using a self-signed server certificate. The Secret must
+                                    be of type `Opaque` or `kubernetes.io/tls`.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                ignore:
+                                  description: |-
+                                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                                    (which is the same as .gitignore). If not provided, a default will be used,
+                                    consult the documentation for your version to find out what those are.
+                                  type: string
+                                insecure:
+                                  description: Insecure allows connecting to a non-TLS HTTP container registry.
+                                  type: boolean
+                                interval:
+                                  description: |-
+                                    Interval at which the OCIRepository URL is checked for updates.
+                                    This interval is approximate and may be subject to jitter to ensure
+                                    efficient use of resources.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                                  type: string
+                                layerSelector:
+                                  description: |-
+                                    LayerSelector specifies which layer should be extracted from the OCI artifact.
+                                    When not specified, the first layer found in the artifact is selected.
+                                  properties:
+                                    mediaType:
+                                      description: |-
+                                        MediaType specifies the OCI media type of the layer
+                                        which should be extracted from the OCI Artifact. The
+                                        first layer matching this type is selected.
+                                      type: string
+                                    operation:
+                                      description: |-
+                                        Operation specifies how the selected layer should be processed.
+                                        By default, the layer compressed content is extracted to storage.
+                                        When the operation is set to 'copy', the layer compressed content
+                                        is persisted to storage as it is.
+                                      enum:
+                                        - extract
+                                        - copy
+                                      type: string
+                                  type: object
+                                provider:
+                                  default: generic
+                                  description: |-
+                                    The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                                    When not specified, defaults to 'generic'.
+                                  enum:
+                                    - generic
+                                    - aws
+                                    - azure
+                                    - gcp
+                                  type: string
+                                proxySecretRef:
+                                  description: |-
+                                    ProxySecretRef specifies the Secret containing the proxy configuration
+                                    to use while communicating with the container registry.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                ref:
+                                  description: |-
+                                    The OCI reference to pull and monitor for changes,
+                                    defaults to the latest tag.
+                                  properties:
+                                    digest:
+                                      description: |-
+                                        Digest is the image digest to pull, takes precedence over SemVer.
+                                        The value should be in the format 'sha256:<HASH>'.
+                                      type: string
+                                    semver:
+                                      description: |-
+                                        SemVer is the range of tags to pull selecting the latest within
+                                        the range, takes precedence over Tag.
+                                      type: string
+                                    semverFilter:
+                                      description: SemverFilter is a regex pattern to filter the tags within the SemVer range.
+                                      type: string
+                                    tag:
+                                      description: Tag is the image tag to pull, defaults to latest.
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    SecretRef contains the secret name containing the registry login
+                                    credentials to resolve image metadata.
+                                    The secret must be of type kubernetes.io/dockerconfigjson.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceAccountName:
+                                  description: |-
+                                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                                    the image pull if the service account has attached pull secrets. For more information:
+                                    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+                                  type: string
+                                suspend:
+                                  description: This flag tells the controller to suspend the reconciliation of this source.
+                                  type: boolean
+                                timeout:
+                                  default: 60s
+                                  description: The timeout for remote OCI Repository operations like pulling, defaults to 60s.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                                  type: string
+                                url:
+                                  description: |-
+                                    URL is a reference to an OCI artifact repository hosted
+                                    on a remote container registry.
+                                  pattern: ^oci://.*$
+                                  type: string
+                                verify:
+                                  description: |-
+                                    Verify contains the secret name containing the trusted public keys
+                                    used to verify the signature and specifies which provider to use to check
+                                    whether OCI image is authentic.
+                                  properties:
+                                    matchOIDCIdentity:
+                                      description: |-
+                                        MatchOIDCIdentity specifies the identity matching criteria to use
+                                        while verifying an OCI artifact which was signed using Cosign keyless
+                                        signing. The artifact's identity is deemed to be verified if any of the
+                                        specified matchers match against the identity.
+                                      items:
+                                        description: |-
+                                          OIDCIdentityMatch specifies options for verifying the certificate identity,
+                                          i.e. the issuer and the subject of the certificate.
+                                        properties:
+                                          issuer:
+                                            description: |-
+                                              Issuer specifies the regex pattern to match against to verify
+                                              the OIDC issuer in the Fulcio certificate. The pattern must be a
+                                              valid Go regular expression.
+                                            type: string
+                                          subject:
+                                            description: |-
+                                              Subject specifies the regex pattern to match against to verify
+                                              the identity subject in the Fulcio certificate. The pattern must
+                                              be a valid Go regular expression.
+                                            type: string
+                                        required:
+                                          - issuer
+                                          - subject
+                                        type: object
+                                      type: array
+                                    provider:
+                                      default: cosign
+                                      description: Provider specifies the technology used to sign the OCI Artifact.
+                                      enum:
+                                        - cosign
+                                        - notation
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        SecretRef specifies the Kubernetes Secret containing the
+                                        trusted public keys.
+                                      properties:
+                                        name:
+                                          description: Name of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - provider
+                                  type: object
+                              required:
+                                - interval
+                                - url
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: Git, Bucket and OCI are mutually exclusive.
+                              rule: 'has(self.git) ? (!has(self.bucket) && !has(self.oci)) : true'
+                            - message: Git, Bucket and OCI are mutually exclusive.
+                              rule: 'has(self.bucket) ? (!has(self.git) && !has(self.oci)) : true'
+                            - message: Git, Bucket and OCI are mutually exclusive.
+                              rule: 'has(self.oci) ? (!has(self.git) && !has(self.bucket)) : true'
+                            - message: One of Git, Bucket or OCI must be specified.
+                              rule: has(self.git) || has(self.bucket) || has(self.oci)
+                      required:
+                        - deploymentType
+                        - path
+                      type: object
+                      x-kubernetes-validations:
+                        - message: Secret and ConfigMap are not supported as Helm chart sources
+                          rule: 'has(self.localSourceRef) ? (self.localSourceRef.kind != ''Secret'' && self.localSourceRef.kind != ''ConfigMap''): true'
+                        - message: LocalSource and RemoteSource are mutually exclusive.
+                          rule: 'has(self.localSourceRef) ? !has(self.remoteSourceSpec): true'
+                        - message: LocalSource and RemoteSource are mutually exclusive.
+                          rule: 'has(self.remoteSourceSpec) ? !has(self.localSourceRef): true'
+                        - message: One of LocalSource or RemoteSource must be specified.
+                          rule: has(self.localSourceRef) || has(self.remoteSourceSpec)
+                    chartSpec:
+                      description: ChartSpec defines the desired state of the HelmChart to be created by the controller
+                      properties:
+                        chart:
+                          description: |-
+                            Chart is the name or path the Helm chart is available at in the
+                            SourceRef.
+                          type: string
+                        ignoreMissingValuesFiles:
+                          description: |-
+                            IgnoreMissingValuesFiles controls whether to silently ignore missing values
+                            files rather than failing.
+                          type: boolean
+                        interval:
+                          description: |-
+                            Interval at which the HelmChart SourceRef is checked for updates.
+                            This interval is approximate and may be subject to jitter to ensure
+                            efficient use of resources.
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                          type: string
+                        reconcileStrategy:
+                          default: ChartVersion
+                          description: |-
+                            ReconcileStrategy determines what enables the creation of a new artifact.
+                            Valid values are ('ChartVersion', 'Revision').
+                            See the documentation of the values for an explanation on their behavior.
+                            Defaults to ChartVersion when omitted.
+                          enum:
+                            - ChartVersion
+                            - Revision
+                          type: string
+                        sourceRef:
+                          description: SourceRef is the reference to the Source the chart is available at.
+                          properties:
+                            apiVersion:
+                              description: APIVersion of the referent.
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+                                'Bucket').
+                              enum:
+                                - HelmRepository
+                                - GitRepository
+                                - Bucket
+                              type: string
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                            - kind
                             - name
-                            type: object
-                        required:
-                        - provider
-                        type: object
-                      version:
-                        default: '*'
-                        description: |-
-                          Version is the chart version semver expression, ignored for charts from
-                          GitRepository and Bucket sources. Defaults to latest when omitted.
-                        type: string
-                    required:
-                    - chart
-                    - interval
-                    - sourceRef
-                    type: object
-                type: object
-                x-kubernetes-validations:
-                - message: chartSpec, chartSource and chartRef are mutually exclusive
-                  rule: '(has(self.chartSpec) ? (!has(self.chartSource) && !has(self.chartRef)):
-                    true)'
-                - message: chartSpec, chartSource and chartRef are mutually exclusive
-                  rule: '(has(self.chartSource) ? (!has(self.chartSpec) && !has(self.chartRef)):
-                    true)'
-                - message: chartSpec, chartSource and chartRef are mutually exclusive
-                  rule: '(has(self.chartRef) ? (!has(self.chartSpec) && !has(self.chartSource)):
-                    true)'
-                - message: one of chartSpec, chartRef or chartSource must be set
-                  rule: has(self.chartSpec) || has(self.chartRef) || has(self.chartSource)
-              k8sVersion:
-                description: Kubernetes exact version in the SemVer format provided
-                  by this ClusterTemplate.
-                type: string
-              providerContracts:
-                additionalProperties:
+                          type: object
+                        suspend:
+                          description: |-
+                            Suspend tells the controller to suspend the reconciliation of this
+                            source.
+                          type: boolean
+                        valuesFiles:
+                          description: |-
+                            ValuesFiles is an alternative list of values files to use as the chart
+                            values (values.yaml is not included by default), expected to be a
+                            relative path in the SourceRef.
+                            Values files are merged in the order of this list with the last file
+                            overriding the first. Ignored when omitted.
+                          items:
+                            type: string
+                          type: array
+                        verify:
+                          description: |-
+                            Verify contains the secret name containing the trusted public keys
+                            used to verify the signature and specifies which provider to use to check
+                            whether OCI image is authentic.
+                            This field is only supported when using HelmRepository source with spec.type 'oci'.
+                            Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+                          properties:
+                            matchOIDCIdentity:
+                              description: |-
+                                MatchOIDCIdentity specifies the identity matching criteria to use
+                                while verifying an OCI artifact which was signed using Cosign keyless
+                                signing. The artifact's identity is deemed to be verified if any of the
+                                specified matchers match against the identity.
+                              items:
+                                description: |-
+                                  OIDCIdentityMatch specifies options for verifying the certificate identity,
+                                  i.e. the issuer and the subject of the certificate.
+                                properties:
+                                  issuer:
+                                    description: |-
+                                      Issuer specifies the regex pattern to match against to verify
+                                      the OIDC issuer in the Fulcio certificate. The pattern must be a
+                                      valid Go regular expression.
+                                    type: string
+                                  subject:
+                                    description: |-
+                                      Subject specifies the regex pattern to match against to verify
+                                      the identity subject in the Fulcio certificate. The pattern must
+                                      be a valid Go regular expression.
+                                    type: string
+                                required:
+                                  - issuer
+                                  - subject
+                                type: object
+                              type: array
+                            provider:
+                              default: cosign
+                              description: Provider specifies the technology used to sign the OCI Artifact.
+                              enum:
+                                - cosign
+                                - notation
+                              type: string
+                            secretRef:
+                              description: |-
+                                SecretRef specifies the Kubernetes Secret containing the
+                                trusted public keys.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - provider
+                          type: object
+                        version:
+                          default: '*'
+                          description: |-
+                            Version is the chart version semver expression, ignored for charts from
+                            GitRepository and Bucket sources. Defaults to latest when omitted.
+                          type: string
+                      required:
+                        - chart
+                        - interval
+                        - sourceRef
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: chartSpec, chartSource and chartRef are mutually exclusive
+                      rule: '(has(self.chartSpec) ? (!has(self.chartSource) && !has(self.chartRef)): true)'
+                    - message: chartSpec, chartSource and chartRef are mutually exclusive
+                      rule: '(has(self.chartSource) ? (!has(self.chartSpec) && !has(self.chartRef)): true)'
+                    - message: chartSpec, chartSource and chartRef are mutually exclusive
+                      rule: '(has(self.chartRef) ? (!has(self.chartSpec) && !has(self.chartSource)): true)'
+                    - message: one of chartSpec, chartRef or chartSource must be set
+                      rule: has(self.chartSpec) || has(self.chartRef) || has(self.chartSource)
+                k8sVersion:
+                  description: Kubernetes exact version in the SemVer format provided by this ClusterTemplate.
                   type: string
-                description: |-
-                  Holds key-value pairs with compatibility [contract versions],
-                  where the key is the name of the provider,
-                  and the value is the provider contract version
-                  required to be supported by the provider.
+                providerContracts:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    Holds key-value pairs with compatibility [contract versions],
+                    where the key is the name of the provider,
+                    and the value is the provider contract version
+                    required to be supported by the provider.
 
-                  [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
-                type: object
-              providers:
-                description: |-
-                  Providers represent required CAPI providers.
-                  Should be set if not present in the Helm chart metadata.
-                items:
+                    [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
+                  type: object
+                providers:
+                  description: |-
+                    Providers represent required CAPI providers.
+                    Should be set if not present in the Helm chart metadata.
+                  items:
+                    type: string
+                  type: array
+              required:
+                - helm
+              type: object
+              x-kubernetes-validations:
+                - message: Spec is immutable
+                  rule: self == oldSelf
+                - message: .spec.helm.chartSource is not supported for ClusterTemplates
+                  rule: '!has(self.helm.chartSource)'
+            status:
+              description: ClusterTemplateStatus defines the observed state of ClusterTemplate
+              properties:
+                chartRef:
+                  description: |-
+                    ChartRef is a reference to a source controller resource containing the
+                    Helm chart representing the template.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the referent.
+                      type: string
+                    kind:
+                      description: Kind of the referent.
+                      enum:
+                        - OCIRepository
+                        - HelmChart
+                        - ExternalArtifact
+                      type: string
+                    name:
+                      description: Name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent, defaults to the namespace of the Kubernetes
+                        resource object that contains the reference.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                    - kind
+                    - name
+                  type: object
+                chartVersion:
+                  description: ChartVersion represents the version of the Helm Chart associated with this template.
                   type: string
-                type: array
-            required:
-            - helm
-            type: object
-            x-kubernetes-validations:
-            - message: Spec is immutable
-              rule: self == oldSelf
-            - message: .spec.helm.chartSource is not supported for ClusterTemplates
-              rule: '!has(self.helm.chartSource)'
-          status:
-            description: ClusterTemplateStatus defines the observed state of ClusterTemplate
-            properties:
-              chartRef:
-                description: |-
-                  ChartRef is a reference to a source controller resource containing the
-                  Helm chart representing the template.
-                properties:
-                  apiVersion:
-                    description: APIVersion of the referent.
-                    type: string
-                  kind:
-                    description: Kind of the referent.
-                    enum:
-                    - OCIRepository
-                    - HelmChart
-                    - ExternalArtifact
-                    type: string
-                  name:
-                    description: Name of the referent.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace of the referent, defaults to the namespace of the Kubernetes
-                      resource object that contains the reference.
-                    maxLength: 63
-                    minLength: 1
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-              chartVersion:
-                description: ChartVersion represents the version of the Helm Chart
-                  associated with this template.
-                type: string
-              config:
-                description: |-
-                  Config demonstrates available parameters for template customization,
-                  that can be used when creating ClusterDeployment objects.
-                x-kubernetes-preserve-unknown-fields: true
-              description:
-                description: Description contains information about the template.
-                type: string
-              k8sVersion:
-                description: Kubernetes exact version in the SemVer format provided
-                  by this ClusterTemplate.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              providerContracts:
-                additionalProperties:
+                config:
+                  description: |-
+                    Config demonstrates available parameters for template customization,
+                    that can be used when creating ClusterDeployment objects.
+                  x-kubernetes-preserve-unknown-fields: true
+                description:
+                  description: Description contains information about the template.
                   type: string
-                description: |-
-                  Holds key-value pairs with compatibility [contract versions],
-                  where the key is the name of the provider,
-                  and the value is the provider contract version
-                  required to be supported by the provider.
+                k8sVersion:
+                  description: Kubernetes exact version in the SemVer format provided by this ClusterTemplate.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                providerContracts:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    Holds key-value pairs with compatibility [contract versions],
+                    where the key is the name of the provider,
+                    and the value is the provider contract version
+                    required to be supported by the provider.
 
-                  [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
-                type: object
-              providers:
-                description: Providers represent required CAPI providers.
-                items:
+                    [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
+                  type: object
+                providers:
+                  description: Providers represent required CAPI providers.
+                  items:
+                    type: string
+                  type: array
+                schemaConfigMapName:
+                  description: SchemaConfigMapName specifies the name of the ConfigMap that contains the JSON Schema definition for Helm Chart validation.
                   type: string
-                type: array
-              schemaConfigMapName:
-                description: SchemaConfigMapName specifies the name of the ConfigMap
-                  that contains the JSON Schema definition for Helm Chart validation.
-                type: string
-              valid:
-                description: Valid indicates whether the template passed validation
-                  or not.
-                type: boolean
-              validationError:
-                description: ValidationError provides information regarding issues
-                  encountered during template validation.
-                type: string
-            required:
-            - valid
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                valid:
+                  description: Valid indicates whether the template passed validation or not.
+                  type: boolean
+                validationError:
+                  description: ValidationError provides information regarding issues encountered during template validation.
+                  type: string
+              required:
+                - valid
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_credentials.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_credentials.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: credentials.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,177 +13,175 @@ spec:
     listKind: CredentialList
     plural: credentials
     shortNames:
-    - cred
+      - cred
     singular: credential
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.ready
-      name: Ready
-      type: string
-    - jsonPath: .spec.region
-      name: Region
-      type: string
-    - jsonPath: .spec.description
-      name: Description
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Credential is the Schema for the credentials API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: CredentialSpec defines the desired state of Credential
-            properties:
-              description:
-                description: Description of the [Credential] object
-                type: string
-              identityRef:
-                description: Reference to the Credential Identity
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: |-
-                      If referring to a piece of an object instead of an entire object, this string
-                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within a pod, this would take on a value like:
-                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]" (container with
-                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
-                      referencing a part of an object.
-                    type: string
-                  kind:
-                    description: |-
-                      Kind of the referent.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                    type: string
-                  name:
-                    description: |-
-                      Name of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                    type: string
-                  resourceVersion:
-                    description: |-
-                      Specific resourceVersion to which this reference is made, if any.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                    type: string
-                  uid:
-                    description: |-
-                      UID of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              region:
-                description: |-
-                  Region specifies the region where [ClusterDeployment] resources using
-                  this [Credential] will be deployed
-                type: string
-                x-kubernetes-validations:
-                - message: Region is immutable
-                  rule: self == oldSelf
-            required:
-            - identityRef
-            type: object
-          status:
-            description: CredentialStatus defines the observed state of Credential
-            properties:
-              conditions:
-                description: Conditions contains details for the current state of
-                  the [Credential].
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+    - additionalPrinterColumns:
+        - jsonPath: .status.ready
+          name: Ready
+          type: string
+        - jsonPath: .spec.region
+          name: Region
+          type: string
+        - jsonPath: .spec.description
+          name: Description
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Credential is the Schema for the credentials API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CredentialSpec defines the desired state of Credential
+              properties:
+                description:
+                  description: Description of the [Credential] object
+                  type: string
+                identityRef:
+                  description: Reference to the Credential Identity
                   properties:
-                    lastTransitionTime:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
                       type: string
-                    message:
+                    kind:
                       description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
-                    observedGeneration:
+                    name:
                       description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
                       description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                       type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                       type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
                   type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              ready:
-                default: false
-                description: Ready holds the readiness of [Credential].
-                type: boolean
-            required:
-            - ready
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  x-kubernetes-map-type: atomic
+                region:
+                  description: |-
+                    Region specifies the region where [ClusterDeployment] resources using
+                    this [Credential] will be deployed
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Region is immutable
+                      rule: self == oldSelf
+              required:
+                - identityRef
+              type: object
+            status:
+              description: CredentialStatus defines the observed state of Credential
+              properties:
+                conditions:
+                  description: Conditions contains details for the current state of the [Credential].
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                ready:
+                  default: false
+                  description: Ready holds the readiness of [Credential].
+                  type: boolean
+              required:
+                - ready
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_datasources.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_datasources.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: datasources.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -14,134 +15,124 @@ spec:
     singular: datasource
   scope: Namespaced
   versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: DataSource is the Schema for the datasources API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: DataSourceSpec defines the desired state of DataSource
-            properties:
-              auth:
-                description: |-
-                  Auth specifies the authentication configuration for accessing the data source.
-                  This field contains credentials required to establish
-                  a secure connection to the external data source.
-                properties:
-                  password:
-                    description: |-
-                      Password is a reference to a secret key containing the password credential
-                      used for data source authentication.
-                    properties:
-                      key:
-                        description: Key is the name of the key for the given Secret
-                          reference where the value is stored.
-                        minLength: 1
-                        type: string
-                      name:
-                        description: name is unique within a namespace to reference
-                          a secret resource.
-                        type: string
-                      namespace:
-                        description: namespace defines the space within which the
-                          secret name must be unique.
-                        type: string
-                    required:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: DataSource is the Schema for the datasources API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DataSourceSpec defines the desired state of DataSource
+              properties:
+                auth:
+                  description: |-
+                    Auth specifies the authentication configuration for accessing the data source.
+                    This field contains credentials required to establish
+                    a secure connection to the external data source.
+                  properties:
+                    password:
+                      description: |-
+                        Password is a reference to a secret key containing the password credential
+                        used for data source authentication.
+                      properties:
+                        key:
+                          description: Key is the name of the key for the given Secret reference where the value is stored.
+                          minLength: 1
+                          type: string
+                        name:
+                          description: name is unique within a namespace to reference a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the secret name must be unique.
+                          type: string
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    username:
+                      description: |-
+                        Username is a reference to a secret key containing the username credential
+                        used for data source authentication.
+                      properties:
+                        key:
+                          description: Key is the name of the key for the given Secret reference where the value is stored.
+                          minLength: 1
+                          type: string
+                        name:
+                          description: name is unique within a namespace to reference a secret resource.
+                          type: string
+                        namespace:
+                          description: namespace defines the space within which the secret name must be unique.
+                          type: string
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                    - password
+                    - username
+                  type: object
+                certificateAuthority:
+                  description: |-
+                    CertificateAuthority optionally specifies the reference to a Secret containing
+                    the certificate authority (CA) certificate used to verify the data source's
+                    server certificate during TLS handshake.
+                  properties:
+                    key:
+                      description: Key is the name of the key for the given Secret reference where the value is stored.
+                      minLength: 1
+                      type: string
+                    name:
+                      description: name is unique within a namespace to reference a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret name must be unique.
+                      type: string
+                  required:
                     - key
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  username:
-                    description: |-
-                      Username is a reference to a secret key containing the username credential
-                      used for data source authentication.
-                    properties:
-                      key:
-                        description: Key is the name of the key for the given Secret
-                          reference where the value is stored.
-                        minLength: 1
-                        type: string
-                      name:
-                        description: name is unique within a namespace to reference
-                          a secret resource.
-                        type: string
-                      namespace:
-                        description: namespace defines the space within which the
-                          secret name must be unique.
-                        type: string
-                    required:
-                    - key
-                    type: object
-                    x-kubernetes-map-type: atomic
-                required:
-                - password
-                - username
-                type: object
-              certificateAuthority:
-                description: |-
-                  CertificateAuthority optionally specifies the reference to a Secret containing
-                  the certificate authority (CA) certificate used to verify the data source's
-                  server certificate during TLS handshake.
-                properties:
-                  key:
-                    description: Key is the name of the key for the given Secret reference
-                      where the value is stored.
-                    minLength: 1
-                    type: string
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                required:
-                - key
-                type: object
-                x-kubernetes-map-type: atomic
-              endpoints:
-                description: |-
-                  Endpoints contains one or more host/port pairs that clients should use to connect to the data source.
+                  type: object
+                  x-kubernetes-map-type: atomic
+                endpoints:
+                  description: |-
+                    Endpoints contains one or more host/port pairs that clients should use to connect to the data source.
 
-                  Only IP:port or FQDN:port, no schema and/or parameters are required.
-                example: '[postgres-db1.example.com:5432, 10.0.12.13:5432]'
-                items:
+                    Only IP:port or FQDN:port, no schema and/or parameters are required.
+                  example: '[postgres-db1.example.com:5432, 10.0.12.13:5432]'
+                  items:
+                    type: string
+                  type: array
+                type:
+                  description: Type specifies the database type to connect to the data source.
+                  enum:
+                    - postgresql
+                  example: postgresql
                   type: string
-                type: array
-              type:
-                description: Type specifies the database type to connect to the data
-                  source.
-                enum:
-                - postgresql
-                example: postgresql
-                type: string
-            required:
-            - auth
-            - endpoints
-            - type
-            type: object
-            x-kubernetes-validations:
-            - message: changing the spec is not supported, create a new object
-              rule: self == oldSelf
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
+              required:
+                - auth
+                - endpoints
+                - type
+              type: object
+              x-kubernetes-validations:
+                - message: changing the spec is not supported, create a new object
+                  rule: self == oldSelf
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_managementbackups.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_managementbackups.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: managementbackups.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,429 +13,415 @@ spec:
     listKind: ManagementBackupList
     plural: managementbackups
     shortNames:
-    - kcmbackup
-    - mgmtbackup
+      - kcmbackup
+      - mgmtbackup
     singular: managementbackup
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - description: Status of last backup run
-      jsonPath: .status.lastBackup.phase
-      name: LastBackupStatus
-      type: string
-    - description: Next scheduled attempt to back up
-      jsonPath: .status.nextAttempt
-      name: NextBackup
-      type: string
-    - description: Time elapsed since last backup run
-      jsonPath: .status.lastBackupTime
-      name: SinceLastBackup
-      priority: 1
-      type: date
-    - description: Time elapsed since object creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Error during creation
-      jsonPath: .status.error
-      name: Error
-      priority: 1
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ManagementBackup is the Schema for the managementbackups API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ManagementBackupSpec defines the desired state of [ManagementBackup].
-            properties:
-              performOnManagementUpgrade:
-                description: |-
-                  PerformOnManagementUpgrade indicates that a single [ManagementBackup]
-                  should be created and stored in the [ManagementBackup] storage location if not default
-                  before the [Management] release upgrade.
-                type: boolean
-              schedule:
-                description: |-
-                  Schedule is a Cron expression defining when to run the scheduled [ManagementBackup].
-                  If not set, the object is considered to be run only once.
-                type: string
-              storageLocation:
-                description: |-
-                  StorageLocation is the name of a [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.StorageLocation]
-                  where the backup should be stored.
-                type: string
-            type: object
-          status:
-            description: ManagementBackupStatus defines the observed state of [ManagementBackup].
-            properties:
-              error:
-                description: Error stores messages in case of failed backup creation.
-                type: string
-              lastBackup:
-                description: Most recently [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup]
-                  that has been created.
-                properties:
-                  backupItemOperationsAttempted:
-                    description: |-
-                      BackupItemOperationsAttempted is the total number of attempted
-                      async BackupItemAction operations for this backup.
-                    type: integer
-                  backupItemOperationsCompleted:
-                    description: |-
-                      BackupItemOperationsCompleted is the total number of successfully completed
-                      async BackupItemAction operations for this backup.
-                    type: integer
-                  backupItemOperationsFailed:
-                    description: |-
-                      BackupItemOperationsFailed is the total number of async
-                      BackupItemAction operations for this backup which ended with an error.
-                    type: integer
-                  completionTimestamp:
-                    description: |-
-                      CompletionTimestamp records the time a backup was completed.
-                      Completion time is recorded even on failed backups.
-                      Completion time is recorded before uploading the backup object.
-                      The server's time is used for CompletionTimestamps
-                    format: date-time
-                    nullable: true
-                    type: string
-                  csiVolumeSnapshotsAttempted:
-                    description: |-
-                      CSIVolumeSnapshotsAttempted is the total number of attempted
-                      CSI VolumeSnapshots for this backup.
-                    type: integer
-                  csiVolumeSnapshotsCompleted:
-                    description: |-
-                      CSIVolumeSnapshotsCompleted is the total number of successfully
-                      completed CSI VolumeSnapshots for this backup.
-                    type: integer
-                  errors:
-                    description: |-
-                      Errors is a count of all error messages that were generated during
-                      execution of the backup.  The actual errors are in the backup's log
-                      file in object storage.
-                    type: integer
-                  expiration:
-                    description: Expiration is when this Backup is eligible for garbage-collection.
-                    format: date-time
-                    nullable: true
-                    type: string
-                  failureReason:
-                    description: FailureReason is an error that caused the entire
-                      backup to fail.
-                    type: string
-                  formatVersion:
-                    description: FormatVersion is the backup format version, including
-                      major, minor, and patch version.
-                    type: string
-                  hookStatus:
-                    description: HookStatus contains information about the status
-                      of the hooks.
-                    nullable: true
-                    properties:
-                      hooksAttempted:
-                        description: |-
-                          HooksAttempted is the total number of attempted hooks
-                          Specifically, HooksAttempted represents the number of hooks that failed to execute
-                          and the number of hooks that executed successfully.
-                        type: integer
-                      hooksFailed:
-                        description: HooksFailed is the total number of hooks which
-                          ended with an error
-                        type: integer
-                    type: object
-                  phase:
-                    description: Phase is the current state of the Backup.
-                    enum:
-                    - New
-                    - FailedValidation
-                    - InProgress
-                    - WaitingForPluginOperations
-                    - WaitingForPluginOperationsPartiallyFailed
-                    - Finalizing
-                    - FinalizingPartiallyFailed
-                    - Completed
-                    - PartiallyFailed
-                    - Failed
-                    - Deleting
-                    type: string
-                  progress:
-                    description: |-
-                      Progress contains information about the backup's execution progress. Note
-                      that this information is best-effort only -- if Velero fails to update it
-                      during a backup for any reason, it may be inaccurate/stale.
-                    nullable: true
-                    properties:
-                      itemsBackedUp:
-                        description: |-
-                          ItemsBackedUp is the number of items that have actually been written to the
-                          backup tarball so far.
-                        type: integer
-                      totalItems:
-                        description: |-
-                          TotalItems is the total number of items to be backed up. This number may change
-                          throughout the execution of the backup due to plugins that return additional related
-                          items to back up, the velero.io/exclude-from-backup label, and various other
-                          filters that happen as items are processed.
-                        type: integer
-                    type: object
-                  startTimestamp:
-                    description: |-
-                      StartTimestamp records the time a backup was started.
-                      Separate from CreationTimestamp, since that value changes
-                      on restores.
-                      The server's time is used for StartTimestamps
-                    format: date-time
-                    nullable: true
-                    type: string
-                  validationErrors:
-                    description: |-
-                      ValidationErrors is a slice of all validation errors (if
-                      applicable).
-                    items:
-                      type: string
-                    nullable: true
-                    type: array
-                  version:
-                    description: |-
-                      Version is the backup format major version.
-                      Deprecated: Please see FormatVersion
-                    type: integer
-                  volumeSnapshotsAttempted:
-                    description: |-
-                      VolumeSnapshotsAttempted is the total number of attempted
-                      volume snapshots for this backup.
-                    type: integer
-                  volumeSnapshotsCompleted:
-                    description: |-
-                      VolumeSnapshotsCompleted is the total number of successfully
-                      completed volume snapshots for this backup.
-                    type: integer
-                  warnings:
-                    description: |-
-                      Warnings is a count of all warning messages that were generated during
-                      execution of the backup. The actual warnings are in the backup's log
-                      file in object storage.
-                    type: integer
-                type: object
-              lastBackupName:
-                description: Name of most recently created [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup].
-                type: string
-              lastBackupTime:
-                description: Time of the most recently created [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup].
-                format: date-time
-                type: string
-              nextAttempt:
-                description: |-
-                  NextAttempt indicates the time when the next backup will be created.
-                  Always absent for a single [ManagementBackup].
-                format: date-time
-                type: string
-              region:
-                description: |-
-                  Region reflects the name of a region for which
-                  the [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup] has been created.
-                type: string
-              regions:
-                description: RegionsLastBackups denotes the status of the last backups
-                  in the corresponding regions.
-                items:
-                  description: ManagementBackupSingleStatus defines the observed state
-                    of a single entry of [ManagementBackupStatus].
+    - additionalPrinterColumns:
+        - description: Status of last backup run
+          jsonPath: .status.lastBackup.phase
+          name: LastBackupStatus
+          type: string
+        - description: Next scheduled attempt to back up
+          jsonPath: .status.nextAttempt
+          name: NextBackup
+          type: string
+        - description: Time elapsed since last backup run
+          jsonPath: .status.lastBackupTime
+          name: SinceLastBackup
+          priority: 1
+          type: date
+        - description: Time elapsed since object creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Error during creation
+          jsonPath: .status.error
+          name: Error
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ManagementBackup is the Schema for the managementbackups API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ManagementBackupSpec defines the desired state of [ManagementBackup].
+              properties:
+                performOnManagementUpgrade:
+                  description: |-
+                    PerformOnManagementUpgrade indicates that a single [ManagementBackup]
+                    should be created and stored in the [ManagementBackup] storage location if not default
+                    before the [Management] release upgrade.
+                  type: boolean
+                schedule:
+                  description: |-
+                    Schedule is a Cron expression defining when to run the scheduled [ManagementBackup].
+                    If not set, the object is considered to be run only once.
+                  type: string
+                storageLocation:
+                  description: |-
+                    StorageLocation is the name of a [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.StorageLocation]
+                    where the backup should be stored.
+                  type: string
+              type: object
+            status:
+              description: ManagementBackupStatus defines the observed state of [ManagementBackup].
+              properties:
+                error:
+                  description: Error stores messages in case of failed backup creation.
+                  type: string
+                lastBackup:
+                  description: Most recently [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup] that has been created.
                   properties:
-                    error:
-                      description: Error stores messages in case of failed backup
-                        creation.
+                    backupItemOperationsAttempted:
+                      description: |-
+                        BackupItemOperationsAttempted is the total number of attempted
+                        async BackupItemAction operations for this backup.
+                      type: integer
+                    backupItemOperationsCompleted:
+                      description: |-
+                        BackupItemOperationsCompleted is the total number of successfully completed
+                        async BackupItemAction operations for this backup.
+                      type: integer
+                    backupItemOperationsFailed:
+                      description: |-
+                        BackupItemOperationsFailed is the total number of async
+                        BackupItemAction operations for this backup which ended with an error.
+                      type: integer
+                    completionTimestamp:
+                      description: |-
+                        CompletionTimestamp records the time a backup was completed.
+                        Completion time is recorded even on failed backups.
+                        Completion time is recorded before uploading the backup object.
+                        The server's time is used for CompletionTimestamps
+                      format: date-time
+                      nullable: true
                       type: string
-                    lastBackup:
-                      description: Most recently [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup]
-                        that has been created.
+                    csiVolumeSnapshotsAttempted:
+                      description: |-
+                        CSIVolumeSnapshotsAttempted is the total number of attempted
+                        CSI VolumeSnapshots for this backup.
+                      type: integer
+                    csiVolumeSnapshotsCompleted:
+                      description: |-
+                        CSIVolumeSnapshotsCompleted is the total number of successfully
+                        completed CSI VolumeSnapshots for this backup.
+                      type: integer
+                    errors:
+                      description: |-
+                        Errors is a count of all error messages that were generated during
+                        execution of the backup.  The actual errors are in the backup's log
+                        file in object storage.
+                      type: integer
+                    expiration:
+                      description: Expiration is when this Backup is eligible for garbage-collection.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    failureReason:
+                      description: FailureReason is an error that caused the entire backup to fail.
+                      type: string
+                    formatVersion:
+                      description: FormatVersion is the backup format version, including major, minor, and patch version.
+                      type: string
+                    hookStatus:
+                      description: HookStatus contains information about the status of the hooks.
+                      nullable: true
                       properties:
-                        backupItemOperationsAttempted:
+                        hooksAttempted:
                           description: |-
-                            BackupItemOperationsAttempted is the total number of attempted
-                            async BackupItemAction operations for this backup.
+                            HooksAttempted is the total number of attempted hooks
+                            Specifically, HooksAttempted represents the number of hooks that failed to execute
+                            and the number of hooks that executed successfully.
                           type: integer
-                        backupItemOperationsCompleted:
-                          description: |-
-                            BackupItemOperationsCompleted is the total number of successfully completed
-                            async BackupItemAction operations for this backup.
-                          type: integer
-                        backupItemOperationsFailed:
-                          description: |-
-                            BackupItemOperationsFailed is the total number of async
-                            BackupItemAction operations for this backup which ended with an error.
-                          type: integer
-                        completionTimestamp:
-                          description: |-
-                            CompletionTimestamp records the time a backup was completed.
-                            Completion time is recorded even on failed backups.
-                            Completion time is recorded before uploading the backup object.
-                            The server's time is used for CompletionTimestamps
-                          format: date-time
-                          nullable: true
-                          type: string
-                        csiVolumeSnapshotsAttempted:
-                          description: |-
-                            CSIVolumeSnapshotsAttempted is the total number of attempted
-                            CSI VolumeSnapshots for this backup.
-                          type: integer
-                        csiVolumeSnapshotsCompleted:
-                          description: |-
-                            CSIVolumeSnapshotsCompleted is the total number of successfully
-                            completed CSI VolumeSnapshots for this backup.
-                          type: integer
-                        errors:
-                          description: |-
-                            Errors is a count of all error messages that were generated during
-                            execution of the backup.  The actual errors are in the backup's log
-                            file in object storage.
-                          type: integer
-                        expiration:
-                          description: Expiration is when this Backup is eligible
-                            for garbage-collection.
-                          format: date-time
-                          nullable: true
-                          type: string
-                        failureReason:
-                          description: FailureReason is an error that caused the entire
-                            backup to fail.
-                          type: string
-                        formatVersion:
-                          description: FormatVersion is the backup format version,
-                            including major, minor, and patch version.
-                          type: string
-                        hookStatus:
-                          description: HookStatus contains information about the status
-                            of the hooks.
-                          nullable: true
-                          properties:
-                            hooksAttempted:
-                              description: |-
-                                HooksAttempted is the total number of attempted hooks
-                                Specifically, HooksAttempted represents the number of hooks that failed to execute
-                                and the number of hooks that executed successfully.
-                              type: integer
-                            hooksFailed:
-                              description: HooksFailed is the total number of hooks
-                                which ended with an error
-                              type: integer
-                          type: object
-                        phase:
-                          description: Phase is the current state of the Backup.
-                          enum:
-                          - New
-                          - FailedValidation
-                          - InProgress
-                          - WaitingForPluginOperations
-                          - WaitingForPluginOperationsPartiallyFailed
-                          - Finalizing
-                          - FinalizingPartiallyFailed
-                          - Completed
-                          - PartiallyFailed
-                          - Failed
-                          - Deleting
-                          type: string
-                        progress:
-                          description: |-
-                            Progress contains information about the backup's execution progress. Note
-                            that this information is best-effort only -- if Velero fails to update it
-                            during a backup for any reason, it may be inaccurate/stale.
-                          nullable: true
-                          properties:
-                            itemsBackedUp:
-                              description: |-
-                                ItemsBackedUp is the number of items that have actually been written to the
-                                backup tarball so far.
-                              type: integer
-                            totalItems:
-                              description: |-
-                                TotalItems is the total number of items to be backed up. This number may change
-                                throughout the execution of the backup due to plugins that return additional related
-                                items to back up, the velero.io/exclude-from-backup label, and various other
-                                filters that happen as items are processed.
-                              type: integer
-                          type: object
-                        startTimestamp:
-                          description: |-
-                            StartTimestamp records the time a backup was started.
-                            Separate from CreationTimestamp, since that value changes
-                            on restores.
-                            The server's time is used for StartTimestamps
-                          format: date-time
-                          nullable: true
-                          type: string
-                        validationErrors:
-                          description: |-
-                            ValidationErrors is a slice of all validation errors (if
-                            applicable).
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        version:
-                          description: |-
-                            Version is the backup format major version.
-                            Deprecated: Please see FormatVersion
-                          type: integer
-                        volumeSnapshotsAttempted:
-                          description: |-
-                            VolumeSnapshotsAttempted is the total number of attempted
-                            volume snapshots for this backup.
-                          type: integer
-                        volumeSnapshotsCompleted:
-                          description: |-
-                            VolumeSnapshotsCompleted is the total number of successfully
-                            completed volume snapshots for this backup.
-                          type: integer
-                        warnings:
-                          description: |-
-                            Warnings is a count of all warning messages that were generated during
-                            execution of the backup. The actual warnings are in the backup's log
-                            file in object storage.
+                        hooksFailed:
+                          description: HooksFailed is the total number of hooks which ended with an error
                           type: integer
                       type: object
-                    lastBackupName:
-                      description: Name of most recently created [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup].
+                    phase:
+                      description: Phase is the current state of the Backup.
+                      enum:
+                        - New
+                        - FailedValidation
+                        - InProgress
+                        - WaitingForPluginOperations
+                        - WaitingForPluginOperationsPartiallyFailed
+                        - Finalizing
+                        - FinalizingPartiallyFailed
+                        - Completed
+                        - PartiallyFailed
+                        - Failed
+                        - Deleting
                       type: string
-                    lastBackupTime:
-                      description: Time of the most recently created [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup].
-                      format: date-time
-                      type: string
-                    nextAttempt:
+                    progress:
                       description: |-
-                        NextAttempt indicates the time when the next backup will be created.
-                        Always absent for a single [ManagementBackup].
-                      format: date-time
-                      type: string
-                    region:
+                        Progress contains information about the backup's execution progress. Note
+                        that this information is best-effort only -- if Velero fails to update it
+                        during a backup for any reason, it may be inaccurate/stale.
+                      nullable: true
+                      properties:
+                        itemsBackedUp:
+                          description: |-
+                            ItemsBackedUp is the number of items that have actually been written to the
+                            backup tarball so far.
+                          type: integer
+                        totalItems:
+                          description: |-
+                            TotalItems is the total number of items to be backed up. This number may change
+                            throughout the execution of the backup due to plugins that return additional related
+                            items to back up, the velero.io/exclude-from-backup label, and various other
+                            filters that happen as items are processed.
+                          type: integer
+                      type: object
+                    startTimestamp:
                       description: |-
-                        Region reflects the name of a region for which
-                        the [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup] has been created.
+                        StartTimestamp records the time a backup was started.
+                        Separate from CreationTimestamp, since that value changes
+                        on restores.
+                        The server's time is used for StartTimestamps
+                      format: date-time
+                      nullable: true
                       type: string
+                    validationErrors:
+                      description: |-
+                        ValidationErrors is a slice of all validation errors (if
+                        applicable).
+                      items:
+                        type: string
+                      nullable: true
+                      type: array
+                    version:
+                      description: |-
+                        Version is the backup format major version.
+                        Deprecated: Please see FormatVersion
+                      type: integer
+                    volumeSnapshotsAttempted:
+                      description: |-
+                        VolumeSnapshotsAttempted is the total number of attempted
+                        volume snapshots for this backup.
+                      type: integer
+                    volumeSnapshotsCompleted:
+                      description: |-
+                        VolumeSnapshotsCompleted is the total number of successfully
+                        completed volume snapshots for this backup.
+                      type: integer
+                    warnings:
+                      description: |-
+                        Warnings is a count of all warning messages that were generated during
+                        execution of the backup. The actual warnings are in the backup's log
+                        file in object storage.
+                      type: integer
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                lastBackupName:
+                  description: Name of most recently created [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup].
+                  type: string
+                lastBackupTime:
+                  description: Time of the most recently created [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup].
+                  format: date-time
+                  type: string
+                nextAttempt:
+                  description: |-
+                    NextAttempt indicates the time when the next backup will be created.
+                    Always absent for a single [ManagementBackup].
+                  format: date-time
+                  type: string
+                region:
+                  description: |-
+                    Region reflects the name of a region for which
+                    the [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup] has been created.
+                  type: string
+                regions:
+                  description: RegionsLastBackups denotes the status of the last backups in the corresponding regions.
+                  items:
+                    description: ManagementBackupSingleStatus defines the observed state of a single entry of [ManagementBackupStatus].
+                    properties:
+                      error:
+                        description: Error stores messages in case of failed backup creation.
+                        type: string
+                      lastBackup:
+                        description: Most recently [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup] that has been created.
+                        properties:
+                          backupItemOperationsAttempted:
+                            description: |-
+                              BackupItemOperationsAttempted is the total number of attempted
+                              async BackupItemAction operations for this backup.
+                            type: integer
+                          backupItemOperationsCompleted:
+                            description: |-
+                              BackupItemOperationsCompleted is the total number of successfully completed
+                              async BackupItemAction operations for this backup.
+                            type: integer
+                          backupItemOperationsFailed:
+                            description: |-
+                              BackupItemOperationsFailed is the total number of async
+                              BackupItemAction operations for this backup which ended with an error.
+                            type: integer
+                          completionTimestamp:
+                            description: |-
+                              CompletionTimestamp records the time a backup was completed.
+                              Completion time is recorded even on failed backups.
+                              Completion time is recorded before uploading the backup object.
+                              The server's time is used for CompletionTimestamps
+                            format: date-time
+                            nullable: true
+                            type: string
+                          csiVolumeSnapshotsAttempted:
+                            description: |-
+                              CSIVolumeSnapshotsAttempted is the total number of attempted
+                              CSI VolumeSnapshots for this backup.
+                            type: integer
+                          csiVolumeSnapshotsCompleted:
+                            description: |-
+                              CSIVolumeSnapshotsCompleted is the total number of successfully
+                              completed CSI VolumeSnapshots for this backup.
+                            type: integer
+                          errors:
+                            description: |-
+                              Errors is a count of all error messages that were generated during
+                              execution of the backup.  The actual errors are in the backup's log
+                              file in object storage.
+                            type: integer
+                          expiration:
+                            description: Expiration is when this Backup is eligible for garbage-collection.
+                            format: date-time
+                            nullable: true
+                            type: string
+                          failureReason:
+                            description: FailureReason is an error that caused the entire backup to fail.
+                            type: string
+                          formatVersion:
+                            description: FormatVersion is the backup format version, including major, minor, and patch version.
+                            type: string
+                          hookStatus:
+                            description: HookStatus contains information about the status of the hooks.
+                            nullable: true
+                            properties:
+                              hooksAttempted:
+                                description: |-
+                                  HooksAttempted is the total number of attempted hooks
+                                  Specifically, HooksAttempted represents the number of hooks that failed to execute
+                                  and the number of hooks that executed successfully.
+                                type: integer
+                              hooksFailed:
+                                description: HooksFailed is the total number of hooks which ended with an error
+                                type: integer
+                            type: object
+                          phase:
+                            description: Phase is the current state of the Backup.
+                            enum:
+                              - New
+                              - FailedValidation
+                              - InProgress
+                              - WaitingForPluginOperations
+                              - WaitingForPluginOperationsPartiallyFailed
+                              - Finalizing
+                              - FinalizingPartiallyFailed
+                              - Completed
+                              - PartiallyFailed
+                              - Failed
+                              - Deleting
+                            type: string
+                          progress:
+                            description: |-
+                              Progress contains information about the backup's execution progress. Note
+                              that this information is best-effort only -- if Velero fails to update it
+                              during a backup for any reason, it may be inaccurate/stale.
+                            nullable: true
+                            properties:
+                              itemsBackedUp:
+                                description: |-
+                                  ItemsBackedUp is the number of items that have actually been written to the
+                                  backup tarball so far.
+                                type: integer
+                              totalItems:
+                                description: |-
+                                  TotalItems is the total number of items to be backed up. This number may change
+                                  throughout the execution of the backup due to plugins that return additional related
+                                  items to back up, the velero.io/exclude-from-backup label, and various other
+                                  filters that happen as items are processed.
+                                type: integer
+                            type: object
+                          startTimestamp:
+                            description: |-
+                              StartTimestamp records the time a backup was started.
+                              Separate from CreationTimestamp, since that value changes
+                              on restores.
+                              The server's time is used for StartTimestamps
+                            format: date-time
+                            nullable: true
+                            type: string
+                          validationErrors:
+                            description: |-
+                              ValidationErrors is a slice of all validation errors (if
+                              applicable).
+                            items:
+                              type: string
+                            nullable: true
+                            type: array
+                          version:
+                            description: |-
+                              Version is the backup format major version.
+                              Deprecated: Please see FormatVersion
+                            type: integer
+                          volumeSnapshotsAttempted:
+                            description: |-
+                              VolumeSnapshotsAttempted is the total number of attempted
+                              volume snapshots for this backup.
+                            type: integer
+                          volumeSnapshotsCompleted:
+                            description: |-
+                              VolumeSnapshotsCompleted is the total number of successfully
+                              completed volume snapshots for this backup.
+                            type: integer
+                          warnings:
+                            description: |-
+                              Warnings is a count of all warning messages that were generated during
+                              execution of the backup. The actual warnings are in the backup's log
+                              file in object storage.
+                            type: integer
+                        type: object
+                      lastBackupName:
+                        description: Name of most recently created [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup].
+                        type: string
+                      lastBackupTime:
+                        description: Time of the most recently created [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup].
+                        format: date-time
+                        type: string
+                      nextAttempt:
+                        description: |-
+                          NextAttempt indicates the time when the next backup will be created.
+                          Always absent for a single [ManagementBackup].
+                        format: date-time
+                        type: string
+                      region:
+                        description: |-
+                          Region reflects the name of a region for which
+                          the [github.com/vmware-tanzu/velero/pkg/apis/velero/v1.Backup] has been created.
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_managements.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_managements.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: managements.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,247 +13,236 @@ spec:
     listKind: ManagementList
     plural: managements
     shortNames:
-    - kcm-mgmt
-    - mgmt
+      - kcm-mgmt
+      - mgmt
     singular: management
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - description: Overall readiness of the Management resource
-      jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - description: Current release version
-      jsonPath: .status.release
-      name: Release
-      type: string
-    - description: Time duration since creation of Management
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Management is the Schema for the managements API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ManagementSpec defines the desired state of Management
-            properties:
-              core:
-                description: |-
-                  Core holds the core components that are mandatory.
-                  If not specified, will be populated with the default values.
-                properties:
-                  capi:
-                    description: CAPI represents the core Cluster API component and
-                      references the Cluster API template.
-                    properties:
-                      config:
-                        description: |-
-                          Config allows to provide parameters for management component customization.
-                          If no Config provided, the field will be populated with the default
-                          values for the template.
-                        x-kubernetes-preserve-unknown-fields: true
-                      template:
-                        description: |-
-                          Template is the name of the Template associated with this component.
-                          If not specified, will be taken from the Release object.
-                        type: string
-                    type: object
-                  kcm:
-                    description: KCM represents the core KCM component and references
-                      the KCM template.
-                    properties:
-                      config:
-                        description: |-
-                          Config allows to provide parameters for management component customization.
-                          If no Config provided, the field will be populated with the default
-                          values for the template.
-                        x-kubernetes-preserve-unknown-fields: true
-                      template:
-                        description: |-
-                          Template is the name of the Template associated with this component.
-                          If not specified, will be taken from the Release object.
-                        type: string
-                    type: object
-                type: object
-              providers:
-                description: Providers is the list of enabled CAPI providers.
-                items:
-                  properties:
-                    config:
-                      description: |-
-                        Config allows to provide parameters for management component customization.
-                        If no Config provided, the field will be populated with the default
-                        values for the template.
-                      x-kubernetes-preserve-unknown-fields: true
-                    name:
-                      description: Name of the provider.
-                      type: string
-                    template:
-                      description: |-
-                        Template is the name of the Template associated with this component.
-                        If not specified, will be taken from the Release object.
-                      type: string
-                  required:
-                  - name
-                  type: object
-                type: array
-              release:
-                description: Release references the Release object.
-                maxLength: 253
-                minLength: 1
-                type: string
-            required:
-            - release
-            type: object
-          status:
-            description: ManagementStatus defines the observed state of Management
-            properties:
-              availableProviders:
-                description: AvailableProviders holds all available CAPI providers.
-                items:
-                  type: string
-                type: array
-              backupName:
-                description: BackupName is a name of the management cluster scheduled
-                  backup.
-                type: string
-              capiContracts:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
+    - additionalPrinterColumns:
+        - description: Overall readiness of the Management resource
+          jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - description: Current release version
+          jsonPath: .status.release
+          name: Release
+          type: string
+        - description: Time duration since creation of Management
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Management is the Schema for the managements API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ManagementSpec defines the desired state of Management
+              properties:
+                core:
                   description: |-
-                    Holds key-value pairs with compatibility [contract versions],
-                    where the key is the core CAPI contract version,
+                    Core holds the core components that are mandatory.
+                    If not specified, will be populated with the default values.
+                  properties:
+                    capi:
+                      description: CAPI represents the core Cluster API component and references the Cluster API template.
+                      properties:
+                        config:
+                          description: |-
+                            Config allows to provide parameters for management component customization.
+                            If no Config provided, the field will be populated with the default
+                            values for the template.
+                          x-kubernetes-preserve-unknown-fields: true
+                        template:
+                          description: |-
+                            Template is the name of the Template associated with this component.
+                            If not specified, will be taken from the Release object.
+                          type: string
+                      type: object
+                    kcm:
+                      description: KCM represents the core KCM component and references the KCM template.
+                      properties:
+                        config:
+                          description: |-
+                            Config allows to provide parameters for management component customization.
+                            If no Config provided, the field will be populated with the default
+                            values for the template.
+                          x-kubernetes-preserve-unknown-fields: true
+                        template:
+                          description: |-
+                            Template is the name of the Template associated with this component.
+                            If not specified, will be taken from the Release object.
+                          type: string
+                      type: object
+                  type: object
+                providers:
+                  description: Providers is the list of enabled CAPI providers.
+                  items:
+                    properties:
+                      config:
+                        description: |-
+                          Config allows to provide parameters for management component customization.
+                          If no Config provided, the field will be populated with the default
+                          values for the template.
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
+                        description: Name of the provider.
+                        type: string
+                      template:
+                        description: |-
+                          Template is the name of the Template associated with this component.
+                          If not specified, will be taken from the Release object.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                release:
+                  description: Release references the Release object.
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+              required:
+                - release
+              type: object
+            status:
+              description: ManagementStatus defines the observed state of Management
+              properties:
+                availableProviders:
+                  description: AvailableProviders holds all available CAPI providers.
+                  items:
+                    type: string
+                  type: array
+                backupName:
+                  description: BackupName is a name of the management cluster scheduled backup.
+                  type: string
+                capiContracts:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Holds key-value pairs with compatibility [contract versions],
+                      where the key is the core CAPI contract version,
+                      and the value is an underscore-delimited (_) list of provider contract versions
+                      supported by the core CAPI.
+
+                      [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
+                    type: object
+                  description: |-
+                    For each CAPI provider name holds its compatibility [contract versions]
+                    in a key-value pairs, where the key is the core CAPI contract version,
                     and the value is an underscore-delimited (_) list of provider contract versions
                     supported by the core CAPI.
 
                     [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
                   type: object
-                description: |-
-                  For each CAPI provider name holds its compatibility [contract versions]
-                  in a key-value pairs, where the key is the core CAPI contract version,
-                  and the value is an underscore-delimited (_) list of provider contract versions
-                  supported by the core CAPI.
-
-                  [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
-                type: object
-              components:
-                additionalProperties:
-                  description: ComponentStatus is the status of Management component
-                    installation
-                  properties:
-                    error:
-                      description: Error stores as error message in case of failed
-                        installation
-                      type: string
-                    exposedProviders:
-                      description: ExposedProviders is a list of CAPI providers this
-                        component exposes
-                      items:
+                components:
+                  additionalProperties:
+                    description: ComponentStatus is the status of Management component installation
+                    properties:
+                      error:
+                        description: Error stores as error message in case of failed installation
                         type: string
-                      type: array
-                    success:
-                      description: Success represents if a component installation
-                        was successful
-                      type: boolean
-                    template:
-                      description: Template is the name of the Template associated
-                        with this component.
-                      type: string
+                      exposedProviders:
+                        description: ExposedProviders is a list of CAPI providers this component exposes
+                        items:
+                          type: string
+                        type: array
+                      success:
+                        description: Success represents if a component installation was successful
+                        type: boolean
+                      template:
+                        description: Template is the name of the Template associated with this component.
+                        type: string
+                    type: object
+                  description: Components indicates the status of installed KCM components and CAPI providers.
                   type: object
-                description: Components indicates the status of installed KCM components
-                  and CAPI providers.
-                type: object
-              conditions:
-                description: Conditions represents the observations of a Management's
-                  current state.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              release:
-                description: Release indicates the current Release object.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                conditions:
+                  description: Conditions represents the observations of a Management's current state.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                release:
+                  description: Release indicates the current Release object.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: multiclusterservices.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,885 +13,839 @@ spec:
     listKind: MultiClusterServiceList
     plural: multiclusterservices
     shortNames:
-    - mcs
+      - mcs
     singular: multiclusterservice
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - description: Number of ready out of total selected clusters
-      jsonPath: .status.conditions[?(@.type=="ClusterInReadyState")].message
-      name: Clusters
-      type: string
-    - description: StateManagementProvider name
-      jsonPath: .spec.serviceSpec.provider.name
-      name: provider
-      type: string
-    - description: Is the MultiClusterService for self-management
-      jsonPath: .spec.serviceSpec.provider.selfManagement
-      name: self-management
-      type: boolean
-    - description: Time elapsed since object creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: MultiClusterService is the Schema for the multiclusterservices
-          API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: MultiClusterServiceSpec defines the desired state of MultiClusterService
-            properties:
-              clusterSelector:
-                description: ClusterSelector identifies target clusters to manage
-                  services on.
-                properties:
-                  matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
-                    items:
-                      description: |-
-                        A label selector requirement is a selector that contains values, a key, and an operator that
-                        relates the key and values.
-                      properties:
-                        key:
-                          description: key is the label key that the selector applies
-                            to.
-                          type: string
-                        operator:
-                          description: |-
-                            operator represents a key's relationship to a set of values.
-                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                          type: string
-                        values:
-                          description: |-
-                            values is an array of string values. If the operator is In or NotIn,
-                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                            the values array must be empty. This array is replaced during a strategic
-                            merge patch.
-                          items:
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      required:
-                      - key
-                      - operator
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    description: |-
-                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                      operator is "In", and the values array contains only "value". The requirements are ANDed.
-                    type: object
-                type: object
-                x-kubernetes-map-type: atomic
-              dependsOn:
-                description: DependsOn is a list of other MultiClusterServices this
-                  one depends on.
-                items:
-                  type: string
-                type: array
-              serviceSpec:
-                description: ServiceSpec is spec related to deployment of services.
-                properties:
-                  continueOnError:
-                    default: false
-                    description: |-
-                      ContinueOnError specifies if the services deployment should continue if an error occurs.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    type: boolean
-                  driftExclusions:
-                    description: |-
-                      DriftExclusions specifies specific configurations of resources to ignore for drift detection.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    items:
-                      properties:
-                        paths:
-                          description: Paths is a slice of JSON6902 paths to exclude
-                            from configuration drift evaluation.
-                          items:
-                            type: string
-                          type: array
-                        target:
-                          description: Target points to the resources that the paths
-                            refers to.
-                          properties:
-                            annotationSelector:
-                              description: |-
-                                AnnotationSelector is a string that follows the label selection expression
-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                It matches with the resource annotations.
-                              type: string
-                            group:
-                              description: |-
-                                Group is the API group to select resources from.
-                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                              type: string
-                            kind:
-                              description: |-
-                                Kind of the API Group to select resources from.
-                                Together with Group and Version it is capable of unambiguously
-                                identifying and/or selecting resources.
-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                              type: string
-                            labelSelector:
-                              description: |-
-                                LabelSelector is a string that follows the label selection expression
-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                It matches with the resource labels.
-                              type: string
-                            name:
-                              description: Name to match resources with.
-                              type: string
-                            namespace:
-                              description: Namespace to select resources from.
-                              type: string
-                            version:
-                              description: |-
-                                Version of the API Group to select resources from.
-                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                              type: string
-                          type: object
-                      required:
-                      - paths
-                      type: object
-                    type: array
-                  driftIgnore:
-                    description: |-
-                      DriftIgnore specifies resources to ignore for drift detection.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    items:
-                      properties:
-                        annotationSelector:
-                          description: |-
-                            AnnotationSelector is a string that follows the label selection expression
-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                            It matches with the resource annotations.
-                          type: string
-                        group:
-                          description: |-
-                            Group is the API group to select resources from.
-                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                          type: string
-                        kind:
-                          description: |-
-                            Kind of the API Group to select resources from.
-                            Together with Group and Version it is capable of unambiguously
-                            identifying and/or selecting resources.
-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                          type: string
-                        labelSelector:
-                          description: |-
-                            LabelSelector is a string that follows the label selection expression
-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                            It matches with the resource labels.
-                          type: string
-                        name:
-                          description: Name to match resources with.
-                          type: string
-                        namespace:
-                          description: Namespace to select resources from.
-                          type: string
-                        version:
-                          description: |-
-                            Version of the API Group to select resources from.
-                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                          type: string
-                      type: object
-                    type: array
-                  policyRefs:
-                    description: |-
-                      PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
-                      that need to be deployed in the target clusters.
-                      The values contained in those resources can be static or leverage Go templates for dynamic customization.
-                      When expressed as templates, the values are filled in using information from
-                      resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    items:
-                      properties:
-                        deploymentType:
-                          default: Remote
-                          description: |-
-                            DeploymentType indicates whether resources need to be deployed
-                            into the management cluster (local) or the managed cluster (remote)
-                          enum:
-                          - Local
-                          - Remote
-                          type: string
-                        kind:
-                          description: |-
-                            Kind of the resource. Supported kinds are:
-                            - ConfigMap/Secret
-                            - flux GitRepository;OCIRepository;Bucket
-                          enum:
-                          - GitRepository
-                          - OCIRepository
-                          - Bucket
-                          - ConfigMap
-                          - Secret
-                          type: string
-                        name:
-                          description: |-
-                            Name of the referenced resource.
-                            Name can be expressed as a template and instantiate using any cluster field.
-                          minLength: 1
-                          type: string
-                        namespace:
-                          description: |-
-                            Namespace of the referenced resource.
-                            For ClusterProfile namespace can be left empty. In such a case, namespace will
-                            be implicit set to cluster's namespace.
-                            For Profile namespace must be left empty. Profile namespace will be used.
-                            Namespace can be expressed as a template and instantiate using any cluster field.
-                          type: string
-                        optional:
-                          default: false
-                          description: |-
-                            Optional indicates that the referenced resource is not mandatory.
-                            If set to true and the resource is not found, the error will be ignored,
-                            and Sveltos will continue processing other PolicyRefs.
-                          type: boolean
-                        path:
-                          description: |-
-                            Path to the directory containing the YAML files.
-                            Defaults to 'None', which translates to the root path of the SourceRef.
-                            Used only for GitRepository;OCIRepository;Bucket
-                          type: string
-                      required:
-                      - kind
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  priority:
-                    default: 100
-                    description: |-
-                      Priority sets the priority for the services defined in this spec.
-                      Higher value means higher priority and lower means lower.
-                      In case of conflict with another object managing the service,
-                      the one with higher priority will get to deploy its services.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    format: int32
-                    maximum: 2147483646
-                    minimum: 1
-                    type: integer
-                  provider:
-                    description: Provider is the definition of the provider to use
-                      to deploy services.
-                    properties:
-                      config:
-                        description: Config is the provider-specific configuration
-                          applied to the produced objects.
-                        x-kubernetes-preserve-unknown-fields: true
-                      name:
-                        description: Name is the name of the [StateManagementProvider]
-                          object.
-                        type: string
-                        x-kubernetes-validations:
-                        - message: Provider name is immutable once set
-                          rule: oldSelf == '' || self == oldSelf
-                      selfManagement:
+    - additionalPrinterColumns:
+        - description: Number of ready out of total selected clusters
+          jsonPath: .status.conditions[?(@.type=="ClusterInReadyState")].message
+          name: Clusters
+          type: string
+        - description: StateManagementProvider name
+          jsonPath: .spec.serviceSpec.provider.name
+          name: provider
+          type: string
+        - description: Is the MultiClusterService for self-management
+          jsonPath: .spec.serviceSpec.provider.selfManagement
+          name: self-management
+          type: boolean
+        - description: Time elapsed since object creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: MultiClusterService is the Schema for the multiclusterservices API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MultiClusterServiceSpec defines the desired state of MultiClusterService
+              properties:
+                clusterSelector:
+                  description: ClusterSelector identifies target clusters to manage services on.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
                         description: |-
-                          SelfManagement flag defines whether resources must be deployed to the management cluster itself.
-                          This field is ignored if set for ClusterDeployment.
-                        type: boolean
-                    type: object
-                  reload:
-                    description: |-
-                      Reload instances via rolling upgrade when a ConfigMap/Secret mounted as volume is modified.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    type: boolean
-                  services:
-                    description: |-
-                      Services is a list of services created via ServiceTemplates
-                      that could be installed on the target cluster.
-                    items:
-                      description: Service represents a Service to be deployed.
-                      properties:
-                        dependsOn:
-                          description: DependsOn specifies a list of other services
-                            that this service depends on.
-                          items:
-                            description: ServiceDependsOn identifies a service by
-                              its release name and namespace.
-                            properties:
-                              name:
-                                description: Name is the release name on target cluster.
-                                maxLength: 253
-                                minLength: 1
-                                type: string
-                              namespace:
-                                description: Namespace is the release namespace on
-                                  target cluster.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        disable:
-                          description: Disable can be set to disable handling of this
-                            service.
-                          type: boolean
-                        helmOptions:
-                          description: HelmOptions are the options to be passed to
-                            the provider for helm installation or updates
-                          properties:
-                            atomic:
-                              description: |-
-                                if set, the installation process deletes the installation/upgrades on failure.
-                                The --wait flag will be set automatically if --atomic is used
-                              type: boolean
-                            createNamespace:
-                              type: boolean
-                            dependencyUpdate:
-                              description: update dependencies if they are missing
-                                before installing the chart
-                              type: boolean
-                            description:
-                              description: Description is the description of an helm
-                                operation
-                              type: string
-                            disableHooks:
-                              description: prevent hooks from running during install/upgrade/uninstall
-                              type: boolean
-                            disableOpenAPIValidation:
-                              description: if set, the installation process will not
-                                validate rendered templates against the Kubernetes
-                                OpenAPI Schema
-                              type: boolean
-                            enableClientCache:
-                              description: EnableClientCache is a flag to enable Helm
-                                client cache. If it is not specified, it will be set
-                                to false.
-                              type: boolean
-                            labels:
-                              additionalProperties:
-                                type: string
-                              description: Labels that would be added to release metadata.
-                              type: object
-                            replace:
-                              description: Replaces if set indicates to replace an
-                                older release with this one
-                              type: boolean
-                            skipCRDs:
-                              description: |-
-                                SkipCRDs controls whether CRDs should be installed during install/upgrade operation.
-                                By default, CRDs are installed if not already present.
-                              type: boolean
-                            skipSchemaValidation:
-                              description: SkipSchemaValidation determines if JSON
-                                schema validation is disabled.
-                              type: boolean
-                            timeout:
-                              description: time to wait for any individual Kubernetes
-                                operation (like Jobs for hooks) (default 5m0s)
-                              type: string
-                            wait:
-                              description: |-
-                                if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet
-                                are in a ready state before marking the release as successful. It will wait for as long as --timeout
-                              type: boolean
-                            waitForJobs:
-                              description: |-
-                                if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful.
-                                It will wait for as long as --timeout
-                              type: boolean
-                          type: object
-                        name:
-                          description: Name is the chart release.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        namespace:
-                          default: default
-                          description: |-
-                            Namespace is the namespace the release will be installed in.
-                            It will default to "default" if not provided.
-                          type: string
-                        template:
-                          description: Template is a reference to a Template object
-                            located in the same namespace.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        templateChain:
-                          description: |-
-                            TemplateChain defines the ServiceTemplateChain object that will be used to deploy the service
-                            along with desired ServiceTemplate version.
-                          type: string
-                        values:
-                          description: |-
-                            Values is the helm values to be passed to the chart used by the template.
-                            The string type is used in order to allow for templating.
-                          type: string
-                        valuesFrom:
-                          description: ValuesFrom can reference a ConfigMap or Secret
-                            containing helm values.
-                          items:
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
                             description: |-
-                              ValuesFrom is the source of the values to pass to the ServiceTemplate. The source
-                              can be a ConfigMap or a Secret located in the same namespace as the ServiceSet.
-                            properties:
-                              kind:
-                                description: Kind is the kind of the source.
-                                enum:
-                                - ConfigMap
-                                - Secret
-                                type: string
-                              name:
-                                description: Name is the name of the source.
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                          type: array
-                        version:
-                          description: Version is the version of the service template.
-                          type: string
-                      required:
-                      - name
-                      - template
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - name
-                    - namespace
-                    x-kubernetes-list-type: map
-                  stopOnConflict:
-                    default: false
-                    description: |-
-                      StopOnConflict specifies what to do in case of a conflict.
-                      E.g. If another object is already managing a service.
-                      By default the remaining services will be deployed even if conflict is detected.
-                      If set to true, the deployment will stop after encountering the first conflict.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    type: boolean
-                  syncMode:
-                    default: Continuous
-                    description: |-
-                      SyncMode specifies how services are synced in the target cluster.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    enum:
-                    - OneTime
-                    - Continuous
-                    - ContinuousWithDriftDetection
-                    - DryRun
-                    type: string
-                  templateResourceRefs:
-                    description: |-
-                      TemplateResourceRefs is a list of resources to collect from the management cluster,
-                      the values from which can be used in templates.
-
-                      Deprecated: use .provider.config field to define provider-specific configuration.
-                    items:
-                      properties:
-                        identifier:
-                          description: |-
-                            Identifier is how the resource will be referred to in the
-                            template
-                          type: string
-                        optional:
-                          default: false
-                          description: |-
-                            Optional indicates that the referenced resource is not mandatory.
-                            If set to true and the resource is not found, the error will be ignored,
-                            and Sveltos will continue processing other TemplateResourceRefs.
-                          type: boolean
-                        resource:
-                          description: |-
-                            Resource references a Kubernetes instance in the management
-                            cluster to fetch and use during template instantiation.
-                            For ClusterProfile namespace can be left empty. In such a case, namespace will
-                            be implicit set to cluster's namespace.
-                            Name and namespace can be expressed as a template and instantiate using any cluster field.
-                          properties:
-                            apiVersion:
-                              description: API version of the referent.
-                              type: string
-                            fieldPath:
-                              description: |-
-                                If referring to a piece of an object instead of an entire object, this string
-                                should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                                For example, if the object reference is to a container within a pod, this would take on a value like:
-                                "spec.containers{name}" (where "name" refers to the name of the container that triggered
-                                the event) or if no container name is specified "spec.containers[2]" (container with
-                                index 2 in this pod). This syntax is chosen only to have some well-defined way of
-                                referencing a part of an object.
-                              type: string
-                            kind:
-                              description: |-
-                                Kind of the referent.
-                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                              type: string
-                            name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              type: string
-                            namespace:
-                              description: |-
-                                Namespace of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                              type: string
-                            resourceVersion:
-                              description: |-
-                                Specific resourceVersion to which this reference is made, if any.
-                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                              type: string
-                            uid:
-                              description: |-
-                                UID of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      required:
-                      - identifier
-                      - resource
-                      type: object
-                    type: array
-                type: object
-            type: object
-          status:
-            description: MultiClusterServiceStatus defines the observed state of MultiClusterService.
-            properties:
-              conditions:
-                description: Conditions contains details for the current state of
-                  the MultiClusterService.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              matchingClusters:
-                description: MatchingClusters contains a list of clusters matching
-                  MultiClusterService selector
-                items:
-                  properties:
-                    apiVersion:
-                      description: API version of the referent.
-                      type: string
-                    deployed:
-                      default: false
-                      description: Deployed indicates whether all services were successfully
-                        deployed.
-                      type: boolean
-                    fieldPath:
-                      description: |-
-                        If referring to a piece of an object instead of an entire object, this string
-                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                        For example, if the object reference is to a container within a pod, this would take on a value like:
-                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
-                        the event) or if no container name is specified "spec.containers[2]" (container with
-                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
-                        referencing a part of an object.
-                      type: string
-                    kind:
-                      description: |-
-                        Kind of the referent.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                      type: string
-                    lastTransitionTime:
-                      description: LastTransitionTime reflects when Deployed state
-                        was changed last time.
-                      format: date-time
-                      type: string
-                    name:
-                      description: |-
-                        Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                      type: string
-                    regional:
-                      default: false
-                      description: Regional indicates whether given cluster is regional.
-                      type: boolean
-                    resourceVersion:
-                      description: |-
-                        Specific resourceVersion to which this reference is made, if any.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                      type: string
-                    uid:
-                      description: |-
-                        UID of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
-                      type: string
-                  required:
-                  - deployed
-                  - regional
                   type: object
                   x-kubernetes-map-type: atomic
-                type: array
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              services:
-                description: Services contains details for the state of services.
-                items:
-                  description: ServiceState is the state of a Service
+                dependsOn:
+                  description: DependsOn is a list of other MultiClusterServices this one depends on.
+                  items:
+                    type: string
+                  type: array
+                serviceSpec:
+                  description: ServiceSpec is spec related to deployment of services.
                   properties:
-                    conditions:
-                      description: Conditions is a list of conditions for the Service
+                    continueOnError:
+                      default: false
+                      description: |-
+                        ContinueOnError specifies if the services deployment should continue if an error occurs.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      type: boolean
+                    driftExclusions:
+                      description: |-
+                        DriftExclusions specifies specific configurations of resources to ignore for drift detection.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
                       items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
                         properties:
-                          lastTransitionTime:
+                          paths:
+                            description: Paths is a slice of JSON6902 paths to exclude from configuration drift evaluation.
+                            items:
+                              type: string
+                            type: array
+                          target:
+                            description: Target points to the resources that the paths refers to.
+                            properties:
+                              annotationSelector:
+                                description: |-
+                                  AnnotationSelector is a string that follows the label selection expression
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                  It matches with the resource annotations.
+                                type: string
+                              group:
+                                description: |-
+                                  Group is the API group to select resources from.
+                                  Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the API Group to select resources from.
+                                  Together with Group and Version it is capable of unambiguously
+                                  identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                type: string
+                              labelSelector:
+                                description: |-
+                                  LabelSelector is a string that follows the label selection expression
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                  It matches with the resource labels.
+                                type: string
+                              name:
+                                description: Name to match resources with.
+                                type: string
+                              namespace:
+                                description: Namespace to select resources from.
+                                type: string
+                              version:
+                                description: |-
+                                  Version of the API Group to select resources from.
+                                  Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                type: string
+                            type: object
+                        required:
+                          - paths
+                        type: object
+                      type: array
+                    driftIgnore:
+                      description: |-
+                        DriftIgnore specifies resources to ignore for drift detection.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      items:
+                        properties:
+                          annotationSelector:
                             description: |-
-                              lastTransitionTime is the last time the condition transitioned from one status to another.
-                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                            format: date-time
+                              AnnotationSelector is a string that follows the label selection expression
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                              It matches with the resource annotations.
                             type: string
-                          message:
+                          group:
                             description: |-
-                              message is a human readable message indicating details about the transition.
-                              This may be an empty string.
-                            maxLength: 32768
+                              Group is the API group to select resources from.
+                              Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                             type: string
-                          observedGeneration:
+                          kind:
                             description: |-
-                              observedGeneration represents the .metadata.generation that the condition was set based upon.
-                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                              with respect to the current state of the instance.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          reason:
-                            description: |-
-                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                              Producers of specific condition types may define expected values and meanings for this field,
-                              and whether the values are considered a guaranteed API.
-                              The value should be a CamelCase string.
-                              This field may not be empty.
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              Kind of the API Group to select resources from.
+                              Together with Group and Version it is capable of unambiguously
+                              identifying and/or selecting resources.
+                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                             type: string
-                          status:
-                            description: status of the condition, one of True, False,
-                              Unknown.
+                          labelSelector:
+                            description: |-
+                              LabelSelector is a string that follows the label selection expression
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                              It matches with the resource labels.
+                            type: string
+                          name:
+                            description: Name to match resources with.
+                            type: string
+                          namespace:
+                            description: Namespace to select resources from.
+                            type: string
+                          version:
+                            description: |-
+                              Version of the API Group to select resources from.
+                              Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            type: string
+                        type: object
+                      type: array
+                    policyRefs:
+                      description: |-
+                        PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
+                        that need to be deployed in the target clusters.
+                        The values contained in those resources can be static or leverage Go templates for dynamic customization.
+                        When expressed as templates, the values are filled in using information from
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      items:
+                        properties:
+                          deploymentType:
+                            default: Remote
+                            description: |-
+                              DeploymentType indicates whether resources need to be deployed
+                              into the management cluster (local) or the managed cluster (remote)
                             enum:
-                            - "True"
-                            - "False"
-                            - Unknown
+                              - Local
+                              - Remote
                             type: string
-                          type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          kind:
+                            description: |-
+                              Kind of the resource. Supported kinds are:
+                              - ConfigMap/Secret
+                              - flux GitRepository;OCIRepository;Bucket
+                            enum:
+                              - GitRepository
+                              - OCIRepository
+                              - Bucket
+                              - ConfigMap
+                              - Secret
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referenced resource.
+                              Name can be expressed as a template and instantiate using any cluster field.
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referenced resource.
+                              For ClusterProfile namespace can be left empty. In such a case, namespace will
+                              be implicit set to cluster's namespace.
+                              For Profile namespace must be left empty. Profile namespace will be used.
+                              Namespace can be expressed as a template and instantiate using any cluster field.
+                            type: string
+                          optional:
+                            default: false
+                            description: |-
+                              Optional indicates that the referenced resource is not mandatory.
+                              If set to true and the resource is not found, the error will be ignored,
+                              and Sveltos will continue processing other PolicyRefs.
+                            type: boolean
+                          path:
+                            description: |-
+                              Path to the directory containing the YAML files.
+                              Defaults to 'None', which translates to the root path of the SourceRef.
+                              Used only for GitRepository;OCIRepository;Bucket
                             type: string
                         required:
-                        - lastTransitionTime
-                        - message
-                        - reason
-                        - status
-                        - type
+                          - kind
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    priority:
+                      default: 100
+                      description: |-
+                        Priority sets the priority for the services defined in this spec.
+                        Higher value means higher priority and lower means lower.
+                        In case of conflict with another object managing the service,
+                        the one with higher priority will get to deploy its services.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      format: int32
+                      maximum: 2147483646
+                      minimum: 1
+                      type: integer
+                    provider:
+                      description: Provider is the definition of the provider to use to deploy services.
+                      properties:
+                        config:
+                          description: Config is the provider-specific configuration applied to the produced objects.
+                          x-kubernetes-preserve-unknown-fields: true
+                        name:
+                          description: Name is the name of the [StateManagementProvider] object.
+                          type: string
+                          x-kubernetes-validations:
+                            - message: Provider name is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        selfManagement:
+                          description: |-
+                            SelfManagement flag defines whether resources must be deployed to the management cluster itself.
+                            This field is ignored if set for ClusterDeployment.
+                          type: boolean
+                      type: object
+                    reload:
+                      description: |-
+                        Reload instances via rolling upgrade when a ConfigMap/Secret mounted as volume is modified.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      type: boolean
+                    services:
+                      description: |-
+                        Services is a list of services created via ServiceTemplates
+                        that could be installed on the target cluster.
+                      items:
+                        description: Service represents a Service to be deployed.
+                        properties:
+                          dependsOn:
+                            description: DependsOn specifies a list of other services that this service depends on.
+                            items:
+                              description: ServiceDependsOn identifies a service by its release name and namespace.
+                              properties:
+                                name:
+                                  description: Name is the release name on target cluster.
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                namespace:
+                                  description: Namespace is the release namespace on target cluster.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            type: array
+                          disable:
+                            description: Disable can be set to disable handling of this service.
+                            type: boolean
+                          helmOptions:
+                            description: HelmOptions are the options to be passed to the provider for helm installation or updates
+                            properties:
+                              atomic:
+                                description: |-
+                                  if set, the installation process deletes the installation/upgrades on failure.
+                                  The --wait flag will be set automatically if --atomic is used
+                                type: boolean
+                              createNamespace:
+                                type: boolean
+                              dependencyUpdate:
+                                description: update dependencies if they are missing before installing the chart
+                                type: boolean
+                              description:
+                                description: Description is the description of an helm operation
+                                type: string
+                              disableHooks:
+                                description: prevent hooks from running during install/upgrade/uninstall
+                                type: boolean
+                              disableOpenAPIValidation:
+                                description: if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema
+                                type: boolean
+                              enableClientCache:
+                                description: EnableClientCache is a flag to enable Helm client cache. If it is not specified, it will be set to false.
+                                type: boolean
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels that would be added to release metadata.
+                                type: object
+                              replace:
+                                description: Replaces if set indicates to replace an older release with this one
+                                type: boolean
+                              skipCRDs:
+                                description: |-
+                                  SkipCRDs controls whether CRDs should be installed during install/upgrade operation.
+                                  By default, CRDs are installed if not already present.
+                                type: boolean
+                              skipSchemaValidation:
+                                description: SkipSchemaValidation determines if JSON schema validation is disabled.
+                                type: boolean
+                              timeout:
+                                description: time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
+                                type: string
+                              wait:
+                                description: |-
+                                  if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet
+                                  are in a ready state before marking the release as successful. It will wait for as long as --timeout
+                                type: boolean
+                              waitForJobs:
+                                description: |-
+                                  if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful.
+                                  It will wait for as long as --timeout
+                                type: boolean
+                            type: object
+                          name:
+                            description: Name is the chart release.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            default: default
+                            description: |-
+                              Namespace is the namespace the release will be installed in.
+                              It will default to "default" if not provided.
+                            type: string
+                          template:
+                            description: Template is a reference to a Template object located in the same namespace.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          templateChain:
+                            description: |-
+                              TemplateChain defines the ServiceTemplateChain object that will be used to deploy the service
+                              along with desired ServiceTemplate version.
+                            type: string
+                          values:
+                            description: |-
+                              Values is the helm values to be passed to the chart used by the template.
+                              The string type is used in order to allow for templating.
+                            type: string
+                          valuesFrom:
+                            description: ValuesFrom can reference a ConfigMap or Secret containing helm values.
+                            items:
+                              description: |-
+                                ValuesFrom is the source of the values to pass to the ServiceTemplate. The source
+                                can be a ConfigMap or a Secret located in the same namespace as the ServiceSet.
+                              properties:
+                                kind:
+                                  description: Kind is the kind of the source.
+                                  enum:
+                                    - ConfigMap
+                                    - Secret
+                                  type: string
+                                name:
+                                  description: Name is the name of the source.
+                                  type: string
+                              required:
+                                - kind
+                                - name
+                              type: object
+                            type: array
+                          version:
+                            description: Version is the version of the service template.
+                            type: string
+                        required:
+                          - name
+                          - template
                         type: object
                       type: array
                       x-kubernetes-list-map-keys:
-                      - type
+                        - name
+                        - namespace
                       x-kubernetes-list-type: map
-                    failureMessage:
-                      description: FailureMessage is the reason why the Service failed
-                        to deploy
-                      type: string
-                    lastStateTransitionTime:
-                      description: LastStateTransitionTime is the time the State was
-                        last transitioned
-                      format: date-time
-                      type: string
-                    name:
-                      description: Name is the name of the Service
-                      type: string
-                    namespace:
-                      description: Namespace is the namespace of the Service
-                      type: string
-                    state:
-                      description: State is the state of the Service
+                    stopOnConflict:
+                      default: false
+                      description: |-
+                        StopOnConflict specifies what to do in case of a conflict.
+                        E.g. If another object is already managing a service.
+                        By default the remaining services will be deployed even if conflict is detected.
+                        If set to true, the deployment will stop after encountering the first conflict.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
+                      type: boolean
+                    syncMode:
+                      default: Continuous
+                      description: |-
+                        SyncMode specifies how services are synced in the target cluster.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
                       enum:
-                      - Deployed
-                      - Provisioning
-                      - Failed
-                      - Pending
-                      - Deleting
+                        - OneTime
+                        - Continuous
+                        - ContinuousWithDriftDetection
+                        - DryRun
                       type: string
-                    template:
-                      description: Template is the name of the ServiceTemplate used
-                        to deploy the Service
-                      type: string
-                    type:
-                      description: Type is the type of the deployment method for the
-                        Service
-                      enum:
-                      - Helm
-                      - Kustomize
-                      - Resource
-                      type: string
-                    version:
-                      description: Version is the version of the Service
-                      type: string
-                  required:
-                  - lastStateTransitionTime
-                  - name
-                  - namespace
-                  - state
-                  - template
-                  - type
-                  type: object
-                type: array
-              servicesUpgradePaths:
-                description: ServicesUpgradePaths contains details for the state of
-                  services upgrade paths.
-                items:
-                  description: ServiceUpgradePaths contains details for the state
-                    of service upgrade paths.
-                  properties:
-                    availableUpgrades:
-                      description: AvailableUpgrades contains details for the state
-                        of available upgrades.
+                    templateResourceRefs:
+                      description: |-
+                        TemplateResourceRefs is a list of resources to collect from the management cluster,
+                        the values from which can be used in templates.
+
+                        Deprecated: use .provider.config field to define provider-specific configuration.
                       items:
-                        description: UpgradePath contains details for the state of
-                          service upgrade paths.
                         properties:
-                          upgradePaths:
-                            description: 'Deprecated: use Versions to define versions
-                              that service can be upgraded to.'
-                            items:
-                              type: string
-                            type: array
-                          versions:
-                            description: Versions contains the list of versions that
-                              service can be upgraded to.
-                            items:
-                              description: AvailableUpgrade is the definition of the
-                                available upgrade for the Template
-                              properties:
-                                name:
-                                  description: Name is the name of the Template to
-                                    which the upgrade is available.
-                                  type: string
-                                version:
-                                  description: Version is the version of the Template
-                                    to which the upgrade is available.
-                                  type: string
-                              required:
-                              - name
-                              - version
-                              type: object
-                            type: array
+                          identifier:
+                            description: |-
+                              Identifier is how the resource will be referred to in the
+                              template
+                            type: string
+                          optional:
+                            default: false
+                            description: |-
+                              Optional indicates that the referenced resource is not mandatory.
+                              If set to true and the resource is not found, the error will be ignored,
+                              and Sveltos will continue processing other TemplateResourceRefs.
+                            type: boolean
+                          resource:
+                            description: |-
+                              Resource references a Kubernetes instance in the management
+                              cluster to fetch and use during template instantiation.
+                              For ClusterProfile namespace can be left empty. In such a case, namespace will
+                              be implicit set to cluster's namespace.
+                              Name and namespace can be expressed as a template and instantiate using any cluster field.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - identifier
+                          - resource
                         type: object
                       type: array
-                    name:
-                      description: Name is the name of the service.
-                      type: string
-                    namespace:
-                      description: Namespace is the namespace of the service.
-                      type: string
-                    template:
-                      description: Template is the name of the current service template.
-                      type: string
-                  required:
-                  - name
-                  - namespace
-                  - template
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              type: object
+            status:
+              description: MultiClusterServiceStatus defines the observed state of MultiClusterService.
+              properties:
+                conditions:
+                  description: Conditions contains details for the current state of the MultiClusterService.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                matchingClusters:
+                  description: MatchingClusters contains a list of clusters matching MultiClusterService selector
+                  items:
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      deployed:
+                        default: false
+                        description: Deployed indicates whether all services were successfully deployed.
+                        type: boolean
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime reflects when Deployed state was changed last time.
+                        format: date-time
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      regional:
+                        default: false
+                        description: Regional indicates whether given cluster is regional.
+                        type: boolean
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    required:
+                      - deployed
+                      - regional
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                services:
+                  description: Services contains details for the state of services.
+                  items:
+                    description: ServiceState is the state of a Service
+                    properties:
+                      conditions:
+                        description: Conditions is a list of conditions for the Service
+                        items:
+                          description: Condition contains details for one aspect of the current state of this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: |-
+                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              format: date-time
+                              type: string
+                            message:
+                              description: |-
+                                message is a human readable message indicating details about the transition.
+                                This may be an empty string.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: |-
+                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                with respect to the current state of the instance.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: |-
+                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                Producers of specific condition types may define expected values and meanings for this field,
+                                and whether the values are considered a guaranteed API.
+                                The value should be a CamelCase string.
+                                This field may not be empty.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      failureMessage:
+                        description: FailureMessage is the reason why the Service failed to deploy
+                        type: string
+                      lastStateTransitionTime:
+                        description: LastStateTransitionTime is the time the State was last transitioned
+                        format: date-time
+                        type: string
+                      name:
+                        description: Name is the name of the Service
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the Service
+                        type: string
+                      state:
+                        description: State is the state of the Service
+                        enum:
+                          - Deployed
+                          - Provisioning
+                          - Failed
+                          - Pending
+                          - Deleting
+                        type: string
+                      template:
+                        description: Template is the name of the ServiceTemplate used to deploy the Service
+                        type: string
+                      type:
+                        description: Type is the type of the deployment method for the Service
+                        enum:
+                          - Helm
+                          - Kustomize
+                          - Resource
+                        type: string
+                      version:
+                        description: Version is the version of the Service
+                        type: string
+                    required:
+                      - lastStateTransitionTime
+                      - name
+                      - namespace
+                      - state
+                      - template
+                      - type
+                    type: object
+                  type: array
+                servicesUpgradePaths:
+                  description: ServicesUpgradePaths contains details for the state of services upgrade paths.
+                  items:
+                    description: ServiceUpgradePaths contains details for the state of service upgrade paths.
+                    properties:
+                      availableUpgrades:
+                        description: AvailableUpgrades contains details for the state of available upgrades.
+                        items:
+                          description: UpgradePath contains details for the state of service upgrade paths.
+                          properties:
+                            upgradePaths:
+                              description: 'Deprecated: use Versions to define versions that service can be upgraded to.'
+                              items:
+                                type: string
+                              type: array
+                            versions:
+                              description: Versions contains the list of versions that service can be upgraded to.
+                              items:
+                                description: AvailableUpgrade is the definition of the available upgrade for the Template
+                                properties:
+                                  name:
+                                    description: Name is the name of the Template to which the upgrade is available.
+                                    type: string
+                                  version:
+                                    description: Version is the version of the Template to which the upgrade is available.
+                                    type: string
+                                required:
+                                  - name
+                                  - version
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                      name:
+                        description: Name is the name of the service.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the service.
+                        type: string
+                      template:
+                        description: Template is the name of the current service template.
+                        type: string
+                    required:
+                      - name
+                      - namespace
+                      - template
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: providertemplates.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,1020 +13,967 @@ spec:
     listKind: ProviderTemplateList
     plural: providertemplates
     shortNames:
-    - providertmpl
+      - providertmpl
     singular: providertemplate
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - description: Valid
-      jsonPath: .status.valid
-      name: valid
-      type: boolean
-    - description: Validation Error
-      jsonPath: .status.validationError
-      name: validationError
-      priority: 1
-      type: string
-    - description: Description
-      jsonPath: .status.description
-      name: description
-      priority: 1
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ProviderTemplate is the Schema for the providertemplates API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ProviderTemplateSpec defines the desired state of ProviderTemplate
-            properties:
-              capiContracts:
-                additionalProperties:
-                  type: string
-                description: |-
-                  Holds key-value pairs with compatibility [contract versions],
-                  where the key is the core CAPI contract version,
-                  and the value is an underscore-delimited (_) list of provider contract versions
-                  supported by the core CAPI.
+    - additionalPrinterColumns:
+        - description: Valid
+          jsonPath: .status.valid
+          name: valid
+          type: boolean
+        - description: Validation Error
+          jsonPath: .status.validationError
+          name: validationError
+          priority: 1
+          type: string
+        - description: Description
+          jsonPath: .status.description
+          name: description
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ProviderTemplate is the Schema for the providertemplates API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ProviderTemplateSpec defines the desired state of ProviderTemplate
+              properties:
+                capiContracts:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    Holds key-value pairs with compatibility [contract versions],
+                    where the key is the core CAPI contract version,
+                    and the value is an underscore-delimited (_) list of provider contract versions
+                    supported by the core CAPI.
 
-                  [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
-                type: object
-              helm:
-                description: HelmSpec references a Helm chart representing the KCM
-                  template
-                properties:
-                  chartRef:
-                    description: |-
-                      ChartRef is a reference to a source controller resource containing the
-                      Helm chart representing the template.
-                    properties:
-                      apiVersion:
-                        description: APIVersion of the referent.
-                        type: string
-                      kind:
-                        description: Kind of the referent.
-                        enum:
-                        - OCIRepository
-                        - HelmChart
-                        - ExternalArtifact
-                        type: string
-                      name:
-                        description: Name of the referent.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      namespace:
-                        description: |-
-                          Namespace of the referent, defaults to the namespace of the Kubernetes
-                          resource object that contains the reference.
-                        maxLength: 63
-                        minLength: 1
-                        type: string
-                    required:
-                    - kind
-                    - name
-                    type: object
-                  chartSource:
-                    description: ChartSource is a source of a Helm chart representing
-                      the template.
-                    properties:
-                      deploymentType:
-                        default: Remote
-                        description: |-
-                          DeploymentType is the type of the deployment. This field is ignored,
-                          when ResourceSpec is used as part of Helm chart configuration.
-                        enum:
-                        - Local
-                        - Remote
-                        type: string
-                      localSourceRef:
-                        description: LocalSourceRef is the local source of the kustomize
-                          manifest.
-                        properties:
-                          kind:
-                            description: Kind is the kind of the local source.
-                            enum:
-                            - ConfigMap
-                            - Secret
-                            - GitRepository
-                            - Bucket
+                    [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
+                  type: object
+                helm:
+                  description: HelmSpec references a Helm chart representing the KCM template
+                  properties:
+                    chartRef:
+                      description: |-
+                        ChartRef is a reference to a source controller resource containing the
+                        Helm chart representing the template.
+                      properties:
+                        apiVersion:
+                          description: APIVersion of the referent.
+                          type: string
+                        kind:
+                          description: Kind of the referent.
+                          enum:
                             - OCIRepository
-                            type: string
-                          name:
-                            description: Name is the name of the local source.
-                            type: string
-                          namespace:
-                            description: |-
-                              Namespace is the namespace of the local source. Cross-namespace references
-                              are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
-                              If the Kind is ConfigMap or Secret, the namespace will be ignored.
-                            type: string
-                        required:
+                            - HelmChart
+                            - ExternalArtifact
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referent, defaults to the namespace of the Kubernetes
+                            resource object that contains the reference.
+                          maxLength: 63
+                          minLength: 1
+                          type: string
+                      required:
                         - kind
                         - name
-                        type: object
-                      path:
-                        description: Path to the directory containing the resource
-                          manifest.
-                        type: string
-                      remoteSourceSpec:
-                        description: RemoteSourceSpec is the remote source of the
-                          kustomize manifest.
-                        properties:
-                          bucket:
-                            description: Bucket is the definition of bucket source.
-                            properties:
-                              bucketName:
-                                description: BucketName is the name of the object
-                                  storage bucket.
-                                type: string
-                              certSecretRef:
-                                description: |-
-                                  CertSecretRef can be given the name of a Secret containing
-                                  either or both of
-
-                                  - a PEM-encoded client certificate (`tls.crt`) and private
-                                  key (`tls.key`);
-                                  - a PEM-encoded CA certificate (`ca.crt`)
-
-                                  and whichever are supplied, will be used for connecting to the
-                                  bucket. The client cert and key are useful if you are
-                                  authenticating with a certificate; the CA cert is useful if
-                                  you are using a self-signed server certificate. The Secret must
-                                  be of type `Opaque` or `kubernetes.io/tls`.
-
-                                  This field is only supported for the `generic` provider.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              endpoint:
-                                description: Endpoint is the object storage address
-                                  the BucketName is located at.
-                                type: string
-                              ignore:
-                                description: |-
-                                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                                  (which is the same as .gitignore). If not provided, a default will be used,
-                                  consult the documentation for your version to find out what those are.
-                                type: string
-                              insecure:
-                                description: Insecure allows connecting to a non-TLS
-                                  HTTP Endpoint.
-                                type: boolean
-                              interval:
-                                description: |-
-                                  Interval at which the Bucket Endpoint is checked for updates.
-                                  This interval is approximate and may be subject to jitter to ensure
-                                  efficient use of resources.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                                type: string
-                              prefix:
-                                description: Prefix to use for server-side filtering
-                                  of files in the Bucket.
-                                type: string
-                              provider:
-                                default: generic
-                                description: |-
-                                  Provider of the object storage bucket.
-                                  Defaults to 'generic', which expects an S3 (API) compatible object
-                                  storage.
-                                enum:
-                                - generic
-                                - aws
-                                - gcp
-                                - azure
-                                type: string
-                              proxySecretRef:
-                                description: |-
-                                  ProxySecretRef specifies the Secret containing the proxy configuration
-                                  to use while communicating with the Bucket server.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              region:
-                                description: Region of the Endpoint where the BucketName
-                                  is located in.
-                                type: string
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Secret containing authentication credentials
-                                  for the Bucket.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceAccountName:
-                                description: |-
-                                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                                  the bucket. This field is only supported for the 'gcp' and 'aws' providers.
-                                  For more information about workload identity:
-                                  https://fluxcd.io/flux/components/source/buckets/#workload-identity
-                                type: string
-                              sts:
-                                description: |-
-                                  STS specifies the required configuration to use a Security Token
-                                  Service for fetching temporary credentials to authenticate in a
-                                  Bucket provider.
-
-                                  This field is only supported for the `aws` and `generic` providers.
-                                properties:
-                                  certSecretRef:
-                                    description: |-
-                                      CertSecretRef can be given the name of a Secret containing
-                                      either or both of
-
-                                      - a PEM-encoded client certificate (`tls.crt`) and private
-                                      key (`tls.key`);
-                                      - a PEM-encoded CA certificate (`ca.crt`)
-
-                                      and whichever are supplied, will be used for connecting to the
-                                      STS endpoint. The client cert and key are useful if you are
-                                      authenticating with a certificate; the CA cert is useful if
-                                      you are using a self-signed server certificate. The Secret must
-                                      be of type `Opaque` or `kubernetes.io/tls`.
-
-                                      This field is only supported for the `ldap` provider.
-                                    properties:
-                                      name:
-                                        description: Name of the referent.
-                                        type: string
-                                    required:
-                                    - name
-                                    type: object
-                                  endpoint:
-                                    description: |-
-                                      Endpoint is the HTTP/S endpoint of the Security Token Service from
-                                      where temporary credentials will be fetched.
-                                    pattern: ^(http|https)://.*$
-                                    type: string
-                                  provider:
-                                    description: Provider of the Security Token Service.
-                                    enum:
-                                    - aws
-                                    - ldap
-                                    type: string
-                                  secretRef:
-                                    description: |-
-                                      SecretRef specifies the Secret containing authentication credentials
-                                      for the STS endpoint. This Secret must contain the fields `username`
-                                      and `password` and is supported only for the `ldap` provider.
-                                    properties:
-                                      name:
-                                        description: Name of the referent.
-                                        type: string
-                                    required:
-                                    - name
-                                    type: object
-                                required:
-                                - endpoint
-                                - provider
-                                type: object
-                              suspend:
-                                description: |-
-                                  Suspend tells the controller to suspend the reconciliation of this
-                                  Bucket.
-                                type: boolean
-                              timeout:
-                                default: 60s
-                                description: Timeout for fetch operations, defaults
-                                  to 60s.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                                type: string
-                            required:
-                            - bucketName
-                            - endpoint
-                            - interval
-                            type: object
-                            x-kubernetes-validations:
-                            - message: STS configuration is only supported for the
-                                'aws' and 'generic' Bucket providers
-                              rule: self.provider == 'aws' || self.provider == 'generic'
-                                || !has(self.sts)
-                            - message: '''aws'' is the only supported STS provider
-                                for the ''aws'' Bucket provider'
-                              rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider
-                                == 'aws'
-                            - message: '''ldap'' is the only supported STS provider
-                                for the ''generic'' Bucket provider'
-                              rule: self.provider != 'generic' || !has(self.sts) ||
-                                self.sts.provider == 'ldap'
-                            - message: spec.sts.secretRef is not required for the
-                                'aws' STS provider
-                              rule: '!has(self.sts) || self.sts.provider != ''aws''
-                                || !has(self.sts.secretRef)'
-                            - message: spec.sts.certSecretRef is not required for
-                                the 'aws' STS provider
-                              rule: '!has(self.sts) || self.sts.provider != ''aws''
-                                || !has(self.sts.certSecretRef)'
-                            - message: ServiceAccountName is not supported for the
-                                'generic' Bucket provider
-                              rule: self.provider != 'generic' || !has(self.serviceAccountName)
-                            - message: cannot set both .spec.secretRef and .spec.serviceAccountName
-                              rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
-                          git:
-                            description: Git is the definition of git repository source.
-                            properties:
-                              ignore:
-                                description: |-
-                                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                                  (which is the same as .gitignore). If not provided, a default will be used,
-                                  consult the documentation for your version to find out what those are.
-                                type: string
-                              include:
-                                description: |-
-                                  Include specifies a list of GitRepository resources which Artifacts
-                                  should be included in the Artifact produced for this GitRepository.
-                                items:
+                      type: object
+                    chartSource:
+                      description: ChartSource is a source of a Helm chart representing the template.
+                      properties:
+                        deploymentType:
+                          default: Remote
+                          description: |-
+                            DeploymentType is the type of the deployment. This field is ignored,
+                            when ResourceSpec is used as part of Helm chart configuration.
+                          enum:
+                            - Local
+                            - Remote
+                          type: string
+                        localSourceRef:
+                          description: LocalSourceRef is the local source of the kustomize manifest.
+                          properties:
+                            kind:
+                              description: Kind is the kind of the local source.
+                              enum:
+                                - ConfigMap
+                                - Secret
+                                - GitRepository
+                                - Bucket
+                                - OCIRepository
+                              type: string
+                            name:
+                              description: Name is the name of the local source.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of the local source. Cross-namespace references
+                                are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
+                                [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
+                                If the Kind is ConfigMap or Secret, the namespace will be ignored.
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                        path:
+                          description: Path to the directory containing the resource manifest.
+                          type: string
+                        remoteSourceSpec:
+                          description: RemoteSourceSpec is the remote source of the kustomize manifest.
+                          properties:
+                            bucket:
+                              description: Bucket is the definition of bucket source.
+                              properties:
+                                bucketName:
+                                  description: BucketName is the name of the object storage bucket.
+                                  type: string
+                                certSecretRef:
                                   description: |-
-                                    GitRepositoryInclude specifies a local reference to a GitRepository which
-                                    Artifact (sub-)contents must be included, and where they should be placed.
+                                    CertSecretRef can be given the name of a Secret containing
+                                    either or both of
+
+                                    - a PEM-encoded client certificate (`tls.crt`) and private
+                                    key (`tls.key`);
+                                    - a PEM-encoded CA certificate (`ca.crt`)
+
+                                    and whichever are supplied, will be used for connecting to the
+                                    bucket. The client cert and key are useful if you are
+                                    authenticating with a certificate; the CA cert is useful if
+                                    you are using a self-signed server certificate. The Secret must
+                                    be of type `Opaque` or `kubernetes.io/tls`.
+
+                                    This field is only supported for the `generic` provider.
                                   properties:
-                                    fromPath:
-                                      description: |-
-                                        FromPath specifies the path to copy contents from, defaults to the root
-                                        of the Artifact.
+                                    name:
+                                      description: Name of the referent.
                                       type: string
-                                    repository:
+                                  required:
+                                    - name
+                                  type: object
+                                endpoint:
+                                  description: Endpoint is the object storage address the BucketName is located at.
+                                  type: string
+                                ignore:
+                                  description: |-
+                                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                                    (which is the same as .gitignore). If not provided, a default will be used,
+                                    consult the documentation for your version to find out what those are.
+                                  type: string
+                                insecure:
+                                  description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+                                  type: boolean
+                                interval:
+                                  description: |-
+                                    Interval at which the Bucket Endpoint is checked for updates.
+                                    This interval is approximate and may be subject to jitter to ensure
+                                    efficient use of resources.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                                  type: string
+                                prefix:
+                                  description: Prefix to use for server-side filtering of files in the Bucket.
+                                  type: string
+                                provider:
+                                  default: generic
+                                  description: |-
+                                    Provider of the object storage bucket.
+                                    Defaults to 'generic', which expects an S3 (API) compatible object
+                                    storage.
+                                  enum:
+                                    - generic
+                                    - aws
+                                    - gcp
+                                    - azure
+                                  type: string
+                                proxySecretRef:
+                                  description: |-
+                                    ProxySecretRef specifies the Secret containing the proxy configuration
+                                    to use while communicating with the Bucket server.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                region:
+                                  description: Region of the Endpoint where the BucketName is located in.
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Secret containing authentication credentials
+                                    for the Bucket.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceAccountName:
+                                  description: |-
+                                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                                    the bucket. This field is only supported for the 'gcp' and 'aws' providers.
+                                    For more information about workload identity:
+                                    https://fluxcd.io/flux/components/source/buckets/#workload-identity
+                                  type: string
+                                sts:
+                                  description: |-
+                                    STS specifies the required configuration to use a Security Token
+                                    Service for fetching temporary credentials to authenticate in a
+                                    Bucket provider.
+
+                                    This field is only supported for the `aws` and `generic` providers.
+                                  properties:
+                                    certSecretRef:
                                       description: |-
-                                        GitRepositoryRef specifies the GitRepository which Artifact contents
-                                        must be included.
+                                        CertSecretRef can be given the name of a Secret containing
+                                        either or both of
+
+                                        - a PEM-encoded client certificate (`tls.crt`) and private
+                                        key (`tls.key`);
+                                        - a PEM-encoded CA certificate (`ca.crt`)
+
+                                        and whichever are supplied, will be used for connecting to the
+                                        STS endpoint. The client cert and key are useful if you are
+                                        authenticating with a certificate; the CA cert is useful if
+                                        you are using a self-signed server certificate. The Secret must
+                                        be of type `Opaque` or `kubernetes.io/tls`.
+
+                                        This field is only supported for the `ldap` provider.
                                       properties:
                                         name:
                                           description: Name of the referent.
                                           type: string
                                       required:
-                                      - name
+                                        - name
                                       type: object
-                                    toPath:
+                                    endpoint:
                                       description: |-
-                                        ToPath specifies the path to copy contents to, defaults to the name of
-                                        the GitRepositoryRef.
+                                        Endpoint is the HTTP/S endpoint of the Security Token Service from
+                                        where temporary credentials will be fetched.
+                                      pattern: ^(http|https)://.*$
                                       type: string
-                                  required:
-                                  - repository
-                                  type: object
-                                type: array
-                              interval:
-                                description: |-
-                                  Interval at which the GitRepository URL is checked for updates.
-                                  This interval is approximate and may be subject to jitter to ensure
-                                  efficient use of resources.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                                type: string
-                              provider:
-                                description: |-
-                                  Provider used for authentication, can be 'azure', 'github', 'generic'.
-                                  When not specified, defaults to 'generic'.
-                                enum:
-                                - generic
-                                - azure
-                                - github
-                                type: string
-                              proxySecretRef:
-                                description: |-
-                                  ProxySecretRef specifies the Secret containing the proxy configuration
-                                  to use while communicating with the Git server.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              recurseSubmodules:
-                                description: |-
-                                  RecurseSubmodules enables the initialization of all submodules within
-                                  the GitRepository as cloned from the URL, using their default settings.
-                                type: boolean
-                              ref:
-                                description: |-
-                                  Reference specifies the Git reference to resolve and monitor for
-                                  changes, defaults to the 'master' branch.
-                                properties:
-                                  branch:
-                                    description: Branch to check out, defaults to
-                                      'master' if no other field is defined.
-                                    type: string
-                                  commit:
-                                    description: |-
-                                      Commit SHA to check out, takes precedence over all reference fields.
-
-                                      This can be combined with Branch to shallow clone the branch, in which
-                                      the commit is expected to exist.
-                                    type: string
-                                  name:
-                                    description: |-
-                                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
-
-                                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
-                                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
-                                    type: string
-                                  semver:
-                                    description: SemVer tag expression to check out,
-                                      takes precedence over Tag.
-                                    type: string
-                                  tag:
-                                    description: Tag to check out, takes precedence
-                                      over Branch.
-                                    type: string
-                                type: object
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Secret containing authentication credentials for
-                                  the GitRepository.
-                                  For HTTPS repositories the Secret must contain 'username' and 'password'
-                                  fields for basic auth or 'bearerToken' field for token auth.
-                                  For SSH repositories the Secret must contain 'identity'
-                                  and 'known_hosts' fields.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceAccountName:
-                                description: |-
-                                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to
-                                  authenticate to the GitRepository. This field is only supported for 'azure' provider.
-                                type: string
-                              sparseCheckout:
-                                description: |-
-                                  SparseCheckout specifies a list of directories to checkout when cloning
-                                  the repository. If specified, only these directories are included in the
-                                  Artifact produced for this GitRepository.
-                                items:
-                                  type: string
-                                type: array
-                              suspend:
-                                description: |-
-                                  Suspend tells the controller to suspend the reconciliation of this
-                                  GitRepository.
-                                type: boolean
-                              timeout:
-                                default: 60s
-                                description: Timeout for Git operations like cloning,
-                                  defaults to 60s.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                                type: string
-                              url:
-                                description: URL specifies the Git repository URL,
-                                  it can be an HTTP/S or SSH address.
-                                pattern: ^(http|https|ssh)://.*$
-                                type: string
-                              verify:
-                                description: |-
-                                  Verification specifies the configuration to verify the Git commit
-                                  signature(s).
-                                properties:
-                                  mode:
-                                    default: HEAD
-                                    description: |-
-                                      Mode specifies which Git object(s) should be verified.
-
-                                      The variants "head" and "HEAD" both imply the same thing, i.e. verify
-                                      the commit that the HEAD of the Git repository points to. The variant
-                                      "head" solely exists to ensure backwards compatibility.
-                                    enum:
-                                    - head
-                                    - HEAD
-                                    - Tag
-                                    - TagAndHEAD
-                                    type: string
-                                  secretRef:
-                                    description: |-
-                                      SecretRef specifies the Secret containing the public keys of trusted Git
-                                      authors.
-                                    properties:
-                                      name:
-                                        description: Name of the referent.
-                                        type: string
-                                    required:
-                                    - name
-                                    type: object
-                                required:
-                                - secretRef
-                                type: object
-                            required:
-                            - interval
-                            - url
-                            type: object
-                            x-kubernetes-validations:
-                            - message: serviceAccountName can only be set when provider
-                                is 'azure'
-                              rule: '!has(self.serviceAccountName) || (has(self.provider)
-                                && self.provider == ''azure'')'
-                          oci:
-                            description: OCI is the definition of OCI repository source.
-                            properties:
-                              certSecretRef:
-                                description: |-
-                                  CertSecretRef can be given the name of a Secret containing
-                                  either or both of
-
-                                  - a PEM-encoded client certificate (`tls.crt`) and private
-                                  key (`tls.key`);
-                                  - a PEM-encoded CA certificate (`ca.crt`)
-
-                                  and whichever are supplied, will be used for connecting to the
-                                  registry. The client cert and key are useful if you are
-                                  authenticating with a certificate; the CA cert is useful if
-                                  you are using a self-signed server certificate. The Secret must
-                                  be of type `Opaque` or `kubernetes.io/tls`.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              ignore:
-                                description: |-
-                                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                                  (which is the same as .gitignore). If not provided, a default will be used,
-                                  consult the documentation for your version to find out what those are.
-                                type: string
-                              insecure:
-                                description: Insecure allows connecting to a non-TLS
-                                  HTTP container registry.
-                                type: boolean
-                              interval:
-                                description: |-
-                                  Interval at which the OCIRepository URL is checked for updates.
-                                  This interval is approximate and may be subject to jitter to ensure
-                                  efficient use of resources.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                                type: string
-                              layerSelector:
-                                description: |-
-                                  LayerSelector specifies which layer should be extracted from the OCI artifact.
-                                  When not specified, the first layer found in the artifact is selected.
-                                properties:
-                                  mediaType:
-                                    description: |-
-                                      MediaType specifies the OCI media type of the layer
-                                      which should be extracted from the OCI Artifact. The
-                                      first layer matching this type is selected.
-                                    type: string
-                                  operation:
-                                    description: |-
-                                      Operation specifies how the selected layer should be processed.
-                                      By default, the layer compressed content is extracted to storage.
-                                      When the operation is set to 'copy', the layer compressed content
-                                      is persisted to storage as it is.
-                                    enum:
-                                    - extract
-                                    - copy
-                                    type: string
-                                type: object
-                              provider:
-                                default: generic
-                                description: |-
-                                  The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
-                                  When not specified, defaults to 'generic'.
-                                enum:
-                                - generic
-                                - aws
-                                - azure
-                                - gcp
-                                type: string
-                              proxySecretRef:
-                                description: |-
-                                  ProxySecretRef specifies the Secret containing the proxy configuration
-                                  to use while communicating with the container registry.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              ref:
-                                description: |-
-                                  The OCI reference to pull and monitor for changes,
-                                  defaults to the latest tag.
-                                properties:
-                                  digest:
-                                    description: |-
-                                      Digest is the image digest to pull, takes precedence over SemVer.
-                                      The value should be in the format 'sha256:<HASH>'.
-                                    type: string
-                                  semver:
-                                    description: |-
-                                      SemVer is the range of tags to pull selecting the latest within
-                                      the range, takes precedence over Tag.
-                                    type: string
-                                  semverFilter:
-                                    description: SemverFilter is a regex pattern to
-                                      filter the tags within the SemVer range.
-                                    type: string
-                                  tag:
-                                    description: Tag is the image tag to pull, defaults
-                                      to latest.
-                                    type: string
-                                type: object
-                              secretRef:
-                                description: |-
-                                  SecretRef contains the secret name containing the registry login
-                                  credentials to resolve image metadata.
-                                  The secret must be of type kubernetes.io/dockerconfigjson.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceAccountName:
-                                description: |-
-                                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                                  the image pull if the service account has attached pull secrets. For more information:
-                                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
-                                type: string
-                              suspend:
-                                description: This flag tells the controller to suspend
-                                  the reconciliation of this source.
-                                type: boolean
-                              timeout:
-                                default: 60s
-                                description: The timeout for remote OCI Repository
-                                  operations like pulling, defaults to 60s.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                                type: string
-                              url:
-                                description: |-
-                                  URL is a reference to an OCI artifact repository hosted
-                                  on a remote container registry.
-                                pattern: ^oci://.*$
-                                type: string
-                              verify:
-                                description: |-
-                                  Verify contains the secret name containing the trusted public keys
-                                  used to verify the signature and specifies which provider to use to check
-                                  whether OCI image is authentic.
-                                properties:
-                                  matchOIDCIdentity:
-                                    description: |-
-                                      MatchOIDCIdentity specifies the identity matching criteria to use
-                                      while verifying an OCI artifact which was signed using Cosign keyless
-                                      signing. The artifact's identity is deemed to be verified if any of the
-                                      specified matchers match against the identity.
-                                    items:
+                                    provider:
+                                      description: Provider of the Security Token Service.
+                                      enum:
+                                        - aws
+                                        - ldap
+                                      type: string
+                                    secretRef:
                                       description: |-
-                                        OIDCIdentityMatch specifies options for verifying the certificate identity,
-                                        i.e. the issuer and the subject of the certificate.
+                                        SecretRef specifies the Secret containing authentication credentials
+                                        for the STS endpoint. This Secret must contain the fields `username`
+                                        and `password` and is supported only for the `ldap` provider.
                                       properties:
-                                        issuer:
-                                          description: |-
-                                            Issuer specifies the regex pattern to match against to verify
-                                            the OIDC issuer in the Fulcio certificate. The pattern must be a
-                                            valid Go regular expression.
-                                          type: string
-                                        subject:
-                                          description: |-
-                                            Subject specifies the regex pattern to match against to verify
-                                            the identity subject in the Fulcio certificate. The pattern must
-                                            be a valid Go regular expression.
+                                        name:
+                                          description: Name of the referent.
                                           type: string
                                       required:
-                                      - issuer
-                                      - subject
+                                        - name
                                       type: object
-                                    type: array
-                                  provider:
-                                    default: cosign
-                                    description: Provider specifies the technology
-                                      used to sign the OCI Artifact.
-                                    enum:
-                                    - cosign
-                                    - notation
-                                    type: string
-                                  secretRef:
-                                    description: |-
-                                      SecretRef specifies the Kubernetes Secret containing the
-                                      trusted public keys.
-                                    properties:
-                                      name:
-                                        description: Name of the referent.
-                                        type: string
-                                    required:
-                                    - name
-                                    type: object
-                                required:
-                                - provider
-                                type: object
-                            required:
-                            - interval
-                            - url
-                            type: object
-                        type: object
-                        x-kubernetes-validations:
-                        - message: Git, Bucket and OCI are mutually exclusive.
-                          rule: 'has(self.git) ? (!has(self.bucket) && !has(self.oci))
-                            : true'
-                        - message: Git, Bucket and OCI are mutually exclusive.
-                          rule: 'has(self.bucket) ? (!has(self.git) && !has(self.oci))
-                            : true'
-                        - message: Git, Bucket and OCI are mutually exclusive.
-                          rule: 'has(self.oci) ? (!has(self.git) && !has(self.bucket))
-                            : true'
-                        - message: One of Git, Bucket or OCI must be specified.
-                          rule: has(self.git) || has(self.bucket) || has(self.oci)
-                    required:
-                    - deploymentType
-                    - path
-                    type: object
-                    x-kubernetes-validations:
-                    - message: Secret and ConfigMap are not supported as Helm chart
-                        sources
-                      rule: 'has(self.localSourceRef) ? (self.localSourceRef.kind
-                        != ''Secret'' && self.localSourceRef.kind != ''ConfigMap''):
-                        true'
-                    - message: LocalSource and RemoteSource are mutually exclusive.
-                      rule: 'has(self.localSourceRef) ? !has(self.remoteSourceSpec):
-                        true'
-                    - message: LocalSource and RemoteSource are mutually exclusive.
-                      rule: 'has(self.remoteSourceSpec) ? !has(self.localSourceRef):
-                        true'
-                    - message: One of LocalSource or RemoteSource must be specified.
-                      rule: has(self.localSourceRef) || has(self.remoteSourceSpec)
-                  chartSpec:
-                    description: ChartSpec defines the desired state of the HelmChart
-                      to be created by the controller
-                    properties:
-                      chart:
-                        description: |-
-                          Chart is the name or path the Helm chart is available at in the
-                          SourceRef.
-                        type: string
-                      ignoreMissingValuesFiles:
-                        description: |-
-                          IgnoreMissingValuesFiles controls whether to silently ignore missing values
-                          files rather than failing.
-                        type: boolean
-                      interval:
-                        description: |-
-                          Interval at which the HelmChart SourceRef is checked for updates.
-                          This interval is approximate and may be subject to jitter to ensure
-                          efficient use of resources.
-                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                        type: string
-                      reconcileStrategy:
-                        default: ChartVersion
-                        description: |-
-                          ReconcileStrategy determines what enables the creation of a new artifact.
-                          Valid values are ('ChartVersion', 'Revision').
-                          See the documentation of the values for an explanation on their behavior.
-                          Defaults to ChartVersion when omitted.
-                        enum:
-                        - ChartVersion
-                        - Revision
-                        type: string
-                      sourceRef:
-                        description: SourceRef is the reference to the Source the
-                          chart is available at.
-                        properties:
-                          apiVersion:
-                            description: APIVersion of the referent.
-                            type: string
-                          kind:
-                            description: |-
-                              Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
-                              'Bucket').
-                            enum:
-                            - HelmRepository
-                            - GitRepository
-                            - Bucket
-                            type: string
-                          name:
-                            description: Name of the referent.
-                            type: string
-                        required:
-                        - kind
-                        - name
-                        type: object
-                      suspend:
-                        description: |-
-                          Suspend tells the controller to suspend the reconciliation of this
-                          source.
-                        type: boolean
-                      valuesFiles:
-                        description: |-
-                          ValuesFiles is an alternative list of values files to use as the chart
-                          values (values.yaml is not included by default), expected to be a
-                          relative path in the SourceRef.
-                          Values files are merged in the order of this list with the last file
-                          overriding the first. Ignored when omitted.
-                        items:
-                          type: string
-                        type: array
-                      verify:
-                        description: |-
-                          Verify contains the secret name containing the trusted public keys
-                          used to verify the signature and specifies which provider to use to check
-                          whether OCI image is authentic.
-                          This field is only supported when using HelmRepository source with spec.type 'oci'.
-                          Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
-                        properties:
-                          matchOIDCIdentity:
-                            description: |-
-                              MatchOIDCIdentity specifies the identity matching criteria to use
-                              while verifying an OCI artifact which was signed using Cosign keyless
-                              signing. The artifact's identity is deemed to be verified if any of the
-                              specified matchers match against the identity.
-                            items:
-                              description: |-
-                                OIDCIdentityMatch specifies options for verifying the certificate identity,
-                                i.e. the issuer and the subject of the certificate.
-                              properties:
-                                issuer:
+                                  required:
+                                    - endpoint
+                                    - provider
+                                  type: object
+                                suspend:
                                   description: |-
-                                    Issuer specifies the regex pattern to match against to verify
-                                    the OIDC issuer in the Fulcio certificate. The pattern must be a
-                                    valid Go regular expression.
-                                  type: string
-                                subject:
-                                  description: |-
-                                    Subject specifies the regex pattern to match against to verify
-                                    the identity subject in the Fulcio certificate. The pattern must
-                                    be a valid Go regular expression.
+                                    Suspend tells the controller to suspend the reconciliation of this
+                                    Bucket.
+                                  type: boolean
+                                timeout:
+                                  default: 60s
+                                  description: Timeout for fetch operations, defaults to 60s.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
                                   type: string
                               required:
-                              - issuer
-                              - subject
+                                - bucketName
+                                - endpoint
+                                - interval
                               type: object
-                            type: array
-                          provider:
-                            default: cosign
-                            description: Provider specifies the technology used to
-                              sign the OCI Artifact.
-                            enum:
-                            - cosign
-                            - notation
-                            type: string
-                          secretRef:
-                            description: |-
-                              SecretRef specifies the Kubernetes Secret containing the
-                              trusted public keys.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                        required:
-                        - provider
-                        type: object
-                      version:
-                        default: '*'
-                        description: |-
-                          Version is the chart version semver expression, ignored for charts from
-                          GitRepository and Bucket sources. Defaults to latest when omitted.
-                        type: string
-                    required:
-                    - chart
-                    - interval
-                    - sourceRef
-                    type: object
-                type: object
-                x-kubernetes-validations:
-                - message: chartSpec, chartSource and chartRef are mutually exclusive
-                  rule: '(has(self.chartSpec) ? (!has(self.chartSource) && !has(self.chartRef)):
-                    true)'
-                - message: chartSpec, chartSource and chartRef are mutually exclusive
-                  rule: '(has(self.chartSource) ? (!has(self.chartSpec) && !has(self.chartRef)):
-                    true)'
-                - message: chartSpec, chartSource and chartRef are mutually exclusive
-                  rule: '(has(self.chartRef) ? (!has(self.chartSpec) && !has(self.chartSource)):
-                    true)'
-                - message: one of chartSpec, chartRef or chartSource must be set
-                  rule: has(self.chartSpec) || has(self.chartRef) || has(self.chartSource)
-              providers:
-                description: |-
-                  Providers represent exposed CAPI providers.
-                  Should be set if not present in the Helm chart metadata.
-                items:
-                  type: string
-                type: array
-            type: object
-            x-kubernetes-validations:
-            - message: Spec is immutable
-              rule: self == oldSelf
-            - message: .spec.helm.chartSource is not supported for ProviderTemplates
-              rule: '!has(self.helm.chartSource)'
-          status:
-            description: ProviderTemplateStatus defines the observed state of ProviderTemplate
-            properties:
-              capiContracts:
-                additionalProperties:
-                  type: string
-                description: |-
-                  Holds key-value pairs with compatibility [contract versions],
-                  where the key is the core CAPI contract version,
-                  and the value is an underscore-delimited (_) list of provider contract versions
-                  supported by the core CAPI.
+                              x-kubernetes-validations:
+                                - message: STS configuration is only supported for the 'aws' and 'generic' Bucket providers
+                                  rule: self.provider == 'aws' || self.provider == 'generic' || !has(self.sts)
+                                - message: '''aws'' is the only supported STS provider for the ''aws'' Bucket provider'
+                                  rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider == 'aws'
+                                - message: '''ldap'' is the only supported STS provider for the ''generic'' Bucket provider'
+                                  rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider == 'ldap'
+                                - message: spec.sts.secretRef is not required for the 'aws' STS provider
+                                  rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
+                                - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
+                                  rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
+                                - message: ServiceAccountName is not supported for the 'generic' Bucket provider
+                                  rule: self.provider != 'generic' || !has(self.serviceAccountName)
+                                - message: cannot set both .spec.secretRef and .spec.serviceAccountName
+                                  rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
+                            git:
+                              description: Git is the definition of git repository source.
+                              properties:
+                                ignore:
+                                  description: |-
+                                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                                    (which is the same as .gitignore). If not provided, a default will be used,
+                                    consult the documentation for your version to find out what those are.
+                                  type: string
+                                include:
+                                  description: |-
+                                    Include specifies a list of GitRepository resources which Artifacts
+                                    should be included in the Artifact produced for this GitRepository.
+                                  items:
+                                    description: |-
+                                      GitRepositoryInclude specifies a local reference to a GitRepository which
+                                      Artifact (sub-)contents must be included, and where they should be placed.
+                                    properties:
+                                      fromPath:
+                                        description: |-
+                                          FromPath specifies the path to copy contents from, defaults to the root
+                                          of the Artifact.
+                                        type: string
+                                      repository:
+                                        description: |-
+                                          GitRepositoryRef specifies the GitRepository which Artifact contents
+                                          must be included.
+                                        properties:
+                                          name:
+                                            description: Name of the referent.
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
+                                      toPath:
+                                        description: |-
+                                          ToPath specifies the path to copy contents to, defaults to the name of
+                                          the GitRepositoryRef.
+                                        type: string
+                                    required:
+                                      - repository
+                                    type: object
+                                  type: array
+                                interval:
+                                  description: |-
+                                    Interval at which the GitRepository URL is checked for updates.
+                                    This interval is approximate and may be subject to jitter to ensure
+                                    efficient use of resources.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                                  type: string
+                                provider:
+                                  description: |-
+                                    Provider used for authentication, can be 'azure', 'github', 'generic'.
+                                    When not specified, defaults to 'generic'.
+                                  enum:
+                                    - generic
+                                    - azure
+                                    - github
+                                  type: string
+                                proxySecretRef:
+                                  description: |-
+                                    ProxySecretRef specifies the Secret containing the proxy configuration
+                                    to use while communicating with the Git server.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                recurseSubmodules:
+                                  description: |-
+                                    RecurseSubmodules enables the initialization of all submodules within
+                                    the GitRepository as cloned from the URL, using their default settings.
+                                  type: boolean
+                                ref:
+                                  description: |-
+                                    Reference specifies the Git reference to resolve and monitor for
+                                    changes, defaults to the 'master' branch.
+                                  properties:
+                                    branch:
+                                      description: Branch to check out, defaults to 'master' if no other field is defined.
+                                      type: string
+                                    commit:
+                                      description: |-
+                                        Commit SHA to check out, takes precedence over all reference fields.
 
-                  [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
-                type: object
-              chartRef:
-                description: |-
-                  ChartRef is a reference to a source controller resource containing the
-                  Helm chart representing the template.
-                properties:
-                  apiVersion:
-                    description: APIVersion of the referent.
+                                        This can be combined with Branch to shallow clone the branch, in which
+                                        the commit is expected to exist.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+                                        It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                                        Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                                      type: string
+                                    semver:
+                                      description: SemVer tag expression to check out, takes precedence over Tag.
+                                      type: string
+                                    tag:
+                                      description: Tag to check out, takes precedence over Branch.
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Secret containing authentication credentials for
+                                    the GitRepository.
+                                    For HTTPS repositories the Secret must contain 'username' and 'password'
+                                    fields for basic auth or 'bearerToken' field for token auth.
+                                    For SSH repositories the Secret must contain 'identity'
+                                    and 'known_hosts' fields.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceAccountName:
+                                  description: |-
+                                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+                                    authenticate to the GitRepository. This field is only supported for 'azure' provider.
+                                  type: string
+                                sparseCheckout:
+                                  description: |-
+                                    SparseCheckout specifies a list of directories to checkout when cloning
+                                    the repository. If specified, only these directories are included in the
+                                    Artifact produced for this GitRepository.
+                                  items:
+                                    type: string
+                                  type: array
+                                suspend:
+                                  description: |-
+                                    Suspend tells the controller to suspend the reconciliation of this
+                                    GitRepository.
+                                  type: boolean
+                                timeout:
+                                  default: 60s
+                                  description: Timeout for Git operations like cloning, defaults to 60s.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                                  type: string
+                                url:
+                                  description: URL specifies the Git repository URL, it can be an HTTP/S or SSH address.
+                                  pattern: ^(http|https|ssh)://.*$
+                                  type: string
+                                verify:
+                                  description: |-
+                                    Verification specifies the configuration to verify the Git commit
+                                    signature(s).
+                                  properties:
+                                    mode:
+                                      default: HEAD
+                                      description: |-
+                                        Mode specifies which Git object(s) should be verified.
+
+                                        The variants "head" and "HEAD" both imply the same thing, i.e. verify
+                                        the commit that the HEAD of the Git repository points to. The variant
+                                        "head" solely exists to ensure backwards compatibility.
+                                      enum:
+                                        - head
+                                        - HEAD
+                                        - Tag
+                                        - TagAndHEAD
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        SecretRef specifies the Secret containing the public keys of trusted Git
+                                        authors.
+                                      properties:
+                                        name:
+                                          description: Name of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - secretRef
+                                  type: object
+                              required:
+                                - interval
+                                - url
+                              type: object
+                              x-kubernetes-validations:
+                                - message: serviceAccountName can only be set when provider is 'azure'
+                                  rule: '!has(self.serviceAccountName) || (has(self.provider) && self.provider == ''azure'')'
+                            oci:
+                              description: OCI is the definition of OCI repository source.
+                              properties:
+                                certSecretRef:
+                                  description: |-
+                                    CertSecretRef can be given the name of a Secret containing
+                                    either or both of
+
+                                    - a PEM-encoded client certificate (`tls.crt`) and private
+                                    key (`tls.key`);
+                                    - a PEM-encoded CA certificate (`ca.crt`)
+
+                                    and whichever are supplied, will be used for connecting to the
+                                    registry. The client cert and key are useful if you are
+                                    authenticating with a certificate; the CA cert is useful if
+                                    you are using a self-signed server certificate. The Secret must
+                                    be of type `Opaque` or `kubernetes.io/tls`.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                ignore:
+                                  description: |-
+                                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                                    (which is the same as .gitignore). If not provided, a default will be used,
+                                    consult the documentation for your version to find out what those are.
+                                  type: string
+                                insecure:
+                                  description: Insecure allows connecting to a non-TLS HTTP container registry.
+                                  type: boolean
+                                interval:
+                                  description: |-
+                                    Interval at which the OCIRepository URL is checked for updates.
+                                    This interval is approximate and may be subject to jitter to ensure
+                                    efficient use of resources.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                                  type: string
+                                layerSelector:
+                                  description: |-
+                                    LayerSelector specifies which layer should be extracted from the OCI artifact.
+                                    When not specified, the first layer found in the artifact is selected.
+                                  properties:
+                                    mediaType:
+                                      description: |-
+                                        MediaType specifies the OCI media type of the layer
+                                        which should be extracted from the OCI Artifact. The
+                                        first layer matching this type is selected.
+                                      type: string
+                                    operation:
+                                      description: |-
+                                        Operation specifies how the selected layer should be processed.
+                                        By default, the layer compressed content is extracted to storage.
+                                        When the operation is set to 'copy', the layer compressed content
+                                        is persisted to storage as it is.
+                                      enum:
+                                        - extract
+                                        - copy
+                                      type: string
+                                  type: object
+                                provider:
+                                  default: generic
+                                  description: |-
+                                    The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                                    When not specified, defaults to 'generic'.
+                                  enum:
+                                    - generic
+                                    - aws
+                                    - azure
+                                    - gcp
+                                  type: string
+                                proxySecretRef:
+                                  description: |-
+                                    ProxySecretRef specifies the Secret containing the proxy configuration
+                                    to use while communicating with the container registry.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                ref:
+                                  description: |-
+                                    The OCI reference to pull and monitor for changes,
+                                    defaults to the latest tag.
+                                  properties:
+                                    digest:
+                                      description: |-
+                                        Digest is the image digest to pull, takes precedence over SemVer.
+                                        The value should be in the format 'sha256:<HASH>'.
+                                      type: string
+                                    semver:
+                                      description: |-
+                                        SemVer is the range of tags to pull selecting the latest within
+                                        the range, takes precedence over Tag.
+                                      type: string
+                                    semverFilter:
+                                      description: SemverFilter is a regex pattern to filter the tags within the SemVer range.
+                                      type: string
+                                    tag:
+                                      description: Tag is the image tag to pull, defaults to latest.
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    SecretRef contains the secret name containing the registry login
+                                    credentials to resolve image metadata.
+                                    The secret must be of type kubernetes.io/dockerconfigjson.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceAccountName:
+                                  description: |-
+                                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                                    the image pull if the service account has attached pull secrets. For more information:
+                                    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+                                  type: string
+                                suspend:
+                                  description: This flag tells the controller to suspend the reconciliation of this source.
+                                  type: boolean
+                                timeout:
+                                  default: 60s
+                                  description: The timeout for remote OCI Repository operations like pulling, defaults to 60s.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                                  type: string
+                                url:
+                                  description: |-
+                                    URL is a reference to an OCI artifact repository hosted
+                                    on a remote container registry.
+                                  pattern: ^oci://.*$
+                                  type: string
+                                verify:
+                                  description: |-
+                                    Verify contains the secret name containing the trusted public keys
+                                    used to verify the signature and specifies which provider to use to check
+                                    whether OCI image is authentic.
+                                  properties:
+                                    matchOIDCIdentity:
+                                      description: |-
+                                        MatchOIDCIdentity specifies the identity matching criteria to use
+                                        while verifying an OCI artifact which was signed using Cosign keyless
+                                        signing. The artifact's identity is deemed to be verified if any of the
+                                        specified matchers match against the identity.
+                                      items:
+                                        description: |-
+                                          OIDCIdentityMatch specifies options for verifying the certificate identity,
+                                          i.e. the issuer and the subject of the certificate.
+                                        properties:
+                                          issuer:
+                                            description: |-
+                                              Issuer specifies the regex pattern to match against to verify
+                                              the OIDC issuer in the Fulcio certificate. The pattern must be a
+                                              valid Go regular expression.
+                                            type: string
+                                          subject:
+                                            description: |-
+                                              Subject specifies the regex pattern to match against to verify
+                                              the identity subject in the Fulcio certificate. The pattern must
+                                              be a valid Go regular expression.
+                                            type: string
+                                        required:
+                                          - issuer
+                                          - subject
+                                        type: object
+                                      type: array
+                                    provider:
+                                      default: cosign
+                                      description: Provider specifies the technology used to sign the OCI Artifact.
+                                      enum:
+                                        - cosign
+                                        - notation
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        SecretRef specifies the Kubernetes Secret containing the
+                                        trusted public keys.
+                                      properties:
+                                        name:
+                                          description: Name of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - provider
+                                  type: object
+                              required:
+                                - interval
+                                - url
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: Git, Bucket and OCI are mutually exclusive.
+                              rule: 'has(self.git) ? (!has(self.bucket) && !has(self.oci)) : true'
+                            - message: Git, Bucket and OCI are mutually exclusive.
+                              rule: 'has(self.bucket) ? (!has(self.git) && !has(self.oci)) : true'
+                            - message: Git, Bucket and OCI are mutually exclusive.
+                              rule: 'has(self.oci) ? (!has(self.git) && !has(self.bucket)) : true'
+                            - message: One of Git, Bucket or OCI must be specified.
+                              rule: has(self.git) || has(self.bucket) || has(self.oci)
+                      required:
+                        - deploymentType
+                        - path
+                      type: object
+                      x-kubernetes-validations:
+                        - message: Secret and ConfigMap are not supported as Helm chart sources
+                          rule: 'has(self.localSourceRef) ? (self.localSourceRef.kind != ''Secret'' && self.localSourceRef.kind != ''ConfigMap''): true'
+                        - message: LocalSource and RemoteSource are mutually exclusive.
+                          rule: 'has(self.localSourceRef) ? !has(self.remoteSourceSpec): true'
+                        - message: LocalSource and RemoteSource are mutually exclusive.
+                          rule: 'has(self.remoteSourceSpec) ? !has(self.localSourceRef): true'
+                        - message: One of LocalSource or RemoteSource must be specified.
+                          rule: has(self.localSourceRef) || has(self.remoteSourceSpec)
+                    chartSpec:
+                      description: ChartSpec defines the desired state of the HelmChart to be created by the controller
+                      properties:
+                        chart:
+                          description: |-
+                            Chart is the name or path the Helm chart is available at in the
+                            SourceRef.
+                          type: string
+                        ignoreMissingValuesFiles:
+                          description: |-
+                            IgnoreMissingValuesFiles controls whether to silently ignore missing values
+                            files rather than failing.
+                          type: boolean
+                        interval:
+                          description: |-
+                            Interval at which the HelmChart SourceRef is checked for updates.
+                            This interval is approximate and may be subject to jitter to ensure
+                            efficient use of resources.
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                          type: string
+                        reconcileStrategy:
+                          default: ChartVersion
+                          description: |-
+                            ReconcileStrategy determines what enables the creation of a new artifact.
+                            Valid values are ('ChartVersion', 'Revision').
+                            See the documentation of the values for an explanation on their behavior.
+                            Defaults to ChartVersion when omitted.
+                          enum:
+                            - ChartVersion
+                            - Revision
+                          type: string
+                        sourceRef:
+                          description: SourceRef is the reference to the Source the chart is available at.
+                          properties:
+                            apiVersion:
+                              description: APIVersion of the referent.
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+                                'Bucket').
+                              enum:
+                                - HelmRepository
+                                - GitRepository
+                                - Bucket
+                              type: string
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                        suspend:
+                          description: |-
+                            Suspend tells the controller to suspend the reconciliation of this
+                            source.
+                          type: boolean
+                        valuesFiles:
+                          description: |-
+                            ValuesFiles is an alternative list of values files to use as the chart
+                            values (values.yaml is not included by default), expected to be a
+                            relative path in the SourceRef.
+                            Values files are merged in the order of this list with the last file
+                            overriding the first. Ignored when omitted.
+                          items:
+                            type: string
+                          type: array
+                        verify:
+                          description: |-
+                            Verify contains the secret name containing the trusted public keys
+                            used to verify the signature and specifies which provider to use to check
+                            whether OCI image is authentic.
+                            This field is only supported when using HelmRepository source with spec.type 'oci'.
+                            Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+                          properties:
+                            matchOIDCIdentity:
+                              description: |-
+                                MatchOIDCIdentity specifies the identity matching criteria to use
+                                while verifying an OCI artifact which was signed using Cosign keyless
+                                signing. The artifact's identity is deemed to be verified if any of the
+                                specified matchers match against the identity.
+                              items:
+                                description: |-
+                                  OIDCIdentityMatch specifies options for verifying the certificate identity,
+                                  i.e. the issuer and the subject of the certificate.
+                                properties:
+                                  issuer:
+                                    description: |-
+                                      Issuer specifies the regex pattern to match against to verify
+                                      the OIDC issuer in the Fulcio certificate. The pattern must be a
+                                      valid Go regular expression.
+                                    type: string
+                                  subject:
+                                    description: |-
+                                      Subject specifies the regex pattern to match against to verify
+                                      the identity subject in the Fulcio certificate. The pattern must
+                                      be a valid Go regular expression.
+                                    type: string
+                                required:
+                                  - issuer
+                                  - subject
+                                type: object
+                              type: array
+                            provider:
+                              default: cosign
+                              description: Provider specifies the technology used to sign the OCI Artifact.
+                              enum:
+                                - cosign
+                                - notation
+                              type: string
+                            secretRef:
+                              description: |-
+                                SecretRef specifies the Kubernetes Secret containing the
+                                trusted public keys.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - provider
+                          type: object
+                        version:
+                          default: '*'
+                          description: |-
+                            Version is the chart version semver expression, ignored for charts from
+                            GitRepository and Bucket sources. Defaults to latest when omitted.
+                          type: string
+                      required:
+                        - chart
+                        - interval
+                        - sourceRef
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: chartSpec, chartSource and chartRef are mutually exclusive
+                      rule: '(has(self.chartSpec) ? (!has(self.chartSource) && !has(self.chartRef)): true)'
+                    - message: chartSpec, chartSource and chartRef are mutually exclusive
+                      rule: '(has(self.chartSource) ? (!has(self.chartSpec) && !has(self.chartRef)): true)'
+                    - message: chartSpec, chartSource and chartRef are mutually exclusive
+                      rule: '(has(self.chartRef) ? (!has(self.chartSpec) && !has(self.chartSource)): true)'
+                    - message: one of chartSpec, chartRef or chartSource must be set
+                      rule: has(self.chartSpec) || has(self.chartRef) || has(self.chartSource)
+                providers:
+                  description: |-
+                    Providers represent exposed CAPI providers.
+                    Should be set if not present in the Helm chart metadata.
+                  items:
                     type: string
-                  kind:
-                    description: Kind of the referent.
-                    enum:
-                    - OCIRepository
-                    - HelmChart
-                    - ExternalArtifact
+                  type: array
+              type: object
+              x-kubernetes-validations:
+                - message: Spec is immutable
+                  rule: self == oldSelf
+                - message: .spec.helm.chartSource is not supported for ProviderTemplates
+                  rule: '!has(self.helm.chartSource)'
+            status:
+              description: ProviderTemplateStatus defines the observed state of ProviderTemplate
+              properties:
+                capiContracts:
+                  additionalProperties:
                     type: string
-                  name:
-                    description: Name of the referent.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace of the referent, defaults to the namespace of the Kubernetes
-                      resource object that contains the reference.
-                    maxLength: 63
-                    minLength: 1
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-              chartVersion:
-                description: ChartVersion represents the version of the Helm Chart
-                  associated with this template.
-                type: string
-              config:
-                description: |-
-                  Config demonstrates available parameters for template customization,
-                  that can be used when creating ClusterDeployment objects.
-                x-kubernetes-preserve-unknown-fields: true
-              description:
-                description: Description contains information about the template.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              providers:
-                description: Providers represent exposed CAPI providers.
-                items:
+                  description: |-
+                    Holds key-value pairs with compatibility [contract versions],
+                    where the key is the core CAPI contract version,
+                    and the value is an underscore-delimited (_) list of provider contract versions
+                    supported by the core CAPI.
+
+                    [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
+                  type: object
+                chartRef:
+                  description: |-
+                    ChartRef is a reference to a source controller resource containing the
+                    Helm chart representing the template.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the referent.
+                      type: string
+                    kind:
+                      description: Kind of the referent.
+                      enum:
+                        - OCIRepository
+                        - HelmChart
+                        - ExternalArtifact
+                      type: string
+                    name:
+                      description: Name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent, defaults to the namespace of the Kubernetes
+                        resource object that contains the reference.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
+                    - kind
+                    - name
+                  type: object
+                chartVersion:
+                  description: ChartVersion represents the version of the Helm Chart associated with this template.
                   type: string
-                type: array
-              schemaConfigMapName:
-                description: SchemaConfigMapName specifies the name of the ConfigMap
-                  that contains the JSON Schema definition for Helm Chart validation.
-                type: string
-              valid:
-                description: Valid indicates whether the template passed validation
-                  or not.
-                type: boolean
-              validationError:
-                description: ValidationError provides information regarding issues
-                  encountered during template validation.
-                type: string
-            required:
-            - valid
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                config:
+                  description: |-
+                    Config demonstrates available parameters for template customization,
+                    that can be used when creating ClusterDeployment objects.
+                  x-kubernetes-preserve-unknown-fields: true
+                description:
+                  description: Description contains information about the template.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                providers:
+                  description: Providers represent exposed CAPI providers.
+                  items:
+                    type: string
+                  type: array
+                schemaConfigMapName:
+                  description: SchemaConfigMapName specifies the name of the ConfigMap that contains the JSON Schema definition for Helm Chart validation.
+                  type: string
+                valid:
+                  description: Valid indicates whether the template passed validation or not.
+                  type: boolean
+                validationError:
+                  description: ValidationError provides information regarding issues encountered during template validation.
+                  type: string
+              required:
+                - valid
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_regions.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_regions.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: regions.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,266 +13,255 @@ spec:
     listKind: RegionList
     plural: regions
     shortNames:
-    - rgn
+      - rgn
     singular: region
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - description: Overall readiness of the Region resource
-      jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: Ready
-      type: string
-    - description: Time duration since creation of Region
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Region is the Schema for the regions API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: RegionSpec defines the desired state of Region
-            properties:
-              clusterDeployment:
-                description: |-
-                  ClusterDeployment is the reference to the existing ClusterDeployment object
-                  to be onboarded as a regional cluster.
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - name
-                - namespace
-                type: object
-                x-kubernetes-validations:
-                - message: clusterDeployment is immutable
-                  rule: self == oldSelf
-              core:
-                description: |-
-                  Core holds the core components that are mandatory.
-                  If not specified, will be populated with the default values.
-                properties:
-                  capi:
-                    description: CAPI represents the core Cluster API component and
-                      references the Cluster API template.
-                    properties:
-                      config:
-                        description: |-
-                          Config allows to provide parameters for management component customization.
-                          If no Config provided, the field will be populated with the default
-                          values for the template.
-                        x-kubernetes-preserve-unknown-fields: true
-                      template:
-                        description: |-
-                          Template is the name of the Template associated with this component.
-                          If not specified, will be taken from the Release object.
-                        type: string
-                    type: object
-                  kcm:
-                    description: KCM represents the core KCM component and references
-                      the KCM template.
-                    properties:
-                      config:
-                        description: |-
-                          Config allows to provide parameters for management component customization.
-                          If no Config provided, the field will be populated with the default
-                          values for the template.
-                        x-kubernetes-preserve-unknown-fields: true
-                      template:
-                        description: |-
-                          Template is the name of the Template associated with this component.
-                          If not specified, will be taken from the Release object.
-                        type: string
-                    type: object
-                type: object
-              kubeConfig:
-                description: |-
-                  KubeConfig references the Secret containing the kubeconfig
-                  of the cluster being onboarded as a regional cluster.
-                  The Secret must reside in the system namespace.
-                properties:
-                  key:
-                    description: Key in the Secret, when not specified an implementation-specific
-                      default key is used.
-                    type: string
-                  name:
-                    description: Name of the Secret.
-                    type: string
-                required:
-                - name
-                type: object
-                x-kubernetes-validations:
-                - message: kubeConfig is immutable
-                  rule: self == oldSelf
-              providers:
-                description: Providers is the list of enabled CAPI providers.
-                items:
+    - additionalPrinterColumns:
+        - description: Overall readiness of the Region resource
+          jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - description: Time duration since creation of Region
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Region is the Schema for the regions API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: RegionSpec defines the desired state of Region
+              properties:
+                clusterDeployment:
+                  description: |-
+                    ClusterDeployment is the reference to the existing ClusterDeployment object
+                    to be onboarded as a regional cluster.
                   properties:
-                    config:
-                      description: |-
-                        Config allows to provide parameters for management component customization.
-                        If no Config provided, the field will be populated with the default
-                        values for the template.
-                      x-kubernetes-preserve-unknown-fields: true
                     name:
-                      description: Name of the provider.
                       type: string
-                    template:
-                      description: |-
-                        Template is the name of the Template associated with this component.
-                        If not specified, will be taken from the Release object.
+                    namespace:
                       type: string
                   required:
-                  - name
+                    - name
+                    - namespace
                   type: object
-                type: array
-            type: object
-            x-kubernetes-validations:
-            - message: exactly one of kubeConfig or clusterDeployment must be set
-              rule: has(self.kubeConfig) != has(self.clusterDeployment)
-          status:
-            description: RegionStatus defines the observed state of Region
-            properties:
-              availableProviders:
-                description: AvailableProviders holds all available CAPI providers.
-                items:
-                  type: string
-                type: array
-              capiContracts:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
+                  x-kubernetes-validations:
+                    - message: clusterDeployment is immutable
+                      rule: self == oldSelf
+                core:
                   description: |-
-                    Holds key-value pairs with compatibility [contract versions],
-                    where the key is the core CAPI contract version,
+                    Core holds the core components that are mandatory.
+                    If not specified, will be populated with the default values.
+                  properties:
+                    capi:
+                      description: CAPI represents the core Cluster API component and references the Cluster API template.
+                      properties:
+                        config:
+                          description: |-
+                            Config allows to provide parameters for management component customization.
+                            If no Config provided, the field will be populated with the default
+                            values for the template.
+                          x-kubernetes-preserve-unknown-fields: true
+                        template:
+                          description: |-
+                            Template is the name of the Template associated with this component.
+                            If not specified, will be taken from the Release object.
+                          type: string
+                      type: object
+                    kcm:
+                      description: KCM represents the core KCM component and references the KCM template.
+                      properties:
+                        config:
+                          description: |-
+                            Config allows to provide parameters for management component customization.
+                            If no Config provided, the field will be populated with the default
+                            values for the template.
+                          x-kubernetes-preserve-unknown-fields: true
+                        template:
+                          description: |-
+                            Template is the name of the Template associated with this component.
+                            If not specified, will be taken from the Release object.
+                          type: string
+                      type: object
+                  type: object
+                kubeConfig:
+                  description: |-
+                    KubeConfig references the Secret containing the kubeconfig
+                    of the cluster being onboarded as a regional cluster.
+                    The Secret must reside in the system namespace.
+                  properties:
+                    key:
+                      description: Key in the Secret, when not specified an implementation-specific default key is used.
+                      type: string
+                    name:
+                      description: Name of the Secret.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                  x-kubernetes-validations:
+                    - message: kubeConfig is immutable
+                      rule: self == oldSelf
+                providers:
+                  description: Providers is the list of enabled CAPI providers.
+                  items:
+                    properties:
+                      config:
+                        description: |-
+                          Config allows to provide parameters for management component customization.
+                          If no Config provided, the field will be populated with the default
+                          values for the template.
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
+                        description: Name of the provider.
+                        type: string
+                      template:
+                        description: |-
+                          Template is the name of the Template associated with this component.
+                          If not specified, will be taken from the Release object.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+              type: object
+              x-kubernetes-validations:
+                - message: exactly one of kubeConfig or clusterDeployment must be set
+                  rule: has(self.kubeConfig) != has(self.clusterDeployment)
+            status:
+              description: RegionStatus defines the observed state of Region
+              properties:
+                availableProviders:
+                  description: AvailableProviders holds all available CAPI providers.
+                  items:
+                    type: string
+                  type: array
+                capiContracts:
+                  additionalProperties:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Holds key-value pairs with compatibility [contract versions],
+                      where the key is the core CAPI contract version,
+                      and the value is an underscore-delimited (_) list of provider contract versions
+                      supported by the core CAPI.
+
+                      [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
+                    type: object
+                  description: |-
+                    For each CAPI provider name holds its compatibility [contract versions]
+                    in a key-value pairs, where the key is the core CAPI contract version,
                     and the value is an underscore-delimited (_) list of provider contract versions
                     supported by the core CAPI.
 
                     [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
                   type: object
-                description: |-
-                  For each CAPI provider name holds its compatibility [contract versions]
-                  in a key-value pairs, where the key is the core CAPI contract version,
-                  and the value is an underscore-delimited (_) list of provider contract versions
-                  supported by the core CAPI.
-
-                  [contract versions]: https://cluster-api.sigs.k8s.io/developer/providers/contracts
-                type: object
-              components:
-                additionalProperties:
-                  description: ComponentStatus is the status of Management component
-                    installation
-                  properties:
-                    error:
-                      description: Error stores as error message in case of failed
-                        installation
-                      type: string
-                    exposedProviders:
-                      description: ExposedProviders is a list of CAPI providers this
-                        component exposes
-                      items:
+                components:
+                  additionalProperties:
+                    description: ComponentStatus is the status of Management component installation
+                    properties:
+                      error:
+                        description: Error stores as error message in case of failed installation
                         type: string
-                      type: array
-                    success:
-                      description: Success represents if a component installation
-                        was successful
-                      type: boolean
-                    template:
-                      description: Template is the name of the Template associated
-                        with this component.
-                      type: string
+                      exposedProviders:
+                        description: ExposedProviders is a list of CAPI providers this component exposes
+                        items:
+                          type: string
+                        type: array
+                      success:
+                        description: Success represents if a component installation was successful
+                        type: boolean
+                      template:
+                        description: Template is the name of the Template associated with this component.
+                        type: string
+                    type: object
+                  description: Components indicates the status of installed KCM components and CAPI providers.
                   type: object
-                description: Components indicates the status of installed KCM components
-                  and CAPI providers.
-                type: object
-              conditions:
-                description: Conditions represents the observations of a Region's
-                  current state.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                conditions:
+                  description: Conditions represents the observations of a Region's current state.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_releases.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_releases.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: releases.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -14,170 +15,162 @@ spec:
     singular: release
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - description: Denotes Release is ready to be used
-      jsonPath: .status.ready
-      name: Ready
-      type: string
-    - description: Time elapsed since object creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: Release is the Schema for the releases API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ReleaseSpec defines the desired state of Release
-            properties:
-              capi:
-                description: CAPI references the Cluster API template.
-                properties:
-                  template:
-                    description: Template references the Template associated with
-                      the provider.
-                    type: string
-                required:
-                - template
-                type: object
-              kcm:
-                description: KCM references the KCM template.
-                properties:
-                  template:
-                    description: Template references the Template associated with
-                      the provider.
-                    type: string
-                required:
-                - template
-                type: object
-              providers:
-                description: Providers contains a list of Providers associated with
-                  the Release.
-                items:
+    - additionalPrinterColumns:
+        - description: Denotes Release is ready to be used
+          jsonPath: .status.ready
+          name: Ready
+          type: string
+        - description: Time elapsed since object creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Release is the Schema for the releases API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ReleaseSpec defines the desired state of Release
+              properties:
+                capi:
+                  description: CAPI references the Cluster API template.
                   properties:
-                    name:
-                      description: Name of the provider.
-                      type: string
                     template:
-                      description: Template references the Template associated with
-                        the provider.
+                      description: Template references the Template associated with the provider.
                       type: string
                   required:
-                  - name
-                  - template
+                    - template
                   type: object
-                type: array
-              regional:
-                description: Regional references the KCM regional template.
-                properties:
-                  template:
-                    description: Template references the Template associated with
-                      the provider.
-                    type: string
-                required:
-                - template
-                type: object
-              version:
-                description: Version of the KCM Release in the semver format.
-                type: string
-            required:
-            - capi
-            - kcm
-            - version
-            type: object
-          status:
-            description: ReleaseStatus defines the observed state of Release
-            properties:
-              conditions:
-                description: Conditions contains details for the current state of
-                  the Release
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                kcm:
+                  description: KCM references the KCM template.
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    template:
+                      description: Template references the Template associated with the provider.
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - template
                   type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              ready:
-                description: Ready indicates whether KCM is ready to be upgraded to
-                  this Release.
-                type: boolean
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                providers:
+                  description: Providers contains a list of Providers associated with the Release.
+                  items:
+                    properties:
+                      name:
+                        description: Name of the provider.
+                        type: string
+                      template:
+                        description: Template references the Template associated with the provider.
+                        type: string
+                    required:
+                      - name
+                      - template
+                    type: object
+                  type: array
+                regional:
+                  description: Regional references the KCM regional template.
+                  properties:
+                    template:
+                      description: Template references the Template associated with the provider.
+                      type: string
+                  required:
+                    - template
+                  type: object
+                version:
+                  description: Version of the KCM Release in the semver format.
+                  type: string
+              required:
+                - capi
+                - kcm
+                - version
+              type: object
+            status:
+              description: ReleaseStatus defines the observed state of Release
+              properties:
+                conditions:
+                  description: Conditions contains details for the current state of the Release
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                ready:
+                  description: Ready indicates whether KCM is ready to be upgraded to this Release.
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: servicesets.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -14,438 +15,417 @@ spec:
     singular: serviceset
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Corresponding ClusterDeployment name
-      jsonPath: .spec.cluster
-      name: cluster
-      type: string
-    - description: Corresponding MultiClusterService name
-      jsonPath: .spec.multiClusterService
-      name: multiClusterServer
-      type: string
-    - description: StateManagementProvider name
-      jsonPath: .spec.provider.name
-      name: provider
-      type: string
-    - description: Is the ServiceSet for self-management
-      jsonPath: .spec.provider.selfManagement
-      name: self-management
-      type: boolean
-    - description: Time elapsed since object creation
-      jsonPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ServiceSet is the Schema for the servicesets API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ServiceSetSpec defines the desired state of ServiceSet
-            properties:
-              cluster:
-                description: Cluster is the name of the ClusterDeployment
-                type: string
-              multiClusterService:
-                description: MultiClusterService is the name of the MultiClusterService
-                type: string
-              provider:
-                description: Provider is the definition of the provider to use to
-                  deploy services defined in the ServiceSet.
-                properties:
-                  config:
-                    description: Config is the provider-specific configuration applied
-                      to the produced objects.
-                    x-kubernetes-preserve-unknown-fields: true
-                  name:
-                    description: Name is the name of the [StateManagementProvider]
-                      object.
-                    type: string
-                    x-kubernetes-validations:
-                    - message: Provider name is immutable once set
-                      rule: oldSelf == '' || self == oldSelf
-                  selfManagement:
-                    description: |-
-                      SelfManagement flag defines whether resources must be deployed to the management cluster itself.
-                      This field is ignored if set for ClusterDeployment.
-                    type: boolean
-                type: object
-              services:
-                description: Services is the list of services to deploy.
-                items:
+    - additionalPrinterColumns:
+        - description: Corresponding ClusterDeployment name
+          jsonPath: .spec.cluster
+          name: cluster
+          type: string
+        - description: Corresponding MultiClusterService name
+          jsonPath: .spec.multiClusterService
+          name: multiClusterServer
+          type: string
+        - description: StateManagementProvider name
+          jsonPath: .spec.provider.name
+          name: provider
+          type: string
+        - description: Is the ServiceSet for self-management
+          jsonPath: .spec.provider.selfManagement
+          name: self-management
+          type: boolean
+        - description: Time elapsed since object creation
+          jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ServiceSet is the Schema for the servicesets API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ServiceSetSpec defines the desired state of ServiceSet
+              properties:
+                cluster:
+                  description: Cluster is the name of the ClusterDeployment
+                  type: string
+                multiClusterService:
+                  description: MultiClusterService is the name of the MultiClusterService
+                  type: string
+                provider:
+                  description: Provider is the definition of the provider to use to deploy services defined in the ServiceSet.
                   properties:
-                    helmOptions:
-                      description: HelmOptions are the options to be passed to the
-                        provider for helm installation or updates
-                      properties:
-                        atomic:
-                          description: |-
-                            if set, the installation process deletes the installation/upgrades on failure.
-                            The --wait flag will be set automatically if --atomic is used
-                          type: boolean
-                        createNamespace:
-                          type: boolean
-                        dependencyUpdate:
-                          description: update dependencies if they are missing before
-                            installing the chart
-                          type: boolean
-                        description:
-                          description: Description is the description of an helm operation
-                          type: string
-                        disableHooks:
-                          description: prevent hooks from running during install/upgrade/uninstall
-                          type: boolean
-                        disableOpenAPIValidation:
-                          description: if set, the installation process will not validate
-                            rendered templates against the Kubernetes OpenAPI Schema
-                          type: boolean
-                        enableClientCache:
-                          description: EnableClientCache is a flag to enable Helm
-                            client cache. If it is not specified, it will be set to
-                            false.
-                          type: boolean
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: Labels that would be added to release metadata.
-                          type: object
-                        replace:
-                          description: Replaces if set indicates to replace an older
-                            release with this one
-                          type: boolean
-                        skipCRDs:
-                          description: |-
-                            SkipCRDs controls whether CRDs should be installed during install/upgrade operation.
-                            By default, CRDs are installed if not already present.
-                          type: boolean
-                        skipSchemaValidation:
-                          description: SkipSchemaValidation determines if JSON schema
-                            validation is disabled.
-                          type: boolean
-                        timeout:
-                          description: time to wait for any individual Kubernetes
-                            operation (like Jobs for hooks) (default 5m0s)
-                          type: string
-                        wait:
-                          description: |-
-                            if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet
-                            are in a ready state before marking the release as successful. It will wait for as long as --timeout
-                          type: boolean
-                        waitForJobs:
-                          description: |-
-                            if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful.
-                            It will wait for as long as --timeout
-                          type: boolean
-                      type: object
+                    config:
+                      description: Config is the provider-specific configuration applied to the produced objects.
+                      x-kubernetes-preserve-unknown-fields: true
                     name:
+                      description: Name is the name of the [StateManagementProvider] object.
+                      type: string
+                      x-kubernetes-validations:
+                        - message: Provider name is immutable once set
+                          rule: oldSelf == '' || self == oldSelf
+                    selfManagement:
                       description: |-
-                        Name is the name of the service. If the ServiceTemplate is backed by Helm chart,
-                        then the name is the name of the Helm release.
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace is the namespace where the service is deployed. If the ServiceTemplate
-                        is backed by Helm chart, then the namespace is the namespace where the Helm release is deployed.
-                      type: string
-                    template:
-                      description: Template is the name of the ServiceTemplate to
-                        use to deploy the service.
-                      type: string
-                    values:
-                      description: Values is the values to pass to the ServiceTemplate.
-                      type: string
-                    valuesFrom:
-                      description: ValuesFrom is the list of sources of the values
-                        to pass to the ServiceTemplate.
-                      items:
+                        SelfManagement flag defines whether resources must be deployed to the management cluster itself.
+                        This field is ignored if set for ClusterDeployment.
+                      type: boolean
+                  type: object
+                services:
+                  description: Services is the list of services to deploy.
+                  items:
+                    properties:
+                      helmOptions:
+                        description: HelmOptions are the options to be passed to the provider for helm installation or updates
+                        properties:
+                          atomic:
+                            description: |-
+                              if set, the installation process deletes the installation/upgrades on failure.
+                              The --wait flag will be set automatically if --atomic is used
+                            type: boolean
+                          createNamespace:
+                            type: boolean
+                          dependencyUpdate:
+                            description: update dependencies if they are missing before installing the chart
+                            type: boolean
+                          description:
+                            description: Description is the description of an helm operation
+                            type: string
+                          disableHooks:
+                            description: prevent hooks from running during install/upgrade/uninstall
+                            type: boolean
+                          disableOpenAPIValidation:
+                            description: if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema
+                            type: boolean
+                          enableClientCache:
+                            description: EnableClientCache is a flag to enable Helm client cache. If it is not specified, it will be set to false.
+                            type: boolean
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels that would be added to release metadata.
+                            type: object
+                          replace:
+                            description: Replaces if set indicates to replace an older release with this one
+                            type: boolean
+                          skipCRDs:
+                            description: |-
+                              SkipCRDs controls whether CRDs should be installed during install/upgrade operation.
+                              By default, CRDs are installed if not already present.
+                            type: boolean
+                          skipSchemaValidation:
+                            description: SkipSchemaValidation determines if JSON schema validation is disabled.
+                            type: boolean
+                          timeout:
+                            description: time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
+                            type: string
+                          wait:
+                            description: |-
+                              if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet
+                              are in a ready state before marking the release as successful. It will wait for as long as --timeout
+                            type: boolean
+                          waitForJobs:
+                            description: |-
+                              if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful.
+                              It will wait for as long as --timeout
+                            type: boolean
+                        type: object
+                      name:
                         description: |-
-                          ValuesFrom is the source of the values to pass to the ServiceTemplate. The source
-                          can be a ConfigMap or a Secret located in the same namespace as the ServiceSet.
-                        properties:
-                          kind:
-                            description: Kind is the kind of the source.
-                            enum:
-                            - ConfigMap
-                            - Secret
-                            type: string
-                          name:
-                            description: Name is the name of the source.
-                            type: string
-                        required:
-                        - kind
-                        - name
-                        type: object
-                      type: array
-                    version:
-                      description: Version is the version of the service.
-                      type: string
-                  required:
-                  - name
-                  - namespace
-                  - template
-                  type: object
-                type: array
-            required:
-            - cluster
-            - provider
-            type: object
-          status:
-            description: ServiceSetStatus defines the observed state of ServiceSet
-            properties:
-              cluster:
-                description: Cluster contains [k8s.io/api/core/v1.ObjectReference]
-                  to the cluster object.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: |-
-                      If referring to a piece of an object instead of an entire object, this string
-                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within a pod, this would take on a value like:
-                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]" (container with
-                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
-                      referencing a part of an object.
-                    type: string
-                  kind:
-                    description: |-
-                      Kind of the referent.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-                    type: string
-                  name:
-                    description: |-
-                      Name of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                    type: string
-                  resourceVersion:
-                    description: |-
-                      Specific resourceVersion to which this reference is made, if any.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                    type: string
-                  uid:
-                    description: |-
-                      UID of the referent.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              conditions:
-                description: Conditions is a list of conditions for the ServiceSet
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                          Name is the name of the service. If the ServiceTemplate is backed by Helm chart,
+                          then the name is the name of the Helm release.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the service is deployed. If the ServiceTemplate
+                          is backed by Helm chart, then the namespace is the namespace where the Helm release is deployed.
+                        type: string
+                      template:
+                        description: Template is the name of the ServiceTemplate to use to deploy the service.
+                        type: string
+                      values:
+                        description: Values is the values to pass to the ServiceTemplate.
+                        type: string
+                      valuesFrom:
+                        description: ValuesFrom is the list of sources of the values to pass to the ServiceTemplate.
+                        items:
+                          description: |-
+                            ValuesFrom is the source of the values to pass to the ServiceTemplate. The source
+                            can be a ConfigMap or a Secret located in the same namespace as the ServiceSet.
+                          properties:
+                            kind:
+                              description: Kind is the kind of the source.
+                              enum:
+                                - ConfigMap
+                                - Secret
+                              type: string
+                            name:
+                              description: Name is the name of the source.
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                        type: array
+                      version:
+                        description: Version is the version of the service.
+                        type: string
+                    required:
+                      - name
+                      - namespace
+                      - template
+                    type: object
+                  type: array
+              required:
+                - cluster
+                - provider
+              type: object
+            status:
+              description: ServiceSetStatus defines the observed state of ServiceSet
+              properties:
+                cluster:
+                  description: Cluster contains [k8s.io/api/core/v1.ObjectReference] to the cluster object.
                   properties:
-                    lastTransitionTime:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
                       type: string
-                    message:
+                    kind:
                       description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              deployed:
-                default: false
-                description: Deployed is true if the ServiceSet has been deployed
-                type: boolean
-              provider:
-                description: Provider is the state of the provider
-                properties:
-                  ready:
-                    description: Ready is true if the provider is ready
-                    type: boolean
-                  suspended:
-                    description: Suspended is true if the provider is suspended
-                    type: boolean
-                type: object
-              services:
-                description: Services is a list of Service states in the ServiceSet
-                items:
-                  description: ServiceState is the state of a Service
-                  properties:
-                    conditions:
-                      description: Conditions is a list of conditions for the Service
-                      items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
-                        properties:
-                          lastTransitionTime:
-                            description: |-
-                              lastTransitionTime is the last time the condition transitioned from one status to another.
-                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                            format: date-time
-                            type: string
-                          message:
-                            description: |-
-                              message is a human readable message indicating details about the transition.
-                              This may be an empty string.
-                            maxLength: 32768
-                            type: string
-                          observedGeneration:
-                            description: |-
-                              observedGeneration represents the .metadata.generation that the condition was set based upon.
-                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                              with respect to the current state of the instance.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          reason:
-                            description: |-
-                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                              Producers of specific condition types may define expected values and meanings for this field,
-                              and whether the values are considered a guaranteed API.
-                              The value should be a CamelCase string.
-                              This field may not be empty.
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - lastTransitionTime
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                      x-kubernetes-list-map-keys:
-                      - type
-                      x-kubernetes-list-type: map
-                    failureMessage:
-                      description: FailureMessage is the reason why the Service failed
-                        to deploy
-                      type: string
-                    lastStateTransitionTime:
-                      description: LastStateTransitionTime is the time the State was
-                        last transitioned
-                      format: date-time
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description: Name is the name of the Service
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
-                      description: Namespace is the namespace of the Service
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                       type: string
-                    state:
-                      description: State is the state of the Service
-                      enum:
-                      - Deployed
-                      - Provisioning
-                      - Failed
-                      - Pending
-                      - Deleting
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
-                    template:
-                      description: Template is the name of the ServiceTemplate used
-                        to deploy the Service
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                       type: string
-                    type:
-                      description: Type is the type of the deployment method for the
-                        Service
-                      enum:
-                      - Helm
-                      - Kustomize
-                      - Resource
-                      type: string
-                    version:
-                      description: Version is the version of the Service
-                      type: string
-                  required:
-                  - lastStateTransitionTime
-                  - name
-                  - namespace
-                  - state
-                  - template
-                  - type
                   type: object
-                type: array
-            required:
-            - deployed
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  x-kubernetes-map-type: atomic
+                conditions:
+                  description: Conditions is a list of conditions for the ServiceSet
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                deployed:
+                  default: false
+                  description: Deployed is true if the ServiceSet has been deployed
+                  type: boolean
+                provider:
+                  description: Provider is the state of the provider
+                  properties:
+                    ready:
+                      description: Ready is true if the provider is ready
+                      type: boolean
+                    suspended:
+                      description: Suspended is true if the provider is suspended
+                      type: boolean
+                  type: object
+                services:
+                  description: Services is a list of Service states in the ServiceSet
+                  items:
+                    description: ServiceState is the state of a Service
+                    properties:
+                      conditions:
+                        description: Conditions is a list of conditions for the Service
+                        items:
+                          description: Condition contains details for one aspect of the current state of this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: |-
+                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              format: date-time
+                              type: string
+                            message:
+                              description: |-
+                                message is a human readable message indicating details about the transition.
+                                This may be an empty string.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: |-
+                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                with respect to the current state of the instance.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: |-
+                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                Producers of specific condition types may define expected values and meanings for this field,
+                                and whether the values are considered a guaranteed API.
+                                The value should be a CamelCase string.
+                                This field may not be empty.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      failureMessage:
+                        description: FailureMessage is the reason why the Service failed to deploy
+                        type: string
+                      lastStateTransitionTime:
+                        description: LastStateTransitionTime is the time the State was last transitioned
+                        format: date-time
+                        type: string
+                      name:
+                        description: Name is the name of the Service
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the Service
+                        type: string
+                      state:
+                        description: State is the state of the Service
+                        enum:
+                          - Deployed
+                          - Provisioning
+                          - Failed
+                          - Pending
+                          - Deleting
+                        type: string
+                      template:
+                        description: Template is the name of the ServiceTemplate used to deploy the Service
+                        type: string
+                      type:
+                        description: Type is the type of the deployment method for the Service
+                        enum:
+                          - Helm
+                          - Kustomize
+                          - Resource
+                        type: string
+                      version:
+                        description: Version is the version of the Service
+                        type: string
+                    required:
+                      - lastStateTransitionTime
+                      - name
+                      - namespace
+                      - state
+                      - template
+                      - type
+                    type: object
+                  type: array
+              required:
+                - deployed
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplatechains.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplatechains.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: servicetemplatechains.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -14,97 +15,89 @@ spec:
     singular: servicetemplatechain
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Is the chain valid
-      jsonPath: .status.valid
-      name: Valid
-      type: boolean
-    - description: Time elapsed since object creation
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ServiceTemplateChain is the Schema for the servicetemplatechains
-          API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: TemplateChainSpec defines the desired state of *TemplateChain
-            properties:
-              supportedTemplates:
-                description: SupportedTemplates is the list of supported Templates
-                  definitions and all available upgrade sequences for it.
-                items:
-                  description: SupportedTemplate is the supported Template definition
-                    and all available upgrade sequences for it
-                  properties:
-                    availableUpgrades:
-                      description: AvailableUpgrades is the list of available upgrades
-                        for the specified Template.
-                      items:
-                        description: AvailableUpgrade is the definition of the available
-                          upgrade for the Template
-                        properties:
-                          name:
-                            description: Name is the name of the Template to which
-                              the upgrade is available.
-                            type: string
-                          version:
-                            description: Version is the version of the Template to
-                              which the upgrade is available.
-                            type: string
-                        required:
-                        - name
-                        - version
-                        type: object
-                      type: array
-                    name:
-                      description: Name is the name of the Template.
-                      type: string
-                  required:
-                  - name
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - name
-                x-kubernetes-list-type: map
-            type: object
-            x-kubernetes-validations:
-            - message: Spec is immutable
-              rule: self == oldSelf
-          status:
-            description: TemplateChainStatus defines the observed state of *TemplateChain
-            properties:
-              valid:
-                description: |-
-                  Valid indicates whether the chain is valid and can be considered when calculating available
-                  upgrade paths.
-                type: boolean
-              validationError:
-                description: ValidationError provides information regarding issues
-                  encountered during templatechain validation.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Is the chain valid
+          jsonPath: .status.valid
+          name: Valid
+          type: boolean
+        - description: Time elapsed since object creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ServiceTemplateChain is the Schema for the servicetemplatechains API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TemplateChainSpec defines the desired state of *TemplateChain
+              properties:
+                supportedTemplates:
+                  description: SupportedTemplates is the list of supported Templates definitions and all available upgrade sequences for it.
+                  items:
+                    description: SupportedTemplate is the supported Template definition and all available upgrade sequences for it
+                    properties:
+                      availableUpgrades:
+                        description: AvailableUpgrades is the list of available upgrades for the specified Template.
+                        items:
+                          description: AvailableUpgrade is the definition of the available upgrade for the Template
+                          properties:
+                            name:
+                              description: Name is the name of the Template to which the upgrade is available.
+                              type: string
+                            version:
+                              description: Version is the version of the Template to which the upgrade is available.
+                              type: string
+                          required:
+                            - name
+                            - version
+                          type: object
+                        type: array
+                      name:
+                        description: Name is the name of the Template.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+              x-kubernetes-validations:
+                - message: Spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: TemplateChainStatus defines the observed state of *TemplateChain
+              properties:
+                valid:
+                  description: |-
+                    Valid indicates whether the chain is valid and can be considered when calculating available
+                    upgrade paths.
+                  type: boolean
+                validationError:
+                  description: ValidationError provides information regarding issues encountered during templatechain validation.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: servicetemplates.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,2537 +13,2393 @@ spec:
     listKind: ServiceTemplateList
     plural: servicetemplates
     shortNames:
-    - svctmpl
+      - svctmpl
     singular: servicetemplate
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Valid
-      jsonPath: .status.valid
-      name: valid
-      type: boolean
-    - description: Validation Error
-      jsonPath: .status.validationError
-      name: validationError
-      priority: 1
-      type: string
-    - description: Description
-      jsonPath: .status.description
-      name: description
-      priority: 1
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: ServiceTemplate is the Schema for the servicetemplates API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ServiceTemplateSpec defines the desired state of ServiceTemplate
-            properties:
-              helm:
-                description: Helm contains the Helm chart information for the template.
-                properties:
-                  chartRef:
-                    description: |-
-                      ChartRef is a reference to a source controller resource containing the
-                      Helm chart representing the template.
-                    properties:
-                      apiVersion:
-                        description: APIVersion of the referent.
-                        type: string
-                      kind:
-                        description: Kind of the referent.
-                        enum:
-                        - OCIRepository
-                        - HelmChart
-                        - ExternalArtifact
-                        type: string
-                      name:
-                        description: Name of the referent.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      namespace:
-                        description: |-
-                          Namespace of the referent, defaults to the namespace of the Kubernetes
-                          resource object that contains the reference.
-                        maxLength: 63
-                        minLength: 1
-                        type: string
-                    required:
-                    - kind
-                    - name
-                    type: object
-                  chartSource:
-                    description: ChartSource is a source of a Helm chart representing
-                      the template.
-                    properties:
-                      deploymentType:
-                        default: Remote
-                        description: |-
-                          DeploymentType is the type of the deployment. This field is ignored,
-                          when ResourceSpec is used as part of Helm chart configuration.
-                        enum:
-                        - Local
-                        - Remote
-                        type: string
-                      localSourceRef:
-                        description: LocalSourceRef is the local source of the kustomize
-                          manifest.
-                        properties:
-                          kind:
-                            description: Kind is the kind of the local source.
-                            enum:
-                            - ConfigMap
-                            - Secret
-                            - GitRepository
-                            - Bucket
+    - additionalPrinterColumns:
+        - description: Valid
+          jsonPath: .status.valid
+          name: valid
+          type: boolean
+        - description: Validation Error
+          jsonPath: .status.validationError
+          name: validationError
+          priority: 1
+          type: string
+        - description: Description
+          jsonPath: .status.description
+          name: description
+          priority: 1
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ServiceTemplate is the Schema for the servicetemplates API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ServiceTemplateSpec defines the desired state of ServiceTemplate
+              properties:
+                helm:
+                  description: Helm contains the Helm chart information for the template.
+                  properties:
+                    chartRef:
+                      description: |-
+                        ChartRef is a reference to a source controller resource containing the
+                        Helm chart representing the template.
+                      properties:
+                        apiVersion:
+                          description: APIVersion of the referent.
+                          type: string
+                        kind:
+                          description: Kind of the referent.
+                          enum:
                             - OCIRepository
-                            type: string
-                          name:
-                            description: Name is the name of the local source.
-                            type: string
-                          namespace:
-                            description: |-
-                              Namespace is the namespace of the local source. Cross-namespace references
-                              are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                              [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
-                              If the Kind is ConfigMap or Secret, the namespace will be ignored.
-                            type: string
-                        required:
+                            - HelmChart
+                            - ExternalArtifact
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referent, defaults to the namespace of the Kubernetes
+                            resource object that contains the reference.
+                          maxLength: 63
+                          minLength: 1
+                          type: string
+                      required:
                         - kind
                         - name
-                        type: object
-                      path:
-                        description: Path to the directory containing the resource
-                          manifest.
-                        type: string
-                      remoteSourceSpec:
-                        description: RemoteSourceSpec is the remote source of the
-                          kustomize manifest.
-                        properties:
-                          bucket:
-                            description: Bucket is the definition of bucket source.
-                            properties:
-                              bucketName:
-                                description: BucketName is the name of the object
-                                  storage bucket.
-                                type: string
-                              certSecretRef:
-                                description: |-
-                                  CertSecretRef can be given the name of a Secret containing
-                                  either or both of
-
-                                  - a PEM-encoded client certificate (`tls.crt`) and private
-                                  key (`tls.key`);
-                                  - a PEM-encoded CA certificate (`ca.crt`)
-
-                                  and whichever are supplied, will be used for connecting to the
-                                  bucket. The client cert and key are useful if you are
-                                  authenticating with a certificate; the CA cert is useful if
-                                  you are using a self-signed server certificate. The Secret must
-                                  be of type `Opaque` or `kubernetes.io/tls`.
-
-                                  This field is only supported for the `generic` provider.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              endpoint:
-                                description: Endpoint is the object storage address
-                                  the BucketName is located at.
-                                type: string
-                              ignore:
-                                description: |-
-                                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                                  (which is the same as .gitignore). If not provided, a default will be used,
-                                  consult the documentation for your version to find out what those are.
-                                type: string
-                              insecure:
-                                description: Insecure allows connecting to a non-TLS
-                                  HTTP Endpoint.
-                                type: boolean
-                              interval:
-                                description: |-
-                                  Interval at which the Bucket Endpoint is checked for updates.
-                                  This interval is approximate and may be subject to jitter to ensure
-                                  efficient use of resources.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                                type: string
-                              prefix:
-                                description: Prefix to use for server-side filtering
-                                  of files in the Bucket.
-                                type: string
-                              provider:
-                                default: generic
-                                description: |-
-                                  Provider of the object storage bucket.
-                                  Defaults to 'generic', which expects an S3 (API) compatible object
-                                  storage.
-                                enum:
-                                - generic
-                                - aws
-                                - gcp
-                                - azure
-                                type: string
-                              proxySecretRef:
-                                description: |-
-                                  ProxySecretRef specifies the Secret containing the proxy configuration
-                                  to use while communicating with the Bucket server.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              region:
-                                description: Region of the Endpoint where the BucketName
-                                  is located in.
-                                type: string
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Secret containing authentication credentials
-                                  for the Bucket.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceAccountName:
-                                description: |-
-                                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                                  the bucket. This field is only supported for the 'gcp' and 'aws' providers.
-                                  For more information about workload identity:
-                                  https://fluxcd.io/flux/components/source/buckets/#workload-identity
-                                type: string
-                              sts:
-                                description: |-
-                                  STS specifies the required configuration to use a Security Token
-                                  Service for fetching temporary credentials to authenticate in a
-                                  Bucket provider.
-
-                                  This field is only supported for the `aws` and `generic` providers.
-                                properties:
-                                  certSecretRef:
-                                    description: |-
-                                      CertSecretRef can be given the name of a Secret containing
-                                      either or both of
-
-                                      - a PEM-encoded client certificate (`tls.crt`) and private
-                                      key (`tls.key`);
-                                      - a PEM-encoded CA certificate (`ca.crt`)
-
-                                      and whichever are supplied, will be used for connecting to the
-                                      STS endpoint. The client cert and key are useful if you are
-                                      authenticating with a certificate; the CA cert is useful if
-                                      you are using a self-signed server certificate. The Secret must
-                                      be of type `Opaque` or `kubernetes.io/tls`.
-
-                                      This field is only supported for the `ldap` provider.
-                                    properties:
-                                      name:
-                                        description: Name of the referent.
-                                        type: string
-                                    required:
-                                    - name
-                                    type: object
-                                  endpoint:
-                                    description: |-
-                                      Endpoint is the HTTP/S endpoint of the Security Token Service from
-                                      where temporary credentials will be fetched.
-                                    pattern: ^(http|https)://.*$
-                                    type: string
-                                  provider:
-                                    description: Provider of the Security Token Service.
-                                    enum:
-                                    - aws
-                                    - ldap
-                                    type: string
-                                  secretRef:
-                                    description: |-
-                                      SecretRef specifies the Secret containing authentication credentials
-                                      for the STS endpoint. This Secret must contain the fields `username`
-                                      and `password` and is supported only for the `ldap` provider.
-                                    properties:
-                                      name:
-                                        description: Name of the referent.
-                                        type: string
-                                    required:
-                                    - name
-                                    type: object
-                                required:
-                                - endpoint
-                                - provider
-                                type: object
-                              suspend:
-                                description: |-
-                                  Suspend tells the controller to suspend the reconciliation of this
-                                  Bucket.
-                                type: boolean
-                              timeout:
-                                default: 60s
-                                description: Timeout for fetch operations, defaults
-                                  to 60s.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                                type: string
-                            required:
-                            - bucketName
-                            - endpoint
-                            - interval
-                            type: object
-                            x-kubernetes-validations:
-                            - message: STS configuration is only supported for the
-                                'aws' and 'generic' Bucket providers
-                              rule: self.provider == 'aws' || self.provider == 'generic'
-                                || !has(self.sts)
-                            - message: '''aws'' is the only supported STS provider
-                                for the ''aws'' Bucket provider'
-                              rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider
-                                == 'aws'
-                            - message: '''ldap'' is the only supported STS provider
-                                for the ''generic'' Bucket provider'
-                              rule: self.provider != 'generic' || !has(self.sts) ||
-                                self.sts.provider == 'ldap'
-                            - message: spec.sts.secretRef is not required for the
-                                'aws' STS provider
-                              rule: '!has(self.sts) || self.sts.provider != ''aws''
-                                || !has(self.sts.secretRef)'
-                            - message: spec.sts.certSecretRef is not required for
-                                the 'aws' STS provider
-                              rule: '!has(self.sts) || self.sts.provider != ''aws''
-                                || !has(self.sts.certSecretRef)'
-                            - message: ServiceAccountName is not supported for the
-                                'generic' Bucket provider
-                              rule: self.provider != 'generic' || !has(self.serviceAccountName)
-                            - message: cannot set both .spec.secretRef and .spec.serviceAccountName
-                              rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
-                          git:
-                            description: Git is the definition of git repository source.
-                            properties:
-                              ignore:
-                                description: |-
-                                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                                  (which is the same as .gitignore). If not provided, a default will be used,
-                                  consult the documentation for your version to find out what those are.
-                                type: string
-                              include:
-                                description: |-
-                                  Include specifies a list of GitRepository resources which Artifacts
-                                  should be included in the Artifact produced for this GitRepository.
-                                items:
+                      type: object
+                    chartSource:
+                      description: ChartSource is a source of a Helm chart representing the template.
+                      properties:
+                        deploymentType:
+                          default: Remote
+                          description: |-
+                            DeploymentType is the type of the deployment. This field is ignored,
+                            when ResourceSpec is used as part of Helm chart configuration.
+                          enum:
+                            - Local
+                            - Remote
+                          type: string
+                        localSourceRef:
+                          description: LocalSourceRef is the local source of the kustomize manifest.
+                          properties:
+                            kind:
+                              description: Kind is the kind of the local source.
+                              enum:
+                                - ConfigMap
+                                - Secret
+                                - GitRepository
+                                - Bucket
+                                - OCIRepository
+                              type: string
+                            name:
+                              description: Name is the name of the local source.
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of the local source. Cross-namespace references
+                                are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
+                                [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
+                                If the Kind is ConfigMap or Secret, the namespace will be ignored.
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                        path:
+                          description: Path to the directory containing the resource manifest.
+                          type: string
+                        remoteSourceSpec:
+                          description: RemoteSourceSpec is the remote source of the kustomize manifest.
+                          properties:
+                            bucket:
+                              description: Bucket is the definition of bucket source.
+                              properties:
+                                bucketName:
+                                  description: BucketName is the name of the object storage bucket.
+                                  type: string
+                                certSecretRef:
                                   description: |-
-                                    GitRepositoryInclude specifies a local reference to a GitRepository which
-                                    Artifact (sub-)contents must be included, and where they should be placed.
+                                    CertSecretRef can be given the name of a Secret containing
+                                    either or both of
+
+                                    - a PEM-encoded client certificate (`tls.crt`) and private
+                                    key (`tls.key`);
+                                    - a PEM-encoded CA certificate (`ca.crt`)
+
+                                    and whichever are supplied, will be used for connecting to the
+                                    bucket. The client cert and key are useful if you are
+                                    authenticating with a certificate; the CA cert is useful if
+                                    you are using a self-signed server certificate. The Secret must
+                                    be of type `Opaque` or `kubernetes.io/tls`.
+
+                                    This field is only supported for the `generic` provider.
                                   properties:
-                                    fromPath:
-                                      description: |-
-                                        FromPath specifies the path to copy contents from, defaults to the root
-                                        of the Artifact.
+                                    name:
+                                      description: Name of the referent.
                                       type: string
-                                    repository:
+                                  required:
+                                    - name
+                                  type: object
+                                endpoint:
+                                  description: Endpoint is the object storage address the BucketName is located at.
+                                  type: string
+                                ignore:
+                                  description: |-
+                                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                                    (which is the same as .gitignore). If not provided, a default will be used,
+                                    consult the documentation for your version to find out what those are.
+                                  type: string
+                                insecure:
+                                  description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+                                  type: boolean
+                                interval:
+                                  description: |-
+                                    Interval at which the Bucket Endpoint is checked for updates.
+                                    This interval is approximate and may be subject to jitter to ensure
+                                    efficient use of resources.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                                  type: string
+                                prefix:
+                                  description: Prefix to use for server-side filtering of files in the Bucket.
+                                  type: string
+                                provider:
+                                  default: generic
+                                  description: |-
+                                    Provider of the object storage bucket.
+                                    Defaults to 'generic', which expects an S3 (API) compatible object
+                                    storage.
+                                  enum:
+                                    - generic
+                                    - aws
+                                    - gcp
+                                    - azure
+                                  type: string
+                                proxySecretRef:
+                                  description: |-
+                                    ProxySecretRef specifies the Secret containing the proxy configuration
+                                    to use while communicating with the Bucket server.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                region:
+                                  description: Region of the Endpoint where the BucketName is located in.
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Secret containing authentication credentials
+                                    for the Bucket.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceAccountName:
+                                  description: |-
+                                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                                    the bucket. This field is only supported for the 'gcp' and 'aws' providers.
+                                    For more information about workload identity:
+                                    https://fluxcd.io/flux/components/source/buckets/#workload-identity
+                                  type: string
+                                sts:
+                                  description: |-
+                                    STS specifies the required configuration to use a Security Token
+                                    Service for fetching temporary credentials to authenticate in a
+                                    Bucket provider.
+
+                                    This field is only supported for the `aws` and `generic` providers.
+                                  properties:
+                                    certSecretRef:
                                       description: |-
-                                        GitRepositoryRef specifies the GitRepository which Artifact contents
-                                        must be included.
+                                        CertSecretRef can be given the name of a Secret containing
+                                        either or both of
+
+                                        - a PEM-encoded client certificate (`tls.crt`) and private
+                                        key (`tls.key`);
+                                        - a PEM-encoded CA certificate (`ca.crt`)
+
+                                        and whichever are supplied, will be used for connecting to the
+                                        STS endpoint. The client cert and key are useful if you are
+                                        authenticating with a certificate; the CA cert is useful if
+                                        you are using a self-signed server certificate. The Secret must
+                                        be of type `Opaque` or `kubernetes.io/tls`.
+
+                                        This field is only supported for the `ldap` provider.
                                       properties:
                                         name:
                                           description: Name of the referent.
                                           type: string
                                       required:
-                                      - name
+                                        - name
                                       type: object
-                                    toPath:
+                                    endpoint:
                                       description: |-
-                                        ToPath specifies the path to copy contents to, defaults to the name of
-                                        the GitRepositoryRef.
+                                        Endpoint is the HTTP/S endpoint of the Security Token Service from
+                                        where temporary credentials will be fetched.
+                                      pattern: ^(http|https)://.*$
+                                      type: string
+                                    provider:
+                                      description: Provider of the Security Token Service.
+                                      enum:
+                                        - aws
+                                        - ldap
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        SecretRef specifies the Secret containing authentication credentials
+                                        for the STS endpoint. This Secret must contain the fields `username`
+                                        and `password` and is supported only for the `ldap` provider.
+                                      properties:
+                                        name:
+                                          description: Name of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - endpoint
+                                    - provider
+                                  type: object
+                                suspend:
+                                  description: |-
+                                    Suspend tells the controller to suspend the reconciliation of this
+                                    Bucket.
+                                  type: boolean
+                                timeout:
+                                  default: 60s
+                                  description: Timeout for fetch operations, defaults to 60s.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                                  type: string
+                              required:
+                                - bucketName
+                                - endpoint
+                                - interval
+                              type: object
+                              x-kubernetes-validations:
+                                - message: STS configuration is only supported for the 'aws' and 'generic' Bucket providers
+                                  rule: self.provider == 'aws' || self.provider == 'generic' || !has(self.sts)
+                                - message: '''aws'' is the only supported STS provider for the ''aws'' Bucket provider'
+                                  rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider == 'aws'
+                                - message: '''ldap'' is the only supported STS provider for the ''generic'' Bucket provider'
+                                  rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider == 'ldap'
+                                - message: spec.sts.secretRef is not required for the 'aws' STS provider
+                                  rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
+                                - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
+                                  rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
+                                - message: ServiceAccountName is not supported for the 'generic' Bucket provider
+                                  rule: self.provider != 'generic' || !has(self.serviceAccountName)
+                                - message: cannot set both .spec.secretRef and .spec.serviceAccountName
+                                  rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
+                            git:
+                              description: Git is the definition of git repository source.
+                              properties:
+                                ignore:
+                                  description: |-
+                                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                                    (which is the same as .gitignore). If not provided, a default will be used,
+                                    consult the documentation for your version to find out what those are.
+                                  type: string
+                                include:
+                                  description: |-
+                                    Include specifies a list of GitRepository resources which Artifacts
+                                    should be included in the Artifact produced for this GitRepository.
+                                  items:
+                                    description: |-
+                                      GitRepositoryInclude specifies a local reference to a GitRepository which
+                                      Artifact (sub-)contents must be included, and where they should be placed.
+                                    properties:
+                                      fromPath:
+                                        description: |-
+                                          FromPath specifies the path to copy contents from, defaults to the root
+                                          of the Artifact.
+                                        type: string
+                                      repository:
+                                        description: |-
+                                          GitRepositoryRef specifies the GitRepository which Artifact contents
+                                          must be included.
+                                        properties:
+                                          name:
+                                            description: Name of the referent.
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
+                                      toPath:
+                                        description: |-
+                                          ToPath specifies the path to copy contents to, defaults to the name of
+                                          the GitRepositoryRef.
+                                        type: string
+                                    required:
+                                      - repository
+                                    type: object
+                                  type: array
+                                interval:
+                                  description: |-
+                                    Interval at which the GitRepository URL is checked for updates.
+                                    This interval is approximate and may be subject to jitter to ensure
+                                    efficient use of resources.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                                  type: string
+                                provider:
+                                  description: |-
+                                    Provider used for authentication, can be 'azure', 'github', 'generic'.
+                                    When not specified, defaults to 'generic'.
+                                  enum:
+                                    - generic
+                                    - azure
+                                    - github
+                                  type: string
+                                proxySecretRef:
+                                  description: |-
+                                    ProxySecretRef specifies the Secret containing the proxy configuration
+                                    to use while communicating with the Git server.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
                                       type: string
                                   required:
-                                  - repository
+                                    - name
                                   type: object
-                                type: array
-                              interval:
+                                recurseSubmodules:
+                                  description: |-
+                                    RecurseSubmodules enables the initialization of all submodules within
+                                    the GitRepository as cloned from the URL, using their default settings.
+                                  type: boolean
+                                ref:
+                                  description: |-
+                                    Reference specifies the Git reference to resolve and monitor for
+                                    changes, defaults to the 'master' branch.
+                                  properties:
+                                    branch:
+                                      description: Branch to check out, defaults to 'master' if no other field is defined.
+                                      type: string
+                                    commit:
+                                      description: |-
+                                        Commit SHA to check out, takes precedence over all reference fields.
+
+                                        This can be combined with Branch to shallow clone the branch, in which
+                                        the commit is expected to exist.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+                                        It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                                        Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                                      type: string
+                                    semver:
+                                      description: SemVer tag expression to check out, takes precedence over Tag.
+                                      type: string
+                                    tag:
+                                      description: Tag to check out, takes precedence over Branch.
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Secret containing authentication credentials for
+                                    the GitRepository.
+                                    For HTTPS repositories the Secret must contain 'username' and 'password'
+                                    fields for basic auth or 'bearerToken' field for token auth.
+                                    For SSH repositories the Secret must contain 'identity'
+                                    and 'known_hosts' fields.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceAccountName:
+                                  description: |-
+                                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+                                    authenticate to the GitRepository. This field is only supported for 'azure' provider.
+                                  type: string
+                                sparseCheckout:
+                                  description: |-
+                                    SparseCheckout specifies a list of directories to checkout when cloning
+                                    the repository. If specified, only these directories are included in the
+                                    Artifact produced for this GitRepository.
+                                  items:
+                                    type: string
+                                  type: array
+                                suspend:
+                                  description: |-
+                                    Suspend tells the controller to suspend the reconciliation of this
+                                    GitRepository.
+                                  type: boolean
+                                timeout:
+                                  default: 60s
+                                  description: Timeout for Git operations like cloning, defaults to 60s.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                                  type: string
+                                url:
+                                  description: URL specifies the Git repository URL, it can be an HTTP/S or SSH address.
+                                  pattern: ^(http|https|ssh)://.*$
+                                  type: string
+                                verify:
+                                  description: |-
+                                    Verification specifies the configuration to verify the Git commit
+                                    signature(s).
+                                  properties:
+                                    mode:
+                                      default: HEAD
+                                      description: |-
+                                        Mode specifies which Git object(s) should be verified.
+
+                                        The variants "head" and "HEAD" both imply the same thing, i.e. verify
+                                        the commit that the HEAD of the Git repository points to. The variant
+                                        "head" solely exists to ensure backwards compatibility.
+                                      enum:
+                                        - head
+                                        - HEAD
+                                        - Tag
+                                        - TagAndHEAD
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        SecretRef specifies the Secret containing the public keys of trusted Git
+                                        authors.
+                                      properties:
+                                        name:
+                                          description: Name of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - secretRef
+                                  type: object
+                              required:
+                                - interval
+                                - url
+                              type: object
+                              x-kubernetes-validations:
+                                - message: serviceAccountName can only be set when provider is 'azure'
+                                  rule: '!has(self.serviceAccountName) || (has(self.provider) && self.provider == ''azure'')'
+                            oci:
+                              description: OCI is the definition of OCI repository source.
+                              properties:
+                                certSecretRef:
+                                  description: |-
+                                    CertSecretRef can be given the name of a Secret containing
+                                    either or both of
+
+                                    - a PEM-encoded client certificate (`tls.crt`) and private
+                                    key (`tls.key`);
+                                    - a PEM-encoded CA certificate (`ca.crt`)
+
+                                    and whichever are supplied, will be used for connecting to the
+                                    registry. The client cert and key are useful if you are
+                                    authenticating with a certificate; the CA cert is useful if
+                                    you are using a self-signed server certificate. The Secret must
+                                    be of type `Opaque` or `kubernetes.io/tls`.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                ignore:
+                                  description: |-
+                                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                                    (which is the same as .gitignore). If not provided, a default will be used,
+                                    consult the documentation for your version to find out what those are.
+                                  type: string
+                                insecure:
+                                  description: Insecure allows connecting to a non-TLS HTTP container registry.
+                                  type: boolean
+                                interval:
+                                  description: |-
+                                    Interval at which the OCIRepository URL is checked for updates.
+                                    This interval is approximate and may be subject to jitter to ensure
+                                    efficient use of resources.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                                  type: string
+                                layerSelector:
+                                  description: |-
+                                    LayerSelector specifies which layer should be extracted from the OCI artifact.
+                                    When not specified, the first layer found in the artifact is selected.
+                                  properties:
+                                    mediaType:
+                                      description: |-
+                                        MediaType specifies the OCI media type of the layer
+                                        which should be extracted from the OCI Artifact. The
+                                        first layer matching this type is selected.
+                                      type: string
+                                    operation:
+                                      description: |-
+                                        Operation specifies how the selected layer should be processed.
+                                        By default, the layer compressed content is extracted to storage.
+                                        When the operation is set to 'copy', the layer compressed content
+                                        is persisted to storage as it is.
+                                      enum:
+                                        - extract
+                                        - copy
+                                      type: string
+                                  type: object
+                                provider:
+                                  default: generic
+                                  description: |-
+                                    The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                                    When not specified, defaults to 'generic'.
+                                  enum:
+                                    - generic
+                                    - aws
+                                    - azure
+                                    - gcp
+                                  type: string
+                                proxySecretRef:
+                                  description: |-
+                                    ProxySecretRef specifies the Secret containing the proxy configuration
+                                    to use while communicating with the container registry.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                ref:
+                                  description: |-
+                                    The OCI reference to pull and monitor for changes,
+                                    defaults to the latest tag.
+                                  properties:
+                                    digest:
+                                      description: |-
+                                        Digest is the image digest to pull, takes precedence over SemVer.
+                                        The value should be in the format 'sha256:<HASH>'.
+                                      type: string
+                                    semver:
+                                      description: |-
+                                        SemVer is the range of tags to pull selecting the latest within
+                                        the range, takes precedence over Tag.
+                                      type: string
+                                    semverFilter:
+                                      description: SemverFilter is a regex pattern to filter the tags within the SemVer range.
+                                      type: string
+                                    tag:
+                                      description: Tag is the image tag to pull, defaults to latest.
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    SecretRef contains the secret name containing the registry login
+                                    credentials to resolve image metadata.
+                                    The secret must be of type kubernetes.io/dockerconfigjson.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceAccountName:
+                                  description: |-
+                                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                                    the image pull if the service account has attached pull secrets. For more information:
+                                    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+                                  type: string
+                                suspend:
+                                  description: This flag tells the controller to suspend the reconciliation of this source.
+                                  type: boolean
+                                timeout:
+                                  default: 60s
+                                  description: The timeout for remote OCI Repository operations like pulling, defaults to 60s.
+                                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                                  type: string
+                                url:
+                                  description: |-
+                                    URL is a reference to an OCI artifact repository hosted
+                                    on a remote container registry.
+                                  pattern: ^oci://.*$
+                                  type: string
+                                verify:
+                                  description: |-
+                                    Verify contains the secret name containing the trusted public keys
+                                    used to verify the signature and specifies which provider to use to check
+                                    whether OCI image is authentic.
+                                  properties:
+                                    matchOIDCIdentity:
+                                      description: |-
+                                        MatchOIDCIdentity specifies the identity matching criteria to use
+                                        while verifying an OCI artifact which was signed using Cosign keyless
+                                        signing. The artifact's identity is deemed to be verified if any of the
+                                        specified matchers match against the identity.
+                                      items:
+                                        description: |-
+                                          OIDCIdentityMatch specifies options for verifying the certificate identity,
+                                          i.e. the issuer and the subject of the certificate.
+                                        properties:
+                                          issuer:
+                                            description: |-
+                                              Issuer specifies the regex pattern to match against to verify
+                                              the OIDC issuer in the Fulcio certificate. The pattern must be a
+                                              valid Go regular expression.
+                                            type: string
+                                          subject:
+                                            description: |-
+                                              Subject specifies the regex pattern to match against to verify
+                                              the identity subject in the Fulcio certificate. The pattern must
+                                              be a valid Go regular expression.
+                                            type: string
+                                        required:
+                                          - issuer
+                                          - subject
+                                        type: object
+                                      type: array
+                                    provider:
+                                      default: cosign
+                                      description: Provider specifies the technology used to sign the OCI Artifact.
+                                      enum:
+                                        - cosign
+                                        - notation
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        SecretRef specifies the Kubernetes Secret containing the
+                                        trusted public keys.
+                                      properties:
+                                        name:
+                                          description: Name of the referent.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - provider
+                                  type: object
+                              required:
+                                - interval
+                                - url
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: Git, Bucket and OCI are mutually exclusive.
+                              rule: 'has(self.git) ? (!has(self.bucket) && !has(self.oci)) : true'
+                            - message: Git, Bucket and OCI are mutually exclusive.
+                              rule: 'has(self.bucket) ? (!has(self.git) && !has(self.oci)) : true'
+                            - message: Git, Bucket and OCI are mutually exclusive.
+                              rule: 'has(self.oci) ? (!has(self.git) && !has(self.bucket)) : true'
+                            - message: One of Git, Bucket or OCI must be specified.
+                              rule: has(self.git) || has(self.bucket) || has(self.oci)
+                      required:
+                        - deploymentType
+                        - path
+                      type: object
+                      x-kubernetes-validations:
+                        - message: Secret and ConfigMap are not supported as Helm chart sources
+                          rule: 'has(self.localSourceRef) ? (self.localSourceRef.kind != ''Secret'' && self.localSourceRef.kind != ''ConfigMap''): true'
+                        - message: LocalSource and RemoteSource are mutually exclusive.
+                          rule: 'has(self.localSourceRef) ? !has(self.remoteSourceSpec): true'
+                        - message: LocalSource and RemoteSource are mutually exclusive.
+                          rule: 'has(self.remoteSourceSpec) ? !has(self.localSourceRef): true'
+                        - message: One of LocalSource or RemoteSource must be specified.
+                          rule: has(self.localSourceRef) || has(self.remoteSourceSpec)
+                    chartSpec:
+                      description: ChartSpec defines the desired state of the HelmChart to be created by the controller
+                      properties:
+                        chart:
+                          description: |-
+                            Chart is the name or path the Helm chart is available at in the
+                            SourceRef.
+                          type: string
+                        ignoreMissingValuesFiles:
+                          description: |-
+                            IgnoreMissingValuesFiles controls whether to silently ignore missing values
+                            files rather than failing.
+                          type: boolean
+                        interval:
+                          description: |-
+                            Interval at which the HelmChart SourceRef is checked for updates.
+                            This interval is approximate and may be subject to jitter to ensure
+                            efficient use of resources.
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                          type: string
+                        reconcileStrategy:
+                          default: ChartVersion
+                          description: |-
+                            ReconcileStrategy determines what enables the creation of a new artifact.
+                            Valid values are ('ChartVersion', 'Revision').
+                            See the documentation of the values for an explanation on their behavior.
+                            Defaults to ChartVersion when omitted.
+                          enum:
+                            - ChartVersion
+                            - Revision
+                          type: string
+                        sourceRef:
+                          description: SourceRef is the reference to the Source the chart is available at.
+                          properties:
+                            apiVersion:
+                              description: APIVersion of the referent.
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+                                'Bucket').
+                              enum:
+                                - HelmRepository
+                                - GitRepository
+                                - Bucket
+                              type: string
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                        suspend:
+                          description: |-
+                            Suspend tells the controller to suspend the reconciliation of this
+                            source.
+                          type: boolean
+                        valuesFiles:
+                          description: |-
+                            ValuesFiles is an alternative list of values files to use as the chart
+                            values (values.yaml is not included by default), expected to be a
+                            relative path in the SourceRef.
+                            Values files are merged in the order of this list with the last file
+                            overriding the first. Ignored when omitted.
+                          items:
+                            type: string
+                          type: array
+                        verify:
+                          description: |-
+                            Verify contains the secret name containing the trusted public keys
+                            used to verify the signature and specifies which provider to use to check
+                            whether OCI image is authentic.
+                            This field is only supported when using HelmRepository source with spec.type 'oci'.
+                            Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+                          properties:
+                            matchOIDCIdentity:
+                              description: |-
+                                MatchOIDCIdentity specifies the identity matching criteria to use
+                                while verifying an OCI artifact which was signed using Cosign keyless
+                                signing. The artifact's identity is deemed to be verified if any of the
+                                specified matchers match against the identity.
+                              items:
                                 description: |-
-                                  Interval at which the GitRepository URL is checked for updates.
-                                  This interval is approximate and may be subject to jitter to ensure
-                                  efficient use of resources.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                                type: string
-                              provider:
+                                  OIDCIdentityMatch specifies options for verifying the certificate identity,
+                                  i.e. the issuer and the subject of the certificate.
+                                properties:
+                                  issuer:
+                                    description: |-
+                                      Issuer specifies the regex pattern to match against to verify
+                                      the OIDC issuer in the Fulcio certificate. The pattern must be a
+                                      valid Go regular expression.
+                                    type: string
+                                  subject:
+                                    description: |-
+                                      Subject specifies the regex pattern to match against to verify
+                                      the identity subject in the Fulcio certificate. The pattern must
+                                      be a valid Go regular expression.
+                                    type: string
+                                required:
+                                  - issuer
+                                  - subject
+                                type: object
+                              type: array
+                            provider:
+                              default: cosign
+                              description: Provider specifies the technology used to sign the OCI Artifact.
+                              enum:
+                                - cosign
+                                - notation
+                              type: string
+                            secretRef:
+                              description: |-
+                                SecretRef specifies the Kubernetes Secret containing the
+                                trusted public keys.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - provider
+                          type: object
+                        version:
+                          default: '*'
+                          description: |-
+                            Version is the chart version semver expression, ignored for charts from
+                            GitRepository and Bucket sources. Defaults to latest when omitted.
+                          type: string
+                      required:
+                        - chart
+                        - interval
+                        - sourceRef
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: chartSpec, chartSource and chartRef are mutually exclusive
+                      rule: '(has(self.chartSpec) ? (!has(self.chartSource) && !has(self.chartRef)): true)'
+                    - message: chartSpec, chartSource and chartRef are mutually exclusive
+                      rule: '(has(self.chartSource) ? (!has(self.chartSpec) && !has(self.chartRef)): true)'
+                    - message: chartSpec, chartSource and chartRef are mutually exclusive
+                      rule: '(has(self.chartRef) ? (!has(self.chartSpec) && !has(self.chartSource)): true)'
+                    - message: one of chartSpec, chartRef or chartSource must be set
+                      rule: has(self.chartSpec) || has(self.chartRef) || has(self.chartSource)
+                helmOptions:
+                  description: HelmOptions are the global options to use when installing or updating the helm chart.
+                  properties:
+                    atomic:
+                      description: |-
+                        if set, the installation process deletes the installation/upgrades on failure.
+                        The --wait flag will be set automatically if --atomic is used
+                      type: boolean
+                    createNamespace:
+                      type: boolean
+                    dependencyUpdate:
+                      description: update dependencies if they are missing before installing the chart
+                      type: boolean
+                    description:
+                      description: Description is the description of an helm operation
+                      type: string
+                    disableHooks:
+                      description: prevent hooks from running during install/upgrade/uninstall
+                      type: boolean
+                    disableOpenAPIValidation:
+                      description: if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema
+                      type: boolean
+                    enableClientCache:
+                      description: EnableClientCache is a flag to enable Helm client cache. If it is not specified, it will be set to false.
+                      type: boolean
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels that would be added to release metadata.
+                      type: object
+                    replace:
+                      description: Replaces if set indicates to replace an older release with this one
+                      type: boolean
+                    skipCRDs:
+                      description: |-
+                        SkipCRDs controls whether CRDs should be installed during install/upgrade operation.
+                        By default, CRDs are installed if not already present.
+                      type: boolean
+                    skipSchemaValidation:
+                      description: SkipSchemaValidation determines if JSON schema validation is disabled.
+                      type: boolean
+                    timeout:
+                      description: time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s)
+                      type: string
+                    wait:
+                      description: |-
+                        if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet
+                        are in a ready state before marking the release as successful. It will wait for as long as --timeout
+                      type: boolean
+                    waitForJobs:
+                      description: |-
+                        if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful.
+                        It will wait for as long as --timeout
+                      type: boolean
+                  type: object
+                k8sConstraint:
+                  description: Constraint describing compatible K8S versions of the cluster set in the SemVer format.
+                  type: string
+                kustomize:
+                  description: Kustomize contains the Kustomize configuration for the template.
+                  properties:
+                    deploymentType:
+                      default: Remote
+                      description: |-
+                        DeploymentType is the type of the deployment. This field is ignored,
+                        when ResourceSpec is used as part of Helm chart configuration.
+                      enum:
+                        - Local
+                        - Remote
+                      type: string
+                    localSourceRef:
+                      description: LocalSourceRef is the local source of the kustomize manifest.
+                      properties:
+                        kind:
+                          description: Kind is the kind of the local source.
+                          enum:
+                            - ConfigMap
+                            - Secret
+                            - GitRepository
+                            - Bucket
+                            - OCIRepository
+                          type: string
+                        name:
+                          description: Name is the name of the local source.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the local source. Cross-namespace references
+                            are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
+                            [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
+                            If the Kind is ConfigMap or Secret, the namespace will be ignored.
+                          type: string
+                      required:
+                        - kind
+                        - name
+                      type: object
+                    path:
+                      description: Path to the directory containing the resource manifest.
+                      type: string
+                    remoteSourceSpec:
+                      description: RemoteSourceSpec is the remote source of the kustomize manifest.
+                      properties:
+                        bucket:
+                          description: Bucket is the definition of bucket source.
+                          properties:
+                            bucketName:
+                              description: BucketName is the name of the object storage bucket.
+                              type: string
+                            certSecretRef:
+                              description: |-
+                                CertSecretRef can be given the name of a Secret containing
+                                either or both of
+
+                                - a PEM-encoded client certificate (`tls.crt`) and private
+                                key (`tls.key`);
+                                - a PEM-encoded CA certificate (`ca.crt`)
+
+                                and whichever are supplied, will be used for connecting to the
+                                bucket. The client cert and key are useful if you are
+                                authenticating with a certificate; the CA cert is useful if
+                                you are using a self-signed server certificate. The Secret must
+                                be of type `Opaque` or `kubernetes.io/tls`.
+
+                                This field is only supported for the `generic` provider.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            endpoint:
+                              description: Endpoint is the object storage address the BucketName is located at.
+                              type: string
+                            ignore:
+                              description: |-
+                                Ignore overrides the set of excluded patterns in the .sourceignore format
+                                (which is the same as .gitignore). If not provided, a default will be used,
+                                consult the documentation for your version to find out what those are.
+                              type: string
+                            insecure:
+                              description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+                              type: boolean
+                            interval:
+                              description: |-
+                                Interval at which the Bucket Endpoint is checked for updates.
+                                This interval is approximate and may be subject to jitter to ensure
+                                efficient use of resources.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                              type: string
+                            prefix:
+                              description: Prefix to use for server-side filtering of files in the Bucket.
+                              type: string
+                            provider:
+                              default: generic
+                              description: |-
+                                Provider of the object storage bucket.
+                                Defaults to 'generic', which expects an S3 (API) compatible object
+                                storage.
+                              enum:
+                                - generic
+                                - aws
+                                - gcp
+                                - azure
+                              type: string
+                            proxySecretRef:
+                              description: |-
+                                ProxySecretRef specifies the Secret containing the proxy configuration
+                                to use while communicating with the Bucket server.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            region:
+                              description: Region of the Endpoint where the BucketName is located in.
+                              type: string
+                            secretRef:
+                              description: |-
+                                SecretRef specifies the Secret containing authentication credentials
+                                for the Bucket.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            serviceAccountName:
+                              description: |-
+                                ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                                the bucket. This field is only supported for the 'gcp' and 'aws' providers.
+                                For more information about workload identity:
+                                https://fluxcd.io/flux/components/source/buckets/#workload-identity
+                              type: string
+                            sts:
+                              description: |-
+                                STS specifies the required configuration to use a Security Token
+                                Service for fetching temporary credentials to authenticate in a
+                                Bucket provider.
+
+                                This field is only supported for the `aws` and `generic` providers.
+                              properties:
+                                certSecretRef:
+                                  description: |-
+                                    CertSecretRef can be given the name of a Secret containing
+                                    either or both of
+
+                                    - a PEM-encoded client certificate (`tls.crt`) and private
+                                    key (`tls.key`);
+                                    - a PEM-encoded CA certificate (`ca.crt`)
+
+                                    and whichever are supplied, will be used for connecting to the
+                                    STS endpoint. The client cert and key are useful if you are
+                                    authenticating with a certificate; the CA cert is useful if
+                                    you are using a self-signed server certificate. The Secret must
+                                    be of type `Opaque` or `kubernetes.io/tls`.
+
+                                    This field is only supported for the `ldap` provider.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                endpoint:
+                                  description: |-
+                                    Endpoint is the HTTP/S endpoint of the Security Token Service from
+                                    where temporary credentials will be fetched.
+                                  pattern: ^(http|https)://.*$
+                                  type: string
+                                provider:
+                                  description: Provider of the Security Token Service.
+                                  enum:
+                                    - aws
+                                    - ldap
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Secret containing authentication credentials
+                                    for the STS endpoint. This Secret must contain the fields `username`
+                                    and `password` and is supported only for the `ldap` provider.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - endpoint
+                                - provider
+                              type: object
+                            suspend:
+                              description: |-
+                                Suspend tells the controller to suspend the reconciliation of this
+                                Bucket.
+                              type: boolean
+                            timeout:
+                              default: 60s
+                              description: Timeout for fetch operations, defaults to 60s.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                              type: string
+                          required:
+                            - bucketName
+                            - endpoint
+                            - interval
+                          type: object
+                          x-kubernetes-validations:
+                            - message: STS configuration is only supported for the 'aws' and 'generic' Bucket providers
+                              rule: self.provider == 'aws' || self.provider == 'generic' || !has(self.sts)
+                            - message: '''aws'' is the only supported STS provider for the ''aws'' Bucket provider'
+                              rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider == 'aws'
+                            - message: '''ldap'' is the only supported STS provider for the ''generic'' Bucket provider'
+                              rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider == 'ldap'
+                            - message: spec.sts.secretRef is not required for the 'aws' STS provider
+                              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
+                            - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
+                              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
+                            - message: ServiceAccountName is not supported for the 'generic' Bucket provider
+                              rule: self.provider != 'generic' || !has(self.serviceAccountName)
+                            - message: cannot set both .spec.secretRef and .spec.serviceAccountName
+                              rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
+                        git:
+                          description: Git is the definition of git repository source.
+                          properties:
+                            ignore:
+                              description: |-
+                                Ignore overrides the set of excluded patterns in the .sourceignore format
+                                (which is the same as .gitignore). If not provided, a default will be used,
+                                consult the documentation for your version to find out what those are.
+                              type: string
+                            include:
+                              description: |-
+                                Include specifies a list of GitRepository resources which Artifacts
+                                should be included in the Artifact produced for this GitRepository.
+                              items:
                                 description: |-
-                                  Provider used for authentication, can be 'azure', 'github', 'generic'.
-                                  When not specified, defaults to 'generic'.
-                                enum:
+                                  GitRepositoryInclude specifies a local reference to a GitRepository which
+                                  Artifact (sub-)contents must be included, and where they should be placed.
+                                properties:
+                                  fromPath:
+                                    description: |-
+                                      FromPath specifies the path to copy contents from, defaults to the root
+                                      of the Artifact.
+                                    type: string
+                                  repository:
+                                    description: |-
+                                      GitRepositoryRef specifies the GitRepository which Artifact contents
+                                      must be included.
+                                    properties:
+                                      name:
+                                        description: Name of the referent.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  toPath:
+                                    description: |-
+                                      ToPath specifies the path to copy contents to, defaults to the name of
+                                      the GitRepositoryRef.
+                                    type: string
+                                required:
+                                  - repository
+                                type: object
+                              type: array
+                            interval:
+                              description: |-
+                                Interval at which the GitRepository URL is checked for updates.
+                                This interval is approximate and may be subject to jitter to ensure
+                                efficient use of resources.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                              type: string
+                            provider:
+                              description: |-
+                                Provider used for authentication, can be 'azure', 'github', 'generic'.
+                                When not specified, defaults to 'generic'.
+                              enum:
                                 - generic
                                 - azure
                                 - github
-                                type: string
-                              proxySecretRef:
-                                description: |-
-                                  ProxySecretRef specifies the Secret containing the proxy configuration
-                                  to use while communicating with the Git server.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              recurseSubmodules:
-                                description: |-
-                                  RecurseSubmodules enables the initialization of all submodules within
-                                  the GitRepository as cloned from the URL, using their default settings.
-                                type: boolean
-                              ref:
-                                description: |-
-                                  Reference specifies the Git reference to resolve and monitor for
-                                  changes, defaults to the 'master' branch.
-                                properties:
-                                  branch:
-                                    description: Branch to check out, defaults to
-                                      'master' if no other field is defined.
-                                    type: string
-                                  commit:
-                                    description: |-
-                                      Commit SHA to check out, takes precedence over all reference fields.
-
-                                      This can be combined with Branch to shallow clone the branch, in which
-                                      the commit is expected to exist.
-                                    type: string
-                                  name:
-                                    description: |-
-                                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
-
-                                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
-                                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
-                                    type: string
-                                  semver:
-                                    description: SemVer tag expression to check out,
-                                      takes precedence over Tag.
-                                    type: string
-                                  tag:
-                                    description: Tag to check out, takes precedence
-                                      over Branch.
-                                    type: string
-                                type: object
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Secret containing authentication credentials for
-                                  the GitRepository.
-                                  For HTTPS repositories the Secret must contain 'username' and 'password'
-                                  fields for basic auth or 'bearerToken' field for token auth.
-                                  For SSH repositories the Secret must contain 'identity'
-                                  and 'known_hosts' fields.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceAccountName:
-                                description: |-
-                                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to
-                                  authenticate to the GitRepository. This field is only supported for 'azure' provider.
-                                type: string
-                              sparseCheckout:
-                                description: |-
-                                  SparseCheckout specifies a list of directories to checkout when cloning
-                                  the repository. If specified, only these directories are included in the
-                                  Artifact produced for this GitRepository.
-                                items:
+                              type: string
+                            proxySecretRef:
+                              description: |-
+                                ProxySecretRef specifies the Secret containing the proxy configuration
+                                to use while communicating with the Git server.
+                              properties:
+                                name:
+                                  description: Name of the referent.
                                   type: string
-                                type: array
-                              suspend:
-                                description: |-
-                                  Suspend tells the controller to suspend the reconciliation of this
-                                  GitRepository.
-                                type: boolean
-                              timeout:
-                                default: 60s
-                                description: Timeout for Git operations like cloning,
-                                  defaults to 60s.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                                type: string
-                              url:
-                                description: URL specifies the Git repository URL,
-                                  it can be an HTTP/S or SSH address.
-                                pattern: ^(http|https|ssh)://.*$
-                                type: string
-                              verify:
-                                description: |-
-                                  Verification specifies the configuration to verify the Git commit
-                                  signature(s).
-                                properties:
-                                  mode:
-                                    default: HEAD
-                                    description: |-
-                                      Mode specifies which Git object(s) should be verified.
+                              required:
+                                - name
+                              type: object
+                            recurseSubmodules:
+                              description: |-
+                                RecurseSubmodules enables the initialization of all submodules within
+                                the GitRepository as cloned from the URL, using their default settings.
+                              type: boolean
+                            ref:
+                              description: |-
+                                Reference specifies the Git reference to resolve and monitor for
+                                changes, defaults to the 'master' branch.
+                              properties:
+                                branch:
+                                  description: Branch to check out, defaults to 'master' if no other field is defined.
+                                  type: string
+                                commit:
+                                  description: |-
+                                    Commit SHA to check out, takes precedence over all reference fields.
 
-                                      The variants "head" and "HEAD" both imply the same thing, i.e. verify
-                                      the commit that the HEAD of the Git repository points to. The variant
-                                      "head" solely exists to ensure backwards compatibility.
-                                    enum:
+                                    This can be combined with Branch to shallow clone the branch, in which
+                                    the commit is expected to exist.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+                                    It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                                    Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                                  type: string
+                                semver:
+                                  description: SemVer tag expression to check out, takes precedence over Tag.
+                                  type: string
+                                tag:
+                                  description: Tag to check out, takes precedence over Branch.
+                                  type: string
+                              type: object
+                            secretRef:
+                              description: |-
+                                SecretRef specifies the Secret containing authentication credentials for
+                                the GitRepository.
+                                For HTTPS repositories the Secret must contain 'username' and 'password'
+                                fields for basic auth or 'bearerToken' field for token auth.
+                                For SSH repositories the Secret must contain 'identity'
+                                and 'known_hosts' fields.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            serviceAccountName:
+                              description: |-
+                                ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+                                authenticate to the GitRepository. This field is only supported for 'azure' provider.
+                              type: string
+                            sparseCheckout:
+                              description: |-
+                                SparseCheckout specifies a list of directories to checkout when cloning
+                                the repository. If specified, only these directories are included in the
+                                Artifact produced for this GitRepository.
+                              items:
+                                type: string
+                              type: array
+                            suspend:
+                              description: |-
+                                Suspend tells the controller to suspend the reconciliation of this
+                                GitRepository.
+                              type: boolean
+                            timeout:
+                              default: 60s
+                              description: Timeout for Git operations like cloning, defaults to 60s.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                              type: string
+                            url:
+                              description: URL specifies the Git repository URL, it can be an HTTP/S or SSH address.
+                              pattern: ^(http|https|ssh)://.*$
+                              type: string
+                            verify:
+                              description: |-
+                                Verification specifies the configuration to verify the Git commit
+                                signature(s).
+                              properties:
+                                mode:
+                                  default: HEAD
+                                  description: |-
+                                    Mode specifies which Git object(s) should be verified.
+
+                                    The variants "head" and "HEAD" both imply the same thing, i.e. verify
+                                    the commit that the HEAD of the Git repository points to. The variant
+                                    "head" solely exists to ensure backwards compatibility.
+                                  enum:
                                     - head
                                     - HEAD
                                     - Tag
                                     - TagAndHEAD
-                                    type: string
-                                  secretRef:
-                                    description: |-
-                                      SecretRef specifies the Secret containing the public keys of trusted Git
-                                      authors.
-                                    properties:
-                                      name:
-                                        description: Name of the referent.
-                                        type: string
-                                    required:
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Secret containing the public keys of trusted Git
+                                    authors.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
                                     - name
-                                    type: object
-                                required:
+                                  type: object
+                              required:
                                 - secretRef
-                                type: object
-                            required:
+                              type: object
+                          required:
                             - interval
                             - url
-                            type: object
-                            x-kubernetes-validations:
-                            - message: serviceAccountName can only be set when provider
-                                is 'azure'
-                              rule: '!has(self.serviceAccountName) || (has(self.provider)
-                                && self.provider == ''azure'')'
-                          oci:
-                            description: OCI is the definition of OCI repository source.
-                            properties:
-                              certSecretRef:
-                                description: |-
-                                  CertSecretRef can be given the name of a Secret containing
-                                  either or both of
+                          type: object
+                          x-kubernetes-validations:
+                            - message: serviceAccountName can only be set when provider is 'azure'
+                              rule: '!has(self.serviceAccountName) || (has(self.provider) && self.provider == ''azure'')'
+                        oci:
+                          description: OCI is the definition of OCI repository source.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                CertSecretRef can be given the name of a Secret containing
+                                either or both of
 
-                                  - a PEM-encoded client certificate (`tls.crt`) and private
-                                  key (`tls.key`);
-                                  - a PEM-encoded CA certificate (`ca.crt`)
+                                - a PEM-encoded client certificate (`tls.crt`) and private
+                                key (`tls.key`);
+                                - a PEM-encoded CA certificate (`ca.crt`)
 
-                                  and whichever are supplied, will be used for connecting to the
-                                  registry. The client cert and key are useful if you are
-                                  authenticating with a certificate; the CA cert is useful if
-                                  you are using a self-signed server certificate. The Secret must
-                                  be of type `Opaque` or `kubernetes.io/tls`.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
+                                and whichever are supplied, will be used for connecting to the
+                                registry. The client cert and key are useful if you are
+                                authenticating with a certificate; the CA cert is useful if
+                                you are using a self-signed server certificate. The Secret must
+                                be of type `Opaque` or `kubernetes.io/tls`.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
                                 - name
-                                type: object
-                              ignore:
-                                description: |-
-                                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                                  (which is the same as .gitignore). If not provided, a default will be used,
-                                  consult the documentation for your version to find out what those are.
-                                type: string
-                              insecure:
-                                description: Insecure allows connecting to a non-TLS
-                                  HTTP container registry.
-                                type: boolean
-                              interval:
-                                description: |-
-                                  Interval at which the OCIRepository URL is checked for updates.
-                                  This interval is approximate and may be subject to jitter to ensure
-                                  efficient use of resources.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                                type: string
-                              layerSelector:
-                                description: |-
-                                  LayerSelector specifies which layer should be extracted from the OCI artifact.
-                                  When not specified, the first layer found in the artifact is selected.
-                                properties:
-                                  mediaType:
-                                    description: |-
-                                      MediaType specifies the OCI media type of the layer
-                                      which should be extracted from the OCI Artifact. The
-                                      first layer matching this type is selected.
-                                    type: string
-                                  operation:
-                                    description: |-
-                                      Operation specifies how the selected layer should be processed.
-                                      By default, the layer compressed content is extracted to storage.
-                                      When the operation is set to 'copy', the layer compressed content
-                                      is persisted to storage as it is.
-                                    enum:
+                              type: object
+                            ignore:
+                              description: |-
+                                Ignore overrides the set of excluded patterns in the .sourceignore format
+                                (which is the same as .gitignore). If not provided, a default will be used,
+                                consult the documentation for your version to find out what those are.
+                              type: string
+                            insecure:
+                              description: Insecure allows connecting to a non-TLS HTTP container registry.
+                              type: boolean
+                            interval:
+                              description: |-
+                                Interval at which the OCIRepository URL is checked for updates.
+                                This interval is approximate and may be subject to jitter to ensure
+                                efficient use of resources.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                              type: string
+                            layerSelector:
+                              description: |-
+                                LayerSelector specifies which layer should be extracted from the OCI artifact.
+                                When not specified, the first layer found in the artifact is selected.
+                              properties:
+                                mediaType:
+                                  description: |-
+                                    MediaType specifies the OCI media type of the layer
+                                    which should be extracted from the OCI Artifact. The
+                                    first layer matching this type is selected.
+                                  type: string
+                                operation:
+                                  description: |-
+                                    Operation specifies how the selected layer should be processed.
+                                    By default, the layer compressed content is extracted to storage.
+                                    When the operation is set to 'copy', the layer compressed content
+                                    is persisted to storage as it is.
+                                  enum:
                                     - extract
                                     - copy
-                                    type: string
-                                type: object
-                              provider:
-                                default: generic
-                                description: |-
-                                  The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
-                                  When not specified, defaults to 'generic'.
-                                enum:
+                                  type: string
+                              type: object
+                            provider:
+                              default: generic
+                              description: |-
+                                The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                                When not specified, defaults to 'generic'.
+                              enum:
                                 - generic
                                 - aws
                                 - azure
                                 - gcp
-                                type: string
-                              proxySecretRef:
-                                description: |-
-                                  ProxySecretRef specifies the Secret containing the proxy configuration
-                                  to use while communicating with the container registry.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
+                              type: string
+                            proxySecretRef:
+                              description: |-
+                                ProxySecretRef specifies the Secret containing the proxy configuration
+                                to use while communicating with the container registry.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
                                 - name
-                                type: object
-                              ref:
-                                description: |-
-                                  The OCI reference to pull and monitor for changes,
-                                  defaults to the latest tag.
-                                properties:
-                                  digest:
-                                    description: |-
-                                      Digest is the image digest to pull, takes precedence over SemVer.
-                                      The value should be in the format 'sha256:<HASH>'.
-                                    type: string
-                                  semver:
-                                    description: |-
-                                      SemVer is the range of tags to pull selecting the latest within
-                                      the range, takes precedence over Tag.
-                                    type: string
-                                  semverFilter:
-                                    description: SemverFilter is a regex pattern to
-                                      filter the tags within the SemVer range.
-                                    type: string
-                                  tag:
-                                    description: Tag is the image tag to pull, defaults
-                                      to latest.
-                                    type: string
-                                type: object
-                              secretRef:
-                                description: |-
-                                  SecretRef contains the secret name containing the registry login
-                                  credentials to resolve image metadata.
-                                  The secret must be of type kubernetes.io/dockerconfigjson.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
+                              type: object
+                            ref:
+                              description: |-
+                                The OCI reference to pull and monitor for changes,
+                                defaults to the latest tag.
+                              properties:
+                                digest:
+                                  description: |-
+                                    Digest is the image digest to pull, takes precedence over SemVer.
+                                    The value should be in the format 'sha256:<HASH>'.
+                                  type: string
+                                semver:
+                                  description: |-
+                                    SemVer is the range of tags to pull selecting the latest within
+                                    the range, takes precedence over Tag.
+                                  type: string
+                                semverFilter:
+                                  description: SemverFilter is a regex pattern to filter the tags within the SemVer range.
+                                  type: string
+                                tag:
+                                  description: Tag is the image tag to pull, defaults to latest.
+                                  type: string
+                              type: object
+                            secretRef:
+                              description: |-
+                                SecretRef contains the secret name containing the registry login
+                                credentials to resolve image metadata.
+                                The secret must be of type kubernetes.io/dockerconfigjson.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
                                 - name
-                                type: object
-                              serviceAccountName:
-                                description: |-
-                                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                                  the image pull if the service account has attached pull secrets. For more information:
-                                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
-                                type: string
-                              suspend:
-                                description: This flag tells the controller to suspend
-                                  the reconciliation of this source.
-                                type: boolean
-                              timeout:
-                                default: 60s
-                                description: The timeout for remote OCI Repository
-                                  operations like pulling, defaults to 60s.
-                                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                                type: string
-                              url:
-                                description: |-
-                                  URL is a reference to an OCI artifact repository hosted
-                                  on a remote container registry.
-                                pattern: ^oci://.*$
-                                type: string
-                              verify:
-                                description: |-
-                                  Verify contains the secret name containing the trusted public keys
-                                  used to verify the signature and specifies which provider to use to check
-                                  whether OCI image is authentic.
-                                properties:
-                                  matchOIDCIdentity:
+                              type: object
+                            serviceAccountName:
+                              description: |-
+                                ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                                the image pull if the service account has attached pull secrets. For more information:
+                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+                              type: string
+                            suspend:
+                              description: This flag tells the controller to suspend the reconciliation of this source.
+                              type: boolean
+                            timeout:
+                              default: 60s
+                              description: The timeout for remote OCI Repository operations like pulling, defaults to 60s.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                              type: string
+                            url:
+                              description: |-
+                                URL is a reference to an OCI artifact repository hosted
+                                on a remote container registry.
+                              pattern: ^oci://.*$
+                              type: string
+                            verify:
+                              description: |-
+                                Verify contains the secret name containing the trusted public keys
+                                used to verify the signature and specifies which provider to use to check
+                                whether OCI image is authentic.
+                              properties:
+                                matchOIDCIdentity:
+                                  description: |-
+                                    MatchOIDCIdentity specifies the identity matching criteria to use
+                                    while verifying an OCI artifact which was signed using Cosign keyless
+                                    signing. The artifact's identity is deemed to be verified if any of the
+                                    specified matchers match against the identity.
+                                  items:
                                     description: |-
-                                      MatchOIDCIdentity specifies the identity matching criteria to use
-                                      while verifying an OCI artifact which was signed using Cosign keyless
-                                      signing. The artifact's identity is deemed to be verified if any of the
-                                      specified matchers match against the identity.
-                                    items:
-                                      description: |-
-                                        OIDCIdentityMatch specifies options for verifying the certificate identity,
-                                        i.e. the issuer and the subject of the certificate.
-                                      properties:
-                                        issuer:
-                                          description: |-
-                                            Issuer specifies the regex pattern to match against to verify
-                                            the OIDC issuer in the Fulcio certificate. The pattern must be a
-                                            valid Go regular expression.
-                                          type: string
-                                        subject:
-                                          description: |-
-                                            Subject specifies the regex pattern to match against to verify
-                                            the identity subject in the Fulcio certificate. The pattern must
-                                            be a valid Go regular expression.
-                                          type: string
-                                      required:
+                                      OIDCIdentityMatch specifies options for verifying the certificate identity,
+                                      i.e. the issuer and the subject of the certificate.
+                                    properties:
+                                      issuer:
+                                        description: |-
+                                          Issuer specifies the regex pattern to match against to verify
+                                          the OIDC issuer in the Fulcio certificate. The pattern must be a
+                                          valid Go regular expression.
+                                        type: string
+                                      subject:
+                                        description: |-
+                                          Subject specifies the regex pattern to match against to verify
+                                          the identity subject in the Fulcio certificate. The pattern must
+                                          be a valid Go regular expression.
+                                        type: string
+                                    required:
                                       - issuer
                                       - subject
-                                      type: object
-                                    type: array
-                                  provider:
-                                    default: cosign
-                                    description: Provider specifies the technology
-                                      used to sign the OCI Artifact.
-                                    enum:
+                                    type: object
+                                  type: array
+                                provider:
+                                  default: cosign
+                                  description: Provider specifies the technology used to sign the OCI Artifact.
+                                  enum:
                                     - cosign
                                     - notation
-                                    type: string
-                                  secretRef:
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Kubernetes Secret containing the
+                                    trusted public keys.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - provider
+                              type: object
+                          required:
+                            - interval
+                            - url
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
+                        - message: Git, Bucket and OCI are mutually exclusive.
+                          rule: 'has(self.git) ? (!has(self.bucket) && !has(self.oci)) : true'
+                        - message: Git, Bucket and OCI are mutually exclusive.
+                          rule: 'has(self.bucket) ? (!has(self.git) && !has(self.oci)) : true'
+                        - message: Git, Bucket and OCI are mutually exclusive.
+                          rule: 'has(self.oci) ? (!has(self.git) && !has(self.bucket)) : true'
+                        - message: One of Git, Bucket or OCI must be specified.
+                          rule: has(self.git) || has(self.bucket) || has(self.oci)
+                  required:
+                    - deploymentType
+                    - path
+                  type: object
+                  x-kubernetes-validations:
+                    - message: LocalSource and RemoteSource are mutually exclusive.
+                      rule: 'has(self.localSourceRef) ? !has(self.remoteSourceSpec): true'
+                    - message: LocalSource and RemoteSource are mutually exclusive.
+                      rule: 'has(self.remoteSourceSpec) ? !has(self.localSourceRef): true'
+                    - message: One of LocalSource or RemoteSource must be specified.
+                      rule: has(self.localSourceRef) || has(self.remoteSourceSpec)
+                resources:
+                  description: Resources contains the resource configuration for the template.
+                  properties:
+                    deploymentType:
+                      default: Remote
+                      description: |-
+                        DeploymentType is the type of the deployment. This field is ignored,
+                        when ResourceSpec is used as part of Helm chart configuration.
+                      enum:
+                        - Local
+                        - Remote
+                      type: string
+                    localSourceRef:
+                      description: LocalSourceRef is the local source of the kustomize manifest.
+                      properties:
+                        kind:
+                          description: Kind is the kind of the local source.
+                          enum:
+                            - ConfigMap
+                            - Secret
+                            - GitRepository
+                            - Bucket
+                            - OCIRepository
+                          type: string
+                        name:
+                          description: Name is the name of the local source.
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the local source. Cross-namespace references
+                            are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
+                            [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
+                            If the Kind is ConfigMap or Secret, the namespace will be ignored.
+                          type: string
+                      required:
+                        - kind
+                        - name
+                      type: object
+                    path:
+                      description: Path to the directory containing the resource manifest.
+                      type: string
+                    remoteSourceSpec:
+                      description: RemoteSourceSpec is the remote source of the kustomize manifest.
+                      properties:
+                        bucket:
+                          description: Bucket is the definition of bucket source.
+                          properties:
+                            bucketName:
+                              description: BucketName is the name of the object storage bucket.
+                              type: string
+                            certSecretRef:
+                              description: |-
+                                CertSecretRef can be given the name of a Secret containing
+                                either or both of
+
+                                - a PEM-encoded client certificate (`tls.crt`) and private
+                                key (`tls.key`);
+                                - a PEM-encoded CA certificate (`ca.crt`)
+
+                                and whichever are supplied, will be used for connecting to the
+                                bucket. The client cert and key are useful if you are
+                                authenticating with a certificate; the CA cert is useful if
+                                you are using a self-signed server certificate. The Secret must
+                                be of type `Opaque` or `kubernetes.io/tls`.
+
+                                This field is only supported for the `generic` provider.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            endpoint:
+                              description: Endpoint is the object storage address the BucketName is located at.
+                              type: string
+                            ignore:
+                              description: |-
+                                Ignore overrides the set of excluded patterns in the .sourceignore format
+                                (which is the same as .gitignore). If not provided, a default will be used,
+                                consult the documentation for your version to find out what those are.
+                              type: string
+                            insecure:
+                              description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+                              type: boolean
+                            interval:
+                              description: |-
+                                Interval at which the Bucket Endpoint is checked for updates.
+                                This interval is approximate and may be subject to jitter to ensure
+                                efficient use of resources.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                              type: string
+                            prefix:
+                              description: Prefix to use for server-side filtering of files in the Bucket.
+                              type: string
+                            provider:
+                              default: generic
+                              description: |-
+                                Provider of the object storage bucket.
+                                Defaults to 'generic', which expects an S3 (API) compatible object
+                                storage.
+                              enum:
+                                - generic
+                                - aws
+                                - gcp
+                                - azure
+                              type: string
+                            proxySecretRef:
+                              description: |-
+                                ProxySecretRef specifies the Secret containing the proxy configuration
+                                to use while communicating with the Bucket server.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            region:
+                              description: Region of the Endpoint where the BucketName is located in.
+                              type: string
+                            secretRef:
+                              description: |-
+                                SecretRef specifies the Secret containing authentication credentials
+                                for the Bucket.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            serviceAccountName:
+                              description: |-
+                                ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                                the bucket. This field is only supported for the 'gcp' and 'aws' providers.
+                                For more information about workload identity:
+                                https://fluxcd.io/flux/components/source/buckets/#workload-identity
+                              type: string
+                            sts:
+                              description: |-
+                                STS specifies the required configuration to use a Security Token
+                                Service for fetching temporary credentials to authenticate in a
+                                Bucket provider.
+
+                                This field is only supported for the `aws` and `generic` providers.
+                              properties:
+                                certSecretRef:
+                                  description: |-
+                                    CertSecretRef can be given the name of a Secret containing
+                                    either or both of
+
+                                    - a PEM-encoded client certificate (`tls.crt`) and private
+                                    key (`tls.key`);
+                                    - a PEM-encoded CA certificate (`ca.crt`)
+
+                                    and whichever are supplied, will be used for connecting to the
+                                    STS endpoint. The client cert and key are useful if you are
+                                    authenticating with a certificate; the CA cert is useful if
+                                    you are using a self-signed server certificate. The Secret must
+                                    be of type `Opaque` or `kubernetes.io/tls`.
+
+                                    This field is only supported for the `ldap` provider.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                endpoint:
+                                  description: |-
+                                    Endpoint is the HTTP/S endpoint of the Security Token Service from
+                                    where temporary credentials will be fetched.
+                                  pattern: ^(http|https)://.*$
+                                  type: string
+                                provider:
+                                  description: Provider of the Security Token Service.
+                                  enum:
+                                    - aws
+                                    - ldap
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Secret containing authentication credentials
+                                    for the STS endpoint. This Secret must contain the fields `username`
+                                    and `password` and is supported only for the `ldap` provider.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - endpoint
+                                - provider
+                              type: object
+                            suspend:
+                              description: |-
+                                Suspend tells the controller to suspend the reconciliation of this
+                                Bucket.
+                              type: boolean
+                            timeout:
+                              default: 60s
+                              description: Timeout for fetch operations, defaults to 60s.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                              type: string
+                          required:
+                            - bucketName
+                            - endpoint
+                            - interval
+                          type: object
+                          x-kubernetes-validations:
+                            - message: STS configuration is only supported for the 'aws' and 'generic' Bucket providers
+                              rule: self.provider == 'aws' || self.provider == 'generic' || !has(self.sts)
+                            - message: '''aws'' is the only supported STS provider for the ''aws'' Bucket provider'
+                              rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider == 'aws'
+                            - message: '''ldap'' is the only supported STS provider for the ''generic'' Bucket provider'
+                              rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider == 'ldap'
+                            - message: spec.sts.secretRef is not required for the 'aws' STS provider
+                              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
+                            - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
+                              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
+                            - message: ServiceAccountName is not supported for the 'generic' Bucket provider
+                              rule: self.provider != 'generic' || !has(self.serviceAccountName)
+                            - message: cannot set both .spec.secretRef and .spec.serviceAccountName
+                              rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
+                        git:
+                          description: Git is the definition of git repository source.
+                          properties:
+                            ignore:
+                              description: |-
+                                Ignore overrides the set of excluded patterns in the .sourceignore format
+                                (which is the same as .gitignore). If not provided, a default will be used,
+                                consult the documentation for your version to find out what those are.
+                              type: string
+                            include:
+                              description: |-
+                                Include specifies a list of GitRepository resources which Artifacts
+                                should be included in the Artifact produced for this GitRepository.
+                              items:
+                                description: |-
+                                  GitRepositoryInclude specifies a local reference to a GitRepository which
+                                  Artifact (sub-)contents must be included, and where they should be placed.
+                                properties:
+                                  fromPath:
                                     description: |-
-                                      SecretRef specifies the Kubernetes Secret containing the
-                                      trusted public keys.
+                                      FromPath specifies the path to copy contents from, defaults to the root
+                                      of the Artifact.
+                                    type: string
+                                  repository:
+                                    description: |-
+                                      GitRepositoryRef specifies the GitRepository which Artifact contents
+                                      must be included.
                                     properties:
                                       name:
                                         description: Name of the referent.
                                         type: string
                                     required:
-                                    - name
+                                      - name
                                     type: object
+                                  toPath:
+                                    description: |-
+                                      ToPath specifies the path to copy contents to, defaults to the name of
+                                      the GitRepositoryRef.
+                                    type: string
                                 required:
-                                - provider
+                                  - repository
                                 type: object
-                            required:
+                              type: array
+                            interval:
+                              description: |-
+                                Interval at which the GitRepository URL is checked for updates.
+                                This interval is approximate and may be subject to jitter to ensure
+                                efficient use of resources.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                              type: string
+                            provider:
+                              description: |-
+                                Provider used for authentication, can be 'azure', 'github', 'generic'.
+                                When not specified, defaults to 'generic'.
+                              enum:
+                                - generic
+                                - azure
+                                - github
+                              type: string
+                            proxySecretRef:
+                              description: |-
+                                ProxySecretRef specifies the Secret containing the proxy configuration
+                                to use while communicating with the Git server.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            recurseSubmodules:
+                              description: |-
+                                RecurseSubmodules enables the initialization of all submodules within
+                                the GitRepository as cloned from the URL, using their default settings.
+                              type: boolean
+                            ref:
+                              description: |-
+                                Reference specifies the Git reference to resolve and monitor for
+                                changes, defaults to the 'master' branch.
+                              properties:
+                                branch:
+                                  description: Branch to check out, defaults to 'master' if no other field is defined.
+                                  type: string
+                                commit:
+                                  description: |-
+                                    Commit SHA to check out, takes precedence over all reference fields.
+
+                                    This can be combined with Branch to shallow clone the branch, in which
+                                    the commit is expected to exist.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+                                    It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                                    Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                                  type: string
+                                semver:
+                                  description: SemVer tag expression to check out, takes precedence over Tag.
+                                  type: string
+                                tag:
+                                  description: Tag to check out, takes precedence over Branch.
+                                  type: string
+                              type: object
+                            secretRef:
+                              description: |-
+                                SecretRef specifies the Secret containing authentication credentials for
+                                the GitRepository.
+                                For HTTPS repositories the Secret must contain 'username' and 'password'
+                                fields for basic auth or 'bearerToken' field for token auth.
+                                For SSH repositories the Secret must contain 'identity'
+                                and 'known_hosts' fields.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            serviceAccountName:
+                              description: |-
+                                ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+                                authenticate to the GitRepository. This field is only supported for 'azure' provider.
+                              type: string
+                            sparseCheckout:
+                              description: |-
+                                SparseCheckout specifies a list of directories to checkout when cloning
+                                the repository. If specified, only these directories are included in the
+                                Artifact produced for this GitRepository.
+                              items:
+                                type: string
+                              type: array
+                            suspend:
+                              description: |-
+                                Suspend tells the controller to suspend the reconciliation of this
+                                GitRepository.
+                              type: boolean
+                            timeout:
+                              default: 60s
+                              description: Timeout for Git operations like cloning, defaults to 60s.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                              type: string
+                            url:
+                              description: URL specifies the Git repository URL, it can be an HTTP/S or SSH address.
+                              pattern: ^(http|https|ssh)://.*$
+                              type: string
+                            verify:
+                              description: |-
+                                Verification specifies the configuration to verify the Git commit
+                                signature(s).
+                              properties:
+                                mode:
+                                  default: HEAD
+                                  description: |-
+                                    Mode specifies which Git object(s) should be verified.
+
+                                    The variants "head" and "HEAD" both imply the same thing, i.e. verify
+                                    the commit that the HEAD of the Git repository points to. The variant
+                                    "head" solely exists to ensure backwards compatibility.
+                                  enum:
+                                    - head
+                                    - HEAD
+                                    - Tag
+                                    - TagAndHEAD
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Secret containing the public keys of trusted Git
+                                    authors.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                          required:
                             - interval
                             - url
-                            type: object
-                        type: object
-                        x-kubernetes-validations:
+                          type: object
+                          x-kubernetes-validations:
+                            - message: serviceAccountName can only be set when provider is 'azure'
+                              rule: '!has(self.serviceAccountName) || (has(self.provider) && self.provider == ''azure'')'
+                        oci:
+                          description: OCI is the definition of OCI repository source.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                CertSecretRef can be given the name of a Secret containing
+                                either or both of
+
+                                - a PEM-encoded client certificate (`tls.crt`) and private
+                                key (`tls.key`);
+                                - a PEM-encoded CA certificate (`ca.crt`)
+
+                                and whichever are supplied, will be used for connecting to the
+                                registry. The client cert and key are useful if you are
+                                authenticating with a certificate; the CA cert is useful if
+                                you are using a self-signed server certificate. The Secret must
+                                be of type `Opaque` or `kubernetes.io/tls`.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            ignore:
+                              description: |-
+                                Ignore overrides the set of excluded patterns in the .sourceignore format
+                                (which is the same as .gitignore). If not provided, a default will be used,
+                                consult the documentation for your version to find out what those are.
+                              type: string
+                            insecure:
+                              description: Insecure allows connecting to a non-TLS HTTP container registry.
+                              type: boolean
+                            interval:
+                              description: |-
+                                Interval at which the OCIRepository URL is checked for updates.
+                                This interval is approximate and may be subject to jitter to ensure
+                                efficient use of resources.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                              type: string
+                            layerSelector:
+                              description: |-
+                                LayerSelector specifies which layer should be extracted from the OCI artifact.
+                                When not specified, the first layer found in the artifact is selected.
+                              properties:
+                                mediaType:
+                                  description: |-
+                                    MediaType specifies the OCI media type of the layer
+                                    which should be extracted from the OCI Artifact. The
+                                    first layer matching this type is selected.
+                                  type: string
+                                operation:
+                                  description: |-
+                                    Operation specifies how the selected layer should be processed.
+                                    By default, the layer compressed content is extracted to storage.
+                                    When the operation is set to 'copy', the layer compressed content
+                                    is persisted to storage as it is.
+                                  enum:
+                                    - extract
+                                    - copy
+                                  type: string
+                              type: object
+                            provider:
+                              default: generic
+                              description: |-
+                                The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                                When not specified, defaults to 'generic'.
+                              enum:
+                                - generic
+                                - aws
+                                - azure
+                                - gcp
+                              type: string
+                            proxySecretRef:
+                              description: |-
+                                ProxySecretRef specifies the Secret containing the proxy configuration
+                                to use while communicating with the container registry.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            ref:
+                              description: |-
+                                The OCI reference to pull and monitor for changes,
+                                defaults to the latest tag.
+                              properties:
+                                digest:
+                                  description: |-
+                                    Digest is the image digest to pull, takes precedence over SemVer.
+                                    The value should be in the format 'sha256:<HASH>'.
+                                  type: string
+                                semver:
+                                  description: |-
+                                    SemVer is the range of tags to pull selecting the latest within
+                                    the range, takes precedence over Tag.
+                                  type: string
+                                semverFilter:
+                                  description: SemverFilter is a regex pattern to filter the tags within the SemVer range.
+                                  type: string
+                                tag:
+                                  description: Tag is the image tag to pull, defaults to latest.
+                                  type: string
+                              type: object
+                            secretRef:
+                              description: |-
+                                SecretRef contains the secret name containing the registry login
+                                credentials to resolve image metadata.
+                                The secret must be of type kubernetes.io/dockerconfigjson.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            serviceAccountName:
+                              description: |-
+                                ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                                the image pull if the service account has attached pull secrets. For more information:
+                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+                              type: string
+                            suspend:
+                              description: This flag tells the controller to suspend the reconciliation of this source.
+                              type: boolean
+                            timeout:
+                              default: 60s
+                              description: The timeout for remote OCI Repository operations like pulling, defaults to 60s.
+                              pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                              type: string
+                            url:
+                              description: |-
+                                URL is a reference to an OCI artifact repository hosted
+                                on a remote container registry.
+                              pattern: ^oci://.*$
+                              type: string
+                            verify:
+                              description: |-
+                                Verify contains the secret name containing the trusted public keys
+                                used to verify the signature and specifies which provider to use to check
+                                whether OCI image is authentic.
+                              properties:
+                                matchOIDCIdentity:
+                                  description: |-
+                                    MatchOIDCIdentity specifies the identity matching criteria to use
+                                    while verifying an OCI artifact which was signed using Cosign keyless
+                                    signing. The artifact's identity is deemed to be verified if any of the
+                                    specified matchers match against the identity.
+                                  items:
+                                    description: |-
+                                      OIDCIdentityMatch specifies options for verifying the certificate identity,
+                                      i.e. the issuer and the subject of the certificate.
+                                    properties:
+                                      issuer:
+                                        description: |-
+                                          Issuer specifies the regex pattern to match against to verify
+                                          the OIDC issuer in the Fulcio certificate. The pattern must be a
+                                          valid Go regular expression.
+                                        type: string
+                                      subject:
+                                        description: |-
+                                          Subject specifies the regex pattern to match against to verify
+                                          the identity subject in the Fulcio certificate. The pattern must
+                                          be a valid Go regular expression.
+                                        type: string
+                                    required:
+                                      - issuer
+                                      - subject
+                                    type: object
+                                  type: array
+                                provider:
+                                  default: cosign
+                                  description: Provider specifies the technology used to sign the OCI Artifact.
+                                  enum:
+                                    - cosign
+                                    - notation
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef specifies the Kubernetes Secret containing the
+                                    trusted public keys.
+                                  properties:
+                                    name:
+                                      description: Name of the referent.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - provider
+                              type: object
+                          required:
+                            - interval
+                            - url
+                          type: object
+                      type: object
+                      x-kubernetes-validations:
                         - message: Git, Bucket and OCI are mutually exclusive.
-                          rule: 'has(self.git) ? (!has(self.bucket) && !has(self.oci))
-                            : true'
+                          rule: 'has(self.git) ? (!has(self.bucket) && !has(self.oci)) : true'
                         - message: Git, Bucket and OCI are mutually exclusive.
-                          rule: 'has(self.bucket) ? (!has(self.git) && !has(self.oci))
-                            : true'
+                          rule: 'has(self.bucket) ? (!has(self.git) && !has(self.oci)) : true'
                         - message: Git, Bucket and OCI are mutually exclusive.
-                          rule: 'has(self.oci) ? (!has(self.git) && !has(self.bucket))
-                            : true'
+                          rule: 'has(self.oci) ? (!has(self.git) && !has(self.bucket)) : true'
                         - message: One of Git, Bucket or OCI must be specified.
                           rule: has(self.git) || has(self.bucket) || has(self.oci)
-                    required:
+                  required:
                     - deploymentType
                     - path
-                    type: object
-                    x-kubernetes-validations:
-                    - message: Secret and ConfigMap are not supported as Helm chart
-                        sources
-                      rule: 'has(self.localSourceRef) ? (self.localSourceRef.kind
-                        != ''Secret'' && self.localSourceRef.kind != ''ConfigMap''):
-                        true'
+                  type: object
+                  x-kubernetes-validations:
                     - message: LocalSource and RemoteSource are mutually exclusive.
-                      rule: 'has(self.localSourceRef) ? !has(self.remoteSourceSpec):
-                        true'
+                      rule: 'has(self.localSourceRef) ? !has(self.remoteSourceSpec): true'
                     - message: LocalSource and RemoteSource are mutually exclusive.
-                      rule: 'has(self.remoteSourceSpec) ? !has(self.localSourceRef):
-                        true'
+                      rule: 'has(self.remoteSourceSpec) ? !has(self.localSourceRef): true'
                     - message: One of LocalSource or RemoteSource must be specified.
                       rule: has(self.localSourceRef) || has(self.remoteSourceSpec)
-                  chartSpec:
-                    description: ChartSpec defines the desired state of the HelmChart
-                      to be created by the controller
-                    properties:
-                      chart:
-                        description: |-
-                          Chart is the name or path the Helm chart is available at in the
-                          SourceRef.
-                        type: string
-                      ignoreMissingValuesFiles:
-                        description: |-
-                          IgnoreMissingValuesFiles controls whether to silently ignore missing values
-                          files rather than failing.
-                        type: boolean
-                      interval:
-                        description: |-
-                          Interval at which the HelmChart SourceRef is checked for updates.
-                          This interval is approximate and may be subject to jitter to ensure
-                          efficient use of resources.
-                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                        type: string
-                      reconcileStrategy:
-                        default: ChartVersion
-                        description: |-
-                          ReconcileStrategy determines what enables the creation of a new artifact.
-                          Valid values are ('ChartVersion', 'Revision').
-                          See the documentation of the values for an explanation on their behavior.
-                          Defaults to ChartVersion when omitted.
-                        enum:
-                        - ChartVersion
-                        - Revision
-                        type: string
-                      sourceRef:
-                        description: SourceRef is the reference to the Source the
-                          chart is available at.
-                        properties:
-                          apiVersion:
-                            description: APIVersion of the referent.
-                            type: string
-                          kind:
-                            description: |-
-                              Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
-                              'Bucket').
-                            enum:
-                            - HelmRepository
-                            - GitRepository
-                            - Bucket
-                            type: string
-                          name:
-                            description: Name of the referent.
-                            type: string
-                        required:
-                        - kind
-                        - name
-                        type: object
-                      suspend:
-                        description: |-
-                          Suspend tells the controller to suspend the reconciliation of this
-                          source.
-                        type: boolean
-                      valuesFiles:
-                        description: |-
-                          ValuesFiles is an alternative list of values files to use as the chart
-                          values (values.yaml is not included by default), expected to be a
-                          relative path in the SourceRef.
-                          Values files are merged in the order of this list with the last file
-                          overriding the first. Ignored when omitted.
-                        items:
-                          type: string
-                        type: array
-                      verify:
-                        description: |-
-                          Verify contains the secret name containing the trusted public keys
-                          used to verify the signature and specifies which provider to use to check
-                          whether OCI image is authentic.
-                          This field is only supported when using HelmRepository source with spec.type 'oci'.
-                          Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
-                        properties:
-                          matchOIDCIdentity:
-                            description: |-
-                              MatchOIDCIdentity specifies the identity matching criteria to use
-                              while verifying an OCI artifact which was signed using Cosign keyless
-                              signing. The artifact's identity is deemed to be verified if any of the
-                              specified matchers match against the identity.
-                            items:
-                              description: |-
-                                OIDCIdentityMatch specifies options for verifying the certificate identity,
-                                i.e. the issuer and the subject of the certificate.
-                              properties:
-                                issuer:
-                                  description: |-
-                                    Issuer specifies the regex pattern to match against to verify
-                                    the OIDC issuer in the Fulcio certificate. The pattern must be a
-                                    valid Go regular expression.
-                                  type: string
-                                subject:
-                                  description: |-
-                                    Subject specifies the regex pattern to match against to verify
-                                    the identity subject in the Fulcio certificate. The pattern must
-                                    be a valid Go regular expression.
-                                  type: string
-                              required:
-                              - issuer
-                              - subject
-                              type: object
-                            type: array
-                          provider:
-                            default: cosign
-                            description: Provider specifies the technology used to
-                              sign the OCI Artifact.
-                            enum:
-                            - cosign
-                            - notation
-                            type: string
-                          secretRef:
-                            description: |-
-                              SecretRef specifies the Kubernetes Secret containing the
-                              trusted public keys.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                        required:
-                        - provider
-                        type: object
-                      version:
-                        default: '*'
-                        description: |-
-                          Version is the chart version semver expression, ignored for charts from
-                          GitRepository and Bucket sources. Defaults to latest when omitted.
-                        type: string
-                    required:
-                    - chart
-                    - interval
-                    - sourceRef
-                    type: object
-                type: object
-                x-kubernetes-validations:
-                - message: chartSpec, chartSource and chartRef are mutually exclusive
-                  rule: '(has(self.chartSpec) ? (!has(self.chartSource) && !has(self.chartRef)):
-                    true)'
-                - message: chartSpec, chartSource and chartRef are mutually exclusive
-                  rule: '(has(self.chartSource) ? (!has(self.chartSpec) && !has(self.chartRef)):
-                    true)'
-                - message: chartSpec, chartSource and chartRef are mutually exclusive
-                  rule: '(has(self.chartRef) ? (!has(self.chartSpec) && !has(self.chartSource)):
-                    true)'
-                - message: one of chartSpec, chartRef or chartSource must be set
-                  rule: has(self.chartSpec) || has(self.chartRef) || has(self.chartSource)
-              helmOptions:
-                description: HelmOptions are the global options to use when installing
-                  or updating the helm chart.
-                properties:
-                  atomic:
-                    description: |-
-                      if set, the installation process deletes the installation/upgrades on failure.
-                      The --wait flag will be set automatically if --atomic is used
-                    type: boolean
-                  createNamespace:
-                    type: boolean
-                  dependencyUpdate:
-                    description: update dependencies if they are missing before installing
-                      the chart
-                    type: boolean
-                  description:
-                    description: Description is the description of an helm operation
-                    type: string
-                  disableHooks:
-                    description: prevent hooks from running during install/upgrade/uninstall
-                    type: boolean
-                  disableOpenAPIValidation:
-                    description: if set, the installation process will not validate
-                      rendered templates against the Kubernetes OpenAPI Schema
-                    type: boolean
-                  enableClientCache:
-                    description: EnableClientCache is a flag to enable Helm client
-                      cache. If it is not specified, it will be set to false.
-                    type: boolean
-                  labels:
-                    additionalProperties:
+                version:
+                  description: Version is the semantic version of the application backed by template.
+                  type: string
+              type: object
+              x-kubernetes-validations:
+                - message: Spec is immutable
+                  rule: self == oldSelf
+                - message: Helm, Kustomize and Resources are mutually exclusive.
+                  rule: 'has(self.helm) ? (!has(self.kustomize) && !has(self.resources)): true'
+                - message: Helm, Kustomize and Resources are mutually exclusive.
+                  rule: 'has(self.kustomize) ? (!has(self.helm) && !has(self.resources)): true'
+                - message: Helm, Kustomize and Resources are mutually exclusive.
+                  rule: 'has(self.resources) ? (!has(self.kustomize) && !has(self.helm)): true'
+                - message: One of Helm, Kustomize, or Resources must be specified.
+                  rule: has(self.helm) || has(self.kustomize) || has(self.resources)
+            status:
+              description: ServiceTemplateStatus defines the observed state of ServiceTemplate
+              properties:
+                chartRef:
+                  description: |-
+                    ChartRef is a reference to a source controller resource containing the
+                    Helm chart representing the template.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the referent.
                       type: string
-                    description: Labels that would be added to release metadata.
-                    type: object
-                  replace:
-                    description: Replaces if set indicates to replace an older release
-                      with this one
-                    type: boolean
-                  skipCRDs:
-                    description: |-
-                      SkipCRDs controls whether CRDs should be installed during install/upgrade operation.
-                      By default, CRDs are installed if not already present.
-                    type: boolean
-                  skipSchemaValidation:
-                    description: SkipSchemaValidation determines if JSON schema validation
-                      is disabled.
-                    type: boolean
-                  timeout:
-                    description: time to wait for any individual Kubernetes operation
-                      (like Jobs for hooks) (default 5m0s)
-                    type: string
-                  wait:
-                    description: |-
-                      if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet
-                      are in a ready state before marking the release as successful. It will wait for as long as --timeout
-                    type: boolean
-                  waitForJobs:
-                    description: |-
-                      if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful.
-                      It will wait for as long as --timeout
-                    type: boolean
-                type: object
-              k8sConstraint:
-                description: Constraint describing compatible K8S versions of the
-                  cluster set in the SemVer format.
-                type: string
-              kustomize:
-                description: Kustomize contains the Kustomize configuration for the
-                  template.
-                properties:
-                  deploymentType:
-                    default: Remote
-                    description: |-
-                      DeploymentType is the type of the deployment. This field is ignored,
-                      when ResourceSpec is used as part of Helm chart configuration.
-                    enum:
-                    - Local
-                    - Remote
-                    type: string
-                  localSourceRef:
-                    description: LocalSourceRef is the local source of the kustomize
-                      manifest.
-                    properties:
-                      kind:
-                        description: Kind is the kind of the local source.
-                        enum:
-                        - ConfigMap
-                        - Secret
-                        - GitRepository
-                        - Bucket
+                    kind:
+                      description: Kind of the referent.
+                      enum:
                         - OCIRepository
-                        type: string
-                      name:
-                        description: Name is the name of the local source.
-                        type: string
-                      namespace:
-                        description: |-
-                          Namespace is the namespace of the local source. Cross-namespace references
-                          are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                          [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
-                          If the Kind is ConfigMap or Secret, the namespace will be ignored.
-                        type: string
-                    required:
+                        - HelmChart
+                        - ExternalArtifact
+                      type: string
+                    name:
+                      description: Name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent, defaults to the namespace of the Kubernetes
+                        resource object that contains the reference.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                  required:
                     - kind
                     - name
-                    type: object
-                  path:
-                    description: Path to the directory containing the resource manifest.
-                    type: string
-                  remoteSourceSpec:
-                    description: RemoteSourceSpec is the remote source of the kustomize
-                      manifest.
-                    properties:
-                      bucket:
-                        description: Bucket is the definition of bucket source.
-                        properties:
-                          bucketName:
-                            description: BucketName is the name of the object storage
-                              bucket.
-                            type: string
-                          certSecretRef:
-                            description: |-
-                              CertSecretRef can be given the name of a Secret containing
-                              either or both of
-
-                              - a PEM-encoded client certificate (`tls.crt`) and private
-                              key (`tls.key`);
-                              - a PEM-encoded CA certificate (`ca.crt`)
-
-                              and whichever are supplied, will be used for connecting to the
-                              bucket. The client cert and key are useful if you are
-                              authenticating with a certificate; the CA cert is useful if
-                              you are using a self-signed server certificate. The Secret must
-                              be of type `Opaque` or `kubernetes.io/tls`.
-
-                              This field is only supported for the `generic` provider.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          endpoint:
-                            description: Endpoint is the object storage address the
-                              BucketName is located at.
-                            type: string
-                          ignore:
-                            description: |-
-                              Ignore overrides the set of excluded patterns in the .sourceignore format
-                              (which is the same as .gitignore). If not provided, a default will be used,
-                              consult the documentation for your version to find out what those are.
-                            type: string
-                          insecure:
-                            description: Insecure allows connecting to a non-TLS HTTP
-                              Endpoint.
-                            type: boolean
-                          interval:
-                            description: |-
-                              Interval at which the Bucket Endpoint is checked for updates.
-                              This interval is approximate and may be subject to jitter to ensure
-                              efficient use of resources.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                            type: string
-                          prefix:
-                            description: Prefix to use for server-side filtering of
-                              files in the Bucket.
-                            type: string
-                          provider:
-                            default: generic
-                            description: |-
-                              Provider of the object storage bucket.
-                              Defaults to 'generic', which expects an S3 (API) compatible object
-                              storage.
-                            enum:
-                            - generic
-                            - aws
-                            - gcp
-                            - azure
-                            type: string
-                          proxySecretRef:
-                            description: |-
-                              ProxySecretRef specifies the Secret containing the proxy configuration
-                              to use while communicating with the Bucket server.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          region:
-                            description: Region of the Endpoint where the BucketName
-                              is located in.
-                            type: string
-                          secretRef:
-                            description: |-
-                              SecretRef specifies the Secret containing authentication credentials
-                              for the Bucket.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          serviceAccountName:
-                            description: |-
-                              ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                              the bucket. This field is only supported for the 'gcp' and 'aws' providers.
-                              For more information about workload identity:
-                              https://fluxcd.io/flux/components/source/buckets/#workload-identity
-                            type: string
-                          sts:
-                            description: |-
-                              STS specifies the required configuration to use a Security Token
-                              Service for fetching temporary credentials to authenticate in a
-                              Bucket provider.
-
-                              This field is only supported for the `aws` and `generic` providers.
-                            properties:
-                              certSecretRef:
-                                description: |-
-                                  CertSecretRef can be given the name of a Secret containing
-                                  either or both of
-
-                                  - a PEM-encoded client certificate (`tls.crt`) and private
-                                  key (`tls.key`);
-                                  - a PEM-encoded CA certificate (`ca.crt`)
-
-                                  and whichever are supplied, will be used for connecting to the
-                                  STS endpoint. The client cert and key are useful if you are
-                                  authenticating with a certificate; the CA cert is useful if
-                                  you are using a self-signed server certificate. The Secret must
-                                  be of type `Opaque` or `kubernetes.io/tls`.
-
-                                  This field is only supported for the `ldap` provider.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              endpoint:
-                                description: |-
-                                  Endpoint is the HTTP/S endpoint of the Security Token Service from
-                                  where temporary credentials will be fetched.
-                                pattern: ^(http|https)://.*$
-                                type: string
-                              provider:
-                                description: Provider of the Security Token Service.
-                                enum:
-                                - aws
-                                - ldap
-                                type: string
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Secret containing authentication credentials
-                                  for the STS endpoint. This Secret must contain the fields `username`
-                                  and `password` and is supported only for the `ldap` provider.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - endpoint
-                            - provider
-                            type: object
-                          suspend:
-                            description: |-
-                              Suspend tells the controller to suspend the reconciliation of this
-                              Bucket.
-                            type: boolean
-                          timeout:
-                            default: 60s
-                            description: Timeout for fetch operations, defaults to
-                              60s.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                            type: string
-                        required:
-                        - bucketName
-                        - endpoint
-                        - interval
-                        type: object
-                        x-kubernetes-validations:
-                        - message: STS configuration is only supported for the 'aws'
-                            and 'generic' Bucket providers
-                          rule: self.provider == 'aws' || self.provider == 'generic'
-                            || !has(self.sts)
-                        - message: '''aws'' is the only supported STS provider for
-                            the ''aws'' Bucket provider'
-                          rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider
-                            == 'aws'
-                        - message: '''ldap'' is the only supported STS provider for
-                            the ''generic'' Bucket provider'
-                          rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider
-                            == 'ldap'
-                        - message: spec.sts.secretRef is not required for the 'aws'
-                            STS provider
-                          rule: '!has(self.sts) || self.sts.provider != ''aws'' ||
-                            !has(self.sts.secretRef)'
-                        - message: spec.sts.certSecretRef is not required for the
-                            'aws' STS provider
-                          rule: '!has(self.sts) || self.sts.provider != ''aws'' ||
-                            !has(self.sts.certSecretRef)'
-                        - message: ServiceAccountName is not supported for the 'generic'
-                            Bucket provider
-                          rule: self.provider != 'generic' || !has(self.serviceAccountName)
-                        - message: cannot set both .spec.secretRef and .spec.serviceAccountName
-                          rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
-                      git:
-                        description: Git is the definition of git repository source.
-                        properties:
-                          ignore:
-                            description: |-
-                              Ignore overrides the set of excluded patterns in the .sourceignore format
-                              (which is the same as .gitignore). If not provided, a default will be used,
-                              consult the documentation for your version to find out what those are.
-                            type: string
-                          include:
-                            description: |-
-                              Include specifies a list of GitRepository resources which Artifacts
-                              should be included in the Artifact produced for this GitRepository.
-                            items:
-                              description: |-
-                                GitRepositoryInclude specifies a local reference to a GitRepository which
-                                Artifact (sub-)contents must be included, and where they should be placed.
-                              properties:
-                                fromPath:
-                                  description: |-
-                                    FromPath specifies the path to copy contents from, defaults to the root
-                                    of the Artifact.
-                                  type: string
-                                repository:
-                                  description: |-
-                                    GitRepositoryRef specifies the GitRepository which Artifact contents
-                                    must be included.
-                                  properties:
-                                    name:
-                                      description: Name of the referent.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                toPath:
-                                  description: |-
-                                    ToPath specifies the path to copy contents to, defaults to the name of
-                                    the GitRepositoryRef.
-                                  type: string
-                              required:
-                              - repository
-                              type: object
-                            type: array
-                          interval:
-                            description: |-
-                              Interval at which the GitRepository URL is checked for updates.
-                              This interval is approximate and may be subject to jitter to ensure
-                              efficient use of resources.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                            type: string
-                          provider:
-                            description: |-
-                              Provider used for authentication, can be 'azure', 'github', 'generic'.
-                              When not specified, defaults to 'generic'.
-                            enum:
-                            - generic
-                            - azure
-                            - github
-                            type: string
-                          proxySecretRef:
-                            description: |-
-                              ProxySecretRef specifies the Secret containing the proxy configuration
-                              to use while communicating with the Git server.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          recurseSubmodules:
-                            description: |-
-                              RecurseSubmodules enables the initialization of all submodules within
-                              the GitRepository as cloned from the URL, using their default settings.
-                            type: boolean
-                          ref:
-                            description: |-
-                              Reference specifies the Git reference to resolve and monitor for
-                              changes, defaults to the 'master' branch.
-                            properties:
-                              branch:
-                                description: Branch to check out, defaults to 'master'
-                                  if no other field is defined.
-                                type: string
-                              commit:
-                                description: |-
-                                  Commit SHA to check out, takes precedence over all reference fields.
-
-                                  This can be combined with Branch to shallow clone the branch, in which
-                                  the commit is expected to exist.
-                                type: string
-                              name:
-                                description: |-
-                                  Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
-
-                                  It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
-                                  Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
-                                type: string
-                              semver:
-                                description: SemVer tag expression to check out, takes
-                                  precedence over Tag.
-                                type: string
-                              tag:
-                                description: Tag to check out, takes precedence over
-                                  Branch.
-                                type: string
-                            type: object
-                          secretRef:
-                            description: |-
-                              SecretRef specifies the Secret containing authentication credentials for
-                              the GitRepository.
-                              For HTTPS repositories the Secret must contain 'username' and 'password'
-                              fields for basic auth or 'bearerToken' field for token auth.
-                              For SSH repositories the Secret must contain 'identity'
-                              and 'known_hosts' fields.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          serviceAccountName:
-                            description: |-
-                              ServiceAccountName is the name of the Kubernetes ServiceAccount used to
-                              authenticate to the GitRepository. This field is only supported for 'azure' provider.
-                            type: string
-                          sparseCheckout:
-                            description: |-
-                              SparseCheckout specifies a list of directories to checkout when cloning
-                              the repository. If specified, only these directories are included in the
-                              Artifact produced for this GitRepository.
-                            items:
-                              type: string
-                            type: array
-                          suspend:
-                            description: |-
-                              Suspend tells the controller to suspend the reconciliation of this
-                              GitRepository.
-                            type: boolean
-                          timeout:
-                            default: 60s
-                            description: Timeout for Git operations like cloning,
-                              defaults to 60s.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                            type: string
-                          url:
-                            description: URL specifies the Git repository URL, it
-                              can be an HTTP/S or SSH address.
-                            pattern: ^(http|https|ssh)://.*$
-                            type: string
-                          verify:
-                            description: |-
-                              Verification specifies the configuration to verify the Git commit
-                              signature(s).
-                            properties:
-                              mode:
-                                default: HEAD
-                                description: |-
-                                  Mode specifies which Git object(s) should be verified.
-
-                                  The variants "head" and "HEAD" both imply the same thing, i.e. verify
-                                  the commit that the HEAD of the Git repository points to. The variant
-                                  "head" solely exists to ensure backwards compatibility.
-                                enum:
-                                - head
-                                - HEAD
-                                - Tag
-                                - TagAndHEAD
-                                type: string
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Secret containing the public keys of trusted Git
-                                  authors.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - secretRef
-                            type: object
-                        required:
-                        - interval
-                        - url
-                        type: object
-                        x-kubernetes-validations:
-                        - message: serviceAccountName can only be set when provider
-                            is 'azure'
-                          rule: '!has(self.serviceAccountName) || (has(self.provider)
-                            && self.provider == ''azure'')'
-                      oci:
-                        description: OCI is the definition of OCI repository source.
-                        properties:
-                          certSecretRef:
-                            description: |-
-                              CertSecretRef can be given the name of a Secret containing
-                              either or both of
-
-                              - a PEM-encoded client certificate (`tls.crt`) and private
-                              key (`tls.key`);
-                              - a PEM-encoded CA certificate (`ca.crt`)
-
-                              and whichever are supplied, will be used for connecting to the
-                              registry. The client cert and key are useful if you are
-                              authenticating with a certificate; the CA cert is useful if
-                              you are using a self-signed server certificate. The Secret must
-                              be of type `Opaque` or `kubernetes.io/tls`.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          ignore:
-                            description: |-
-                              Ignore overrides the set of excluded patterns in the .sourceignore format
-                              (which is the same as .gitignore). If not provided, a default will be used,
-                              consult the documentation for your version to find out what those are.
-                            type: string
-                          insecure:
-                            description: Insecure allows connecting to a non-TLS HTTP
-                              container registry.
-                            type: boolean
-                          interval:
-                            description: |-
-                              Interval at which the OCIRepository URL is checked for updates.
-                              This interval is approximate and may be subject to jitter to ensure
-                              efficient use of resources.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                            type: string
-                          layerSelector:
-                            description: |-
-                              LayerSelector specifies which layer should be extracted from the OCI artifact.
-                              When not specified, the first layer found in the artifact is selected.
-                            properties:
-                              mediaType:
-                                description: |-
-                                  MediaType specifies the OCI media type of the layer
-                                  which should be extracted from the OCI Artifact. The
-                                  first layer matching this type is selected.
-                                type: string
-                              operation:
-                                description: |-
-                                  Operation specifies how the selected layer should be processed.
-                                  By default, the layer compressed content is extracted to storage.
-                                  When the operation is set to 'copy', the layer compressed content
-                                  is persisted to storage as it is.
-                                enum:
-                                - extract
-                                - copy
-                                type: string
-                            type: object
-                          provider:
-                            default: generic
-                            description: |-
-                              The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
-                              When not specified, defaults to 'generic'.
-                            enum:
-                            - generic
-                            - aws
-                            - azure
-                            - gcp
-                            type: string
-                          proxySecretRef:
-                            description: |-
-                              ProxySecretRef specifies the Secret containing the proxy configuration
-                              to use while communicating with the container registry.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          ref:
-                            description: |-
-                              The OCI reference to pull and monitor for changes,
-                              defaults to the latest tag.
-                            properties:
-                              digest:
-                                description: |-
-                                  Digest is the image digest to pull, takes precedence over SemVer.
-                                  The value should be in the format 'sha256:<HASH>'.
-                                type: string
-                              semver:
-                                description: |-
-                                  SemVer is the range of tags to pull selecting the latest within
-                                  the range, takes precedence over Tag.
-                                type: string
-                              semverFilter:
-                                description: SemverFilter is a regex pattern to filter
-                                  the tags within the SemVer range.
-                                type: string
-                              tag:
-                                description: Tag is the image tag to pull, defaults
-                                  to latest.
-                                type: string
-                            type: object
-                          secretRef:
-                            description: |-
-                              SecretRef contains the secret name containing the registry login
-                              credentials to resolve image metadata.
-                              The secret must be of type kubernetes.io/dockerconfigjson.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          serviceAccountName:
-                            description: |-
-                              ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                              the image pull if the service account has attached pull secrets. For more information:
-                              https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
-                            type: string
-                          suspend:
-                            description: This flag tells the controller to suspend
-                              the reconciliation of this source.
-                            type: boolean
-                          timeout:
-                            default: 60s
-                            description: The timeout for remote OCI Repository operations
-                              like pulling, defaults to 60s.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                            type: string
-                          url:
-                            description: |-
-                              URL is a reference to an OCI artifact repository hosted
-                              on a remote container registry.
-                            pattern: ^oci://.*$
-                            type: string
-                          verify:
-                            description: |-
-                              Verify contains the secret name containing the trusted public keys
-                              used to verify the signature and specifies which provider to use to check
-                              whether OCI image is authentic.
-                            properties:
-                              matchOIDCIdentity:
-                                description: |-
-                                  MatchOIDCIdentity specifies the identity matching criteria to use
-                                  while verifying an OCI artifact which was signed using Cosign keyless
-                                  signing. The artifact's identity is deemed to be verified if any of the
-                                  specified matchers match against the identity.
-                                items:
-                                  description: |-
-                                    OIDCIdentityMatch specifies options for verifying the certificate identity,
-                                    i.e. the issuer and the subject of the certificate.
-                                  properties:
-                                    issuer:
-                                      description: |-
-                                        Issuer specifies the regex pattern to match against to verify
-                                        the OIDC issuer in the Fulcio certificate. The pattern must be a
-                                        valid Go regular expression.
-                                      type: string
-                                    subject:
-                                      description: |-
-                                        Subject specifies the regex pattern to match against to verify
-                                        the identity subject in the Fulcio certificate. The pattern must
-                                        be a valid Go regular expression.
-                                      type: string
-                                  required:
-                                  - issuer
-                                  - subject
-                                  type: object
-                                type: array
-                              provider:
-                                default: cosign
-                                description: Provider specifies the technology used
-                                  to sign the OCI Artifact.
-                                enum:
-                                - cosign
-                                - notation
-                                type: string
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Kubernetes Secret containing the
-                                  trusted public keys.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - provider
-                            type: object
-                        required:
-                        - interval
-                        - url
-                        type: object
-                    type: object
-                    x-kubernetes-validations:
-                    - message: Git, Bucket and OCI are mutually exclusive.
-                      rule: 'has(self.git) ? (!has(self.bucket) && !has(self.oci))
-                        : true'
-                    - message: Git, Bucket and OCI are mutually exclusive.
-                      rule: 'has(self.bucket) ? (!has(self.git) && !has(self.oci))
-                        : true'
-                    - message: Git, Bucket and OCI are mutually exclusive.
-                      rule: 'has(self.oci) ? (!has(self.git) && !has(self.bucket))
-                        : true'
-                    - message: One of Git, Bucket or OCI must be specified.
-                      rule: has(self.git) || has(self.bucket) || has(self.oci)
-                required:
-                - deploymentType
-                - path
-                type: object
-                x-kubernetes-validations:
-                - message: LocalSource and RemoteSource are mutually exclusive.
-                  rule: 'has(self.localSourceRef) ? !has(self.remoteSourceSpec): true'
-                - message: LocalSource and RemoteSource are mutually exclusive.
-                  rule: 'has(self.remoteSourceSpec) ? !has(self.localSourceRef): true'
-                - message: One of LocalSource or RemoteSource must be specified.
-                  rule: has(self.localSourceRef) || has(self.remoteSourceSpec)
-              resources:
-                description: Resources contains the resource configuration for the
-                  template.
-                properties:
-                  deploymentType:
-                    default: Remote
-                    description: |-
-                      DeploymentType is the type of the deployment. This field is ignored,
-                      when ResourceSpec is used as part of Helm chart configuration.
-                    enum:
-                    - Local
-                    - Remote
-                    type: string
-                  localSourceRef:
-                    description: LocalSourceRef is the local source of the kustomize
-                      manifest.
-                    properties:
-                      kind:
-                        description: Kind is the kind of the local source.
-                        enum:
-                        - ConfigMap
-                        - Secret
-                        - GitRepository
-                        - Bucket
-                        - OCIRepository
-                        type: string
-                      name:
-                        description: Name is the name of the local source.
-                        type: string
-                      namespace:
-                        description: |-
-                          Namespace is the namespace of the local source. Cross-namespace references
-                          are only allowed when the Kind is one of [github.com/fluxcd/source-controller/api/v1.GitRepository],
-                          [github.com/fluxcd/source-controller/api/v1.Bucket] or [github.com/fluxcd/source-controller/api/v1.OCIRepository].
-                          If the Kind is ConfigMap or Secret, the namespace will be ignored.
-                        type: string
-                    required:
-                    - kind
-                    - name
-                    type: object
-                  path:
-                    description: Path to the directory containing the resource manifest.
-                    type: string
-                  remoteSourceSpec:
-                    description: RemoteSourceSpec is the remote source of the kustomize
-                      manifest.
-                    properties:
-                      bucket:
-                        description: Bucket is the definition of bucket source.
-                        properties:
-                          bucketName:
-                            description: BucketName is the name of the object storage
-                              bucket.
-                            type: string
-                          certSecretRef:
-                            description: |-
-                              CertSecretRef can be given the name of a Secret containing
-                              either or both of
-
-                              - a PEM-encoded client certificate (`tls.crt`) and private
-                              key (`tls.key`);
-                              - a PEM-encoded CA certificate (`ca.crt`)
-
-                              and whichever are supplied, will be used for connecting to the
-                              bucket. The client cert and key are useful if you are
-                              authenticating with a certificate; the CA cert is useful if
-                              you are using a self-signed server certificate. The Secret must
-                              be of type `Opaque` or `kubernetes.io/tls`.
-
-                              This field is only supported for the `generic` provider.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          endpoint:
-                            description: Endpoint is the object storage address the
-                              BucketName is located at.
-                            type: string
-                          ignore:
-                            description: |-
-                              Ignore overrides the set of excluded patterns in the .sourceignore format
-                              (which is the same as .gitignore). If not provided, a default will be used,
-                              consult the documentation for your version to find out what those are.
-                            type: string
-                          insecure:
-                            description: Insecure allows connecting to a non-TLS HTTP
-                              Endpoint.
-                            type: boolean
-                          interval:
-                            description: |-
-                              Interval at which the Bucket Endpoint is checked for updates.
-                              This interval is approximate and may be subject to jitter to ensure
-                              efficient use of resources.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                            type: string
-                          prefix:
-                            description: Prefix to use for server-side filtering of
-                              files in the Bucket.
-                            type: string
-                          provider:
-                            default: generic
-                            description: |-
-                              Provider of the object storage bucket.
-                              Defaults to 'generic', which expects an S3 (API) compatible object
-                              storage.
-                            enum:
-                            - generic
-                            - aws
-                            - gcp
-                            - azure
-                            type: string
-                          proxySecretRef:
-                            description: |-
-                              ProxySecretRef specifies the Secret containing the proxy configuration
-                              to use while communicating with the Bucket server.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          region:
-                            description: Region of the Endpoint where the BucketName
-                              is located in.
-                            type: string
-                          secretRef:
-                            description: |-
-                              SecretRef specifies the Secret containing authentication credentials
-                              for the Bucket.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          serviceAccountName:
-                            description: |-
-                              ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                              the bucket. This field is only supported for the 'gcp' and 'aws' providers.
-                              For more information about workload identity:
-                              https://fluxcd.io/flux/components/source/buckets/#workload-identity
-                            type: string
-                          sts:
-                            description: |-
-                              STS specifies the required configuration to use a Security Token
-                              Service for fetching temporary credentials to authenticate in a
-                              Bucket provider.
-
-                              This field is only supported for the `aws` and `generic` providers.
-                            properties:
-                              certSecretRef:
-                                description: |-
-                                  CertSecretRef can be given the name of a Secret containing
-                                  either or both of
-
-                                  - a PEM-encoded client certificate (`tls.crt`) and private
-                                  key (`tls.key`);
-                                  - a PEM-encoded CA certificate (`ca.crt`)
-
-                                  and whichever are supplied, will be used for connecting to the
-                                  STS endpoint. The client cert and key are useful if you are
-                                  authenticating with a certificate; the CA cert is useful if
-                                  you are using a self-signed server certificate. The Secret must
-                                  be of type `Opaque` or `kubernetes.io/tls`.
-
-                                  This field is only supported for the `ldap` provider.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              endpoint:
-                                description: |-
-                                  Endpoint is the HTTP/S endpoint of the Security Token Service from
-                                  where temporary credentials will be fetched.
-                                pattern: ^(http|https)://.*$
-                                type: string
-                              provider:
-                                description: Provider of the Security Token Service.
-                                enum:
-                                - aws
-                                - ldap
-                                type: string
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Secret containing authentication credentials
-                                  for the STS endpoint. This Secret must contain the fields `username`
-                                  and `password` and is supported only for the `ldap` provider.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - endpoint
-                            - provider
-                            type: object
-                          suspend:
-                            description: |-
-                              Suspend tells the controller to suspend the reconciliation of this
-                              Bucket.
-                            type: boolean
-                          timeout:
-                            default: 60s
-                            description: Timeout for fetch operations, defaults to
-                              60s.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                            type: string
-                        required:
-                        - bucketName
-                        - endpoint
-                        - interval
-                        type: object
-                        x-kubernetes-validations:
-                        - message: STS configuration is only supported for the 'aws'
-                            and 'generic' Bucket providers
-                          rule: self.provider == 'aws' || self.provider == 'generic'
-                            || !has(self.sts)
-                        - message: '''aws'' is the only supported STS provider for
-                            the ''aws'' Bucket provider'
-                          rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider
-                            == 'aws'
-                        - message: '''ldap'' is the only supported STS provider for
-                            the ''generic'' Bucket provider'
-                          rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider
-                            == 'ldap'
-                        - message: spec.sts.secretRef is not required for the 'aws'
-                            STS provider
-                          rule: '!has(self.sts) || self.sts.provider != ''aws'' ||
-                            !has(self.sts.secretRef)'
-                        - message: spec.sts.certSecretRef is not required for the
-                            'aws' STS provider
-                          rule: '!has(self.sts) || self.sts.provider != ''aws'' ||
-                            !has(self.sts.certSecretRef)'
-                        - message: ServiceAccountName is not supported for the 'generic'
-                            Bucket provider
-                          rule: self.provider != 'generic' || !has(self.serviceAccountName)
-                        - message: cannot set both .spec.secretRef and .spec.serviceAccountName
-                          rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
-                      git:
-                        description: Git is the definition of git repository source.
-                        properties:
-                          ignore:
-                            description: |-
-                              Ignore overrides the set of excluded patterns in the .sourceignore format
-                              (which is the same as .gitignore). If not provided, a default will be used,
-                              consult the documentation for your version to find out what those are.
-                            type: string
-                          include:
-                            description: |-
-                              Include specifies a list of GitRepository resources which Artifacts
-                              should be included in the Artifact produced for this GitRepository.
-                            items:
-                              description: |-
-                                GitRepositoryInclude specifies a local reference to a GitRepository which
-                                Artifact (sub-)contents must be included, and where they should be placed.
-                              properties:
-                                fromPath:
-                                  description: |-
-                                    FromPath specifies the path to copy contents from, defaults to the root
-                                    of the Artifact.
-                                  type: string
-                                repository:
-                                  description: |-
-                                    GitRepositoryRef specifies the GitRepository which Artifact contents
-                                    must be included.
-                                  properties:
-                                    name:
-                                      description: Name of the referent.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                toPath:
-                                  description: |-
-                                    ToPath specifies the path to copy contents to, defaults to the name of
-                                    the GitRepositoryRef.
-                                  type: string
-                              required:
-                              - repository
-                              type: object
-                            type: array
-                          interval:
-                            description: |-
-                              Interval at which the GitRepository URL is checked for updates.
-                              This interval is approximate and may be subject to jitter to ensure
-                              efficient use of resources.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                            type: string
-                          provider:
-                            description: |-
-                              Provider used for authentication, can be 'azure', 'github', 'generic'.
-                              When not specified, defaults to 'generic'.
-                            enum:
-                            - generic
-                            - azure
-                            - github
-                            type: string
-                          proxySecretRef:
-                            description: |-
-                              ProxySecretRef specifies the Secret containing the proxy configuration
-                              to use while communicating with the Git server.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          recurseSubmodules:
-                            description: |-
-                              RecurseSubmodules enables the initialization of all submodules within
-                              the GitRepository as cloned from the URL, using their default settings.
-                            type: boolean
-                          ref:
-                            description: |-
-                              Reference specifies the Git reference to resolve and monitor for
-                              changes, defaults to the 'master' branch.
-                            properties:
-                              branch:
-                                description: Branch to check out, defaults to 'master'
-                                  if no other field is defined.
-                                type: string
-                              commit:
-                                description: |-
-                                  Commit SHA to check out, takes precedence over all reference fields.
-
-                                  This can be combined with Branch to shallow clone the branch, in which
-                                  the commit is expected to exist.
-                                type: string
-                              name:
-                                description: |-
-                                  Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
-
-                                  It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
-                                  Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
-                                type: string
-                              semver:
-                                description: SemVer tag expression to check out, takes
-                                  precedence over Tag.
-                                type: string
-                              tag:
-                                description: Tag to check out, takes precedence over
-                                  Branch.
-                                type: string
-                            type: object
-                          secretRef:
-                            description: |-
-                              SecretRef specifies the Secret containing authentication credentials for
-                              the GitRepository.
-                              For HTTPS repositories the Secret must contain 'username' and 'password'
-                              fields for basic auth or 'bearerToken' field for token auth.
-                              For SSH repositories the Secret must contain 'identity'
-                              and 'known_hosts' fields.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          serviceAccountName:
-                            description: |-
-                              ServiceAccountName is the name of the Kubernetes ServiceAccount used to
-                              authenticate to the GitRepository. This field is only supported for 'azure' provider.
-                            type: string
-                          sparseCheckout:
-                            description: |-
-                              SparseCheckout specifies a list of directories to checkout when cloning
-                              the repository. If specified, only these directories are included in the
-                              Artifact produced for this GitRepository.
-                            items:
-                              type: string
-                            type: array
-                          suspend:
-                            description: |-
-                              Suspend tells the controller to suspend the reconciliation of this
-                              GitRepository.
-                            type: boolean
-                          timeout:
-                            default: 60s
-                            description: Timeout for Git operations like cloning,
-                              defaults to 60s.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                            type: string
-                          url:
-                            description: URL specifies the Git repository URL, it
-                              can be an HTTP/S or SSH address.
-                            pattern: ^(http|https|ssh)://.*$
-                            type: string
-                          verify:
-                            description: |-
-                              Verification specifies the configuration to verify the Git commit
-                              signature(s).
-                            properties:
-                              mode:
-                                default: HEAD
-                                description: |-
-                                  Mode specifies which Git object(s) should be verified.
-
-                                  The variants "head" and "HEAD" both imply the same thing, i.e. verify
-                                  the commit that the HEAD of the Git repository points to. The variant
-                                  "head" solely exists to ensure backwards compatibility.
-                                enum:
-                                - head
-                                - HEAD
-                                - Tag
-                                - TagAndHEAD
-                                type: string
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Secret containing the public keys of trusted Git
-                                  authors.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - secretRef
-                            type: object
-                        required:
-                        - interval
-                        - url
-                        type: object
-                        x-kubernetes-validations:
-                        - message: serviceAccountName can only be set when provider
-                            is 'azure'
-                          rule: '!has(self.serviceAccountName) || (has(self.provider)
-                            && self.provider == ''azure'')'
-                      oci:
-                        description: OCI is the definition of OCI repository source.
-                        properties:
-                          certSecretRef:
-                            description: |-
-                              CertSecretRef can be given the name of a Secret containing
-                              either or both of
-
-                              - a PEM-encoded client certificate (`tls.crt`) and private
-                              key (`tls.key`);
-                              - a PEM-encoded CA certificate (`ca.crt`)
-
-                              and whichever are supplied, will be used for connecting to the
-                              registry. The client cert and key are useful if you are
-                              authenticating with a certificate; the CA cert is useful if
-                              you are using a self-signed server certificate. The Secret must
-                              be of type `Opaque` or `kubernetes.io/tls`.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          ignore:
-                            description: |-
-                              Ignore overrides the set of excluded patterns in the .sourceignore format
-                              (which is the same as .gitignore). If not provided, a default will be used,
-                              consult the documentation for your version to find out what those are.
-                            type: string
-                          insecure:
-                            description: Insecure allows connecting to a non-TLS HTTP
-                              container registry.
-                            type: boolean
-                          interval:
-                            description: |-
-                              Interval at which the OCIRepository URL is checked for updates.
-                              This interval is approximate and may be subject to jitter to ensure
-                              efficient use of resources.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                            type: string
-                          layerSelector:
-                            description: |-
-                              LayerSelector specifies which layer should be extracted from the OCI artifact.
-                              When not specified, the first layer found in the artifact is selected.
-                            properties:
-                              mediaType:
-                                description: |-
-                                  MediaType specifies the OCI media type of the layer
-                                  which should be extracted from the OCI Artifact. The
-                                  first layer matching this type is selected.
-                                type: string
-                              operation:
-                                description: |-
-                                  Operation specifies how the selected layer should be processed.
-                                  By default, the layer compressed content is extracted to storage.
-                                  When the operation is set to 'copy', the layer compressed content
-                                  is persisted to storage as it is.
-                                enum:
-                                - extract
-                                - copy
-                                type: string
-                            type: object
-                          provider:
-                            default: generic
-                            description: |-
-                              The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
-                              When not specified, defaults to 'generic'.
-                            enum:
-                            - generic
-                            - aws
-                            - azure
-                            - gcp
-                            type: string
-                          proxySecretRef:
-                            description: |-
-                              ProxySecretRef specifies the Secret containing the proxy configuration
-                              to use while communicating with the container registry.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          ref:
-                            description: |-
-                              The OCI reference to pull and monitor for changes,
-                              defaults to the latest tag.
-                            properties:
-                              digest:
-                                description: |-
-                                  Digest is the image digest to pull, takes precedence over SemVer.
-                                  The value should be in the format 'sha256:<HASH>'.
-                                type: string
-                              semver:
-                                description: |-
-                                  SemVer is the range of tags to pull selecting the latest within
-                                  the range, takes precedence over Tag.
-                                type: string
-                              semverFilter:
-                                description: SemverFilter is a regex pattern to filter
-                                  the tags within the SemVer range.
-                                type: string
-                              tag:
-                                description: Tag is the image tag to pull, defaults
-                                  to latest.
-                                type: string
-                            type: object
-                          secretRef:
-                            description: |-
-                              SecretRef contains the secret name containing the registry login
-                              credentials to resolve image metadata.
-                              The secret must be of type kubernetes.io/dockerconfigjson.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          serviceAccountName:
-                            description: |-
-                              ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                              the image pull if the service account has attached pull secrets. For more information:
-                              https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
-                            type: string
-                          suspend:
-                            description: This flag tells the controller to suspend
-                              the reconciliation of this source.
-                            type: boolean
-                          timeout:
-                            default: 60s
-                            description: The timeout for remote OCI Repository operations
-                              like pulling, defaults to 60s.
-                            pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                            type: string
-                          url:
-                            description: |-
-                              URL is a reference to an OCI artifact repository hosted
-                              on a remote container registry.
-                            pattern: ^oci://.*$
-                            type: string
-                          verify:
-                            description: |-
-                              Verify contains the secret name containing the trusted public keys
-                              used to verify the signature and specifies which provider to use to check
-                              whether OCI image is authentic.
-                            properties:
-                              matchOIDCIdentity:
-                                description: |-
-                                  MatchOIDCIdentity specifies the identity matching criteria to use
-                                  while verifying an OCI artifact which was signed using Cosign keyless
-                                  signing. The artifact's identity is deemed to be verified if any of the
-                                  specified matchers match against the identity.
-                                items:
-                                  description: |-
-                                    OIDCIdentityMatch specifies options for verifying the certificate identity,
-                                    i.e. the issuer and the subject of the certificate.
-                                  properties:
-                                    issuer:
-                                      description: |-
-                                        Issuer specifies the regex pattern to match against to verify
-                                        the OIDC issuer in the Fulcio certificate. The pattern must be a
-                                        valid Go regular expression.
-                                      type: string
-                                    subject:
-                                      description: |-
-                                        Subject specifies the regex pattern to match against to verify
-                                        the identity subject in the Fulcio certificate. The pattern must
-                                        be a valid Go regular expression.
-                                      type: string
-                                  required:
-                                  - issuer
-                                  - subject
-                                  type: object
-                                type: array
-                              provider:
-                                default: cosign
-                                description: Provider specifies the technology used
-                                  to sign the OCI Artifact.
-                                enum:
-                                - cosign
-                                - notation
-                                type: string
-                              secretRef:
-                                description: |-
-                                  SecretRef specifies the Kubernetes Secret containing the
-                                  trusted public keys.
-                                properties:
-                                  name:
-                                    description: Name of the referent.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - provider
-                            type: object
-                        required:
-                        - interval
-                        - url
-                        type: object
-                    type: object
-                    x-kubernetes-validations:
-                    - message: Git, Bucket and OCI are mutually exclusive.
-                      rule: 'has(self.git) ? (!has(self.bucket) && !has(self.oci))
-                        : true'
-                    - message: Git, Bucket and OCI are mutually exclusive.
-                      rule: 'has(self.bucket) ? (!has(self.git) && !has(self.oci))
-                        : true'
-                    - message: Git, Bucket and OCI are mutually exclusive.
-                      rule: 'has(self.oci) ? (!has(self.git) && !has(self.bucket))
-                        : true'
-                    - message: One of Git, Bucket or OCI must be specified.
-                      rule: has(self.git) || has(self.bucket) || has(self.oci)
-                required:
-                - deploymentType
-                - path
-                type: object
-                x-kubernetes-validations:
-                - message: LocalSource and RemoteSource are mutually exclusive.
-                  rule: 'has(self.localSourceRef) ? !has(self.remoteSourceSpec): true'
-                - message: LocalSource and RemoteSource are mutually exclusive.
-                  rule: 'has(self.remoteSourceSpec) ? !has(self.localSourceRef): true'
-                - message: One of LocalSource or RemoteSource must be specified.
-                  rule: has(self.localSourceRef) || has(self.remoteSourceSpec)
-              version:
-                description: Version is the semantic version of the application backed
-                  by template.
-                type: string
-            type: object
-            x-kubernetes-validations:
-            - message: Spec is immutable
-              rule: self == oldSelf
-            - message: Helm, Kustomize and Resources are mutually exclusive.
-              rule: 'has(self.helm) ? (!has(self.kustomize) && !has(self.resources)):
-                true'
-            - message: Helm, Kustomize and Resources are mutually exclusive.
-              rule: 'has(self.kustomize) ? (!has(self.helm) && !has(self.resources)):
-                true'
-            - message: Helm, Kustomize and Resources are mutually exclusive.
-              rule: 'has(self.resources) ? (!has(self.kustomize) && !has(self.helm)):
-                true'
-            - message: One of Helm, Kustomize, or Resources must be specified.
-              rule: has(self.helm) || has(self.kustomize) || has(self.resources)
-          status:
-            description: ServiceTemplateStatus defines the observed state of ServiceTemplate
-            properties:
-              chartRef:
-                description: |-
-                  ChartRef is a reference to a source controller resource containing the
-                  Helm chart representing the template.
-                properties:
-                  apiVersion:
-                    description: APIVersion of the referent.
-                    type: string
-                  kind:
-                    description: Kind of the referent.
-                    enum:
-                    - OCIRepository
-                    - HelmChart
-                    - ExternalArtifact
-                    type: string
-                  name:
-                    description: Name of the referent.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace of the referent, defaults to the namespace of the Kubernetes
-                      resource object that contains the reference.
-                    maxLength: 63
-                    minLength: 1
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-              chartVersion:
-                description: ChartVersion represents the version of the Helm Chart
-                  associated with this template.
-                type: string
-              config:
-                description: |-
-                  Config demonstrates available parameters for template customization,
-                  that can be used when creating ClusterDeployment objects.
-                x-kubernetes-preserve-unknown-fields: true
-              description:
-                description: Description contains information about the template.
-                type: string
-              k8sConstraint:
-                description: Constraint describing compatible K8S versions of the
-                  cluster set in the SemVer format.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              schemaConfigMapName:
-                description: SchemaConfigMapName specifies the name of the ConfigMap
-                  that contains the JSON Schema definition for Helm Chart validation.
-                type: string
-              sourceStatus:
-                description: SourceStatus reflects the status of the source.
-                properties:
-                  artifact:
-                    description: Artifact is the artifact that was generated from
-                      the template source.
-                    properties:
-                      digest:
-                        description: Digest is the digest of the file in the form
-                          of '<algorithm>:<checksum>'.
-                        pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                        type: string
-                      lastUpdateTime:
-                        description: |-
-                          LastUpdateTime is the timestamp corresponding to the last update of the
-                          Artifact.
-                        format: date-time
-                        type: string
-                      metadata:
-                        additionalProperties:
-                          type: string
-                        description: Metadata holds upstream information such as OCI
-                          annotations.
-                        type: object
-                      path:
-                        description: |-
-                          Path is the relative file path of the Artifact. It can be used to locate
-                          the file in the root of the Artifact storage on the local file system of
-                          the controller managing the Source.
-                        type: string
-                      revision:
-                        description: |-
-                          Revision is a human-readable identifier traceable in the origin source
-                          system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                        type: string
-                      size:
-                        description: Size is the number of bytes in the file.
-                        format: int64
-                        type: integer
-                      url:
-                        description: |-
-                          URL is the HTTP address of the Artifact as exposed by the controller
-                          managing the Source. It can be used to retrieve the Artifact for
-                          consumption, e.g. by another controller applying the Artifact contents.
-                        type: string
-                    required:
-                    - digest
-                    - lastUpdateTime
-                    - path
-                    - revision
-                    - url
-                    type: object
-                  conditions:
-                    description: Conditions reflects the conditions of the remote
-                      source object.
-                    items:
-                      description: Condition contains details for one aspect of the
-                        current state of this API Resource.
+                  type: object
+                chartVersion:
+                  description: ChartVersion represents the version of the Helm Chart associated with this template.
+                  type: string
+                config:
+                  description: |-
+                    Config demonstrates available parameters for template customization,
+                    that can be used when creating ClusterDeployment objects.
+                  x-kubernetes-preserve-unknown-fields: true
+                description:
+                  description: Description contains information about the template.
+                  type: string
+                k8sConstraint:
+                  description: Constraint describing compatible K8S versions of the cluster set in the SemVer format.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                schemaConfigMapName:
+                  description: SchemaConfigMapName specifies the name of the ConfigMap that contains the JSON Schema definition for Helm Chart validation.
+                  type: string
+                sourceStatus:
+                  description: SourceStatus reflects the status of the source.
+                  properties:
+                    artifact:
+                      description: Artifact is the artifact that was generated from the template source.
                       properties:
-                        lastTransitionTime:
+                        digest:
+                          description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                          pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                          type: string
+                        lastUpdateTime:
                           description: |-
-                            lastTransitionTime is the last time the condition transitioned from one status to another.
-                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            LastUpdateTime is the timestamp corresponding to the last update of the
+                            Artifact.
                           format: date-time
                           type: string
-                        message:
+                        metadata:
+                          additionalProperties:
+                            type: string
+                          description: Metadata holds upstream information such as OCI annotations.
+                          type: object
+                        path:
                           description: |-
-                            message is a human readable message indicating details about the transition.
-                            This may be an empty string.
-                          maxLength: 32768
+                            Path is the relative file path of the Artifact. It can be used to locate
+                            the file in the root of the Artifact storage on the local file system of
+                            the controller managing the Source.
                           type: string
-                        observedGeneration:
+                        revision:
                           description: |-
-                            observedGeneration represents the .metadata.generation that the condition was set based upon.
-                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                            with respect to the current state of the instance.
+                            Revision is a human-readable identifier traceable in the origin source
+                            system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                          type: string
+                        size:
+                          description: Size is the number of bytes in the file.
                           format: int64
-                          minimum: 0
                           type: integer
-                        reason:
+                        url:
                           description: |-
-                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                            Producers of specific condition types may define expected values and meanings for this field,
-                            and whether the values are considered a guaranteed API.
-                            The value should be a CamelCase string.
-                            This field may not be empty.
-                          maxLength: 1024
-                          minLength: 1
-                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                          type: string
-                        status:
-                          description: status of the condition, one of True, False,
-                            Unknown.
-                          enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                          type: string
-                        type:
-                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                          maxLength: 316
-                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            URL is the HTTP address of the Artifact as exposed by the controller
+                            managing the Source. It can be used to retrieve the Artifact for
+                            consumption, e.g. by another controller applying the Artifact contents.
                           type: string
                       required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                        - digest
+                        - lastUpdateTime
+                        - path
+                        - revision
+                        - url
                       type: object
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - type
-                    x-kubernetes-list-type: map
-                  kind:
-                    description: Kind is the kind of the remote source.
-                    type: string
-                  name:
-                    description: Name is the name of the remote source.
-                    type: string
-                  namespace:
-                    description: Namespace is the namespace of the remote source.
-                    type: string
-                  observedGeneration:
-                    description: ObservedGeneration is the latest source generation
-                      observed by the controller.
-                    format: int64
-                    type: integer
-                required:
-                - kind
-                - name
-                - namespace
-                type: object
-              valid:
-                description: Valid indicates whether the template passed validation
-                  or not.
-                type: boolean
-              validationError:
-                description: ValidationError provides information regarding issues
-                  encountered during template validation.
-                type: string
-            required:
-            - valid
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    conditions:
+                      description: Conditions reflects the conditions of the remote source object.
+                      items:
+                        description: Condition contains details for one aspect of the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False, Unknown.
+                            enum:
+                              - "True"
+                              - "False"
+                              - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                          - lastTransitionTime
+                          - message
+                          - reason
+                          - status
+                          - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - type
+                      x-kubernetes-list-type: map
+                    kind:
+                      description: Kind is the kind of the remote source.
+                      type: string
+                    name:
+                      description: Name is the name of the remote source.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the remote source.
+                      type: string
+                    observedGeneration:
+                      description: ObservedGeneration is the latest source generation observed by the controller.
+                      format: int64
+                      type: integer
+                  required:
+                    - kind
+                    - name
+                    - namespace
+                  type: object
+                valid:
+                  description: Valid indicates whether the template passed validation or not.
+                  type: boolean
+                validationError:
+                  description: ValidationError provides information regarding issues encountered during template validation.
+                  type: string
+              required:
+                - valid
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_statemanagementproviders.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_statemanagementproviders.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: statemanagementproviders.k0rdent.mirantis.com
 spec:
   group: k0rdent.mirantis.com
@@ -12,102 +13,68 @@ spec:
     listKind: StateManagementProviderList
     plural: statemanagementproviders
     shortNames:
-    - smp
+      - smp
     singular: statemanagementprovider
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - description: Shows readiness of RBAC objects
-      jsonPath: .status.conditions[?(@.type=="RBACReady")].status
-      name: rbac
-      type: string
-    - description: Shows readiness of adapter
-      jsonPath: .status.conditions[?(@.type=="AdapterReady")].status
-      name: adapter
-      type: string
-    - description: Shows readiness of provisioner
-      jsonPath: .status.conditions[?(@.type=="ProvisionerReady")].status
-      name: provisioner
-      type: string
-    - description: Shows readiness of required custom resources
-      jsonPath: .status.conditions[?(@.type=="ProvisionerCRDsReady")].status
-      name: provisioner crds
-      type: string
-    - description: Shows readiness of provider
-      jsonPath: .status.ready
-      name: ready
-      type: boolean
-    - description: Shows whether provider is suspended
-      jsonPath: .spec.suspend
-      name: suspended
-      type: boolean
-    - description: Time elapsed since object creation
-      jsonPath: .metadata.creationTimestamp
-      name: age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: StateManagementProvider is the Schema for the statemanagementproviders
-          API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: StateManagementProviderSpec defines the desired state of
-              StateManagementProvider
-            properties:
-              adapter:
-                description: |-
-                  Adapter is an operator with translates the k0rdent API objects into provider-specific API objects.
-                  It is represented as a reference to operator object
-                properties:
-                  apiVersion:
-                    description: APIVersion is the API version of the resource
-                    type: string
-                  kind:
-                    description: Kind is the kind of the resource
-                    type: string
-                  name:
-                    description: Name is the name of the resource
-                    type: string
-                  namespace:
-                    description: Namespace is the namespace of the resource
-                    type: string
-                  readinessRule:
-                    description: ReadinessRule is a CEL expression that evaluates
-                      to true when the resource is ready
-                    type: string
-                required:
-                - apiVersion
-                - kind
-                - name
-                - namespace
-                - readinessRule
-                type: object
-              provisioner:
-                description: |-
-                  Provisioner is a set of resources required for the provider to operate. These resources
-                  reconcile provider-specific API objects. It is represented as a list of references to
-                  provider's objects
-                items:
-                  description: ResourceReference is a cross-namespace reference to
-                    a resource
+    - additionalPrinterColumns:
+        - description: Shows readiness of RBAC objects
+          jsonPath: .status.conditions[?(@.type=="RBACReady")].status
+          name: rbac
+          type: string
+        - description: Shows readiness of adapter
+          jsonPath: .status.conditions[?(@.type=="AdapterReady")].status
+          name: adapter
+          type: string
+        - description: Shows readiness of provisioner
+          jsonPath: .status.conditions[?(@.type=="ProvisionerReady")].status
+          name: provisioner
+          type: string
+        - description: Shows readiness of required custom resources
+          jsonPath: .status.conditions[?(@.type=="ProvisionerCRDsReady")].status
+          name: provisioner crds
+          type: string
+        - description: Shows readiness of provider
+          jsonPath: .status.ready
+          name: ready
+          type: boolean
+        - description: Shows whether provider is suspended
+          jsonPath: .spec.suspend
+          name: suspended
+          type: boolean
+        - description: Time elapsed since object creation
+          jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: StateManagementProvider is the Schema for the statemanagementproviders API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: StateManagementProviderSpec defines the desired state of StateManagementProvider
+              properties:
+                adapter:
+                  description: |-
+                    Adapter is an operator with translates the k0rdent API objects into provider-specific API objects.
+                    It is represented as a reference to operator object
                   properties:
                     apiVersion:
                       description: APIVersion is the API version of the resource
@@ -122,176 +89,197 @@ spec:
                       description: Namespace is the namespace of the resource
                       type: string
                     readinessRule:
-                      description: ReadinessRule is a CEL expression that evaluates
-                        to true when the resource is ready
+                      description: ReadinessRule is a CEL expression that evaluates to true when the resource is ready
                       type: string
                   required:
-                  - apiVersion
-                  - kind
-                  - name
-                  - namespace
-                  - readinessRule
+                    - apiVersion
+                    - kind
+                    - name
+                    - namespace
+                    - readinessRule
                   type: object
-                type: array
-              provisionerCRDs:
-                description: |-
-                  ProvisionerCRDs is a set of references to provider-specific CustomResourceDefinition objects,
-                  which are required for the provider to operate.
-                items:
-                  description: ProvisionerCRD is a GVRs for a custom resource reconciled
-                    by provisioners
-                  properties:
-                    group:
-                      description: Group is the API group of the resources
-                      type: string
-                    resources:
-                      description: Resources is the list of resources under given
-                        APIVersion
-                      items:
+                provisioner:
+                  description: |-
+                    Provisioner is a set of resources required for the provider to operate. These resources
+                    reconcile provider-specific API objects. It is represented as a list of references to
+                    provider's objects
+                  items:
+                    description: ResourceReference is a cross-namespace reference to a resource
+                    properties:
+                      apiVersion:
+                        description: APIVersion is the API version of the resource
                         type: string
-                      type: array
-                    version:
-                      description: Version is the API version of the resources
-                      type: string
-                  required:
-                  - group
-                  - resources
-                  - version
-                  type: object
-                type: array
-              selector:
-                description: Selector is label selector to be used to filter the [ServiceSet]
-                  objects to be reconciled.
-                properties:
-                  matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
-                    items:
-                      description: |-
-                        A label selector requirement is a selector that contains values, a key, and an operator that
-                        relates the key and values.
-                      properties:
-                        key:
-                          description: key is the label key that the selector applies
-                            to.
-                          type: string
-                        operator:
-                          description: |-
-                            operator represents a key's relationship to a set of values.
-                            Valid operators are In, NotIn, Exists and DoesNotExist.
-                          type: string
-                        values:
-                          description: |-
-                            values is an array of string values. If the operator is In or NotIn,
-                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                            the values array must be empty. This array is replaced during a strategic
-                            merge patch.
-                          items:
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      required:
-                      - key
-                      - operator
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    description: |-
-                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      kind:
+                        description: Kind is the kind of the resource
+                        type: string
+                      name:
+                        description: Name is the name of the resource
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the resource
+                        type: string
+                      readinessRule:
+                        description: ReadinessRule is a CEL expression that evaluates to true when the resource is ready
+                        type: string
+                    required:
+                      - apiVersion
+                      - kind
+                      - name
+                      - namespace
+                      - readinessRule
                     type: object
-                type: object
-                x-kubernetes-map-type: atomic
-              suspend:
-                default: false
-                description: |-
-                  Suspend suspends the StateManagementProvider. Suspending a StateManagementProvider
-                  will prevent the adapter from reconciling any resources.
-                type: boolean
-            required:
-            - adapter
-            - provisioner
-            - provisionerCRDs
-            - selector
-            - suspend
-            type: object
-          status:
-            description: StateManagementProviderStatus defines the observed state
-              of StateManagementProvider
-            properties:
-              conditions:
-                description: Conditions is a list of conditions for the state management
-                  provider
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  type: array
+                provisionerCRDs:
+                  description: |-
+                    ProvisionerCRDs is a set of references to provider-specific CustomResourceDefinition objects,
+                    which are required for the provider to operate.
+                  items:
+                    description: ProvisionerCRD is a GVRs for a custom resource reconciled by provisioners
+                    properties:
+                      group:
+                        description: Group is the API group of the resources
+                        type: string
+                      resources:
+                        description: Resources is the list of resources under given APIVersion
+                        items:
+                          type: string
+                        type: array
+                      version:
+                        description: Version is the API version of the resources
+                        type: string
+                    required:
+                      - group
+                      - resources
+                      - version
+                    type: object
+                  type: array
+                selector:
+                  description: Selector is label selector to be used to filter the [ServiceSet] objects to be reconciled.
                   properties:
-                    lastTransitionTime:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
                   type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              ready:
-                description: Ready is true if the state management provider is valid
-                type: boolean
-            required:
-            - ready
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  x-kubernetes-map-type: atomic
+                suspend:
+                  default: false
+                  description: |-
+                    Suspend suspends the StateManagementProvider. Suspending a StateManagementProvider
+                    will prevent the adapter from reconciling any resources.
+                  type: boolean
+              required:
+                - adapter
+                - provisioner
+                - provisionerCRDs
+                - selector
+                - suspend
+              type: object
+            status:
+              description: StateManagementProviderStatus defines the observed state of StateManagementProvider
+              properties:
+                conditions:
+                  description: Conditions is a list of conditions for the state management provider
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                ready:
+                  description: Ready is true if the state management provider is valid
+                  type: boolean
+              required:
+                - ready
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -173,6 +173,19 @@
     "flux2": {
       "type": "object",
       "properties": {
+        "crds": {
+          "type": "object",
+          "properties": {
+            "annotations": {
+              "type": "object",
+              "properties": {
+                "helm.sh/resource-policy": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
         "enabled": {
           "type": "boolean"
         },

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -92,6 +92,9 @@ flux2:
     container:
       additionalArgs:
         - --watch-label-selector=k0rdent.mirantis.com/managed=true
+  crds:
+    annotations:
+      "helm.sh/resource-policy": "keep"
 
 rbac-manager:
   enabled: true


### PR DESCRIPTION
Remaining CRDs that are not annotated (since the configuration is not exposed in the corresponding charts):
* all Sveltos CRDs
* rbac-manager CRD

Fixes: #1863 