### PR TITLE
fix: run ksm tests via test config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ load-e2e-config: yq
 		echo "E2E_CONFIG_B64 is empty, the default configuration from test/e2e/config/config.yaml will be used"; \
 		exit 0; \
 	fi; \
-	@config_content="$$(echo -n "$(E2E_CONFIG_B64)" | base64 -d)"; \
+	config_content="$$(echo -n "$(E2E_CONFIG_B64)" | base64 -d)"; \
 	echo "Validating provided configuration..."; \
 	if ! echo "$$config_content" | $(YQ) eval > /dev/null 2>&1; then \
 		echo "Invalid YAML configuration provided:"; \

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -30,14 +30,15 @@ import (
 type TestingProvider string
 
 const (
-	TestingProviderAWS       TestingProvider = "aws"
-	TestingProviderAzure     TestingProvider = "azure"
-	TestingProviderGCP       TestingProvider = "gcp"
-	TestingProviderOpenstack TestingProvider = "openstack"
-	TestingProviderVsphere   TestingProvider = "vsphere"
-	TestingProviderAdopted   TestingProvider = "adopted"
-	TestingProviderRemote    TestingProvider = "remote"
-	TestingProviderDocker    TestingProvider = "docker"
+	TestingProviderAWS        TestingProvider = "aws"
+	TestingProviderAzure      TestingProvider = "azure"
+	TestingProviderGCP        TestingProvider = "gcp"
+	TestingProviderOpenstack  TestingProvider = "openstack"
+	TestingProviderVsphere    TestingProvider = "vsphere"
+	TestingProviderAdopted    TestingProvider = "adopted"
+	TestingProviderRemote     TestingProvider = "remote"
+	TestingProviderDocker     TestingProvider = "docker"
+	TestingProviderMothership TestingProvider = "mothership"
 )
 
 type Architecture string
@@ -108,6 +109,7 @@ func initialize() {
 		TestingProviderVsphere,
 		TestingProviderAdopted,
 		TestingProviderRemote,
+		TestingProviderMothership,
 	}
 
 	Config = make(map[TestingProvider][]ProviderTestingConfig)

--- a/test/e2e/config/config.yaml
+++ b/test/e2e/config/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024
+# Copyright 2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,4 +38,3 @@
 #- template: vsphere-standalone-cp-0-2-0
 
 aws: []
-docker: []

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -174,14 +174,14 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 		}
 	})
 
-	It("MultiCluster services no longer match", func() {
-		const (
-			multiClusterServiceName       = "test-multicluster"
-			multiClusterServiceMatchLabel = "k0rdent.mirantis.com/test-cluster-name"
-		)
+	for i, cfg := range config.Config[config.TestingProviderDocker] {
+		It("MultiCluster services no longer match", func() {
+			const (
+				multiClusterServiceName       = "test-multicluster"
+				multiClusterServiceMatchLabel = "k0rdent.mirantis.com/test-cluster-name"
+			)
 
-		defer GinkgoRecover()
-		for i, cfg := range config.Config[config.TestingProviderDocker] {
+			defer GinkgoRecover()
 			ctx := context.Background()
 			cfg.SetDefaults(clusterTemplates, config.TestingProviderDocker)
 
@@ -202,12 +202,10 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 			multiclusterservice.DeleteMultiClusterService(ctx, kc.CrClient, mcs)
 			Expect(clusterDeleteFunc()).Error().NotTo(HaveOccurred(), "failed to delete cluster")
 			clusterDeleteFunc = nil
-		}
-	})
+		})
 
-	It("Performing sequential upgrades", func() {
-		defer GinkgoRecover()
-		for i, cfg := range config.Config[config.TestingProviderDocker] {
+		It("Performing sequential upgrades", func() {
+			defer GinkgoRecover()
 			ctx := context.Background()
 			cfg.SetDefaults(clusterTemplates, config.TestingProviderDocker)
 
@@ -244,12 +242,10 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 
 			Expect(clusterDeleteFunc()).Error().NotTo(HaveOccurred(), "failed to delete cluster")
 			clusterDeleteFunc = nil
-		}
-	})
+		})
 
-	It("Performing upgrades with dependent services", func() {
-		defer GinkgoRecover()
-		for i, cfg := range config.Config[config.TestingProviderDocker] {
+		It("Performing upgrades with dependent services", func() {
+			defer GinkgoRecover()
 			ctx := context.Background()
 			cfg.SetDefaults(clusterTemplates, config.TestingProviderDocker)
 
@@ -324,12 +320,10 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 			Expect(serviceSet.Spec.Services).To(HaveLen(3))
 			Expect(clusterDeleteFunc()).Error().NotTo(HaveOccurred(), "failed to delete cluster")
 			clusterDeleteFunc = nil
-		}
-	})
+		})
 
-	It("Pause service deployment", func() {
-		defer GinkgoRecover()
-		for i, cfg := range config.Config[config.TestingProviderDocker] {
+		It("Pause service deployment", func() {
+			defer GinkgoRecover()
 			ctx := context.Background()
 			cfg.SetDefaults(clusterTemplates, config.TestingProviderDocker)
 
@@ -371,8 +365,8 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 
 			Expect(clusterDeleteFunc()).Error().NotTo(HaveOccurred(), "failed to delete cluster")
 			clusterDeleteFunc = nil
-		}
-	})
+		})
+	}
 })
 
 // createAndWaitCluster centralizes cluster creation, waiting for deploy and returns the created ClusterDeployment + delete function.


### PR DESCRIPTION
# Description
Fixes https://github.com/k0rdent/kcm/issues/2291.

Made mothership and functional tests run only when the config has `mothership` and `docker` entries respectively. Similar to [how it is done for aws tests](https://github.com/k0rdent/kcm/blob/f1af46d67aac7cf2f1447a72a1091e2e5151d59d/test/e2e/provider_aws_test.go#L145).

# Verification

I ran the e2e tests in CI and verified the following:
1. With empty or `aws: []` only the AWS test was run.
2. With `docker: []` only the functional tests were run.
3. With `mothership: []` only the mothership tests were run,