### PR TITLE
feat(templates): upgrade eks to 1.35

### DIFF
--- a/config/dev/eks-clusterdeployment.yaml
+++ b/config/dev/eks-clusterdeployment.yaml
@@ -4,10 +4,11 @@ metadata:
   name: eks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-eks-1-0-7
+  template: aws-eks-1-0-8
   credential: "aws-cluster-identity-cred"
   config:
     clusterLabels: {}
     clusterAnnotations: {}
+    eksClusterName: eks-${CLUSTER_NAME_SUFFIX}
     region: ${AWS_REGION}
     workersNumber: 1

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-eks/templates/_helpers.tpl
+++ b/templates/cluster/aws-eks/templates/_helpers.tpl
@@ -14,6 +14,6 @@
     {{- include "cluster.name" . }}-cp
 {{- end }}
 
-{{- define "eksconfigtemplate.name" -}}
+{{- define "nodeamdconfigtemplate.name" -}}
     {{- include "cluster.name" . }}-machine-config
 {{- end }}

--- a/templates/cluster/aws-eks/templates/awsmachinetemplate-worker.yaml
+++ b/templates/cluster/aws-eks/templates/awsmachinetemplate-worker.yaml
@@ -5,9 +5,17 @@ metadata:
 spec:
   template:
     spec:
-      {{- if not (quote .Values.worker.amiID | empty) }}
+      {{- $ami := default dict .Values.worker.ami }}
       ami:
+        {{- if $ami.id }}
+        id: {{ $ami.id | quote }}
+        {{- else if .Values.worker.amiID }}
         id: {{ .Values.worker.amiID  | quote }}
+        {{- else }}
+        eksLookupType: {{ default "AmazonLinux2023" $ami.eksLookupType | quote }}
+        {{- end }}
+      {{- with .Values.worker.cloudInit }}
+      cloudInit: {{- toYaml . | nindent 8 }}
       {{- end }}
       imageLookupFormat: {{ .Values.worker.imageLookup.format  | quote }}
       imageLookupOrg: {{ .Values.worker.imageLookup.org  | quote }}

--- a/templates/cluster/aws-eks/templates/eksconfigtemplate.yaml
+++ b/templates/cluster/aws-eks/templates/eksconfigtemplate.yaml
@@ -1,6 +1,0 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
-kind: EKSConfigTemplate
-metadata:
-  name: {{ include "eksconfigtemplate.name" . }}
-spec:
-  template: {}

--- a/templates/cluster/aws-eks/templates/machinedeployment.yaml
+++ b/templates/cluster/aws-eks/templates/machinedeployment.yaml
@@ -20,8 +20,8 @@ spec:
       bootstrap:
         configRef:
           apiGroup: bootstrap.cluster.x-k8s.io
-          kind: EKSConfigTemplate
-          name: {{ include "eksconfigtemplate.name" . }}
+          kind: NodeadmConfigTemplate
+          name: {{ include "nodeamdconfigtemplate.name" . }}
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: AWSMachineTemplate

--- a/templates/cluster/aws-eks/templates/nodeadmconfigtemplate.yaml
+++ b/templates/cluster/aws-eks/templates/nodeadmconfigtemplate.yaml
@@ -1,0 +1,6 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: NodeadmConfigTemplate
+metadata:
+  name: {{ include "nodeamdconfigtemplate.name" . }}
+spec:
+  template: {}

