### PR TITLE
chore(templates): change default calico mode

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-21
+  template: aws-standalone-cp-1-0-22
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-21
+  template: azure-standalone-cp-1-0-22
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-19
+  template: gcp-standalone-cp-1-0-20
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-2
+  template: kubevirt-standalone-cp-1-0-3
   credential: kubevirt-cred
   propagateCredentials: false
   config:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-23
+  template: openstack-standalone-cp-1-0-24
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-19
+  template: vsphere-standalone-cp-1-0-20
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.22
+version: 1.0.23
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/values.schema.json
+++ b/templates/cluster/aws-hosted-cp/values.schema.json
@@ -226,11 +226,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 }
               },
@@ -244,6 +247,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -74,6 +74,6 @@ k0s: # @schema description: K0s parameters; type: object
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: ipip # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.21
+version: 1.0.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/values.schema.json
+++ b/templates/cluster/aws-standalone-cp/values.schema.json
@@ -249,11 +249,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 }
               },
@@ -267,6 +270,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -69,7 +69,7 @@ k0s: # @schema description: K0s parameters; type: object; additionalProperties: 
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: ipip # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1
   files: [] # @schema description: Specifies extra files to be passed to user_data upon creation; type: array; item: object

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/values.schema.json
+++ b/templates/cluster/azure-hosted-cp/values.schema.json
@@ -183,11 +183,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 }
               },
@@ -201,6 +204,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -72,6 +72,6 @@ k0s: # @schema description: K0s parameters; type: object
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.21
+version: 1.0.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/values.schema.json
+++ b/templates/cluster/azure-standalone-cp/values.schema.json
@@ -191,11 +191,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 }
               },
@@ -209,6 +212,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/azure-standalone-cp/values.yaml
+++ b/templates/cluster/azure-standalone-cp/values.yaml
@@ -66,6 +66,6 @@ k0s: # @schema description: K0s parameters; type: object
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.21
+version: 1.0.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/values.schema.json
+++ b/templates/cluster/gcp-hosted-cp/values.schema.json
@@ -164,11 +164,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 }
               },
@@ -182,6 +185,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -73,6 +73,6 @@ k0s: # @schema description: K0s parameters; type: object
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.19
+version: 1.0.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/values.schema.json
+++ b/templates/cluster/gcp-standalone-cp/values.schema.json
@@ -242,11 +242,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 }
               },
@@ -260,6 +263,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/gcp-standalone-cp/values.yaml
+++ b/templates/cluster/gcp-standalone-cp/values.yaml
@@ -77,6 +77,6 @@ k0s: # @schema description: K0s parameters; type: object
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: ipip # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-hosted-cp/values.schema.json
+++ b/templates/cluster/kubevirt-hosted-cp/values.schema.json
@@ -242,11 +242,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 },
                 "vxlanPort": {
@@ -266,6 +269,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/kubevirt-hosted-cp/values.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/values.yaml
@@ -88,9 +88,9 @@ k0s: # @schema description: K0s parameters; type: object
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1
       vxlanPort: 6789 # @schema description: UDP port for VXLAN (uses network.vxlanPort if not set); type: integer; minimum: 1; maximum: 65535
       envVars: # @schema description: Additional environment variables to set in calico-node pods; type: object; additionalProperties: true
         CLUSTER_TYPE: "k8s" # @schema description: Comma delimited list of indicators about this cluster; examples: [k8s, mesos, kubeadm, canal, bgp]; type: string

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-standalone-cp/values.schema.json
+++ b/templates/cluster/kubevirt-standalone-cp/values.schema.json
@@ -370,11 +370,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 },
                 "vxlanPort": {
@@ -394,6 +397,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/kubevirt-standalone-cp/values.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/values.yaml
@@ -109,9 +109,9 @@ k0s: # @schema description: K0s parameters; type: object
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1
       vxlanPort: 6789 # @schema description: UDP port for VXLAN (uses network.vxlanPort if not set); type: integer; minimum: 1; maximum: 65535
       envVars: # @schema description: Additional environment variables to set in calico-node pods; type: object; additionalProperties: true
         CLUSTER_TYPE: "k8s" # @schema description: Comma delimited list of indicators about this cluster; examples: [k8s, mesos, kubeadm, canal, bgp]; type: string

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/values.schema.json
+++ b/templates/cluster/openstack-hosted-cp/values.schema.json
@@ -305,11 +305,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 }
               },
