### PR TITLE
fix: define provider's CRDs install/upgrade policy

### DIFF
--- a/internal/controller/components/reconciler.go
+++ b/internal/controller/components/reconciler.go
@@ -93,6 +93,7 @@ type component struct {
 	helmReleaseName string
 	targetNamespace string
 	installSettings *helmcontrollerv2.Install
+	upgradeSettings *helmcontrollerv2.Upgrade
 	// helm release dependencies
 	dependsOn      []fluxmeta.NamespacedObjectReference
 	isCAPIProvider bool
@@ -242,6 +243,7 @@ func Reconcile(
 			DependsOn:       dependsOn,
 			TargetNamespace: component.targetNamespace,
 			Install:         component.installSettings,
+			Upgrade:         component.upgradeSettings,
 			Timeout:         opts.DefaultHelmTimeout,
 		}
 
@@ -357,6 +359,10 @@ func getWrappedComponents(ctx context.Context, cluster clusterInterface, release
 			helmReleaseName: cluster.HelmReleaseName(p.Name),
 			installSettings: &helmcontrollerv2.Install{
 				Remediation: remediationSettings,
+				CRDs:        helmcontrollerv2.CreateReplace,
+			},
+			upgradeSettings: &helmcontrollerv2.Upgrade{
+				CRDs: helmcontrollerv2.CreateReplace,
 			},
 			dependsOn: []fluxmeta.NamespacedObjectReference{{Name: kcmv1.CoreCAPIName}}, isCAPIProvider: true,
 		}

--- a/internal/helm/release.go
+++ b/internal/helm/release.go
@@ -40,6 +40,7 @@ type ReconcileHelmReleaseOpts struct {
 	ChartRef          *helmcontrollerv2.CrossNamespaceSourceReference
 	ReconcileInterval *time.Duration
 	Install           *helmcontrollerv2.Install
+	Upgrade           *helmcontrollerv2.Upgrade
 	KubeConfigRef     *fluxmeta.SecretKeyReference
 	Labels            map[string]string
 
@@ -97,9 +98,8 @@ func ReconcileHelmRelease(ctx context.Context,
 		if opts.Timeout != 0 {
 			hr.Spec.Timeout = &metav1.Duration{Duration: opts.Timeout}
 		}
-		if opts.Install != nil {
-			hr.Spec.Install = opts.Install
-		}
+		hr.Spec.Install = opts.Install
+		hr.Spec.Upgrade = opts.Upgrade
 		if opts.KubeConfigRef != nil {
 			hr.Spec.KubeConfig = &fluxmeta.KubeConfigReference{
 				SecretRef: opts.KubeConfigRef,


### PR DESCRIPTION
**What this PR does / why we need it**:
Define install and upgrade CRDs policy to CreateReplace to allow providers update already installed CRDs.

Fixes #2488
