### PR TITLE
ci: fix after-merge WF telemetry img

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -71,7 +71,6 @@ jobs:
           IMG_TELEMETRY: ghcr.io/k0rdent/kcm/staging/telemetry:${{ steps.version.outputs.version }}
         run: |
           make set-kcm-repo
-          make set-regional-telemetry-repo
           make set-templates-repo
           make kcm-chart-release
           make helm-push

--- a/.github/workflows/post-merge-push.yaml
+++ b/.github/workflows/post-merge-push.yaml
@@ -69,6 +69,7 @@ jobs:
           IMG_TELEMETRY: ghcr.io/k0rdent/kcm/telemetry-ci:${{ steps.version.outputs.version }}
         run: |
           make set-kcm-repo
+          make set-templates-repo
           make kcm-chart-release
           make helm-push
 

--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,6 @@ set-kcm-version: yq
 .PHONY: set-kcm-repo
 set-kcm-repo: yq
 	$(YQ) eval '.image.repository = "$(IMG_REPO)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm/values.yaml
-
-.PHONY: set-regional-telemetry-repo
-set-regional-telemetry-repo: yq
 	$(YQ) eval '.telemetry.controller.image.repository = "$(IMG_TELEMETRY_REPO)"' -i $(PROVIDER_TEMPLATES_DIR)/kcm-regional/values.yaml
 
 .PHONY: set-templates-repo


### PR DESCRIPTION
**What this PR does / why we need it**:

Explicitly sets in the corresponding chart `values.yaml` files:
- `.telemetry.controller.image.repository`
- `.controller.templatesRepoURL`

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2495