### PR TITLE
fix: cleanup sveltos util code for service set upgrades

### DIFF
--- a/api/v1beta1/indexers.go
+++ b/api/v1beta1/indexers.go
@@ -23,8 +23,12 @@ import (
 )
 
 func SetupIndexers(ctx context.Context, mgr ctrl.Manager) error {
+	return SetupFieldIndexers(ctx, mgr.GetFieldIndexer())
+}
+
+func SetupFieldIndexers(ctx context.Context, indexer client.FieldIndexer) error {
 	var merr error
-	for _, f := range []func(context.Context, ctrl.Manager) error{
+	for _, f := range []func(context.Context, client.FieldIndexer) error{
 		setupClusterDeploymentIndexer,
 		setupClusterDeploymentServicesIndexer,
 		setupClusterDeploymentServiceTemplateChainIndexer,
@@ -45,7 +49,7 @@ func SetupIndexers(ctx context.Context, mgr ctrl.Manager) error {
 		setupServiceSetProviderIndexer,
 		setupCredentialRegionIndexer,
 	} {
-		merr = errors.Join(merr, f(ctx, mgr))
+		merr = errors.Join(merr, f(ctx, indexer))
 	}
 
 	return merr
@@ -56,8 +60,8 @@ func SetupIndexers(ctx context.Context, mgr ctrl.Manager) error {
 // ClusterDeploymentTemplateIndexKey indexer field name to extract ClusterTemplate name reference from a ClusterDeployment object.
 const ClusterDeploymentTemplateIndexKey = ".spec.template"
 
-func setupClusterDeploymentIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ClusterDeployment{}, ClusterDeploymentTemplateIndexKey, ExtractTemplateNameFromClusterDeployment)
+func setupClusterDeploymentIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ClusterDeployment{}, ClusterDeploymentTemplateIndexKey, ExtractTemplateNameFromClusterDeployment)
 }
 
 // ExtractTemplateNameFromClusterDeployment returns referenced ClusterTemplate name
@@ -74,8 +78,8 @@ func ExtractTemplateNameFromClusterDeployment(rawObj client.Object) []string {
 // ClusterDeploymentServiceTemplatesIndexKey indexer field name to extract service templates names from a ClusterDeployment object.
 const ClusterDeploymentServiceTemplatesIndexKey = ".spec.services[].Template"
 
-func setupClusterDeploymentServicesIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ClusterDeployment{}, ClusterDeploymentServiceTemplatesIndexKey, ExtractServiceTemplateNamesFromClusterDeployment)
+func setupClusterDeploymentServicesIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ClusterDeployment{}, ClusterDeploymentServiceTemplatesIndexKey, ExtractServiceTemplateNamesFromClusterDeployment)
 }
 
 // ExtractServiceTemplateNamesFromClusterDeployment returns a list of service templates names
@@ -97,8 +101,8 @@ func ExtractServiceTemplateNamesFromClusterDeployment(rawObj client.Object) []st
 // ClusterDeploymentServiceTemplateChainIndexKey indexer field name to extract service template chain name from a ClusterDeployment object.
 const ClusterDeploymentServiceTemplateChainIndexKey = ".spec.serviceSpec.services[].templateChain"
 
-func setupClusterDeploymentServiceTemplateChainIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ClusterDeployment{}, ClusterDeploymentServiceTemplateChainIndexKey, ExtractServiceTemplateChainNameFromClusterDeployment)
+func setupClusterDeploymentServiceTemplateChainIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ClusterDeployment{}, ClusterDeploymentServiceTemplateChainIndexKey, ExtractServiceTemplateChainNameFromClusterDeployment)
 }
 
 // ExtractServiceTemplateChainNameFromClusterDeployment returns a list of service template chain names
@@ -123,8 +127,8 @@ func ExtractServiceTemplateChainNameFromClusterDeployment(rawObj client.Object) 
 // ClusterDeploymentCredentialIndexKey indexer field name to extract Credential name reference from a ClusterDeployment object.
 const ClusterDeploymentCredentialIndexKey = ".spec.credential"
 
-func setupClusterDeploymentCredentialIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ClusterDeployment{}, ClusterDeploymentCredentialIndexKey, ExtractCredentialNameFromClusterDeployment)
+func setupClusterDeploymentCredentialIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ClusterDeployment{}, ClusterDeploymentCredentialIndexKey, ExtractCredentialNameFromClusterDeployment)
 }
 
 // ExtractCredentialNameFromClusterDeployment returns referenced Credential name
