### PR TITLE
test: add region controller integration tests

### DIFF
--- a/internal/controller/region/controller.go
+++ b/internal/controller/region/controller.go
@@ -63,6 +63,8 @@ type Reconciler struct {
 
 	IsDisabledValidationWH bool // is webhook disabled set via the controller flags
 
+	skipCertManagerInstalledCheck bool
+
 	DefaultHelmTimeout time.Duration
 	defaultRequeueTime time.Duration
 }

--- a/internal/controller/region/controller_test.go
+++ b/internal/controller/region/controller_test.go
@@ -1,0 +1,558 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package region
+
+import (
+	"fmt"
+	"time"
+
+	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
+	fluxmeta "github.com/fluxcd/pkg/apis/meta"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+)
+
+const (
+	systemNamespace = "kcm-system"
+	releaseName     = "test-release-name"
+
+	registryCertSecretName = "registry-cert"
+	imagePullSecretName    = "image-pull-secret"
+
+	kubeconfigSecretKey = "value"
+
+	coreKCMTemplateName           = "test-template-kcm"
+	coreKCMRegionalTemplateName   = "test-template-kcm-regional"
+	coreCAPITemplateName          = "test-template-capi"
+	awsProviderTemplateName       = "test-template-aws"
+	openstackProviderTemplateName = "test-template-openstack"
+	azureProviderTemplateName     = "test-template-azure"
+)
+
+var secretsToCopy = map[string]map[string][]byte{
+	registryCertSecretName: {
+		"tls.crt": []byte("test-cert"),
+	},
+	imagePullSecretName: {
+		".dockerconfigjson": []byte("test"),
+	},
+}
+
+type testCase struct {
+	// regionName is the name of the Region being tested.
+	regionName types.NamespacedName
+	// enabledProviders defines the list of enabled providers;
+	// key is the provider name, value is the corresponding ProviderTemplate name.
+	enabledProviders map[string]string
+	// clusterDeploymentRef marks that the Region being tested should contain
+	// a reference to an existing ClusterDeployment object to be onboarded
+	// as a regional cluster.
+	clusterDeploymentRef *kcmv1.ClusterDeploymentRef
+}
+
+var providers = map[string]string{
+	"aws":       awsProviderTemplateName,
+	"openstack": openstackProviderTemplateName,
+	"azure":     azureProviderTemplateName,
+}
+
+var tests = []testCase{
+	{
+		regionName: types.NamespacedName{Name: "rgn1"},
+		enabledProviders: map[string]string{
+			"aws":       awsProviderTemplateName,
+			"openstack": openstackProviderTemplateName,
+		},
+	},
+	{
+		regionName: types.NamespacedName{Name: "rgn2"},
+		enabledProviders: map[string]string{
+			"azure": azureProviderTemplateName,
+		},
+		clusterDeploymentRef: &kcmv1.ClusterDeploymentRef{
+			Namespace: "cld-ns",
+			Name:      "cld-name",
+		},
+	},
+}
+
+var _ = Describe("Region controller", Ordered, func() {
+	var supportedProviders []kcmv1.NamedProviderTemplate
+
+	for name, tpl := range providers {
+		supportedProviders = append(supportedProviders, kcmv1.NamedProviderTemplate{
+			Name:                 name,
+			CoreProviderTemplate: kcmv1.CoreProviderTemplate{Template: tpl},
+		})
+	}
+
+	BeforeAll(func() {
+		By("Creating the system namespace")
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: systemNamespace,
+			},
+		}
+		Expect(mgmtClient.Create(ctx, ns)).To(Succeed())
+
+		By("Creating the Release object")
+		release := &kcmv1.Release{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: releaseName,
+			},
+			Spec: kcmv1.ReleaseSpec{
+				Version:   "test-version",
+				KCM:       kcmv1.CoreProviderTemplate{Template: coreKCMTemplateName},
+				Regional:  kcmv1.CoreProviderTemplate{Template: coreKCMRegionalTemplateName},
+				CAPI:      kcmv1.CoreProviderTemplate{Template: coreCAPITemplateName},
+				Providers: supportedProviders,
+			},
+		}
+		Expect(mgmtClient.Create(ctx, release)).To(Succeed())
+
+		By("Creating the Management object")
+		mgmt := &kcmv1.Management{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: kcmv1.ManagementName,
+			},
+			Spec: kcmv1.ManagementSpec{
+				Release: releaseName,
+				ComponentsCommonSpec: kcmv1.ComponentsCommonSpec{
+					Core: &kcmv1.Core{
+						KCM:  kcmv1.Component{},
+						CAPI: kcmv1.Component{},
+					},
+				},
+			},
+		}
+		Expect(mgmtClient.Create(ctx, mgmt)).To(Succeed())
+
+		By("Creating required secrets in the system namespace")
+		for secretName, secretData := range secretsToCopy {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: systemNamespace,
+				},
+				Data: secretData,
+			}
+			Expect(mgmtClient.Create(ctx, secret)).To(Succeed())
+		}
+
+		By("Creating ProviderTemplate objects and marking them as valid")
+		for _, ptName := range []string{
+			coreKCMTemplateName,
+			coreKCMRegionalTemplateName,
+			coreCAPITemplateName,
+			awsProviderTemplateName,
+			openstackProviderTemplateName,
+			azureProviderTemplateName,
+		} {
+			pt := &kcmv1.ProviderTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ptName,
+					Namespace: systemNamespace,
+				},
+				Spec: kcmv1.ProviderTemplateSpec{
+					Helm: kcmv1.HelmSpec{
+						ChartSpec: &sourcev1.HelmChartSpec{
+							Chart:    ptName,
+							Version:  "1.0.0",
+							Interval: metav1.Duration{Duration: 10 * time.Minute},
+							SourceRef: sourcev1.LocalHelmChartSourceReference{
+								Kind: "HelmRepository",
+								Name: "kcm-templates",
+							},
+						},
+					},
+				},
+			}
+			Expect(mgmtClient.Create(ctx, pt)).To(Succeed())
+
+			err := mgmtClient.Get(ctx, types.NamespacedName{Namespace: systemNamespace, Name: ptName}, pt)
+			Expect(err).NotTo(HaveOccurred())
+
+			pt.Status.Valid = true
+			pt.Status.ChartRef = &helmcontrollerv2.CrossNamespaceSourceReference{
+				Kind:      "HelmChart",
+				Name:      ptName,
+				Namespace: systemNamespace,
+			}
+			Expect(mgmtClient.Status().Update(ctx, pt)).To(Succeed())
+		}
+	})
+
+	Context("When reconciling Region resources", func() {
+		for _, testCfg := range tests {
+			t := testCfg
+
+			var (
+				kubeconfigSecretName      = "kubeconfig-secret"
+				kubeconfigSecretNamespace = systemNamespace
+			)
+
+			if t.clusterDeploymentRef != nil {
+				kubeconfigSecretName = t.clusterDeploymentRef.Name + "-kubeconfig"
+				kubeconfigSecretNamespace = t.clusterDeploymentRef.Namespace
+			}
+
+			kubeconfigSecretRef := &fluxmeta.SecretKeyReference{
+				Name: kubeconfigSecretName,
+				Key:  kubeconfigSecretKey,
+			}
+			kubeconfigSecretNamespacedName := types.NamespacedName{
+				Namespace: kubeconfigSecretNamespace,
+				Name:      kubeconfigSecretName,
+			}
+
+			BeforeEach(func() {
+				By("Ensuring the kubeconfig namespace exists")
+				ns := &corev1.Namespace{}
+				err := mgmtClient.Get(ctx, types.NamespacedName{Name: kubeconfigSecretNamespace}, ns)
+				if apierrors.IsNotFound(err) {
+					ns = &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: kubeconfigSecretNamespace,
+						},
+					}
+					Expect(mgmtClient.Create(ctx, ns)).To(Succeed())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				By("Ensuring the kubeconfig Secret exists")
+				kubeconfigSecret := &corev1.Secret{}
+				err = mgmtClient.Get(ctx, kubeconfigSecretNamespacedName, kubeconfigSecret)
+				if apierrors.IsNotFound(err) {
+					secret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: kubeconfigSecretNamespace,
+							Name:      kubeconfigSecretName,
+						},
+						Data: map[string][]byte{
+							kubeconfigSecretKey: rgnKubeconfig,
+						},
+					}
+					Expect(mgmtClient.Create(ctx, secret)).To(Succeed())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				if t.clusterDeploymentRef != nil {
+					By("Ensuring the ClusterDeployment object exists")
+					cld := &kcmv1.ClusterDeployment{}
+					err := mgmtClient.Get(ctx, types.NamespacedName{
+						Namespace: t.clusterDeploymentRef.Namespace,
+						Name:      t.clusterDeploymentRef.Name,
+					}, cld)
+					if apierrors.IsNotFound(err) {
+						cld = &kcmv1.ClusterDeployment{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: t.clusterDeploymentRef.Namespace,
+								Name:      t.clusterDeploymentRef.Name,
+							},
+							Spec: kcmv1.ClusterDeploymentSpec{
+								Template: "test-template",
+							},
+						}
+						Expect(mgmtClient.Create(ctx, cld)).To(Succeed())
+					} else {
+						Expect(err).NotTo(HaveOccurred())
+					}
+				}
+			})
+
+			It("reconciles Region "+t.regionName.Name, func() {
+				By("Creating the Region custom resource if it does not exist")
+				rgn := &kcmv1.Region{}
+				err := mgmtClient.Get(ctx, t.regionName, rgn)
+				if apierrors.IsNotFound(err) {
+					componentsSpec := kcmv1.ComponentsCommonSpec{
+						Core: &kcmv1.Core{
+							KCM:  kcmv1.Component{},
+							CAPI: kcmv1.Component{},
+						},
+					}
+					for name := range t.enabledProviders {
+						componentsSpec.Providers = append(componentsSpec.Providers, kcmv1.Provider{Name: name})
+					}
+
+					rgn = &kcmv1.Region{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: t.regionName.Name,
+						},
+						Spec: kcmv1.RegionSpec{
+							ComponentsCommonSpec: componentsSpec,
+						},
+					}
+
+					if t.clusterDeploymentRef != nil {
+						rgn.Spec.ClusterDeployment = t.clusterDeploymentRef
+					} else {
+						rgn.Spec.KubeConfig = kubeconfigSecretRef
+					}
+
+					rgn.GetObjectKind().SetGroupVersionKind(kcmv1.GroupVersion.WithKind(kcmv1.RegionKind))
+
+					Expect(mgmtClient.Create(ctx, rgn)).To(Succeed())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				reconciler := newTestReconciler()
+				testRegionReconciliation(reconciler, t)
+			})
+
+			It("cleans up Region "+t.regionName.Name, func() {
+				rgn := &kcmv1.Region{}
+				err := mgmtClient.Get(ctx, t.regionName, rgn)
+				if err == nil {
+					Expect(mgmtClient.Delete(ctx, rgn)).To(Succeed())
+				} else if !apierrors.IsNotFound(err) {
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				reconciler := newTestReconciler()
+				testRegionCleanup(reconciler, t)
+			})
+		}
+	})
+})
+
+func newTestReconciler() *Reconciler {
+	return &Reconciler{
+		MgmtClient:                    mgmtClient,
+		SystemNamespace:               systemNamespace,
+		RegistryCertSecretName:        registryCertSecretName,
+		ImagePullSecretName:           imagePullSecretName,
+		skipCertManagerInstalledCheck: true,
+	}
+}
+
+func testRegionReconciliation(reconciler *Reconciler, t testCase) {
+	By("Reconciling the Region: should add finalizer")
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+
+	rgn := &kcmv1.Region{}
+	err = mgmtClient.Get(ctx, t.regionName, rgn)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(rgn.Finalizers).To(ContainElement(kcmv1.RegionFinalizer))
+
+	By("Reconciling the Region: should add KCM component label")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = mgmtClient.Get(ctx, t.regionName, rgn)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(rgn.Labels[kcmv1.GenericComponentNameLabel]).To(Equal(kcmv1.GenericComponentLabelValueKCM))
+
+	By("Reconciling the Region: initial setup")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+
+	if t.clusterDeploymentRef != nil {
+		By("Reconciling the Region: should copy the regional kubeconfig Secret to the system namespace")
+		copiedSecret := &corev1.Secret{}
+		secretName := t.clusterDeploymentRef.Namespace + "." + t.clusterDeploymentRef.Name + "-kubeconfig"
+		err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: systemNamespace, Name: secretName}, copiedSecret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(copiedSecret.Data[kubeconfigSecretKey]).To(Equal(rgnKubeconfig))
+	}
+
+	By("Reconciling the Region: should copy the required Secrets to the regional cluster")
+	for secretName, secretData := range secretsToCopy {
+		secret := &corev1.Secret{}
+		err = rgnClient.Get(ctx, types.NamespacedName{Namespace: systemNamespace, Name: secretName}, secret)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(secret.Data).To(Equal(secretData))
+		Expect(secret.Labels).To(HaveKeyWithValue(kcmv1.KCMRegionLabelKey, t.regionName.Name))
+	}
+
+	By("Reconciling the Region: should create kcm-regional HelmRelease")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+	markHelmReleaseReady(rgn.Name, kcmv1.CoreKCMRegionalName)
+
+	By("Reconciling the Region: should create CAPI HelmRelease")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+	markHelmReleaseReady(rgn.Name, kcmv1.CoreCAPIName)
+
+	By("Reconciling the Region: should set partial status with core components ready")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = mgmtClient.Get(ctx, t.regionName, rgn)
+	Expect(err).NotTo(HaveOccurred())
+
+	partialComponentsStatus := map[string]kcmv1.ComponentStatus{
+		kcmv1.CoreKCMRegionalName: {
+			Template: coreKCMRegionalTemplateName,
+			Success:  true,
+		},
+		kcmv1.CoreCAPIName: {
+			Template: coreCAPITemplateName,
+			Success:  true,
+		},
+	}
+	for _, provider := range rgn.Spec.Providers {
+		partialComponentsStatus[provider.Name] = kcmv1.ComponentStatus{
+			Template: t.enabledProviders[provider.Name],
+			Error:    fmt.Sprintf("HelmRelease %s/%s-%s Ready condition is not updated yet", systemNamespace, rgn.Name, provider.Name),
+		}
+	}
+
+	Expect(rgn.Status.ComponentsCommonStatus.Components).To(Equal(partialComponentsStatus))
+
+	By("Reconciling the Region: should create providers' HelmReleases")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+
+	for providerName := range t.enabledProviders {
+		markHelmReleaseReady(rgn.Name, providerName)
+	}
+
+	By("Reconciling the Region: should have correct status and mark Region as Ready")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = mgmtClient.Get(ctx, t.regionName, rgn)
+	Expect(err).NotTo(HaveOccurred())
+
+	expectedComponentsStatus := map[string]kcmv1.ComponentStatus{
+		kcmv1.CoreKCMRegionalName: {
+			Template: coreKCMRegionalTemplateName,
+			Success:  true,
+		},
+		kcmv1.CoreCAPIName: {
+			Template: coreCAPITemplateName,
+			Success:  true,
+		},
+	}
+
+	for _, provider := range rgn.Spec.Providers {
+		expectedComponentsStatus[provider.Name] = kcmv1.ComponentStatus{
+			Template: t.enabledProviders[provider.Name],
+			Success:  true,
+		}
+	}
+
+	Expect(rgn.Status.ComponentsCommonStatus.Components).To(Equal(expectedComponentsStatus))
+}
+
+func testRegionCleanup(reconciler *Reconciler, t testCase) {
+	By("Reconciling the Region cleanup: should remove provider HelmReleases first")
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+
+	rgn := &kcmv1.Region{}
+	rgnName := t.regionName.Name
+	err = mgmtClient.Get(ctx, t.regionName, rgn)
+	Expect(err).NotTo(HaveOccurred())
+
+	for providerName := range t.enabledProviders {
+		hr := &helmcontrollerv2.HelmRelease{}
+		err := mgmtClient.Get(ctx, types.NamespacedName{
+			Namespace: systemNamespace,
+			Name:      rgnName + "-" + providerName,
+		}, hr)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	}
+
+	By("Reconciling the Region cleanup: should remove CAPI HelmRelease")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+
+	hr := &helmcontrollerv2.HelmRelease{}
+	err = mgmtClient.Get(ctx, types.NamespacedName{
+		Namespace: systemNamespace,
+		Name:      rgnName + "-" + coreCAPITemplateName,
+	}, hr)
+	Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+	By("Reconciling the Region cleanup: should remove kcm-regional HelmRelease")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = mgmtClient.Get(ctx, types.NamespacedName{
+		Namespace: systemNamespace,
+		Name:      rgnName + "-" + coreKCMRegionalTemplateName,
+	}, hr)
+	Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+	By("Reconciling the Region cleanup: should remove all Secrets managed by the Region")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: t.regionName})
+	Expect(err).NotTo(HaveOccurred())
+
+	for secretName := range secretsToCopy {
+		By(fmt.Sprintf("Ensuring Secret is removed from regional cluster: %s/%s", systemNamespace, secretName))
+		secret := &corev1.Secret{}
+		err = rgnClient.Get(ctx, types.NamespacedName{
+			Namespace: systemNamespace,
+			Name:      secretName,
+		}, secret)
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	}
+
+	By("Ensuring the Region object is removed")
+	err = mgmtClient.Get(ctx, t.regionName, rgn)
+	Expect(apierrors.IsNotFound(err)).To(BeTrue())
+}
+
+func markHelmReleaseReady(rgnName, componentName string) {
+	hr := &helmcontrollerv2.HelmRelease{}
+	err := mgmtClient.Get(ctx, types.NamespacedName{
+		Namespace: systemNamespace,
+		Name:      rgnName + "-" + componentName,
+	}, hr)
+	Expect(err).NotTo(HaveOccurred())
+
+	const (
+		helmReleaseConfigDigest           = "sha256:some_digest"
+		helmReleaseSnapshotDeployedStatus = "deployed"
+	)
+
+	hr.Status.History = helmcontrollerv2.Snapshots{
+		{
+			Name:          componentName,
+			FirstDeployed: metav1.Now(),
+			LastDeployed:  metav1.Now(),
+			Status:        helmReleaseSnapshotDeployedStatus,
+			ConfigDigest:  helmReleaseConfigDigest,
+		},
+	}
+
+	apimeta.SetStatusCondition(&hr.Status.Conditions, metav1.Condition{
+		Type:               fluxmeta.ReadyCondition,
+		Status:             metav1.ConditionTrue,
+		Reason:             fluxmeta.SucceededReason,
+		ObservedGeneration: hr.Generation,
+	})
+
+	hr.Status.ObservedGeneration = hr.Generation
+	hr.Status.LastAttemptedConfigDigest = helmReleaseConfigDigest
+
+	Expect(mgmtClient.Status().Update(ctx, hr)).To(Succeed())
+}

