### PR TITLE
chore: bump k0s to v1.35.1+k0s.1

### DIFF
--- a/config/dev/aks-clusterdeployment.yaml
+++ b/config/dev/aks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-aks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-aks-1-0-4
+  template: azure-aks-1-0-5
   credential: azure-aks-credential
   propagateCredentials: false
   config:

--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-23
+  template: aws-standalone-cp-1-0-24
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-23
+  template: azure-standalone-cp-1-0-24
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/docker-clusterdeployment.yaml
+++ b/config/dev/docker-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: docker-hosted-cp-1-0-5
+  template: docker-hosted-cp-1-0-6
   credential: docker-stub-credential
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-21
+  template: gcp-standalone-cp-1-0-22
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-4
+  template: kubevirt-standalone-cp-1-0-5
   credential: kubevirt-cred
   propagateCredentials: false
   config:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-25
+  template: openstack-standalone-cp-1-0-26
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-22
+  template: remote-cluster-1-0-23
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-21
+  template: vsphere-standalone-cp-1-0-22
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -28,7 +28,7 @@ spec:
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -68,7 +68,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.23
+version: 1.0.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -13,7 +13,7 @@ spec:
     args:
       - --enable-worker
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       - --disable-components=konnectivity-server
       {{- range $arg := .Values.k0s.cpArgs }}
       - {{ toYaml $arg }}

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -28,7 +28,7 @@ spec:
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -62,7 +62,7 @@ worker: # @schema description: The configuration of the worker machines; type: o
 # K0s parameters
 # # NOTE: .k0s additional properties are to support prior .k0s.auth implementation
 k0s: # @schema description: K0s parameters; type: object; additionalProperties: true
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/cluster/azure-aks/Chart.yaml
+++ b/templates/cluster/azure-aks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure
   cluster.x-k8s.io/infrastructure-azure: v1beta1

--- a/templates/cluster/azure-aks/values.yaml
+++ b/templates/cluster/azure-aks/values.yaml
@@ -106,4 +106,4 @@ machinePools:
 kubernetes:
   networkPolicy: azure
   networkPlugin: azure
-  version: v1.32.9 # used in both ASO (patch is not required) and CAPI (patch is required) objects
+  version: v1.34.2 # used in both ASO (patch is not required) and CAPI (patch is required) objects

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -28,7 +28,7 @@ spec:
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -66,7 +66,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.23
+version: 1.0.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -39,7 +39,7 @@ spec:
     args:
       - --enable-worker
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       - --disable-components=konnectivity-server
       {{- range $arg := .Values.k0s.cpArgs }}
       - {{ toYaml $arg }}

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -28,7 +28,7 @@ spec:
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}

--- a/templates/cluster/azure-standalone-cp/values.yaml
+++ b/templates/cluster/azure-standalone-cp/values.yaml
@@ -59,7 +59,7 @@ worker: # @schema description: Worker nodes parameters; type: object; required: 
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-docker, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.23
+version: 1.0.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -28,7 +28,7 @@ spec:
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -67,7 +67,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.21
+version: 1.0.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -39,7 +39,7 @@ spec:
     args:
       - --enable-worker
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       - --disable-components=konnectivity-server
       {{- range $arg := .Values.k0s.cpArgs }}
       - {{ toYaml $arg }}

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -28,7 +28,7 @@ spec:
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}

--- a/templates/cluster/gcp-standalone-cp/values.yaml
+++ b/templates/cluster/gcp-standalone-cp/values.yaml
@@ -70,7 +70,7 @@ worker: # @schema description: Worker parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-kubevirt, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -27,6 +27,7 @@ spec:
       {{- end }}
       version: {{ .Values.k0s.version }}
       args:
+      - --kubelet-extra-args="--fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}

--- a/templates/cluster/kubevirt-hosted-cp/values.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/values.yaml
@@ -82,7 +82,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-kubevirt, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
@@ -39,6 +39,7 @@ spec:
     args:
       - --enable-worker
       - --disable-components=konnectivity-server