--- a/templates/cluster/aws-eks/values.schema.json
+++ b/templates/cluster/aws-eks/values.schema.json
@@ -19,7 +19,7 @@
             "type": "string"
           },
           "conflictResolution": {
-            "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none",
+            "description": "ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to overwrite",
             "type": "string",
             "enum": [
               "overwrite",
@@ -140,7 +140,7 @@
       "type": "object"
     },
     "publicIP": {
-      "description": "Specifies whether the instance should get a public IP",
+      "description": "Whether to open port 22 to the public internet",
       "type": "boolean"
     },
     "region": {
@@ -179,9 +179,39 @@
         "instanceType"
       ],
       "properties": {
+        "ami": {
+          "type": "object",
+          "properties": {
+            "eksLookupType": {
+              "description": "If specified, will look up an EKS Optimized image in SSM Parameter store",
+              "type": "string",
+              "enum": [
+                "AmazonLinux",
+                "AmazonLinuxGPU",
+                "AmazonLinux2023",
+                "AmazonLinux2023GPU"
+              ]
+            },
+            "id": {
+              "description": "The ID of Amazon Machine Image",
+              "type": "string"
+            }
+          }
+        },
         "amiID": {
-          "description": "The ID of Amazon Machine Image",
+          "description": "Deprecated: use .worker.ami.id instead. The ID of Amazon Machine Image",
           "type": "string"
+        },
+        "cloudInit": {
+          "description": "Defines options related to the bootstrapping systems where CloudInit is used. However with NodeadmConfig there is not CloudInit",
+          "type": "object",
+          "properties": {
+            "insecureSkipSecretsManager": {
+              "description": "InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": true
         },
         "iamInstanceProfile": {
           "description": "A name of an IAM instance profile to assign to the instance",
@@ -227,7 +257,7 @@
           "minimum": 8
         },
         "uncompressedUserData": {
-          "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed",
+          "description": "Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed. However NodeadmConfig comes with no support of the gzip-compressed user-data",
           "type": "boolean"
         }
       }

--- a/templates/cluster/aws-eks/values.yaml
+++ b/templates/cluster/aws-eks/values.yaml
@@ -16,7 +16,7 @@ clusterAnnotations: {} # @schema description: Annotations to apply to the cluste
 eksClusterName: "" # @schema description: The name of the EKS cluster in AWS. If unset, the default name will be created based on the namespace and name of the managed control plane; type: string
 region: "" # @schema description: AWS region to deploy the cluster in; type: string; required: true
 sshKeyName: "" # @schema description: The name of the key pair to securely connect to your instances. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name); type: [string, null]
-publicIP: false # @schema description: Specifies whether the instance should get a public IP; type: boolean
+publicIP: false # @schema description: Whether to open port 22 to the public internet; type: boolean
 
 associateOIDCProvider: false # @schema description: Automatically create an identity provider for the controller for use with IAM roles for service accounts; type: boolean
 oidcIdentityProviderConfig: {} # @schema description: The oidc provider config to be attached with this eks cluster; type: object
@@ -34,7 +34,10 @@ clusterIdentity: # @schema description: A reference to an identity to be used wh
 
 # EKS machines parameters
 worker: # @schema description: The configuration of the worker machines; type: object
-  amiID: "" # @schema description: The ID of Amazon Machine Image; type: string
+  amiID: "" # @schema description: Deprecated: use .worker.ami.id instead. The ID of Amazon Machine Image; type: string
+  ami:
+    id: "" # @schema description: The ID of Amazon Machine Image; type: string
+    eksLookupType: "AmazonLinux2023" # @schema description: If specified, will look up an EKS Optimized image in SSM Parameter store; type: string; enum: AmazonLinux,AmazonLinuxGPU,AmazonLinux2023,AmazonLinux2023GPU
   iamInstanceProfile: nodes.cluster-api-provider-aws.sigs.k8s.io # @schema description: A name of an IAM instance profile to assign to the instance; type: string; required: true
   instanceType: "t3.small" # @schema description: The type of instance to create. Example: m4.xlarge; type: string; required: true
   rootVolumeSize: 30 # @schema description: Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater); type: integer; minimum: 8
@@ -43,17 +46,19 @@ worker: # @schema description: The configuration of the worker machines; type: o
     format: "" # @schema description: The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set; type: string; required: true
     org: "" # @schema description: The AWS Organization ID to use for image lookup if AMI is not set; type: string; required: true
     baseOS: "" # @schema description: The name of the base operating system to use for image lookup the AMI is not set; type: string
-  uncompressedUserData: false # @schema description: Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed; type: boolean
+  cloudInit: # @schema description: Defines options related to the bootstrapping systems where CloudInit is used. However with NodeadmConfig there is not CloudInit; type: object; additionalProperties: true
+    insecureSkipSecretsManager: true # @schema description: InsecureSkipSecretsManager, when set to true will not use AWS Secrets Manager or AWS Systems Manager Parameter Store to ensure privacy of userdata. By default, a cloud-init boothook shell script is prepended to download the userdata from Secrets Manager and additionally delete the secret; type: boolean
+  uncompressedUserData: true # @schema description: Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed. However NodeadmConfig comes with no support of the gzip-compressed user-data; type: boolean
 
-addons: # @schema description: The EKS addons to enable with the EKS cluster; type: array
+addons: # @schema description: The EKS addons to enable with the EKS cluster; type: array; item: object
 - name: aws-ebs-csi-driver # @schema description: The name of the addon; type: string
-  version: v1.37.0-eksbuild.1 # @schema description: The version of the addon to use; type: string
+  version: v1.56.0-eksbuild.1 # @schema description: The version of the addon to use; type: string
   configuration: | # @schema description: Optional configuration of the EKS addon in YAML format; type: string
     defaultStorageClass:
       enabled: true
-  conflictResolution: "none" # @schema description: ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none; enum: overwrite,none; type: string
+  conflictResolution: "overwrite" # @schema description: ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to overwrite; enum: overwrite,none; type: string
   serviceAccountRoleARN: null # @schema description: ServiceAccountRoleArn is the ARN of an IAM role to bind to the addons service account; type: [string, null]
 
 # Kubernetes version
 kubernetes: # @schema description: Kubernetes parameters; type: object
-  version: v1.32.6 # @schema description: Kubernetes version to use; type: string; required: true
+  version: v1.35.0 # @schema description: Kubernetes version to use; type: string; required: true

--- a/templates/provider/kcm-templates/files/templates/aws-eks-1-0-8.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-1-0-8.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-eks-1-0-7
+  name: aws-eks-1-0-8
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: aws-eks
-      version: 1.0.7
+      version: 1.0.8
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces the new NodeadmConfigTemplate object usage instead of the outdated EKSConfigTemplate which used to use the obsolete bootstrap.sh.

Sets the default image to the AL2023 which is the EKS default now since k8s 1.33.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #2468