--- a/internal/controller/region/suite_test.go
+++ b/internal/controller/region/suite_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package region
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+)
+
+var (
+	ctx        context.Context
+	cancel     context.CancelFunc
+	mgmtEnv    *envtest.Environment
+	mgmtClient client.Client
+	config     *rest.Config
+
+	rgnEnv        *envtest.Environment
+	rgnClient     client.Client
+	rgnKubeconfig []byte
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Region Integration")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO()) //nolint:fatcontext
+	mgmtEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "templates", "provider", "kcm", "templates", "crds"),
+			filepath.Join("..", "..", "..", "templates", "provider", "kcm-regional", "templates", "crds"),
+			filepath.Join("..", "..", "..", "bin", "crd"),
+		},
+		ErrorIfCRDPathMissing: true,
+
+		// The BinaryAssetsDirectory is only required if you want to run the tests directly
+		// without call the makefile target test. If not informed it will look for the
+		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
+		// Note that you must have the required binaries setup under the bin directory to perform
+		// the tests directly. When we run make test it will be setup and used automatically.
+		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
+			fmt.Sprintf("1.33.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
+	var err error
+	config, err = mgmtEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(config).NotTo(BeNil())
+
+	Expect(kcmv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(sourcev1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(helmcontrollerv2.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(addoncontrollerv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(libsveltosv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(clusterapiv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	mgmtClient, err = client.New(config, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mgmtClient).NotTo(BeNil())
+
+	rgnEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "templates", "provider", "kcm-regional", "templates", "crds"),
+			filepath.Join("..", "..", "..", "bin", "crd"),
+		},
+	}
+
+	rgnClient, rgnKubeconfig = getRegionalClient()
+
+	komega.SetClient(mgmtClient)
+	komega.SetContext(ctx)
+})
+
+var _ = AfterSuite(func() {
+	Expect(rgnEnv.Stop()).NotTo(HaveOccurred())
+	Expect(mgmtEnv.Stop()).NotTo(HaveOccurred())
+	cancel()
+})
+
+func getRegionalClient() (client.Client, []byte) {
+	var err error
+	cfg, err := rgnEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+
+	clusterName := "rgn"
+	userName := "rgn-user"
+	contextName := "rgn-context"
+
+	kc := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			clusterName: {
+				Server:                   cfg.Host,
+				CertificateAuthorityData: cfg.CAData,
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			userName: {
+				ClientCertificateData: cfg.CertData,
+				ClientKeyData:         cfg.KeyData,
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			contextName: {
+				Cluster:  clusterName,
+				AuthInfo: userName,
+			},
+		},
+		CurrentContext: contextName,
+	}
+
+	kubeconfig, err := clientcmd.Write(kc)
+	Expect(err).NotTo(HaveOccurred())
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	Expect(err).NotTo(HaveOccurred())
+
+	cl, err := client.New(restConfig, client.Options{})
+	Expect(err).NotTo(HaveOccurred())
+
+	return cl, kubeconfig
+}

--- a/internal/util/kube/secrets.go
+++ b/internal/util/kube/secrets.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
@@ -163,7 +164,10 @@ func CopySecret(
 	newSecret.SetUID("")
 
 	if owner != nil {
-		AddOwnerReference(newSecret, owner)
+		err := controllerutil.SetOwnerReference(owner, newSecret, targetClient.Scheme())
+		if err != nil {
+			return fmt.Errorf("failed to set owner reference on Secret: %w", err)
+		}
 	}
 
 	newSecret.SetNamespace(toNamespace)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces integration tests for the Region controller.

Additionally, it includes the following improvements:
1. Ensures the image pull secret copied to the regional cluster includes the region label, allowing it to be properly cleaned up when a Region is deleted
2. Adds an option to skip the cert-manager presence check to simulate an installed cert-manager without integrating its API, which is required for integration tests.
3. Uses `controllerutil.SetOwnerReference` (that correctly finds the `GroupVersionKind` associated with the owner) in the `CopySecret` function to ensure owner references are set correctly in test environments where APIVersion and Kind are not automatically populated.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2283
