### PR TITLE
fix: remove reading from cluster network field and instead use node network

### DIFF
--- a/internal/controller/ipam/adapter/ipam_incluster_adapter.go
+++ b/internal/controller/ipam/adapter/ipam_incluster_adapter.go
@@ -41,7 +41,7 @@ func NewInClusterAdapter() *InClusterAdapter {
 }
 
 func (InClusterAdapter) BindAddress(ctx context.Context, config IPAMConfig, c client.Client) (kcmv1.ClusterIPAMProviderData, error) {
-	ipAddresses := config.ClusterIPAMClaim.Spec.ClusterNetwork.IPAddresses
+	ipAddresses := config.ClusterIPAMClaim.Spec.NodeNetwork.IPAddresses
 	if len(ipAddresses) == 0 {
 		ipAddresses = []string{config.ClusterIPAMClaim.Spec.NodeNetwork.CIDR}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This removes referencing the cluster network field from the ipam claim since it should be using the node network one per the documentation and design. The cluster network field is for future work.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2459