@@ -141,8 +145,8 @@ func ExtractCredentialNameFromClusterDeployment(rawObj client.Object) []string {
 // ClusterDeploymentAuthenticationIndexKey indexer field name to extract ClusterAuthentication name reference from a ClusterDeployment object.
 const ClusterDeploymentAuthenticationIndexKey = ".spec.authentication"
 
-func setupClusterDeploymentAuthenticationIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ClusterDeployment{}, ClusterDeploymentAuthenticationIndexKey, ExtractClusterAuthenticationNameFromClusterDeployment)
+func setupClusterDeploymentAuthenticationIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ClusterDeployment{}, ClusterDeploymentAuthenticationIndexKey, ExtractClusterAuthenticationNameFromClusterDeployment)
 }
 
 // ExtractClusterAuthenticationNameFromClusterDeployment returns referenced ClusterAuthentication name
@@ -161,8 +165,8 @@ func ExtractClusterAuthenticationNameFromClusterDeployment(rawObj client.Object)
 // ReleaseVersionIndexKey indexer field name to extract release version from a Release object.
 const ReleaseVersionIndexKey = ".spec.version"
 
-func setupReleaseVersionIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &Release{}, ReleaseVersionIndexKey, extractReleaseVersion)
+func setupReleaseVersionIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &Release{}, ReleaseVersionIndexKey, extractReleaseVersion)
 }
 
 func extractReleaseVersion(rawObj client.Object) []string {
@@ -176,8 +180,8 @@ func extractReleaseVersion(rawObj client.Object) []string {
 // ReleaseTemplatesIndexKey indexer field name to extract component template names from a Release object.
 const ReleaseTemplatesIndexKey = "releaseTemplates"
 
-func setupReleaseTemplatesIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &Release{}, ReleaseTemplatesIndexKey, extractReleaseTemplates)
+func setupReleaseTemplatesIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &Release{}, ReleaseTemplatesIndexKey, extractReleaseTemplates)
 }
 
 func extractReleaseTemplates(rawObj client.Object) []string {
@@ -194,12 +198,12 @@ func extractReleaseTemplates(rawObj client.Object) []string {
 // TemplateChainSupportedTemplatesIndexKey indexer field name to extract supported template names from an according TemplateChain object.
 const TemplateChainSupportedTemplatesIndexKey = ".spec.supportedTemplates[].Name"
 
-func setupClusterTemplateChainIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ClusterTemplateChain{}, TemplateChainSupportedTemplatesIndexKey, extractSupportedTemplatesNames)
+func setupClusterTemplateChainIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ClusterTemplateChain{}, TemplateChainSupportedTemplatesIndexKey, extractSupportedTemplatesNames)
 }
 
-func setupServiceTemplateChainIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ServiceTemplateChain{}, TemplateChainSupportedTemplatesIndexKey, extractSupportedTemplatesNames)
+func setupServiceTemplateChainIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ServiceTemplateChain{}, TemplateChainSupportedTemplatesIndexKey, extractSupportedTemplatesNames)
 }
 
 func extractSupportedTemplatesNames(rawObj client.Object) []string {
@@ -226,8 +230,8 @@ func extractSupportedTemplatesNames(rawObj client.Object) []string {
 // ClusterTemplateProvidersIndexKey indexer field name to extract provider names from a ClusterTemplate object.
 const ClusterTemplateProvidersIndexKey = "clusterTemplateProviders"
 
-func setupClusterTemplateProvidersIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ClusterTemplate{}, ClusterTemplateProvidersIndexKey, ExtractProvidersFromClusterTemplate)
+func setupClusterTemplateProvidersIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ClusterTemplate{}, ClusterTemplateProvidersIndexKey, ExtractProvidersFromClusterTemplate)
 }
 
 // ExtractProvidersFromClusterTemplate returns provider names from a ClusterTemplate object.
