### PR TITLE
fix: do not validate template/management relationship when management is being deleted

### DIFF
--- a/internal/webhook/template_webhook.go
+++ b/internal/webhook/template_webhook.go
@@ -219,7 +219,7 @@ func (v *ProviderTemplateValidator) ValidateDelete(ctx context.Context, obj *kcm
 		}
 		return nil, err
 	}
-	if slices.Contains(mgmt.Templates(), obj.Name) {
+	if mgmt.DeletionTimestamp.IsZero() && slices.Contains(mgmt.Templates(), obj.Name) {
 		return admission.Warnings{fmt.Sprintf("The ProviderTemplate %s cannot be removed while it is used in the Management spec",
 			obj.Name)}, errTemplateDeletionForbidden
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where provider templates cannot be deleted while a management deletion is being processed.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2375 