### PR TITLE
fix: remove flux source-controller cert secret workaround

### DIFF
--- a/internal/controller/components/values.go
+++ b/internal/controller/components/values.go
@@ -69,20 +69,6 @@ func getComponentValues(
 			componentValues["admissionWebhook"] = map[string]any{"enabled": true}
 		}
 
-		if opts.RegistryCertSecretName != "" {
-			fluxV := make(map[string]any)
-			if currentValues != nil {
-				if raw, ok := currentValues["flux2"]; ok {
-					var castOk bool
-					if fluxV, castOk = raw.(map[string]any); !castOk {
-						return nil, fmt.Errorf("failed to cast 'flux2' (type %T) to map[string]any", raw)
-					}
-				}
-			}
-
-			componentValues["flux2"] = processFluxCertVolumeMounts(fluxV, opts.RegistryCertSecretName)
-		}
-
 		regionalConfig, err := getRegionalComponentValues(ctx, currentValues, opts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get regional values: %w", err)
@@ -314,37 +300,6 @@ func processCAPIOperatorCertVolumeMounts(capiOperatorValues map[string]any, regi
 	capiOperatorValues["volumeMounts"] = vmRaw
 
 	return capiOperatorValues
-}
-
-func processFluxCertVolumeMounts(fluxValues map[string]any, registryCertSecret string) map[string]any {
-	certVolumeName := "registry-cert"
-	registryCertVolume := getRegistryCertVolumeValues(certVolumeName, registryCertSecret)
-
-	if fluxValues == nil {
-		fluxValues = make(map[string]any)
-	}
-
-	registryCertMount := getRegistryCertVolumeMountValues(certVolumeName)
-	componentName := "sourceController"
-	values, ok := fluxValues[componentName].(map[string]any)
-	if !ok || values == nil {
-		values = make(map[string]any)
-	}
-	certVolumes := []any{registryCertVolume}
-	if existing, ok := values["volumes"].([]any); ok {
-		values["volumes"] = append(existing, certVolumes...)
-	} else {
-		values["volumes"] = certVolumes
-	}
-
-	volumeMounts := []any{registryCertMount}
-	if vm, ok := values["volumeMounts"].([]any); ok {
-		values["volumeMounts"] = append(vm, volumeMounts...)
-	} else {
-		values["volumeMounts"] = volumeMounts
-	}
-	fluxValues[componentName] = values
-	return fluxValues
 }
 
 func getRegistryCertVolumeValues(volumeName, secretName string) map[string]any {

--- a/internal/controller/release_controller.go
+++ b/internal/controller/release_controller.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -30,8 +29,6 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/storage/driver"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -39,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -321,12 +317,6 @@ func (r *ReleaseReconciler) reconcileKCMTemplates(ctx context.Context, releaseNa
 			return false, fmt.Errorf("some of the predeclared Secrets (%v) are missing (%v) in the %s namespace", helmRepositorySecrets, missingSecrets, r.SystemNamespace)
 		}
 
-		if r.DefaultRegistryConfig.CertSecretName != "" && r.FluxEnabled {
-			if err = r.patchFluxWithRegistryCASecret(ctx); err != nil {
-				return false, fmt.Errorf("failed to patch flux components with registry CA secret volume: %w", err)
-			}
-		}
-
 		releaseName, err = releaseutil.ReleaseNameFromVersion(build.Version)
 		if err != nil {
 			return false, fmt.Errorf("failed to get Release name from version %q: %w", build.Version, err)
@@ -410,71 +400,6 @@ func (r *ReleaseReconciler) reconcileKCMTemplates(ctx context.Context, releaseNa
 		return true, nil
 	}
 	return false, nil
-}
-
-// Workaround for Flux issue https://github.com/fluxcd/flux2/issues/4838.
-// Applies only to the initial deployment to add the registry
-// CA certificate to flux components before installing kcm-templates HelmChart
-func (r *ReleaseReconciler) patchFluxWithRegistryCASecret(ctx context.Context) error {
-	const (
-		deploymentName       = "source-controller"
-		caCertVolumeName     = "registry-cert"
-		caCertFileName       = "registry-ca.pem"
-		managerContainerName = "manager"
-	)
-
-	deployment := &appsv1.Deployment{}
-	if err := r.Get(ctx, client.ObjectKey{Name: deploymentName, Namespace: r.SystemNamespace}, deployment); err != nil {
-		return err
-	}
-
-	managerIdx := slices.IndexFunc(deployment.Spec.Template.Spec.Containers, func(c corev1.Container) bool {
-		return c.Name == managerContainerName
-	})
-	if managerIdx == -1 {
-		return fmt.Errorf("container %q not found in deployment %q", managerContainerName, deploymentName)
-	}
-
-	hasVolume := slices.ContainsFunc(deployment.Spec.Template.Spec.Volumes, func(v corev1.Volume) bool {
-		return v.Name == caCertVolumeName
-	})
-	hasMount := slices.ContainsFunc(deployment.Spec.Template.Spec.Containers[managerIdx].VolumeMounts, func(vm corev1.VolumeMount) bool {
-		return vm.Name == caCertVolumeName
-	})
-
-	if hasVolume && hasMount {
-		return nil
-	}
-
-	patchHelper, err := patch.NewHelper(deployment, r.Client)
-	if err != nil {
-		return err
-	}
-
-	if !hasVolume {
-		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
-			Name: caCertVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					DefaultMode: new(int32(420)),
-					Items: []corev1.KeyToPath{
-						{Key: "ca.crt", Path: caCertFileName},
-					},
-					SecretName: r.DefaultRegistryConfig.CertSecretName,
-				},
-			},
-		})
-	}
-
-	if !hasMount {
-		manager := &deployment.Spec.Template.Spec.Containers[managerIdx]
-		manager.VolumeMounts = append(manager.VolumeMounts, corev1.VolumeMount{
-			Name:      caCertVolumeName,
-			MountPath: "/etc/ssl/certs/" + caCertFileName,
-			SubPath:   caCertFileName,
-		})
-	}
-	return patchHelper.Patch(ctx, deployment)
 }
 
 func (r *ReleaseReconciler) getCurrentRelease(ctx context.Context) (*kcmv1.Release, error) {

--- a/internal/controller/release_controller_test.go
+++ b/internal/controller/release_controller_test.go
@@ -24,7 +24,6 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -55,9 +54,6 @@ const (
 
 	regCertSecretName       = "test-reg-cert-secret"
 	regCredentialSecretName = "test-reg-credential-secret"
-
-	fluxTestSourceControllerDeploymentName = "source-controller"
-	fluxTestExistingVolumeMountName        = "vol0"
 )
 
 var testReleaseSpec = kcmv1.ReleaseSpec{
@@ -113,10 +109,6 @@ var _ = Describe("Release Controller", Ordered, func() {
 		build.Version = ""
 	})
 
-	BeforeEach(func() {
-		createTestFluxSourceControllerDeployment()
-	})
-
 	AfterEach(func() {
 		// Clean up secrets
 		Expect(crclient.IgnoreNotFound(k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: regCertSecretName, Namespace: systemNamespace}}))).To(Succeed())
@@ -156,10 +148,6 @@ var _ = Describe("Release Controller", Ordered, func() {
 
 		// Clean up Release
 		Expect(crclient.IgnoreNotFound(k8sClient.Delete(ctx, &kcmv1.Release{ObjectMeta: metav1.ObjectMeta{Name: testReleaseName}}))).To(Succeed())
-
-		// Clean up Flux source-controller deployment
-		err := k8sClient.Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: fluxTestSourceControllerDeploymentName, Namespace: systemNamespace}})
-		Expect(crclient.IgnoreNotFound(err)).To(Succeed())
 	})
 
 	DescribeTable("Release Reconciliation",
@@ -201,16 +189,6 @@ var _ = Describe("Release Controller", Ordered, func() {
 			},
 			registryCertSecretName:        regCertSecretName,
 			registryCredentialsSecretName: regCredentialSecretName,
-		}),
-		Entry("Should reconcile and patch flux source controller with cert secret volume mount", releaseTestCase{
-			createTemplates:  true,
-			createManagement: false,
-			createRelease:    true,
-			fluxEnabled:      true,
-			createPredeclaredSecretsFunc: func() error {
-				return createTestRegistrySecret(regCertSecretName)
-			},
-			registryCertSecretName: regCertSecretName,
 		}),
 	)
 })