@@ -245,8 +249,8 @@ func ExtractProvidersFromClusterTemplate(o client.Object) []string {
 // MultiClusterServiceTemplatesIndexKey indexer field name to extract service templates names from a MultiClusterService object.
 const MultiClusterServiceTemplatesIndexKey = "serviceTemplates"
 
-func setupMultiClusterServiceServicesIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &MultiClusterService{}, MultiClusterServiceTemplatesIndexKey, ExtractServiceTemplateNamesFromMultiClusterService)
+func setupMultiClusterServiceServicesIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &MultiClusterService{}, MultiClusterServiceTemplatesIndexKey, ExtractServiceTemplateNamesFromMultiClusterService)
 }
 
 // ExtractServiceTemplateNamesFromMultiClusterService returns a list of service templates names
@@ -268,8 +272,8 @@ func ExtractServiceTemplateNamesFromMultiClusterService(rawObj client.Object) []
 // MultiClusterServiceTemplateChainIndexKey indexer field name to extract template chain names from a MultiClusterService object.
 const MultiClusterServiceTemplateChainIndexKey = ".spec.serviceSpec.services[].templateChain"
 
-func setupMultiClusterServiceTemplateChainIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &MultiClusterService{}, MultiClusterServiceTemplateChainIndexKey, ExtractServiceTemplateChainNamesFromMultiClusterService)
+func setupMultiClusterServiceTemplateChainIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &MultiClusterService{}, MultiClusterServiceTemplateChainIndexKey, ExtractServiceTemplateChainNamesFromMultiClusterService)
 }
 
 // ExtractServiceTemplateChainNamesFromMultiClusterService returns a list of template chain names
@@ -296,13 +300,13 @@ func ExtractServiceTemplateChainNamesFromMultiClusterService(rawObj client.Objec
 // OwnerRefIndexKey indexer field name to extract ownerReference names from objects
 const OwnerRefIndexKey = ".metadata.ownerReferences"
 
-func setupOwnerReferenceIndexers(ctx context.Context, mgr ctrl.Manager) error {
+func setupOwnerReferenceIndexers(ctx context.Context, indexer client.FieldIndexer) error {
 	var merr error
 	for _, obj := range []client.Object{
 		&ProviderTemplate{},
 		&ServiceSet{},
 	} {
-		merr = errors.Join(merr, mgr.GetFieldIndexer().IndexField(ctx, obj, OwnerRefIndexKey, extractOwnerReferences))
+		merr = errors.Join(merr, indexer.IndexField(ctx, obj, OwnerRefIndexKey, extractOwnerReferences))
 	}
 
 	return merr
@@ -324,8 +328,8 @@ func extractOwnerReferences(rawObj client.Object) []string {
 // that either has schedule or has NOT been completed yet.
 const ManagementBackupIndexKey = "k0rdent.management-backup"
 
-func setupManagementBackupIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ManagementBackup{}, ManagementBackupIndexKey, ExtractScheduledOrIncompleteBackups)
+func setupManagementBackupIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ManagementBackup{}, ManagementBackupIndexKey, ExtractScheduledOrIncompleteBackups)
 }
 
 // ExtractScheduledOrIncompleteBackups returns either scheduled or incomplete backups.
@@ -346,8 +350,8 @@ func ExtractScheduledOrIncompleteBackups(o client.Object) []string {
 // with schedule and auto-upgrade set.
 const ManagementBackupAutoUpgradeIndexKey = "k0rdent.management-backup-upgrades"
 
-func setupManagementBackupAutoUpgradesIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ManagementBackup{}, ManagementBackupAutoUpgradeIndexKey, func(o client.Object) []string {
+func setupManagementBackupAutoUpgradesIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ManagementBackup{}, ManagementBackupAutoUpgradeIndexKey, func(o client.Object) []string {
 		mb, ok := o.(*ManagementBackup)
 		if !ok || mb.Spec.Schedule == "" || !mb.Spec.PerformOnManagementUpgrade {
 			return nil
@@ -362,8 +366,8 @@ func setupManagementBackupAutoUpgradesIndexer(ctx context.Context, mgr ctrl.Mana
 // ServiceSetClusterIndexKey indexer field name to extract cluster name from [ServiceSet] object.
 const ServiceSetClusterIndexKey = "k0rdent.service-set.cluster"
 
-func setupServiceSetClusterIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ServiceSet{}, ServiceSetClusterIndexKey, ExtractServiceSetCluster)
+func setupServiceSetClusterIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ServiceSet{}, ServiceSetClusterIndexKey, ExtractServiceSetCluster)
 }
 
 // ExtractServiceSetCluster returns the cluster name from [ServiceSet] object.
@@ -378,8 +382,8 @@ func ExtractServiceSetCluster(o client.Object) []string {
 // ServiceSetMultiClusterServiceIndexKey indexer field name to extract multi-cluster-service from [ServiceSet] object.
 const ServiceSetMultiClusterServiceIndexKey = "k0rdent.service-set.multi-cluster-service"
 
-func setupServiceSetMultiClusterServiceIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ServiceSet{}, ServiceSetMultiClusterServiceIndexKey, ExtractServiceSetMultiClusterService)
+func setupServiceSetMultiClusterServiceIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ServiceSet{}, ServiceSetMultiClusterServiceIndexKey, ExtractServiceSetMultiClusterService)
 }
 
 // ExtractServiceSetMultiClusterService returns the multi-cluster-service from [ServiceSet] object.
@@ -397,8 +401,8 @@ func ExtractServiceSetMultiClusterService(o client.Object) []string {
 // ServiceSetProviderIndexKey indexer field name to extract provider name from [ServiceSet] object.
 const ServiceSetProviderIndexKey = "k0rdent.service-set.provider"
 
-func setupServiceSetProviderIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &ServiceSet{}, ServiceSetProviderIndexKey, ExtractServiceSetProvider)
+func setupServiceSetProviderIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &ServiceSet{}, ServiceSetProviderIndexKey, ExtractServiceSetProvider)
 }
 
 // ExtractServiceSetProvider returns the provider name from [ServiceSet] object.
