### PR TITLE
fix: reuse http client when downloading helm charts

### DIFF
--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -51,7 +51,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 			clusterDeploymentName   = "test-clusterdeployment"
 		)
 
-		fakeDownloadHelmChartFunc := func(context.Context, *fluxmeta.Artifact) (*chart.Chart, error) {
+		fakeDownloadHelmChartFunc := func(_ context.Context, _, _ string) (*chart.Chart, error) {
 			return &chart.Chart{
 				Metadata: &chart.Metadata{
 					APIVersion: "v2",

--- a/internal/controller/template_controller_test.go
+++ b/internal/controller/template_controller_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Template Controller", func() {
 			helmChartURL      = "http://source-controller.kcm-system.svc.cluster.local./helmchart/kcm-system/test-chart/0.1.0.tar.gz"
 		)
 
-		fakeDownloadHelmChartFunc := func(context.Context, *fluxmeta.Artifact) (*chart.Chart, error) {
+		fakeDownloadHelmChartFunc := func(_ context.Context, _, _ string) (*chart.Chart, error) {
 			return &chart.Chart{
 				Metadata: &chart.Metadata{
 					APIVersion: "v2",

--- a/internal/helm/utils.go
+++ b/internal/helm/utils.go
@@ -23,7 +23,6 @@ import (
 	"runtime"
 	"sync"
 
-	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	"github.com/hashicorp/go-retryablehttp"
 	godigest "github.com/opencontainers/go-digest"
 	"helm.sh/helm/v3/pkg/chart"
@@ -49,14 +48,10 @@ func getHTTPClient() *retryablehttp.Client {
 			// we'll instead ensure global limit accommodates per-host default
 			maxProcs := runtime.GOMAXPROCS(0)
 			transport.MaxIdleConnsPerHost = maxProcs + 1
-			transport.MaxIdleConns = (maxProcs + 1) * 10  // support ~10 hosts
+			transport.MaxIdleConns = (maxProcs + 1) * 10 // support ~10 hosts
 		}
 	})
 	return httpClient
-}
-
-func DownloadChartFromArtifact(ctx context.Context, artifact *fluxmeta.Artifact) (*chart.Chart, error) {
-	return DownloadChart(ctx, artifact.URL, artifact.Digest)
 }
 
 func DownloadChart(ctx context.Context, chartURL, digest string) (*chart.Chart, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds re-use for HTTP client used for Helm chart download. This should decrease memory consumption and uncontrolled heap growth.

It was observed that the `net/http.dialConn` responsible for almost 50% of mem consumtion growth:

```
go tool pprof -sample_index=inuse_space -top -base startup.pprof later.pprof 2>/dev/null | head -60
File: manager
Build ID: 65bb427b4e0f9d983a8b67444c01c5dee371a6ae
Type: inuse_space
Time: Feb 27, 2026 at 2:37pm (WET)
Showing nodes accounting for 174.83MB, 82.36% of 212.29MB total
Dropped 318 nodes (cum <= 1.06MB)
      flat  flat%   sum%        cum   cum%
   43.16MB 20.33% 20.33%    43.16MB 20.33%  bufio.NewWriterSize (inline)
   39.65MB 18.68% 39.01%    39.65MB 18.68%  bufio.NewReaderSize (inline)
   13.01MB  6.13% 45.14%    13.01MB  6.13%  runtime.mallocgc
   12.51MB  5.89% 51.03%    12.51MB  5.89%  net/http.(*Transport).queueForIdleConn
   11.01MB  5.18% 56.22%    15.01MB  7.07%  net/http.(*Transport).tryPutIdleConn
      11MB  5.18% 61.40%    15.50MB  7.30%  net/http.http2configureTransports
       9MB  4.24% 65.64%    94.32MB 44.43%  net/http.(*Transport).dialConn
    6.50MB  3.06% 68.70%     6.50MB  3.06%  github.com/hashicorp/go-cleanhttp.DefaultPooledTransport
    4.50MB  2.12% 70.82%     4.50MB  2.12%  net/http.(*Transport).RegisterProtocol
    4.50MB  2.12% 72.94%    17.01MB  8.01%  net/http.(*Transport).getConn
    3.50MB  1.65% 74.59%     3.50MB  1.65%  net/http.(*Transport).prepareTransportCancel
       3MB  1.41% 76.01%        3MB  1.41%  k8s.io/api/events/v1.(*Event).DeepCopy (inline)
    2.05MB  0.97% 76.97%     2.05MB  0.97%  time.newTimer
    2.01MB  0.95% 77.92%     2.01MB  0.95%  k8s.io/client-go/tools/events.(*eventBroadcasterImpl).recordToSink.func1.1
       2MB  0.94% 78.86%     2.50MB  1.18%  net/http.(*connLRU).add
    1.51MB  0.71% 79.57%     1.51MB  0.71%  k8s.io/apimachinery/pkg/api/meta.(*DefaultRESTMapper).AddSpecific (inline)
    1.50MB  0.71% 80.28%    16.51MB  7.78%  net/http.(*persistConn).readLoop
    1.50MB  0.71% 80.99%     1.50MB  0.71%  net.sockaddrToTCP
    1.50MB  0.71% 81.69%     1.50MB  0.71%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).literalStore
   -1.09MB  0.51% 81.18%    -1.09MB  0.51%  k8s.io/api/core/v1.(*ConfigMap).Unmarshal
    1.02MB  0.48% 81.66%     1.02MB  0.48%  k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.(*JSON).UnmarshalJSON
       1MB  0.47% 82.13%        1MB  0.47%  fmt.Sprintf
       1MB  0.47% 82.60%        1MB  0.47%  k8s.io/apimachinery/pkg/apis/meta/v1.(*ObjectMeta).Unmarshal
       1MB  0.47% 83.07%        1MB  0.47%  syscall.anyToSockaddr
   -0.88MB  0.42% 82.66%    -2.05MB  0.97%  compress/flate.NewWriter (inline)
   -0.64MB   0.3% 82.36%    -1.17MB  0.55%  compress/flate.(*compressor).init
   -0.50MB  0.24% 82.12%       -1MB  0.47%  k8s.io/api/core/v1.init
    0.50MB  0.24% 82.36%     1.01MB  0.48%  google.golang.org/protobuf/reflect/protoregistry.(*Files).RegisterFile
         0     0% 82.36%    -2.05MB  0.97%  compress/gzip.(*Writer).Write
         0     0% 82.36%        1MB  0.47%  github.com/K0rdent/kcm/api/v1beta1.(*ClusterDeployment).DeepCopy (inline)
         0     0% 82.36%        1MB  0.47%  github.com/K0rdent/kcm/api/v1beta1.(*ClusterDeployment).DeepCopyInto
         0     0% 82.36%        1MB  0.47%  github.com/K0rdent/kcm/api/v1beta1.(*ClusterDeployment).DeepCopyObject
         0     0% 82.36%     1.01MB  0.47%  github.com/K0rdent/kcm/api/v1beta1.SetupIndexers
         0     0% 82.36%    -1.07MB   0.5%  github.com/K0rdent/kcm/api/v1beta1.init.14.(*Builder).Register.func1
         0     0% 82.36%     1.01MB  0.47%  github.com/K0rdent/kcm/api/v1beta1.setupClusterDeploymentIndexer
         0     0% 82.36%    45.52MB 21.44%  github.com/K0rdent/kcm/internal/controller.(*ClusterDeploymentReconciler).Reconcile
         0     0% 82.36%    45.52MB 21.44%  github.com/K0rdent/kcm/internal/controller.(*ClusterDeploymentReconciler).reconcileUpdate
         0     0% 82.36%    45.02MB 21.21%  github.com/K0rdent/kcm/internal/controller.(*ClusterDeploymentReconciler).updateCluster
         0     0% 82.36%    45.02MB 21.21%  github.com/K0rdent/kcm/internal/controller.(*ClusterDeploymentReconciler).validateConfig
         0     0% 82.36%     1.01MB  0.48%  github.com/K0rdent/kcm/internal/controller.(*MultiClusterServiceReconciler).Reconcile
         0     0% 82.36%     1.01MB  0.48%  github.com/K0rdent/kcm/internal/controller.(*MultiClusterServiceReconciler).reconcileUpdate
         0     0% 82.36%        3MB  1.41%  github.com/K0rdent/kcm/internal/controller/adapters/sveltos.(*ServiceSetReconciler).Reconcile
         0     0% 82.36%        1MB  0.47%  github.com/K0rdent/kcm/internal/controller/adapters/sveltos.(*ServiceSetReconciler).collectServiceStatuses
         0     0% 82.36%     1.50MB  0.71%  github.com/K0rdent/kcm/internal/controller/adapters/sveltos.(*ServiceSetReconciler).ensureProfile
         0     0% 82.36%        1MB  0.47%  github.com/K0rdent/kcm/internal/controller/adapters/sveltos.(*ServiceSetReconciler).ensureProfile.func1
         0     0% 82.36%        1MB  0.47%  github.com/K0rdent/kcm/internal/controller/statemanagementprovider.(*Reconciler).Reconcile
         0     0% 82.36%        1MB  0.47%  github.com/K0rdent/kcm/internal/controller/statemanagementprovider.(*Reconciler).ensureRBAC
         0     0% 82.36%    44.02MB 20.74%  github.com/K0rdent/kcm/internal/helm.(*Actor).DownloadChartFromArtifact
         0     0% 82.36%        1MB  0.47%  github.com/K0rdent/kcm/internal/helm.(*Actor).EnsureReleaseWithValues
         0     0% 82.36%    44.02MB 20.74%  github.com/K0rdent/kcm/internal/helm.DownloadChart
         0     0% 82.36%        1MB  0.47%  github.com/K0rdent/kcm/internal/record.Eventf
         0     0% 82.36%    -1.07MB   0.5%  github.com/K0rdent/kcm/internal/util/scheme.MustGetManagementScheme (inline)
         0     0% 82.36%    -1.07MB   0.5%  github.com/K0rdent/kcm/internal/util/scheme.getManagementScheme
```

**Which issue(s) this PR fixes**:
Fixes #2469 