@@ -323,6 +326,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -100,6 +100,6 @@ k0s: # @schema description: K0s parameters; type: object
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.23
+version: 1.0.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -371,11 +371,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 }
               },
@@ -389,6 +392,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -102,6 +102,6 @@ k0s: # @schema description: K0s parameters; type: object
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.20
+version: 1.0.21
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -137,11 +137,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 }
               },
@@ -155,6 +158,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -64,6 +64,6 @@ k0s: # @schema description: K0s parameters; type: object
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.19
+version: 1.0.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/values.schema.json
+++ b/templates/cluster/vsphere-standalone-cp/values.schema.json
@@ -156,11 +156,14 @@
                 "mode": {
                   "description": "Calico network mode",
                   "examples": [
-                    "ipip",
                     "vxlan",
-                    "never"
+                    "bird"
                   ],
                   "type": "string",
+                  "enum": [
+                    "vxlan",
+                    "bird"
+                  ],
                   "minLength": 1
                 }
               },
@@ -174,6 +177,11 @@
                 "custom"
               ],
               "type": "string",
+              "enum": [
+                "kuberouter",
+                "calico",
+                "custom"
+              ],
               "minLength": 1
             }
           },

--- a/templates/cluster/vsphere-standalone-cp/values.yaml
+++ b/templates/cluster/vsphere-standalone-cp/values.yaml
@@ -65,6 +65,6 @@ k0s: # @schema description: K0s parameters; type: object
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true
   network: # @schema description: Kubernetes cluster network configuration; type: object; additionalProperties: true
-    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
+    provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; enum: kuberouter, calico, custom; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
-      mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+      mode: vxlan # @schema description: Calico network mode; type: string; examples: [vxlan, bird]; enum: vxlan, bird; minLength: 1

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-23.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-23.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-14
+  name: aws-hosted-cp-1-0-23
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.14
+      chart: aws-hosted-cp
+      version: 1.0.23
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-22.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-22.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-21
+  name: aws-standalone-cp-1-0-22
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.21
+      chart: aws-standalone-cp
+      version: 1.0.22
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-25.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-25.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-21
+  name: azure-hosted-cp-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.21
+      chart: azure-hosted-cp
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-22.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-22.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-24
+  name: azure-standalone-cp-1-0-22
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.24
+      chart: azure-standalone-cp
+      version: 1.0.22
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-22.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-22.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-23
+  name: gcp-hosted-cp-1-0-22
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.23
+      chart: gcp-hosted-cp
+      version: 1.0.22
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-20.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-20.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-19
+  name: gcp-standalone-cp-1-0-20
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-standalone-cp
-      version: 1.0.19
+      version: 1.0.20
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-3.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-3.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-hosted-cp-1-0-2
+  name: kubevirt-hosted-cp-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kubevirt-hosted-cp
-      version: 1.0.2
+      version: 1.0.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-3.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-3.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-20
+  name: kubevirt-standalone-cp-1-0-3
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.20
+      chart: kubevirt-standalone-cp
+      version: 1.0.3
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-15.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-15.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-21
+  name: openstack-hosted-cp-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.21
+      chart: openstack-hosted-cp
+      version: 1.0.15
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-24.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-24.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-19
+  name: openstack-standalone-cp-1-0-24
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.19
+      chart: openstack-standalone-cp
+      version: 1.0.24
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-21.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-21.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-2
+  name: vsphere-hosted-cp-1-0-21
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-standalone-cp
-      version: 1.0.2
+      chart: vsphere-hosted-cp
+      version: 1.0.21
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-20.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-20.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-22
+  name: vsphere-standalone-cp-1-0-20
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.22
+      chart: vsphere-standalone-cp
+      version: 1.0.20
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the default calico mode from ipip to vxlan in:
- aws-standalone
- aws-hosted
- gcp-standalone

Added new examples and enums to k0s.network.provider and k0s.network.calico.mode in all of the cluster templates to provide the most up-to-date state.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
