### PR TITLE
fix: incorrect ASO version

### DIFF
--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.17
+version: 1.0.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-azure/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-azure/templates/provider.yaml
@@ -1,6 +1,6 @@
 {{- $global := .Values.global | default dict }}
 {{- $version := .Chart.AppVersion }}
-{{- $asoVersion := "v2.11.0" }}
+{{- $asoVersion := "v2.13.0" }}
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider
 metadata:

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -16,7 +16,7 @@ spec:
     - name: cluster-api-provider-k0sproject-k0smotron
       template: cluster-api-provider-k0sproject-k0smotron-1-0-18
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-1-0-17
+      template: cluster-api-provider-azure-1-0-18
     - name: cluster-api-provider-vsphere
       template: cluster-api-provider-vsphere-1-0-12
     - name: cluster-api-provider-aws

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-1-0-17
+  name: cluster-api-provider-azure-1-0-18
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-azure
-      version: 1.0.17
+      version: 1.0.18
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes incorrect azure-service-operator version. If used with a custom registry may cause pull errors or CRD issues (if older version is running with newer CRDs).
