### PR TITLE
fix(templates): allow empty gke locationPolicy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -827,7 +827,7 @@ cli-install: controller-gen envtest golangci-lint helm kind yq cloud-nuke azure-
 
 .PHONY: helm-plugin-schema
 helm-plugin-schema: HELM_PLUGIN_URL ?= https://github.com/losisin/helm-values-schema-json.git
-helm-plugin-schema: HELM_SCHEMA_PLUGIN_VERSION ?= 2.2.1
+helm-plugin-schema: HELM_SCHEMA_PLUGIN_VERSION ?= 2.3.1
 helm-plugin-schema: HELM_SCHEMA_PLUGIN_NAME ?= schema
 helm-plugin-schema: helm
 	@set -e; \

--- a/config/dev/gke-clusterdeployment.yaml
+++ b/config/dev/gke-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-gke-1-0-8
+  template: gcp-gke-1-0-9
   credential: gcp-credential
   propagateCredentials: false
   config:

--- a/templates/cluster/gcp-gke/Chart.yaml
+++ b/templates/cluster/gcp-gke/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-gke/templates/gcpmanagedmachinepool.yaml
+++ b/templates/cluster/gcp-gke/templates/gcpmanagedmachinepool.yaml
@@ -9,8 +9,15 @@ spec:
   diskSizeGB: {{ .Values.machines.diskSizeGB }}
   {{- with .Values.machines }}
   localSsdCount: {{ .localSsdCount }}
+  # See: https://github.com/k0rdent/kcm/issues/2034
+  # Omit locationPolicy if empty is set.
+  # Empty value is allowed to survive k8s CRD JSON (de)serializations and null pruning.
   {{- with .scaling }}
-  scaling: {{- toYaml . | nindent 4 }}
+  {{- $scaling := . }}
+  {{- if and (hasKey . "locationPolicy") (eq (get . "locationPolicy") "") }}
+  {{- $scaling = omit . "locationPolicy" }}
+  {{- end }}
+  scaling: {{- toYaml $scaling | nindent 4 }}
   {{- end }}
   {{- with .nodeLocations }}
   nodeLocations: {{- toYaml . | nindent 4 }}

--- a/templates/cluster/gcp-gke/values.schema.json
+++ b/templates/cluster/gcp-gke/values.schema.json
@@ -181,13 +181,11 @@
             },
             "locationPolicy": {
               "description": "Location policy used when scaling up a nodepool",
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": "string",
               "enum": [
                 "balanced",
-                "any"
+                "any",
+                ""
               ]
             },
             "maxCount": {

--- a/templates/cluster/gcp-gke/values.yaml
+++ b/templates/cluster/gcp-gke/values.yaml
@@ -39,7 +39,7 @@ machines: # @schema description: Managed machines' parameters; type: object
     enableAutoscaling: true # @schema description: Is autoscaling enabled for this node pool. If unspecified, the default value is true; type: boolean
     minCount: # @schema description: The minimum number of nodes in the node pool; type: [number, null]
     maxCount: # @schema description: The maximum number of nodes in the node pool; type: [number, null]
-    locationPolicy: "balanced" # @schema description: Location policy used when scaling up a nodepool; type: [string, null]; enum: balanced,any
+    locationPolicy: "balanced" # @schema description: Location policy used when scaling up a nodepool; type:string; enum:[balanced, any, ""]
   nodeLocations: [] # @schema description: The list of zones in which the NodePool's nodes should be located; type: array; item: string
   imageType: "" # @schema description: The image type to use for this nodepool; type: string
   instanceType: "" # @schema description: The name of Compute Engine machine type; type: string

--- a/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-9.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-9.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-gke-1-0-8
+  name: gcp-gke-1-0-9
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-gke
-      version: 1.0.8
+      version: 1.0.9
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
The previous fix #2036 allowed `null` only on the JSON Schema level but apiserver prunes the `null` values on the wire (if `nullable: true` is not set, which cannot be the case with the current approach), resulting in the empty `{}` object, which on the `helm` side end up with "nothing" effectively choosing the default value.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Related to: #2034 