### PR TITLE
fix: do not validate template / multi cluster service relationship if mcs is being deleted

### DIFF
--- a/internal/webhook/template_webhook.go
+++ b/internal/webhook/template_webhook.go
@@ -155,15 +155,15 @@ func (v *ServiceTemplateValidator) ValidateDelete(ctx context.Context, obj *kcmv
 			return nil, err
 		}
 
-		var mscNames []string
+		mcsNames := make([]string, 0, len(multiSvcClusters.Items))
 		for _, msc := range multiSvcClusters.Items {
 			if msc.GetDeletionTimestamp().IsZero() {
-				mscNames = append(mscNames, msc.Name)
+				mcsNames = append(mcsNames, msc.Name)
 			}
 		}
 
-		if len(mscNames) > 0 {
-			return admission.Warnings{fmt.Sprintf("The %s ServiceTemplate object can't be removed if MultiClusterService objects [%s] referencing it still exist", obj.Name, strings.Join(mscNames, ","))}, errTemplateDeletionForbidden
+		if len(mcsNames) > 0 {
+			return admission.Warnings{fmt.Sprintf("The %s ServiceTemplate object can't be removed if MultiClusterService objects [%s] referencing it still exist", obj.Name, strings.Join(mcsNames, ","))}, errTemplateDeletionForbidden
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This fix allows service templates to be deleted in the case where the multi cluster service that references it is being deleted.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
https://github.com/k0rdent/k0rdent-enterprise/issues/191