### PR TITLE
fix: servicetemplate spec.resources.path

### DIFF
--- a/api/v1beta1/servicetemplate_types.go
+++ b/api/v1beta1/servicetemplate_types.go
@@ -82,7 +82,7 @@ type SourceSpec struct {
 	DeploymentType string `json:"deploymentType"`
 
 	// Path to the directory containing the resource manifest.
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 }
 
 // LocalSourceRef defines the reference to the local resource to be used as the source.

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
@@ -714,7 +714,6 @@ spec:
                               rule: has(self.git) || has(self.bucket) || has(self.oci)
                       required:
                         - deploymentType
-                        - path
                       type: object
                       x-kubernetes-validations:
                         - message: Secret and ConfigMap are not supported as Helm chart sources

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
@@ -725,7 +725,6 @@ spec:
                               rule: has(self.git) || has(self.bucket) || has(self.oci)
                       required:
                         - deploymentType
-                        - path
                       type: object
                       x-kubernetes-validations:
                         - message: Secret and ConfigMap are not supported as Helm chart sources

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
@@ -714,7 +714,6 @@ spec:
                               rule: has(self.git) || has(self.bucket) || has(self.oci)
                       required:
                         - deploymentType
-                        - path
                       type: object
                       x-kubernetes-validations:
                         - message: Secret and ConfigMap are not supported as Helm chart sources
@@ -1661,7 +1660,6 @@ spec:
                           rule: has(self.git) || has(self.bucket) || has(self.oci)
                   required:
                     - deploymentType
-                    - path
                   type: object
                   x-kubernetes-validations:
                     - message: LocalSource and RemoteSource are mutually exclusive.
@@ -2293,7 +2291,6 @@ spec:
                           rule: has(self.git) || has(self.bucket) || has(self.oci)
                   required:
                     - deploymentType
-                    - path
                   type: object
                   x-kubernetes-validations:
                     - message: LocalSource and RemoteSource are mutually exclusive.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes `serviceTemplate.spec.resources.path` field optional.

**Which issue(s) this PR fixes**:
Fixes #2510 
