### PR TITLE
ci(chore): issue templates, guides, gh releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[bug] <your bug title here>"
-labels: bug
+labels: ["bug", "needs-triage"]
+type: Bug
 assignees: ''
 
 ---
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. <step 1>
 2. <step 2>
 3. <step 3>
@@ -21,3 +22,5 @@ A clear and concise description of what you expected to happen.
 
 **Additional context**
 Add any other context about the problem here.
+
+- [ ] This is NOT a request to change or create a new provider or cluster template

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,8 +1,8 @@
 ---
 name: Epic
 about: Feature request that is larger body of work
-title: ''
-labels: epic
+labels: ["epic", "needs-triage"]
+type: Feature
 assignees: ''
 
 ---
@@ -17,6 +17,7 @@ assignees: ''
 <describe groups / target audience and what are the benefits of feature implementation for them>
 
 **Acceptance criteria**
+
 - <acc criterion 1>
 - <acc criterion 2>
 - <acc criterion 3>
@@ -24,7 +25,7 @@ assignees: ''
 **Telemetry & Success Criteria**
 <is any telemetry data needed? If yes, what is it?>
 
-**Assumptions** 
+**Assumptions**
 <any assumptions that are taken into account>
 
 **Limitations**
@@ -33,5 +34,5 @@ assignees: ''
 **Out of scope**
 <clear description of what is out of scope>
 
-**User stories** 
+**User stories**
 <list of user stories>

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[enhancement] <your feature request title>"
-labels: enhancement
+labels: ["enhancement", "needs-triage"]
+type: Feature
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/template-request.md
+++ b/.github/ISSUE_TEMPLATE/template-request.md
@@ -1,0 +1,17 @@
+---
+name: Template request
+about: Request changes or create a new cluster or provider template
+labels: ["template", "needs-triage"]
+assignees: ''
+
+---
+
+**Describe the change you'd like to see to the templates**
+A clear and concise description of what should be changed to the existing templates,
+or added a new template. The latter requires a clear reasoning behind it.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -106,6 +106,7 @@ jobs:
 
           # Conventional commit regex (simplified)
           CONVENTIONAL_REGEX='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-zA-Z0-9_-]+\))??!?:.+$'
+          REVERT_REGEX='^Revert ".+"$'
 
           pr_title="${{ github.event.pull_request.title }}"
           echo "PR title: $pr_title"
@@ -113,13 +114,13 @@ jobs:
           commit_title="$(git log -2 --pretty=%s | tail -n 1)"
           echo "Commit title: $commit_title"
 
-          if [[ ! "$pr_title" =~ $CONVENTIONAL_REGEX ]]; then
-            echo "::error::PR title does not follow Conventional Commits format: https://www.conventionalcommits.org/"
+          if [[ ! "$pr_title" =~ $CONVENTIONAL_REGEX && ! "$pr_title" =~ $REVERT_REGEX ]]; then
+            echo "::error::PR title must follow Conventional Commits (https://www.conventionalcommits.org) or be an auto-generated revert"
             exit 1
           fi
 
-          if [[ ! "$commit_title" =~ $CONVENTIONAL_REGEX ]]; then
-            echo "::error::Commit message does not follow Conventional Commits format: https://www.conventionalcommits.org/"
+          if [[ ! "$commit_title" =~ $CONVENTIONAL_REGEX && ! "$commit_title" =~ $REVERT_REGEX ]]; then
+            echo "::error::Commit message must follow Conventional Commits (https://www.conventionalcommits.org) or be an auto-generated revert"
             exit 1
           fi
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -17,10 +17,10 @@ jobs:
           # issues
           days-before-issue-stale: 14
           days-before-issue-close: 14
-          only-issue-labels: "needs-triage,question / discussion"
+          only-issue-labels: "needs-triage,question/discussion"
           exempt-issue-labels: "keep"
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open 14 days, labeled with needs-triage and question / discussion, and with no activity. Remove stale label or comment or this will be closed in 14 days."
+          stale-issue-message: "This issue is stale because it has been open 14 days, labeled with 'needs-triage' and 'question/discussion', and with no activity. Remove stale label or comment or this will be closed in 14 days."
 
           # pull requests
           days-before-pr-stale: 90

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -145,8 +145,7 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
 changelog:
-  disable: >-
-    {{ if eq (index .Env "SKIP_SCM_RELEASE") "true" }}{{true}}{{ else }}{{false}}{{ end }}
+  disable: '{{ or (contains .Tag "-rc") (eq (index .Env "SKIP_SCM_RELEASE") "true") }}'
   sort: asc
   use: github
   format: "{{ .SHA }}: {{ .Message }}{{ with .AuthorUsername }} by @{{ . }}{{ end }}"
@@ -158,7 +157,6 @@ changelog:
       - "^ci\\("
       - "^chore:"
       - "^chore\\("
-      - "merge conflict"
       - "merge conflict"
       - Merge pull request
       - Merge remote-tracking branch
@@ -190,8 +188,7 @@ release:
   make_latest: true
   mode: replace
 
-  disable: >-
-    {{ if eq (index .Env "SKIP_SCM_RELEASE") "true" }}{{true}}{{ else }}{{false}}{{ end }}
+  disable: '{{ or (contains .Tag "-rc") (eq (index .Env "SKIP_SCM_RELEASE") "true") }}'
 
   header: |
     ## 📋 Components Versions 📋

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing
+
+By participating in this project, you agree to abide our
+[code of conduct](https://github.com/k0rdent/community/blob/main/CODE_OF_CONDUCT.md).
+
+## Set up your machine
+
+> NOTE: we do not currently support Windows development,
+> thus the following is applicable for Linux and Darwin.
+
+Prerequisites:
+
+- [Make](https://www.gnu.org/software/make/manual/make.html)
+- [Go](https://go.dev/doc/install)
+
+To install the required CLI tools:
+
+```bash
+make cli-install
+```
+
+## Build
+
+Clone `kcm` anywhere:
+
+```sh
+git clone https://github.com/k0rdent/kcm.git
+```
+
+`cd` into the directory and install the dependencies:
+
+```bash
+go mod tidy
+```
+
+Build then the binaries:
+
+```bash
+make build
+```
+
+## Test
+
+When you are satisfied with the changes you have made, run linter, and
+unit- and env-tests:
+
+```bash
+make lint test
+```
+
+Before you commit the changes, generate the code and templates.
+Optionally, a base and a head commits to diff changes from can be set:
+
+```bash
+make generate-all
+# or
+make BASE_COMMIT=origin/main HEAD_COMMIT=HEAD generate-all
+```
+
+To run E2E tests, please refer to the corresponding section of the
+[dev docs](./docs/dev.md#running-e2e-tests-locally).
+
+## Create a commit
+
+Commit messages should follow
+the [Conventional Commits](https://www.conventionalcommits.org) convention.
+
+## Submit a PR
+
+Push your branch to your fork, and open a new pull request against the `main` branch.
+
+Please make sure that the title of the PR also follows the
+[Conventional Commits](https://www.conventionalcommits.org) convention.


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes creation of GH Releases and changelog generation on RC tags.

Amends existing issue templates adding the corresponding types and triage labels automatically. Added template-related question to the bug request issue template.

Adds a new Template Request issue template.

Adds contributing guide, referring the common COC.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #1955 