### PR TITLE
fix: do not patch flux with CA volume if flux is unmanaged by KCM

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,6 +69,7 @@ type config struct {
 	enableSveltosCtrl             bool
 	enableSveltosExpireCtrl       bool
 	createManagement              bool
+	fluxEnabled                   bool
 }
 
 var (
@@ -105,6 +106,7 @@ func main() {
 		enableSveltosExpireCtrl       bool
 		defaultHelmTimeout            time.Duration
 		maxConcurrentReconciles       int
+		fluxEnabled                   bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -145,6 +147,7 @@ func main() {
 	flag.BoolVar(&enableSveltosExpireCtrl, "enable-sveltos-expire-ctrl", false, "Enable SveltosCluster stuck (expired) tokens controller")
 	flag.DurationVar(&defaultHelmTimeout, "default-helm-timeout", 0, "Specifies the timeout duration for Helm install or upgrade operations. If unset, Flux’s default value will be used")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 10, "Specifies the maximum number of concurrent reconciles that will be run for each controller.")
+	flag.BoolVar(&fluxEnabled, "flux-enabled", true, "The flag that indicates whether Flux integration is enabled")
 
 	// TODO: remove in one of the upcoming releases
 	_ = flag.Bool("enable-telemetry", false, "[Deprecated] Has no effect, use a dedicated telemetry chart")
@@ -267,6 +270,7 @@ func main() {
 		enableSveltosCtrl:             enableSveltosCtrl,
 		enableSveltosExpireCtrl:       enableSveltosExpireCtrl,
 		defaultHelmTimeout:            defaultHelmTimeout,
+		fluxEnabled:                   fluxEnabled,
 	}
 	if err := setupControllers(mgr, systemNamespace, cfg); err != nil {
 		setupLog.Error(err, "failed to setup controllers")
@@ -405,6 +409,7 @@ func setupControllers(mgr ctrl.Manager, currentNamespace string, cfg config) err
 			Insecure:              cfg.insecureRegistry,
 		},
 		DefaultHelmTimeout: cfg.defaultHelmTimeout,
+		FluxEnabled:        cfg.fluxEnabled,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Release")
 		return err

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -77,6 +77,7 @@ type ReleaseReconciler struct {
 	CreateManagement bool
 	CreateRelease    bool
 	CreateTemplates  bool
+	FluxEnabled      bool
 }
 
 func (r *ReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
@@ -321,9 +322,8 @@ func (r *ReleaseReconciler) reconcileKCMTemplates(ctx context.Context, releaseNa
 			return false, fmt.Errorf("some of the predeclared Secrets (%v) are missing (%v) in the %s namespace", helmRepositorySecrets, missingSecrets, r.SystemNamespace)
 		}
 
-		if r.DefaultRegistryConfig.CertSecretName != "" {
-			err = r.patchFluxWithRegistryCASecret(ctx)
-			if err != nil {
+		if r.DefaultRegistryConfig.CertSecretName != "" && r.FluxEnabled {
+			if err = r.patchFluxWithRegistryCASecret(ctx); err != nil {
 				return false, fmt.Errorf("failed to patch flux components with registry CA secret volume: %w", err)
 			}
 		}

--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
         - --default-helm-timeout={{ .Values.controller.defaultHelmTimeout }}
         {{- end }}
         - --max-concurrent-reconciles={{ .Values.controller.maxConcurrentReconciles }}
+        - --flux-enabled={{ .Values.flux2.enabled }}
         command:
         - /manager
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where the KCM deployment is stuck while trying to patch the flux source controller with the CA certificate when the source controller is unmanaged by KCM.

The fix was validated by deploying KCM with a custom self-signed registry, with flux both enabled and disabled.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2435