+      - --kubelet-extra-args="--fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.cpArgs }}
       - {{ toYaml $arg }}
       {{- end }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -27,6 +27,7 @@ spec:
       {{- end }}
       version: {{ .Values.k0s.version }}
       args:
+      - --kubelet-extra-args="--fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}

--- a/templates/cluster/kubevirt-standalone-cp/values.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/values.yaml
@@ -102,7 +102,7 @@ worker: # @schema description: Worker parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.16
+version: 1.0.17
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-openstack, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -28,7 +28,7 @@ spec:
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       - --debug=true
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -94,7 +94,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.25
+version: 1.0.26
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-openstack, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -39,7 +39,7 @@ spec:
     args:
       - --enable-worker
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       - --disable-components=konnectivity-server
       {{- range $arg := .Values.k0s.cpArgs }}
       - {{ toYaml $arg }}

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -28,7 +28,7 @@ spec:
       version: {{ .Values.k0s.version }}
       args:
       - --enable-cloud-provider
-      - --kubelet-extra-args="--cloud-provider=external"
+      - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -95,7 +95,7 @@ worker: # @schema description: Configuration of the worker instances; type: obje
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.22
+version: 1.0.23
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -50,6 +50,7 @@ spec:
   {{- end }}
   {{- if and $machine.k0s $machine.k0s.args }}
   args:
+    - --kubelet-extra-args="--fail-cgroupv1=false"
     {{- toYaml $machine.k0s.args | nindent 4 }}
   {{- end }}
 ---

--- a/templates/cluster/remote-cluster/values.yaml
+++ b/templates/cluster/remote-cluster/values.yaml
@@ -56,7 +56,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.22
+version: 1.0.23
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-vsphere, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   k0rdent.mirantis.com/type: deployment

--- a/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -10,6 +10,11 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       version: {{ .Values.k0s.version }}
+      args:
+        - --kubelet-extra-args="--fail-cgroupv1=false"
+      {{- range $arg := .Values.k0s.workerArgs }}
+        - {{ toYaml $arg }}
+      {{- end }}
       files:
         - path: /home/{{ .Values.ssh.user }}/.ssh/authorized_keys
           permissions: "0600"
@@ -32,7 +37,4 @@ spec:
         {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
         - "sudo update-ca-certificates"
         {{- end }}
-      {{- with .Values.k0s.workerArgs }}
-      args: {{ toYaml . | nindent 8 }}
-      {{- end }}
 

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -58,7 +58,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.21
+version: 1.0.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.32.8+k0s.0"
+appVersion: "v1.35.1+k0s.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-vsphere, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   k0rdent.mirantis.com/type: deployment

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -44,6 +44,7 @@ spec:
     args:
       - --enable-worker
       - --disable-components=konnectivity-server
+      - --kubelet-extra-args="--fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.cpArgs }}
       - {{ toYaml $arg }}
       {{- end }}

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -10,8 +10,10 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       version: {{ .Values.k0s.version }}
-      {{- with .Values.k0s.workerArgs }}
-      args: {{ toYaml . | nindent 8 }}
+      args:
+        - --kubelet-extra-args="--fail-cgroupv1=false"
+      {{- range $arg := .Values.k0s.workerArgs }}
+        - {{ toYaml $arg }}
       {{- end }}
       files:
         - path: /home/{{ .Values.worker.ssh.user }}/.ssh/authorized_keys

--- a/templates/cluster/vsphere-standalone-cp/values.yaml
+++ b/templates/cluster/vsphere-standalone-cp/values.yaml
@@ -58,7 +58,7 @@ worker:
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.32.8+k0s.0 # @schema description: K0s version; type: string
+  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-25.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-25.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-23
+  name: aws-hosted-cp-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.23
+      chart: aws-hosted-cp
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-24.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-24.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-21
+  name: aws-standalone-cp-1-0-24
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.21
+      chart: aws-standalone-cp
+      version: 1.0.24
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-aks-1-0-5.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-aks-1-0-5.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-22
+  name: azure-aks-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.22
+      chart: azure-aks
+      version: 1.0.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-27.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-27.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-16
+  name: azure-hosted-cp-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.16
+      chart: azure-hosted-cp
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-24.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-24.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-26
+  name: azure-standalone-cp-1-0-24
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.26
+      chart: azure-standalone-cp
+      version: 1.0.24
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: docker-hosted-cp-1-0-5
+  name: docker-hosted-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: docker-hosted-cp
-      version: 1.0.5
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-24.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-24.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-23
+  name: gcp-hosted-cp-1-0-24
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.23
+      chart: gcp-hosted-cp
+      version: 1.0.24
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-22.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-22.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-hosted-cp-1-0-4
+  name: gcp-standalone-cp-1-0-22
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-hosted-cp
-      version: 1.0.4
+      chart: gcp-standalone-cp
+      version: 1.0.22
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-5.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-5.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-4
+  name: kubevirt-hosted-cp-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-standalone-cp
-      version: 1.0.4
+      chart: kubevirt-hosted-cp
+      version: 1.0.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-5.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-5.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-23
+  name: kubevirt-standalone-cp-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.23
+      chart: kubevirt-standalone-cp
+      version: 1.0.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-17.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-17.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-22
+  name: openstack-hosted-cp-1-0-17
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.22
+      chart: openstack-hosted-cp
+      version: 1.0.17
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-26.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-26.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-25
+  name: openstack-standalone-cp-1-0-26
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-standalone-cp
-      version: 1.0.25
+      version: 1.0.26
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-23.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-23.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-aks-1-0-4
+  name: remote-cluster-1-0-23
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-aks
-      version: 1.0.4
+      chart: remote-cluster
+      version: 1.0.23
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-23.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-23.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-21
+  name: vsphere-hosted-cp-1-0-23
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.21
+      chart: vsphere-hosted-cp
+      version: 1.0.23
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-22.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-22.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-24
+  name: vsphere-standalone-cp-1-0-22
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.24
+      chart: vsphere-standalone-cp
+      version: 1.0.22
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps k0s to v1.35.1+k0s.1

`--fail-cgroupv1` flag is needed to deal with cgroup v1 deprecation. This version doesn't have issue with ipip calico mode, which was specifically tested on AWS