@@ -415,8 +419,8 @@ func ExtractServiceSetProvider(o client.Object) []string {
 // CredentialRegionIndexKey indexer field name to extract region name from [Credential] object.
 const CredentialRegionIndexKey = ".spec.region"
 
-func setupCredentialRegionIndexer(ctx context.Context, mgr ctrl.Manager) error {
-	return mgr.GetFieldIndexer().IndexField(ctx, &Credential{}, CredentialRegionIndexKey, ExtractCredentialRegion)
+func setupCredentialRegionIndexer(ctx context.Context, indexer client.FieldIndexer) error {
+	return indexer.IndexField(ctx, &Credential{}, CredentialRegionIndexKey, ExtractCredentialRegion)
 }
 
 // ExtractCredentialRegion returns the region name from [Credential] object.

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -21,8 +21,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 
+	"github.com/Masterminds/semver/v3"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -482,6 +484,36 @@ func ServicesToDeploy(
 	return services
 }
 
+func normalizeVersion(v string) string {
+	versionRegex := regexp.MustCompile(`\d+\.\d+\.\d+|\d+-\d+-\d+`)
+	m := versionRegex.FindStringSubmatch(v)
+	if len(m) != 4 {
+		return ""
+	}
+	return m[1] + "." + m[2] + "." + m[3]
+}
+
+func isUpgradeAvailable(current, desired string) bool {
+	cur := normalizeVersion(current)
+	des := normalizeVersion(desired)
+
+	if cur == "" || des == "" {
+		return false
+	}
+
+	curVer, err := semver.NewVersion(cur)
+	if err != nil {
+		return false
+	}
+
+	desVer, err := semver.NewVersion(des)
+	if err != nil {
+		return false
+	}
+
+	return curVer.GreaterThan(desVer)
+}
+
 func servicesToBeUpdated(
 	serviceSet *kcmv1.ServiceSet,
 	desiredServices []kcmv1.Service,
@@ -498,7 +530,7 @@ func servicesToBeUpdated(
 		key := client.ObjectKey{Namespace: effectiveServiceNs, Name: svc.Name}
 		desiredVersion := desiredServiceVersions[key]
 		// check upgrade availability
-		upgradeAvailable[key] = svc.Version != nil && desiredVersion < *svc.Version ||
+		upgradeAvailable[key] = svc.Version != nil && isUpgradeAvailable(*svc.Version, desiredVersion) ||
 			desiredVersionInUpgradePaths(upgradePaths, svc, desiredVersion)
 		for _, serviceState := range serviceSet.Status.Services {
 			if serviceState.State == kcmv1.ServiceStateDeployed &&
@@ -608,6 +640,10 @@ func GetServiceSetWithOperation(
 		return nil, kcmv1.ServiceSetOperationNone, fmt.Errorf("failed to get ServiceSet %s: %w", operationReq.ObjectKey, err)
 	}
 
+	// Save current spec before Build() overwrites it in place
+	// to compare spec and decide whether action is required.
+	existingSpec := serviceSet.Spec.DeepCopy()
+
 	templateNamespace := serviceSet.Namespace
 	upgradePaths, err := ServicesUpgradePaths(
 		ctx, c, ServicesWithDesiredChains(desiredServices, serviceSet.Spec.Services), templateNamespace)
@@ -634,10 +670,6 @@ func GetServiceSetWithOperation(
 	resultingServices := ServicesToDeploy(upgradePaths, filteredServices, serviceSet)
 	l.V(1).Info("Services to deploy", "services", resultingServices)
 
-	// Save current spec before Build() overwrites it in place
-	// to compare spec and decide whether action is required.
-	existingSpec := serviceSet.Spec
-
 	candidate, err := NewBuilder(operationReq.CD, serviceSet, provider.Spec.Selector).
 		WithMultiClusterService(operationReq.MCS).
 		WithServicesToDeploy(resultingServices).Build()
@@ -645,7 +677,7 @@ func GetServiceSetWithOperation(
 		return nil, kcmv1.ServiceSetOperationNone, fmt.Errorf("failed to build ServiceSet: %w", err)
 	}
 
-	if op == kcmv1.ServiceSetOperationUpdate && equality.Semantic.DeepEqual(existingSpec, candidate.Spec) {
+	if op == kcmv1.ServiceSetOperationUpdate && equality.Semantic.DeepEqual(existingSpec, &candidate.Spec) {
 		l.V(1).Info("No actions required, ServiceSet is up to date", "operation", kcmv1.ServiceSetOperationNone)
 		return serviceSet, kcmv1.ServiceSetOperationNone, nil
 	}

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -61,64 +61,43 @@ func ObjectKey(systemNamespace string, cd *kcmv1.ClusterDeployment, mcs *kcmv1.M
 	}
 }
 
-func ResolveServiceVersions(ctx context.Context, c client.Client, namespace string, services any) error {
-	switch s := services.(type) {
-	case []kcmv1.Service:
-		ptrs := make([]*kcmv1.Service, len(s))
-		for i := range s {
-			ptrs[i] = &s[i]
-		}
-		return fillServiceVersions(ctx, c, namespace, ptrs)
-
-	case []kcmv1.ServiceWithValues:
-		ptrs := make([]*kcmv1.ServiceWithValues, len(s))
-		for i := range s {
-			ptrs[i] = &s[i]
-		}
-		return fillServiceWithValueVersions(ctx, c, namespace, ptrs)
-
-	default:
-		return fmt.Errorf("unsupported slice type %T", services)
-	}
-}
-
-func fillServiceVersions(ctx context.Context, c client.Client, namespace string, services []*kcmv1.Service) error {
-	for _, svc := range services {
-		if svc.Version == "" && svc.Template != "" {
+func fillServiceVersions(ctx context.Context, c client.Client, namespace string, services []kcmv1.Service) error {
+	for i := range services {
+		if services[i].Version == "" && services[i].Template != "" {
 			template := kcmv1.ServiceTemplate{}
-			if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: svc.Template}, &template); err != nil {
-				return fmt.Errorf("failed to fetch template %s: %w", svc.Template, err)
+			if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: services[i].Template}, &template); err != nil {
+				return fmt.Errorf("failed to fetch template %s: %w", services[i].Template, err)
 			}
 
 			version := template.Spec.Version
 			if version == "" && template.Spec.Helm != nil && template.Spec.Helm.ChartSpec != nil {
 				version = template.Spec.Helm.ChartSpec.Version
 			}
-			svc.Version = version
+			services[i].Version = version
 
-			if svc.Version == "" {
-				svc.Version = svc.Template
+			if services[i].Version == "" {
+				services[i].Version = services[i].Template
 			}
 		}
 	}
 	return nil
 }
 
-func fillServiceWithValueVersions(ctx context.Context, c client.Client, namespace string, services []*kcmv1.ServiceWithValues) error {
-	for _, svc := range services {
-		if svc.Values == "" && svc.Template != "" {
+func fillServiceWithValueVersions(ctx context.Context, c client.Client, namespace string, services []kcmv1.ServiceWithValues) error {
+	for i := range services {
+		if services[i].Values == "" && services[i].Template != "" {
 			template := kcmv1.ServiceTemplate{}
-			if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: svc.Template}, &template); err != nil {
-				return fmt.Errorf("failed to fetch Template %s: %w", svc.Template, err)
+			if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: services[i].Template}, &template); err != nil {
+				return fmt.Errorf("failed to fetch Template %s: %w", services[i].Template, err)
 			}
 
 			version := template.Spec.Version
 			if version == "" && template.Spec.Helm != nil && template.Spec.Helm.ChartSpec != nil {
 				version = template.Spec.Helm.ChartSpec.Version
 			}
-			svc.Version = &version
-			if svc.Version == nil {
-				svc.Version = &svc.Template
+			services[i].Version = &version
+			if services[i].Version == nil {
+				services[i].Version = &services[i].Template
 			}
 		}
 	}
@@ -644,12 +623,11 @@ func GetServiceSetWithOperation(
 	}
 	l.V(1).Info("Services after dependency filtering", "services", filteredServices)
 
-	if err := ResolveServiceVersions(ctx, c, templateNamespace, filteredServices); err != nil {
+	if err := fillServiceVersions(ctx, c, templateNamespace, filteredServices); err != nil {
 		return nil, kcmv1.ServiceSetOperationNone, fmt.Errorf("failed to resolve versions for filtered services: %w", err)
 	}
 
-	serviceSetServices := serviceSet.Spec.Services
-	if err := ResolveServiceVersions(ctx, c, templateNamespace, serviceSetServices); err != nil {
+	if err := fillServiceWithValueVersions(ctx, c, templateNamespace, serviceSet.Spec.Services); err != nil {
 		return nil, kcmv1.ServiceSetOperationNone, fmt.Errorf("failed to resolve versions for service set services: %w", err)
 	}
 

--- a/internal/serviceset/util_test.go
+++ b/internal/serviceset/util_test.go
@@ -34,6 +34,20 @@ import (
 	kubeutil "github.com/K0rdent/kcm/internal/util/kube"
 )
 
+type fakeFieldIndexer struct {
+	builder *fake.ClientBuilder
+}
+
+func (f *fakeFieldIndexer) IndexField(
+	_ context.Context,
+	obj client.Object,
+	field string,
+	extractValue client.IndexerFunc,
+) error {
+	f.builder.WithIndex(obj, field, extractValue)
+	return nil
+}
+
 func Test_GetServiceSetWithOperation(t *testing.T) {
 	ctx := context.Background()
 
@@ -45,6 +59,43 @@ func Test_GetServiceSetWithOperation(t *testing.T) {
 		Namespace: "default",
 	}
 
+	provider := &kcmv1.StateManagementProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ksm-projectsveltos",
+		},
+		Spec: kcmv1.StateManagementProviderSpec{
+			Selector: &metav1.LabelSelector{},
+		},
+		Status: kcmv1.StateManagementProviderStatus{
+			Ready: true,
+		},
+	}
+
+	template := &kcmv1.ServiceTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: kcmv1.ClusterDeploymentSpec{
+			ServiceSpec: kcmv1.ServiceSpec{
+				Services: []kcmv1.Service{
+					{
+						Name:      "test-service",
+						Namespace: "default",
+						Template:  "test",
+					},
+				},
+			},
+		},
+	}
+
 	tests := []struct {
 		name         string
 		existingObjs []client.Object
@@ -53,25 +104,50 @@ func Test_GetServiceSetWithOperation(t *testing.T) {
 		expectErr    bool
 	}{
 		{
-			name:         "serviceset not found -> create",
-			existingObjs: nil,
+			name: "serviceset not found -> create",
+			existingObjs: []client.Object{
+				provider,
+				template,
+			},
 			operationReq: OperationRequisites{
 				ObjectKey: key,
+				CD:        cd,
 			},
 			expectOp: kcmv1.ServiceSetOperationCreate,
 		},
 		{
 			name: "serviceset exists -> none",
 			existingObjs: []client.Object{
+				provider,
+				template,
 				&kcmv1.ServiceSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      key.Name,
 						Namespace: key.Namespace,
 					},
+					Spec: kcmv1.ServiceSetSpec{
+						Cluster: cd.Name,
+						Provider: kcmv1.StateManagementProviderConfig{
+							Config: &apiextv1.JSON{
+								Raw: []byte("{}"),
+							},
+							Name:           provider.Name,
+							SelfManagement: false,
+						},
+						Services: []kcmv1.ServiceWithValues{
+							{
+								Name:      cd.Spec.ServiceSpec.Services[0].Name,
+								Namespace: cd.Spec.ServiceSpec.Services[0].Namespace,
+								Template:  cd.Spec.ServiceSpec.Services[0].Template,
+								Version:   &cd.Spec.ServiceSpec.Services[0].Template,
+							},
+						},
+					},
 				},
 			},
 			operationReq: OperationRequisites{
 				ObjectKey: key,
+				CD:        cd,
 			},
 			expectOp: kcmv1.ServiceSetOperationNone,
 		},
@@ -83,7 +159,11 @@ func Test_GetServiceSetWithOperation(t *testing.T) {
 			if len(tt.existingObjs) > 0 {
 				builder = builder.WithObjects(tt.existingObjs...)
 			}
+			indexer := &fakeFieldIndexer{
+				builder: builder,
+			}
 
+			require.NoError(t, kcmv1.SetupFieldIndexers(ctx, indexer))
 			c := builder.Build()
 			serviceSet, op, err := GetServiceSetWithOperation(ctx, c, tt.operationReq)
 
@@ -112,7 +192,7 @@ func Test_FillServiceVersions(t *testing.T) {
 	tests := []struct {
 		name        string
 		templates   []runtime.Object
-		services    []*kcmv1.Service
+		services    []kcmv1.Service
 		expectErr   bool
 		expectedVer string
 	}{
@@ -129,7 +209,7 @@ func Test_FillServiceVersions(t *testing.T) {
 					},
 				},
 			},
-			services: []*kcmv1.Service{
+			services: []kcmv1.Service{
 				{
 					Template: "tmpl1",
 				},
@@ -153,7 +233,7 @@ func Test_FillServiceVersions(t *testing.T) {
 					},
 				},
 			},
-			services: []*kcmv1.Service{
+			services: []kcmv1.Service{
 				{
 					Template: "tmpl2",
 				},
@@ -170,7 +250,7 @@ func Test_FillServiceVersions(t *testing.T) {
 					},
 				},
 			},
-			services: []*kcmv1.Service{
+			services: []kcmv1.Service{
 				{
 					Template: "tmpl3",
 				},
@@ -180,7 +260,7 @@ func Test_FillServiceVersions(t *testing.T) {
 		{
 			name:      "already has version",
 			templates: []runtime.Object{},
-			services: []*kcmv1.Service{
+			services: []kcmv1.Service{
 				{
 					Version:  "existing",
 					Template: "tmpl4",
@@ -191,7 +271,7 @@ func Test_FillServiceVersions(t *testing.T) {
 		{
 			name:      "template not found",
 			templates: []runtime.Object{},
-			services: []*kcmv1.Service{
+			services: []kcmv1.Service{
 				{
 					Template: "missing",
 				},

--- a/internal/serviceset/util_test.go
+++ b/internal/serviceset/util_test.go
@@ -15,8 +15,10 @@
 package serviceset
 
 import (
+	"context"
 	"testing"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,6 +33,193 @@ import (
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	kubeutil "github.com/K0rdent/kcm/internal/util/kube"
 )
+
+func Test_GetServiceSetWithOperation(t *testing.T) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, kcmv1.AddToScheme(scheme))
+
+	key := client.ObjectKey{
+		Name:      "test-serviceset",
+		Namespace: "default",
+	}
+
+	tests := []struct {
+		name         string
+		existingObjs []client.Object
+		operationReq OperationRequisites
+		expectOp     kcmv1.ServiceSetOperation
+		expectErr    bool
+	}{
+		{
+			name:         "serviceset not found -> create",
+			existingObjs: nil,
+			operationReq: OperationRequisites{
+				ObjectKey: key,
+			},
+			expectOp: kcmv1.ServiceSetOperationCreate,
+		},
+		{
+			name: "serviceset exists -> none",
+			existingObjs: []client.Object{
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      key.Name,
+						Namespace: key.Namespace,
+					},
+				},
+			},
+			operationReq: OperationRequisites{
+				ObjectKey: key,
+			},
+			expectOp: kcmv1.ServiceSetOperationNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if len(tt.existingObjs) > 0 {
+				builder = builder.WithObjects(tt.existingObjs...)
+			}
+
+			c := builder.Build()
+			serviceSet, op, err := GetServiceSetWithOperation(ctx, c, tt.operationReq)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectOp, op)
+			require.NotNil(t, serviceSet)
+
+			if op == kcmv1.ServiceSetOperationCreate {
+				require.Equal(t, key.Name, serviceSet.Name)
+				require.Equal(t, key.Namespace, serviceSet.Namespace)
+			}
+		})
+	}
+}
+
+func Test_FillServiceVersions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, kcmv1.AddToScheme(scheme))
+	ctx := context.Background()
+	namespace := "test-ns"
+	tests := []struct {
+		name        string
+		templates   []runtime.Object
+		services    []*kcmv1.Service
+		expectErr   bool
+		expectedVer string
+	}{
+		{
+			name: "version from spec.version",
+			templates: []runtime.Object{
+				&kcmv1.ServiceTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tmpl1",
+						Namespace: namespace,
+					},
+					Spec: kcmv1.ServiceTemplateSpec{
+						Version: "1.2.3",
+					},
+				},
+			},
+			services: []*kcmv1.Service{
+				{
+					Template: "tmpl1",
+				},
+			},
+			expectedVer: "1.2.3",
+		},
+		{
+			name: "version from helm chart",
+			templates: []runtime.Object{
+				&kcmv1.ServiceTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tmpl2",
+						Namespace: namespace,
+					},
+					Spec: kcmv1.ServiceTemplateSpec{
+						Helm: &kcmv1.HelmSpec{
+							ChartSpec: &sourcev1.HelmChartSpec{
+								Version: "9.9.9",
+							},
+						},
+					},
+				},
+			},
+			services: []*kcmv1.Service{
+				{
+					Template: "tmpl2",
+				},
+			},
+			expectedVer: "9.9.9",
+		},
+		{
+			name: "fallback to template name",
+			templates: []runtime.Object{
+				&kcmv1.ServiceTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "tmpl3",
+						Namespace: namespace,
+					},
+				},
+			},
+			services: []*kcmv1.Service{
+				{
+					Template: "tmpl3",
+				},
+			},
+			expectedVer: "tmpl3",
+		},
+		{
+			name:      "already has version",
+			templates: []runtime.Object{},
+			services: []*kcmv1.Service{
+				{
+					Version:  "existing",
+					Template: "tmpl4",
+				},
+			},
+			expectedVer: "existing",
+		},
+		{
+			name:      "template not found",
+			templates: []runtime.Object{},
+			services: []*kcmv1.Service{
+				{
+					Template: "missing",
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if len(tt.templates) > 0 {
+				builder = builder.WithRuntimeObjects(tt.templates...)
+			}
+
+			cl := builder.Build()
+
+			err := fillServiceVersions(ctx, cl, namespace, tt.services)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedVer, tt.services[0].Version)
+		})
+	}
+}
 
 func Test_ServicesToDeploy(t *testing.T) {
 	t.Parallel()

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -360,8 +360,11 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 				return nil
 			}, 30*time.Minute, 10*time.Second).Should(Succeed())
 
-			serviceSet.SetAnnotations(map[string]string{})
-			Expect(kc.CrClient.Update(ctx, serviceSet)).NotTo(HaveOccurred(), "failed to update ServiceSet")
+			Eventually(ctx, func() error {
+				Expect(kc.CrClient.Get(ctx, crclient.ObjectKeyFromObject(serviceSet), serviceSet)).NotTo(HaveOccurred())
+				serviceSet.SetAnnotations(map[string]string{})
+				return kc.CrClient.Update(ctx, serviceSet)
+			}, 30*time.Minute, 10*time.Second).Should(Succeed())
 
 			Expect(clusterDeleteFunc()).Error().NotTo(HaveOccurred(), "failed to delete cluster")
 			clusterDeleteFunc = nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cleans up some code in the sveltos util and also fixes a small issue where conflicts can occur because of stale updates to a service set object in the functional tests.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2506