@@ -382,11 +360,6 @@ func testReleaseInitialReconciliation(reconciler *ReleaseReconciler, tc releaseT
 		}
 	}
 
-	if tc.registryCertSecretName != "" {
-		By("Should patch Flux source-controller deployment to add registry cert secret as a volume and volume mount")
-		testPatchFluxWithRegistryCASecret(tc)
-	}
-
 	if tc.createRelease || tc.createTemplates {
 		By("Should create default HelmRepository on initial installation")
 		helmRepo := &sourcev1.HelmRepository{}
@@ -397,9 +370,11 @@ func testReleaseInitialReconciliation(reconciler *ReleaseReconciler, tc releaseT
 		expectedHelmRepoSpec := reconciler.DefaultRegistryConfig.HelmRepositorySpec()
 		Expect(helmRepo.Spec.URL).To(Equal(expectedHelmRepoSpec.URL))
 		Expect(helmRepo.Spec.SecretRef).To(Equal(expectedHelmRepoSpec.SecretRef))
-		// we don't set cert secret ref in HelmRepository spec, even if it's provided in DefaultRegistryConfig
-		// to address Flux bug https://github.com/fluxcd/flux2/issues/4838
-		Expect(helmRepo.Spec.CertSecretRef).To(BeNil())
+		if tc.registryCertSecretName != "" {
+			Expect(helmRepo.Spec.CertSecretRef).NotTo(BeNil())
+		} else {
+			Expect(helmRepo.Spec.CertSecretRef).To(BeNil())
+		}
 		Expect(helmRepo.Spec.Insecure).To(Equal(tc.insecureRegistry))
 	}
 
@@ -415,81 +390,6 @@ func testReleaseInitialReconciliation(reconciler *ReleaseReconciler, tc releaseT
 		return false
 	}
 	return true
-}
-
-// testPatchFluxWithRegistryCASecret validates patching of the Flux source-controller deployment with a registry CA secret
-func testPatchFluxWithRegistryCASecret(tc releaseTestCase) {
-	deploy := &appsv1.Deployment{}
-	Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: systemNamespace, Name: fluxTestSourceControllerDeploymentName}, deploy)).To(Succeed())
-
-	if !tc.fluxEnabled {
-		By("Flux is not enabled, should not patch Flux source-controller deployment")
-		Expect(deploy.Spec.Template.Spec.Volumes).To(HaveLen(1))
-		Expect(deploy.Spec.Template.Spec.Volumes[0].Name).To(Equal(fluxTestExistingVolumeMountName))
-
-		Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
-		Expect(deploy.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(1))
-		Expect(deploy.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(fluxTestExistingVolumeMountName))
-
-		return
-	}
-
-	const caCertVolumeName = "registry-cert"
-
-	By("Flux is enabled, should patch Flux source-controller deployment with registry cert secret volume mount")
-	Expect(deploy.Spec.Template.Spec.Volumes).To(HaveLen(2))
-	Expect(deploy.Spec.Template.Spec.Volumes[0].Name).To(Equal(fluxTestExistingVolumeMountName))
-	Expect(deploy.Spec.Template.Spec.Volumes[1].Name).To(Equal(caCertVolumeName))
-
-	Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
-	Expect(deploy.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
-	Expect(deploy.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(Equal(fluxTestExistingVolumeMountName))
-	Expect(deploy.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(Equal(caCertVolumeName))
-}
-
-// createTestFluxSourceControllerDeployment creates a test Flux source-controller Deployment
-func createTestFluxSourceControllerDeployment() {
-	deploy := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fluxTestSourceControllerDeploymentName,
-			Namespace: systemNamespace,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"foo": "bar"},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"foo": "bar"},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "manager",
-							Image: "source-controller:v1.0.0",
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      fluxTestExistingVolumeMountName,
-									MountPath: "/etc/testmount",
-								},
-							},
-						},
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: fluxTestExistingVolumeMountName,
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: "existing-secret",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	Expect(k8sClient.Create(ctx, deploy)).To(Succeed())
 }
 
 // testReleaseNextReconciliation validates the reconciliation logic for a Release object

--- a/internal/helm/repo.go
+++ b/internal/helm/repo.go
@@ -54,6 +54,14 @@ func (r *DefaultRegistryConfig) HelmRepositorySpec() sourcev1.HelmRepositorySpec
 			}
 			return nil
 		}(),
+		CertSecretRef: func() *fluxmeta.LocalObjectReference {
+			if r.CertSecretName != "" {
+				return &fluxmeta.LocalObjectReference{
+					Name: r.CertSecretName,
+				}
+			}
+			return nil
+		}(),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Initially, it was needed to address a known issue in Flux, but since the bug has been resolved, we can remove the workaround.

Verified manually using a custom self-signed registry with redirects and two certificates provided in registry cert secret.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Related task: #2485
