### PR TITLE
fix: define default network configuration in KubeVirt templates

### DIFF
--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-0
+  template: kubevirt-standalone-cp-1-0-1
   credential: kubevirt-cred
   propagateCredentials: false
   config:
@@ -19,12 +19,12 @@ spec:
     controlPlane:
       dnsConfig:
         nameservers:
-        - 8.8.8.8
+          - 8.8.8.8
       cpu:
         model: host-passthrough
     worker:
       dnsConfig:
         nameservers:
-        - 8.8.8.8
+          - 8.8.8.8
       cpu:
         model: host-passthrough

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-hosted-cp/values.schema.json
+++ b/templates/cluster/kubevirt-hosted-cp/values.schema.json
@@ -386,7 +386,17 @@
               "description": "Network interfaces which are added to the vmi",
               "type": "array",
               "items": {
-                "type": "object"
+                "type": "object",
+                "properties": {
+                  "bridge": {
+                    "description": "Bridge interface mode. Read mode: https://kubevirt.io/user-guide/network/interfaces_and_networks/#bridge",
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "Name of the network interface",
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -431,7 +441,17 @@
           "description": "List of networks that can be attached to a vm’s virtual interface",
           "type": "array",
           "items": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the network",
+                "type": "string"
+              },
+              "pod": {
+                "description": "Pod network type",
+                "type": "object"
+              }
+            }
           }
         },
         "nodeSelector": {

--- a/templates/cluster/kubevirt-hosted-cp/values.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/values.yaml
@@ -57,9 +57,13 @@ worker: # @schema description: Worker parameters; type: object
     numa: {} # @schema description: NUMA configuration; type: object; additionalProperties: true
 
   devices: # @schema description: Device configuration; type: object
-    interfaces: [] # @schema description: Network interfaces which are added to the vmi; type: array; item: object
+    interfaces: # @schema description: Network interfaces which are added to the vmi; type: array; item: object
+    - name: default # @schema description: Name of the network interface; type: string
+      bridge: {} # @schema description: Bridge interface mode. Read mode: https://kubevirt.io/user-guide/network/interfaces_and_networks/#bridge; type: object
 
-  networks: [] # @schema description: List of networks that can be attached to a vm’s virtual interface; type: array; item: object
+  networks: # @schema description: List of networks that can be attached to a vm’s virtual interface; type: array; item: object
+  - name: default # @schema description: Name of the network; type: string
+    pod: {} # @schema description: Pod network type; type: object
 
   networkInterfaceMultiqueue: true # @schema description: Enable network interface multiqueue; type: boolean
 

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-standalone-cp/values.schema.json
+++ b/templates/cluster/kubevirt-standalone-cp/values.schema.json
@@ -181,7 +181,17 @@
               "description": "Network interfaces which are added to the vmi",
               "type": "array",
               "items": {
-                "type": "object"
+                "type": "object",
+                "properties": {
+                  "bridge": {
+                    "description": "Bridge interface mode. Read mode: https://kubevirt.io/user-guide/network/interfaces_and_networks/#bridge",
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "Name of the network interface",
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -226,7 +236,17 @@
           "description": "List of networks that can be attached to a vm’s virtual interface",
           "type": "array",
           "items": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the network",
+                "type": "string"
+              },
+              "pod": {
+                "description": "Pod network type",
+                "type": "object"
+              }
+            }
           }
         },
         "nodeSelector": {
@@ -452,7 +472,17 @@
               "description": "Network interfaces which are added to the vmi",
               "type": "array",
               "items": {
-                "type": "object"
+                "type": "object",
+                "properties": {
+                  "bridge": {
+                    "description": "Bridge interface mode. Read mode: https://kubevirt.io/user-guide/network/interfaces_and_networks/#bridge",
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "Name of the network interface",
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -497,7 +527,17 @@
           "description": "List of networks that can be attached to a vm’s virtual interface",
           "type": "array",
           "items": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the network",
+                "type": "string"
+              },
+              "pod": {
+                "description": "Pod network type",
+                "type": "object"
+              }
+            }
           }
         },
         "nodeSelector": {

--- a/templates/cluster/kubevirt-standalone-cp/values.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/values.yaml
@@ -50,9 +50,13 @@ controlPlane: # @schema description: Configuration of the control plane machines
     numa: {} # @schema description: NUMA configuration; type: object; additionalProperties: true
 
   devices: # @schema description: Device configuration; type: object
-    interfaces: [] # @schema description: Network interfaces which are added to the vmi; type: array; item: object
+    interfaces: # @schema description: Network interfaces which are added to the vmi; type: array; item: object
+    - name: default # @schema description: Name of the network interface; type: string
+      bridge: {} # @schema description: Bridge interface mode. Read mode: https://kubevirt.io/user-guide/network/interfaces_and_networks/#bridge; type: object
 
-  networks: [] # @schema description: List of networks that can be attached to a vm’s virtual interface; type: array; item: object
+  networks: # @schema description: List of networks that can be attached to a vm’s virtual interface; type: array; item: object
+  - name: default # @schema description: Name of the network; type: string
+    pod: {} # @schema description: Pod network type; type: object
 
   networkInterfaceMultiqueue: true # @schema description: Enable network interface multiqueue; type: boolean
 
@@ -81,9 +85,13 @@ worker: # @schema description: Worker parameters; type: object
     numa: {} # @schema description: NUMA configuration; type: object; additionalProperties: true
 
   devices: # @schema description: Device configuration; type: object
-    interfaces: [] # @schema description: Network interfaces which are added to the vmi; type: array; item: object
+    interfaces: # @schema description: Network interfaces which are added to the vmi; type: array; item: object
+    - name: default # @schema description: Name of the network interface; type: string
+      bridge: {} # @schema description: Bridge interface mode. Read mode: https://kubevirt.io/user-guide/network/interfaces_and_networks/#bridge; type: object
 
-  networks: [] # @schema description: List of networks that can be attached to a vm’s virtual interface; type: array; item: object
+  networks: # @schema description: List of networks that can be attached to a vm’s virtual interface; type: array; item: object
+  - name: default # @schema description: Name of the network; type: string
+    pod: {} # @schema description: Pod network type; type: object
 
   networkInterfaceMultiqueue: true # @schema description: Enable network interface multiqueue; type: boolean
 

--- a/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-hosted-cp-1-0-0
+  name: kubevirt-hosted-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kubevirt-hosted-cp
-      version: 1.0.0
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-1.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-1.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-0
+  name: kubevirt-standalone-cp-1-0-1
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kubevirt-standalone-cp
-      version: 1.0.0
+      version: 1.0.1
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Define the default network configuration with the `bridge` interface for KubeVirt VMs.

Related task #2351 