### PR TITLE
feat: support for registry with authentication when creating child clusters.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,10 @@ update-dev-confs: yq
 capo-orc-fetch: CAPO_DIR := $(PROVIDER_TEMPLATES_DIR)/cluster-api-provider-openstack
 capo-orc-fetch: CAPO_ORC_VERSION := 2.1.0
 capo-orc-fetch: CAPO_ORC_TEMPLATE := "$(CAPO_DIR)/templates/orc.yaml"
-capo-orc-fetch:
+capo-orc-fetch: yq
 	@curl -L --fail -s https://github.com/k-orc/openstack-resource-controller/releases/download/v$(CAPO_ORC_VERSION)/install.yaml | \
+	$(YQ) 'del(select(.kind == "Namespace"))' | \
+	$(YQ) '(select(.metadata.namespace) | .metadata.namespace) = "{{ .Release.Namespace }}"' | \
 	awk 'NR==1{print "{{- $$global := .Values.global | default dict }}"} \
 	{ \
 	  if ($$0 ~ /controller-gen.kubebuilder.io\/version/) { \
@@ -158,24 +160,24 @@ capo-orc-fetch:
 	    for(i=2;i<=length(arr);i++) { \
 	      image_path = image_path ((i>2)?"/":"") arr[i]; \
 	    } \
-	    print "        image: {{ default \"" registry "\" $$global.registry }}/" image_path; \
+	    print "          image: {{ default \"" registry "\" $$global.registry }}/" image_path; \
 	    next; \
 	  } \
 \
 	  print; \
 \
 	  if ($$0 ~ /^[ \t]*name: manager$$/) { \
-	    print "        {{- $$proxyEnv := include \"infrastructureProvider.proxyEnv\" . | fromYaml }}"; \
-	    print "        {{- if $$proxyEnv }}"; \
-	    print "        env:"; \
-	    print "        {{ toYaml $$proxyEnv.env | nindent 8 }}"; \
-	    print "        {{- end }}"; \
+	    print "          {{- $$proxyEnv := include \"infrastructureProvider.proxyEnv\" . | fromYaml }}"; \
+	    print "          {{- if $$proxyEnv }}"; \
+	    print "          env:"; \
+	    print "          {{ toYaml $$proxyEnv.env | nindent 8 }}"; \
+	    print "          {{- end }}"; \
 	  } \
 \
 	  if ($$0 ~ /serviceAccountName: orc-controller-manager/) { \
-	    print "      {{- if $$global.imagePullSecrets }}"; \
-	    print "      imagePullSecrets: {{ toYaml $$global.imagePullSecrets | nindent 8 }}"; \
-	    print "      {{- end }}"; \
+	    print "        {{- if $$global.imagePullSecrets }}"; \
+	    print "        imagePullSecrets: {{ toYaml $$global.imagePullSecrets | nindent 8 }}"; \
+	    print "        {{- end }}"; \
 	  } \
 	}' > $(CAPO_ORC_TEMPLATE)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -343,15 +343,16 @@ func setupControllers(mgr ctrl.Manager, currentNamespace string, cfg config) err
 		return err
 	}
 	if err = (&controller.ManagementReconciler{
-		SystemNamespace:        currentNamespace,
-		CreateAccessManagement: cfg.createAccessManagement,
-		IsDisabledValidationWH: !cfg.enableWebhook,
-		GlobalRegistry:         cfg.globalRegistry,
-		GlobalK0sURL:           cfg.globalK0sURL,
-		K0sURLCertSecretName:   cfg.k0sURLCertSecretName,
-		RegistryCertSecretName: cfg.registryCertSecretName,
-		ImagePullSecretName:    cfg.imagePullSecretName,
-		DefaultHelmTimeout:     cfg.defaultHelmTimeout,
+		SystemNamespace:               currentNamespace,
+		CreateAccessManagement:        cfg.createAccessManagement,
+		IsDisabledValidationWH:        !cfg.enableWebhook,
+		GlobalRegistry:                cfg.globalRegistry,
+		GlobalK0sURL:                  cfg.globalK0sURL,
+		K0sURLCertSecretName:          cfg.k0sURLCertSecretName,
+		RegistryCertSecretName:        cfg.registryCertSecretName,
+		ImagePullSecretName:           cfg.imagePullSecretName,
+		RegistryCredentialsSecretName: cfg.registryCredentialsSecretName,
+		DefaultHelmTimeout:            cfg.defaultHelmTimeout,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Management")
 		return err

--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-24
+  template: aws-standalone-cp-1-0-25
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-24
+  template: azure-standalone-cp-1-0-25
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-22
+  template: gcp-standalone-cp-1-0-23
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-5
+  template: kubevirt-standalone-cp-1-0-6
   credential: kubevirt-cred
   propagateCredentials: false
   config:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-26
+  template: openstack-standalone-cp-1-0-27
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-23
+  template: remote-cluster-1-0-24
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-22
+  template: vsphere-standalone-cp-1-0-23
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/K0rdent/kcm
 go 1.26
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/a8m/envsubst v1.4.3
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -53,7 +54,6 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -85,11 +85,12 @@ type helmActor interface {
 type ClusterDeploymentReconciler struct {
 	MgmtClient client.Client
 	helmActor
-	SystemNamespace        string
-	GlobalRegistry         string
-	GlobalK0sURL           string
-	K0sURLCertSecretName   string // Name of a Secret with K0s Download URL Root CA with ca.crt key
-	RegistryCertSecretName string // Name of a Secret with Registry Root CA with ca.crt key
+	SystemNamespace           string
+	GlobalRegistry            string
+	GlobalK0sURL              string
+	K0sURLCertSecretName      string // Name of a Secret with K0s Download URL Root CA with ca.crt key
+	RegistryCertSecretName    string // Name of a Secret with Registry Root CA with ca.crt key
+	CldRegistryCredSecretName string
 
 	DefaultHelmTimeout time.Duration
 	defaultRequeueTime time.Duration
@@ -842,10 +843,11 @@ func (r *ClusterDeploymentReconciler) fillHelmValues(scope *clusterScope) error 
 		}
 
 		global := map[string]any{
-			"registry":           r.GlobalRegistry,
-			"k0sURL":             r.GlobalK0sURL,
-			"registryCertSecret": r.RegistryCertSecretName,
-			"k0sURLCertSecret":   r.K0sURLCertSecretName,
+			"registry":                 r.GlobalRegistry,
+			"k0sURL":                   r.GlobalK0sURL,
+			"registryCertSecret":       r.RegistryCertSecretName,
+			"k0sURLCertSecret":         r.K0sURLCertSecretName,
+			"registryCredentialSecret": r.CldRegistryCredSecretName,
 		}
 		for _, v := range global {
 			if v != "" {
@@ -1715,7 +1717,7 @@ func (r *ClusterDeploymentReconciler) processClusterIPAM(ctx context.Context, cd
 }
 
 func (r *ClusterDeploymentReconciler) handleCertificateSecrets(ctx context.Context, rgnClient client.Client, cd *kcmv1.ClusterDeployment) error {
-	secretsToHandle := []string{r.K0sURLCertSecretName, r.RegistryCertSecretName}
+	secretsToHandle := []string{r.K0sURLCertSecretName, r.RegistryCertSecretName, r.CldRegistryCredSecretName}
 
 	l := ctrl.LoggerFrom(ctx).WithName("handle-secrets")
 
@@ -1723,7 +1725,7 @@ func (r *ClusterDeploymentReconciler) handleCertificateSecrets(ctx context.Conte
 		return nil
 	}
 
-	l.V(1).Info("Copying certificate secrets from the system namespace to the ClusterDeployment namespace")
+	l.V(1).Info("Copying certificate secrets and registry secret from the system namespace to the ClusterDeployment namespace")
 	for _, secretName := range secretsToHandle {
 		if err := kubeutil.CopySecret(
 			ctx,

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -16,16 +16,20 @@ package controller
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,16 +57,17 @@ import (
 
 // ManagementReconciler reconciles a Management object
 type ManagementReconciler struct {
-	Client                 client.Client
-	Manager                manager.Manager
-	Config                 *rest.Config
-	DynamicClient          *dynamic.DynamicClient
-	SystemNamespace        string
-	GlobalRegistry         string
-	GlobalK0sURL           string
-	K0sURLCertSecretName   string // Name of a Secret with K0s Download URL Root CA with ca.crt key; to be passed to the ClusterDeploymentReconciler
-	RegistryCertSecretName string // Name of a Secret with Registry Root CA with ca.crt key; used by ManagementReconciler and ClusterDeploymentReconciler
-	ImagePullSecretName    string
+	Client                        client.Client
+	Manager                       manager.Manager
+	Config                        *rest.Config
+	DynamicClient                 *dynamic.DynamicClient
+	SystemNamespace               string
+	GlobalRegistry                string
+	GlobalK0sURL                  string
+	K0sURLCertSecretName          string // Name of a Secret with K0s Download URL Root CA with ca.crt key; to be passed to the ClusterDeploymentReconciler
+	RegistryCertSecretName        string // Name of a Secret with Registry Root CA with ca.crt key; used by ManagementReconciler and ClusterDeploymentReconciler
+	ImagePullSecretName           string
+	RegistryCredentialsSecretName string
 
 	DefaultHelmTimeout time.Duration
 	defaultRequeueTime time.Duration
@@ -72,6 +77,8 @@ type ManagementReconciler struct {
 
 	sveltosDependentControllersStarted bool
 }
+
+const cldRegSecretName string = "cld-registry-credentials"
 
 func (r *ManagementReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := ctrl.LoggerFrom(ctx)
@@ -114,7 +121,7 @@ func (r *ManagementReconciler) update(ctx context.Context, management *kcmv1.Man
 		return ctrl.Result{}, err
 	}
 
-	if changed, err := kubeutil.SetPredeclaredSecretsCondition(ctx, r.Client, management, r.SystemNamespace, r.RegistryCertSecretName); err != nil { // if changed and NO error we will eventually update the status
+	if changed, err := kubeutil.SetPredeclaredSecretsCondition(ctx, r.Client, management, r.SystemNamespace, r.RegistryCertSecretName, r.RegistryCredentialsSecretName); err != nil { // if changed and NO error we will eventually update the status
 		l.Error(err, "failed to check if given Secrets exist")
 		if changed {
 			return ctrl.Result{}, r.updateStatus(ctx, management)
@@ -188,6 +195,14 @@ func (r *ManagementReconciler) update(ctx context.Context, management *kcmv1.Man
 		management.Status.Release = management.Spec.Release
 	}
 	management.Status.ObservedGeneration = management.Generation
+
+	if r.RegistryCredentialsSecretName != "" && r.GlobalRegistry != "" {
+		if err := r.createCldRegistryCredSecret(ctx); err != nil {
+			r.warnf(management, "RegistryCredentialSecretCreationFailed", "Failed to create registry credential secret: %v", err)
+			l.Error(err, "failed to create registry credential secret")
+			return ctrl.Result{}, err
+		}
+	}
 
 	shouldRequeue, err := r.startDependentControllers(ctx, management)
 	if err != nil {
@@ -291,15 +306,21 @@ func (r *ManagementReconciler) startDependentControllers(ctx context.Context, ma
 
 	currentNamespace := kubeutil.CurrentNamespace()
 
+	cldCredSecret := ""
+	if r.RegistryCredentialsSecretName != "" && r.GlobalRegistry != "" {
+		cldCredSecret = cldRegSecretName
+	}
+
 	l.Info("Provider has been successfully installed, so setting up controller for ClusterDeployment")
 	if err = (&ClusterDeploymentReconciler{
-		SystemNamespace:        currentNamespace,
-		IsDisabledValidationWH: r.IsDisabledValidationWH,
-		GlobalRegistry:         r.GlobalRegistry,
-		GlobalK0sURL:           r.GlobalK0sURL,
-		K0sURLCertSecretName:   r.K0sURLCertSecretName,
-		RegistryCertSecretName: r.RegistryCertSecretName,
-		DefaultHelmTimeout:     r.DefaultHelmTimeout,
+		SystemNamespace:           currentNamespace,
+		IsDisabledValidationWH:    r.IsDisabledValidationWH,
+		GlobalRegistry:            r.GlobalRegistry,
+		GlobalK0sURL:              r.GlobalK0sURL,
+		K0sURLCertSecretName:      r.K0sURLCertSecretName,
+		RegistryCertSecretName:    r.RegistryCertSecretName,
+		CldRegistryCredSecretName: cldCredSecret,
+		DefaultHelmTimeout:        r.DefaultHelmTimeout,
 	}).SetupWithManager(r.Manager); err != nil {
 		return false, fmt.Errorf("failed to setup controller for ClusterDeployment: %w", err)
 	}
@@ -670,6 +691,93 @@ func (r *ManagementReconciler) setReadyCondition(management *kcmv1.Management) {
 func (r *ManagementReconciler) getRelease(ctx context.Context, mgmt *kcmv1.Management) (release *kcmv1.Release, _ error) {
 	release = new(kcmv1.Release)
 	return release, r.Client.Get(ctx, client.ObjectKey{Name: mgmt.Spec.Release}, release)
+}
+
+func makeContainerdAuth(registry, user, pass string) ([]byte, error) {
+	registryHost := strings.Split(registry, "/")[0]
+	auth := map[string]any{
+		"auth": map[string]any{
+			"username": user,
+			"password": pass,
+		},
+	}
+
+	rcfg := make(map[string]any)
+
+	rcfg[registryHost] = auth
+
+	cfg := map[string]any{
+		"plugins": map[string]any{
+			"io.containerd.grpc.v1.cri": map[string]any{
+				"registry": map[string]any{
+					"configs": rcfg,
+				},
+			},
+		},
+	}
+
+	return toml.Marshal(cfg)
+}
+
+func (r *ManagementReconciler) createCldRegistryCredSecret(ctx context.Context) error {
+	regSecret := new(corev1.Secret)
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: r.RegistryCredentialsSecretName, Namespace: r.SystemNamespace}, regSecret); err != nil {
+		return fmt.Errorf("failed to get registry credential secret %s/%s: %w", r.SystemNamespace, r.RegistryCredentialsSecretName, err)
+	}
+
+	user, ok := regSecret.Data["username"]
+	if !ok {
+		return errors.New("failed to get username field from registry credential secret provided")
+	}
+
+	pass, ok := regSecret.Data["password"]
+	if !ok {
+		return errors.New("failed to get password field from registry credential secret provided")
+	}
+
+	containerdAuth, err := makeContainerdAuth(r.GlobalRegistry, string(user), string(pass))
+	if err != nil {
+		return fmt.Errorf("failed to make containerd configuration for registry %s from secret %s: %w", r.GlobalRegistry, r.RegistryCredentialsSecretName, err)
+	}
+
+	// secret with k0s chart configuration to be created on child cluster
+	helmCredsSecretTpl := `apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+  namespace: kube-system
+type: Opaque
+data:
+  username: %s
+  password: %s`
+
+	helmCredsSecret := fmt.Sprintf(helmCredsSecretTpl,
+		cldRegSecretName,
+		base64.StdEncoding.EncodeToString(user),
+		base64.StdEncoding.EncodeToString(pass))
+
+	// secret that will be passed to clusterdeployment on management cluster
+	cldSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cldRegSecretName,
+			Namespace: r.SystemNamespace,
+		},
+	}
+
+	cldSecretData := map[string][]byte{
+		"registryCredential": []byte(helmCredsSecret),
+		"containerdAuth":     containerdAuth,
+	}
+
+	_, err = ctrl.CreateOrUpdate(ctx, r.Client, cldSecret, func() error {
+		cldSecret.Data = cldSecretData
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create cld credential secret %s: %w", cldRegSecretName, err)
+	}
+
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.25
+version: 1.0.26
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -49,6 +49,18 @@ spec:
   {{- if .Values.dataSource.kineDataSourceSecretName }}
   kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
   {{- end }}
+  manifests:
+    - name: manifests
+      configMap:
+        name: {{ include "k0smotroncontrolplane.name" . }}-manifests
+    {{- if $global.registryCredentialSecret }}
+    - name: helm-registry-credentials
+      secret:
+        secretName: {{ $global.registryCredentialSecret }}
+        items:
+          - key: registryCredential
+            path: helm-registry-credentials.yaml
+    {{- end }}
   controllerPlaneFlags:
     - --enable-cloud-provider=true
     - --debug=true
@@ -76,86 +88,116 @@ spec:
       images:
         repository: "{{ $global.registry }}"
       {{- end }}
-      extensions:
-        helm:
-          repositories:
-          {{- if not $global.registry }}
-            - name: mirantis
-              url: https://charts.mirantis.com
-            - name: aws-ebs-csi-driver
-              url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
-          {{- else }}
-            - name: global-registry
-              url: oci://{{ regexReplaceAll "/.*" $global.registry "" }}
-              {{- if $global.registryCertSecret }}
-              caFile: /usr/local/share/ca-certificates/registry/ca.crt
-              {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "k0smotroncontrolplane.name" . }}-manifests
+data:
+  chart-aws-cloud-controller-manager.yaml: |
+    apiVersion: helm.k0sproject.io/v1beta1
+    kind: Chart
+    metadata:
+      name: aws-cloud-controller-manager
+      namespace: kube-system
+    spec:
+      {{- if not $global.registry }}
+      repository:
+        url: https://charts.mirantis.com
+      {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      repository:
+        configFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+        {{- if $global.registryCertSecret }}
+        caFile: /usr/local/share/ca-certificates/registry/ca.crt
+        {{- end }}
+      {{- end }}
+      {{- if $global.registry }}
+      chartName: oci://{{ $global.registry }}/charts/aws-cloud-controller-manager
+      {{- else }}
+      chartName: aws-cloud-controller-manager/aws-cloud-controller-manager
+      {{- end }}
+      version: 0.0.9
+      releaseName: aws-cloud-controller-manager
+      namespace: kube-system
+      values: |
+        image:
+          {{- if $global.registry }}
+          repository: {{ $global.registry }}/provider-aws/cloud-controller-manager
           {{- end }}
-          charts:
-          - name: aws-cloud-controller-manager
-            namespace: kube-system
-            {{- if $global.registry }}
-            chartname: oci://{{ $global.registry }}/charts/aws-cloud-controller-manager
-            {{- else }}
-            chartname: mirantis/aws-cloud-controller-manager
-            {{- end }}
-            version: "0.0.9"
-            values: |
-              image:
-                {{- if $global.registry }}
-                repository: {{ $global.registry }}/provider-aws/cloud-controller-manager
-                {{- end }}
-                tag: v1.30.3
-              args:
-                - --v=2
-                - --cloud-provider=aws
-                - --cluster-cidr={{ first .Values.clusterNetwork.pods.cidrBlocks }}
-                - --allocate-node-cidrs=true
-                - --cluster-name={{ include "cluster.name" . }}
-              cloudConfig:
-                enabled: true
-                global:
-                  KubernetesClusterID: {{ required ".Values.managementClusterName is required on AWS hosted deployment" .Values.managementClusterName }}
-              # Removing the default `node-role.kubernetes.io/control-plane` node selector
-              # TODO: it does not work
-              nodeSelector:
-                node-role.kubernetes.io/control-plane: null
-          - name: aws-ebs-csi-driver
-            namespace: kube-system
-            {{- if $global.registry }}
-            chartname: oci://{{ $global.registry }}/charts/aws-ebs-csi-driver
-            {{- else }}
-            chartname: aws-ebs-csi-driver/aws-ebs-csi-driver
-            {{- end }}
-            version: 2.33.0
-            values: |
-              {{- if $global.registry }}
-              image:
-                repository: {{ $global.registry }}/ebs-csi-driver/aws-ebs-csi-driver
-              sidecars:
-                provisioner:
-                  image:
-                    repository: {{ $global.registry }}/kubernetes-csi/external-provisioner
-                attacher:
-                  image:
-                    repository: {{ $global.registry }}/kubernetes-csi/external-attacher
-                snapshotter:
-                  image:
-                    repository: {{ $global.registry }}/external-snapshotter/csi-snapshotter
-                livenessProbe:
-                  image:
-                    repository: {{ $global.registry }}/kubernetes-csi/livenessprobe
-                resizer:
-                  image:
-                    repository: {{ $global.registry }}/kubernetes-csi/external-resizer
-                nodeDriverRegistrar:
-                  image:
-                    repository: {{ $global.registry }}/kubernetes-csi/node-driver-registrar
-                volumemodifier:
-                  image:
-                    repository: {{ $global.registry }}/ebs-csi-driver/volume-modifier-for-k8s
-              {{- end }}
-              defaultStorageClass:
-                enabled: true
-              node:
-                kubeletPath: /var/lib/k0s/kubelet
+          tag: v1.30.3
+        args:
+          - --v=2
+          - --cloud-provider=aws
+          - --cluster-cidr={{ first .Values.clusterNetwork.pods.cidrBlocks }}
+          - --allocate-node-cidrs=true
+          - --cluster-name={{ include "cluster.name" . }}
+        cloudConfig:
+          enabled: true
+          global:
+            KubernetesClusterID: {{ required ".Values.managementClusterName is required on AWS hosted deployment" .Values.managementClusterName }}
+        # Removing the default `node-role.kubernetes.io/control-plane` node selector
+        # TODO: it does not work
+        nodeSelector:
+          node-role.kubernetes.io/control-plane: null
+  chart-aws-ebs-csi-driver.yaml: |
+    apiVersion: helm.k0sproject.io/v1beta1
+    kind: Chart
+    metadata:
+      name: aws-ebs-csi-driver
+      namespace: kube-system
+    spec:
+      {{- if not $global.registry }}
+      repository:
+        url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+      {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      repository:
+        configFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+        {{- if $global.registryCertSecret }}
+        caFile: /usr/local/share/ca-certificates/registry/ca.crt
+        {{- end }}
+      {{- end }}
+      {{- if $global.registry }}
+      chartName: oci://{{ $global.registry }}/charts/aws-ebs-csi-driver
+      {{- else }}
+      chartName: aws-ebs-csi-driver/aws-ebs-csi-driver
+      {{- end }}
+      version: 2.33.0
+      releaseName: aws-ebs-csi-driver
+      namespace: kube-system
+      values: |
+        {{- if $global.registry }}
+        image:
+          repository: {{ $global.registry }}/ebs-csi-driver/aws-ebs-csi-driver
+        sidecars:
+          provisioner:
+            image:
+              repository: {{ $global.registry }}/kubernetes-csi/external-provisioner
+          attacher:
+            image:
+              repository: {{ $global.registry }}/kubernetes-csi/external-attacher
+          snapshotter:
+            image:
+              repository: {{ $global.registry }}/external-snapshotter/csi-snapshotter
+          livenessProbe:
+            image:
+              repository: {{ $global.registry }}/kubernetes-csi/livenessprobe
+          resizer:
+            image:
+              repository: {{ $global.registry }}/kubernetes-csi/external-resizer
+          nodeDriverRegistrar:
+            image:
+              repository: {{ $global.registry }}/kubernetes-csi/node-driver-registrar
+          volumemodifier:
+            image:
+              repository: {{ $global.registry }}/ebs-csi-driver/volume-modifier-for-k8s
+        {{- end }}
+        defaultStorageClass:
+          enabled: true
+        node:
+          kubeletPath: /var/lib/k0s/kubelet

--- a/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
       {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
@@ -22,6 +22,16 @@ spec:
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}
         {{- end }}
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
+      {{- end }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -18,12 +18,12 @@ spec:
       {{- range $arg := .Values.k0s.cpArgs }}
       - {{ toYaml $arg }}
       {{- end }}
+    files:
     {{- $files := .Values.k0s.files }}
     # DEPRECATED: The `k0s.auth` field is deprecated.
     # Use the `ClusterAuthentication` resource to configure authentication instead.
     {{- $auth := .Values.k0s.auth }}
     {{- if or (and $auth $auth.enabled) $files $global.registryCertSecret $global.k0sURLCertSecret .Values.auth.configSecret.name }}
-    files:
     {{- if and $auth $auth.enabled }}
     - content: | {{ toYaml $auth.config | nindent 8 }}
       permissions: "0644"
@@ -51,6 +51,119 @@ spec:
       path: /usr/local/share/ca-certificates/{{ $path }}
     {{- end }}
     {{- end }}
+    {{- if $global.registryCredentialSecret }}
+    - contentFrom:
+        secretRef:
+          name: {{ $global.registryCredentialSecret }}
+          key: registryCredential
+      permissions: "0644"
+      path: /var/lib/k0s/manifests/kcm/helm-registry-credentials.yaml
+    - contentFrom:
+        secretRef:
+          name: {{ $global.registryCredentialSecret }}
+          key: containerdAuth
+      permissions: "0664"
+      path: /etc/k0s/containerd.d/registry-auth.toml
+    {{- end }}
+    - path: /var/lib/k0s/manifests/kcm/chart-aws-cloud-controller-manager.yaml
+      permissions: "0644"
+      content: |
+        apiVersion: helm.k0sproject.io/v1beta1
+        kind: Chart
+        metadata:
+          name: aws-cloud-controller-manager
+          namespace: kube-system
+        spec:
+          {{- if not $global.registry }}
+          repository:
+            url: https://charts.mirantis.com
+          {{- end }}
+          {{- if $global.registryCredentialSecret }}
+          repository:
+            configFrom:
+              secretRef:
+                name: {{ $global.registryCredentialSecret }}
+          {{- end }}
+          {{- if $global.registry }}
+          chartName: oci://{{ $global.registry }}/charts/aws-cloud-controller-manager
+          {{- else }}
+          chartName: aws-cloud-controller-manager/aws-cloud-controller-manager
+          {{- end }}
+          version: 0.0.9
+          releaseName: aws-cloud-controller-manager
+          namespace: kube-system
+          values: |
+            nodeSelector:
+              node-role.kubernetes.io/control-plane: "true"
+            image:
+              {{- if $global.registry }}
+              repository: {{ $global.registry }}/provider-aws/cloud-controller-manager
+              {{- end }}
+              tag: v1.30.3
+            args:
+              - --v=2
+              - --cloud-provider=aws
+              - --cluster-cidr={{ first .Values.clusterNetwork.pods.cidrBlocks }}
+              - --allocate-node-cidrs=true
+              - --cluster-name={{ include "cluster.name" . }}
+    - path: /var/lib/k0s/manifests/kcm/chart-aws-ebs-csi-driver.yaml
+      permissions: "0644"
+      content: |
+        apiVersion: helm.k0sproject.io/v1beta1
+        kind: Chart
+        metadata:
+          name: aws-ebs-csi-driver
+          namespace: kube-system
+        spec:
+          {{- if not $global.registry }}
+          repository:
+            url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+          {{- end }}
+          {{- if $global.registryCredentialSecret }}
+          repository:
+            configFrom:
+              secretRef:
+                name: {{ $global.registryCredentialSecret }}
+          {{- end }}
+          {{- if $global.registry }}
+          chartName: oci://{{ $global.registry }}/charts/aws-ebs-csi-driver
+          {{- else }}
+          chartName: aws-ebs-csi-driver/aws-ebs-csi-driver
+          {{- end }}
+          version: 2.33.0
+          releaseName: aws-ebs-csi-driver
+          namespace: kube-system
+          values: |
+            {{- if $global.registry }}
+            image:
+              repository: {{ $global.registry }}/ebs-csi-driver/aws-ebs-csi-driver
+            sidecars:
+              provisioner:
+                image:
+                  repository: {{ $global.registry }}/kubernetes-csi/external-provisioner
+              attacher:
+                image:
+                  repository: {{ $global.registry }}/kubernetes-csi/external-attacher
+              snapshotter:
+                image:
+                  repository: {{ $global.registry }}/external-snapshotter/csi-snapshotter
+              livenessProbe:
+                image:
+                  repository: {{ $global.registry }}/kubernetes-csi/livenessprobe
+              resizer:
+                image:
+                  repository: {{ $global.registry }}/kubernetes-csi/external-resizer
+              nodeDriverRegistrar:
+                image:
+                  repository: {{ $global.registry }}/kubernetes-csi/node-driver-registrar
+              volumemodifier:
+                image:
+                  repository: {{ $global.registry }}/ebs-csi-driver/volume-modifier-for-k8s
+            {{- end }}
+            defaultStorageClass:
+              enabled: true
+            node:
+              kubeletPath: /var/lib/k0s/kubelet
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
     preStartCommands:
     - "sudo update-ca-certificates"
@@ -83,77 +196,6 @@ spec:
         images:
           repository: "{{ $global.registry }}"
         {{- end }}
-        extensions:
-          helm:
-            {{- if not $global.registry }}
-            repositories:
-              - name: mirantis
-                url: https://charts.mirantis.com
-              - name: aws-ebs-csi-driver
-                url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
-            {{- end }}
-            charts:
-              - name: aws-cloud-controller-manager
-                namespace: kube-system
-                {{- if $global.registry }}
-                chartname: oci://{{ $global.registry }}/charts/aws-cloud-controller-manager
-                {{- else }}
-                chartname: mirantis/aws-cloud-controller-manager
-                {{- end }}
-                version: "0.0.9"
-                values: |
-                  nodeSelector:
-                    node-role.kubernetes.io/control-plane: "true"
-                  image:
-                    {{- if $global.registry }}
-                    repository: {{ $global.registry }}/provider-aws/cloud-controller-manager
-                    {{- end }}
-                    tag: v1.30.3
-                  args:
-                    - --v=2
-                    - --cloud-provider=aws
-                    - --cluster-cidr={{ first .Values.clusterNetwork.pods.cidrBlocks }}
-                    - --allocate-node-cidrs=true
-                    - --cluster-name={{ include "cluster.name" . }}
-              - name: aws-ebs-csi-driver
-                namespace: kube-system
-                {{- if $global.registry }}
-                chartname: oci://{{ $global.registry }}/charts/aws-ebs-csi-driver
-                {{- else }}
-                chartname: aws-ebs-csi-driver/aws-ebs-csi-driver
-                {{- end }}
-                version: 2.33.0
-                values: |
-                  {{- if $global.registry }}
-                  image:
-                    repository: {{ $global.registry }}/ebs-csi-driver/aws-ebs-csi-driver
-                  sidecars:
-                    provisioner:
-                      image:
-                        repository: {{ $global.registry }}/kubernetes-csi/external-provisioner
-                    attacher:
-                      image:
-                        repository: {{ $global.registry }}/kubernetes-csi/external-attacher
-                    snapshotter:
-                      image:
-                        repository: {{ $global.registry }}/external-snapshotter/csi-snapshotter
-                    livenessProbe:
-                      image:
-                        repository: {{ $global.registry }}/kubernetes-csi/livenessprobe
-                    resizer:
-                      image:
-                        repository: {{ $global.registry }}/kubernetes-csi/external-resizer
-                    nodeDriverRegistrar:
-                      image:
-                        repository: {{ $global.registry }}/kubernetes-csi/node-driver-registrar
-                    volumemodifier:
-                      image:
-                        repository: {{ $global.registry }}/ebs-csi-driver/volume-modifier-for-k8s
-                  {{- end }}
-                  defaultStorageClass:
-                    enabled: true
-                  node:
-                    kubeletPath: /var/lib/k0s/kubelet
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta2

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
       {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
@@ -22,6 +22,16 @@ spec:
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}
         {{- end }}
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
+      {{- end }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.27
+version: 1.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -48,6 +48,18 @@ spec:
   {{- if .Values.dataSource.kineDataSourceSecretName }}
   kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
   {{- end }}
+  manifests:
+    - name: manifests
+      configMap:
+        name: {{ include "k0smotroncontrolplane.name" . }}-manifests
+    {{- if $global.registryCredentialSecret }}
+    - name: helm-registry-credentials
+      secret:
+        secretName: {{ $global.registryCredentialSecret }}
+        items:
+          - key: registryCredential
+            path: helm-registry-credentials.yaml
+    {{- end }}
   controllerPlaneFlags:
     - --enable-cloud-provider=true
     - --debug=true
@@ -75,80 +87,110 @@ spec:
       images:
         repository: "{{ $global.registry }}"
       {{- end }}
-      extensions:
-        helm:
-          repositories:
-          {{- if not $global.registry }}
-            - name: mirantis
-              url: https://charts.mirantis.com
-            - name: azuredisk-csi-driver
-              url: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
-          {{- else }}
-            - name: global-registry
-              url: oci://{{ regexReplaceAll "/.*" $global.registry "" }}
-              {{- if $global.registryCertSecret }}
-              caFile: /usr/local/share/ca-certificates/registry/ca.crt
-              {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "k0smotroncontrolplane.name" . }}-manifests
+data:
+  chart-cloud-provider-azure.yaml: |
+    apiVersion: helm.k0sproject.io/v1beta1
+    kind: Chart
+    metadata:
+      name: cloud-provider-azure
+      namespace: kube-system
+    spec:
+      {{- if not $global.registry }}
+      repository:
+        url: https://charts.mirantis.com
+      {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      repository:
+        configFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+        {{- if $global.registryCertSecret }}
+        caFile: /usr/local/share/ca-certificates/registry/ca.crt
+        {{- end }}
+      {{- end }}
+      {{- if $global.registry }}
+      chartName: oci://{{ $global.registry }}/charts/cloud-provider-azure
+      {{- else }}
+      chartName: cloud-provider-azure/cloud-provider-azure
+      {{- end }}
+      version: 1.31.2
+      order: 1
+      releaseName: cloud-provider-azure
+      namespace: kube-system
+      values: |
+        cloudControllerManager:
+          cloudConfigSecretName: azure-cloud-provider
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: null
+          {{- if $global.registry }}
+          imageRepository: {{ $global.registry }}
           {{- end }}
-          charts:
-            - name: cloud-provider-azure
-              namespace: kube-system
-              {{- if $global.registry }}
-              chartname: oci://{{ $global.registry }}/charts/cloud-provider-azure
-              {{- else }}
-              chartname: mirantis/cloud-provider-azure
-              {{- end }}
-              version: 1.31.2
-              order: 1
-              values: |
-                cloudControllerManager:
-                  cloudConfigSecretName: azure-cloud-provider
-                  nodeSelector:
-                    node-role.kubernetes.io/control-plane: null
-                  {{- if $global.registry }}
-                  imageRepository: {{ $global.registry }}
-                  {{- end }}
-                  imageTag: v1.32.4
-                cloudNodeManager:
-                  imageTag: v1.32.4
-                {{- if $global.registry }}
-                  imageRepository: {{ $global.registry }}
-                {{- end }}
-            - name: azuredisk-csi-driver
-              namespace: kube-system
-              {{- if $global.registry }}
-              chartname: oci://{{ $global.registry }}/charts/azuredisk-csi-driver
-              {{- else }}
-              chartname: azuredisk-csi-driver/azuredisk-csi-driver
-              {{- end }}
-              version: v1.30.3
-              order: 2
-              values: |
-                {{- if $global.registry }}
-                image:
-                  baseRepo: {{ $global.registry }}
-                  azuredisk:
-                    repository: /kubernetes-csi/azuredisk-csi
-                  csiProvisioner:
-                    repository: /kubernetes-csi/csi-provisioner
-                  csiAttacher:
-                    repository: /kubernetes-csi/csi-attacher
-                  csiResizer:
-                    repository: /kubernetes-csi/csi-resizer
-                  livenessProbe:
-                    repository: /kubernetes-csi/livenessprobe
-                  nodeDriverRegistrar:
-                    repository: /kubernetes-csi/csi-node-driver-registrar
-                snapshot:
-                  image:
-                    csiSnapshotter:
-                      repository: /kubernetes-csi/csi-snapshotter
-                    csiSnapshotController:
-                      repository: /kubernetes-csi/snapshot-controller
-                {{- end }}
-                controller:
-                  cloudConfigSecretName: azure-cloud-provider
-                node:
-                  cloudConfigSecretName: azure-cloud-provider
-                linux:
-                  kubelet: "/var/lib/k0s/kubelet"
+          imageTag: v1.32.4
+        cloudNodeManager:
+          imageTag: v1.32.4
+        {{- if $global.registry }}
+          imageRepository: {{ $global.registry }}
+        {{- end }}
+  chart-azuredisk-csi-driver.yaml: |
+    apiVersion: helm.k0sproject.io/v1beta1
+    kind: Chart
+    metadata:
+      name: azuredisk-csi-driver
+      namespace: kube-system
+    spec:
+      {{- if not $global.registry }}
+      repository:
+        url: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
+      {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      repository:
+        configFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+        {{- if $global.registryCertSecret }}
+        caFile: /usr/local/share/ca-certificates/registry/ca.crt
+        {{- end }}
+      {{- end }}
+      {{- if $global.registry }}
+      chartName: oci://{{ $global.registry }}/charts/azuredisk-csi-driver
+      {{- else }}
+      chartName: azuredisk-csi-driver/azuredisk-csi-driver
+      {{- end }}
+      version: v1.30.3
+      order: 2
+      releaseName: azuredisk-csi-driver
+      namespace: kube-system
+      values: |
+        {{- if $global.registry }}
+        image:
+          baseRepo: {{ $global.registry }}
+          azuredisk:
+            repository: /kubernetes-csi/azuredisk-csi
+          csiProvisioner:
+            repository: /kubernetes-csi/csi-provisioner
+          csiAttacher:
+            repository: /kubernetes-csi/csi-attacher
+          csiResizer:
+            repository: /kubernetes-csi/csi-resizer
+          livenessProbe:
+            repository: /kubernetes-csi/livenessprobe
+          nodeDriverRegistrar:
+            repository: /kubernetes-csi/csi-node-driver-registrar
+        snapshot:
+          image:
+            csiSnapshotter:
+              repository: /kubernetes-csi/csi-snapshotter
+            csiSnapshotController:
+              repository: /kubernetes-csi/snapshot-controller
+        {{- end }}
+        controller:
+          cloudConfigSecretName: azure-cloud-provider
+        node:
+          cloudConfigSecretName: azure-cloud-provider
+        linux:
+          kubelet: "/var/lib/k0s/kubelet"

--- a/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
       {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
@@ -22,6 +22,16 @@ spec:
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}
         {{- end }}
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
+      {{- end }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -10,9 +10,8 @@ spec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
     {{- end }}
-    {{- if or $global.registryCertSecret $global.k0sURLCertSecret .Values.auth.configSecret.name }}
-    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     files:
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- range $path, $secret := $certs }}
       {{- if $secret }}
       - contentFrom:
@@ -31,7 +30,119 @@ spec:
         permissions: "0644"
         path: {{ include "authentication-config.fullpath" . }}
       {{- end }}
-    {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      - contentFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+            key: registryCredential
+        permissions: "0644"
+        path: /var/lib/k0s/manifests/kcm/helm-registry-credentials.yaml
+      - contentFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+            key: containerdAuth
+        permissions: "0664"
+        path: /etc/k0s/containerd.d/registry-auth.toml
+      {{- end }}
+      - path: /var/lib/k0s/manifests/kcm/chart-cloud-provider-azure.yaml
+        permissions: "0644"
+        content: |
+          apiVersion: helm.k0sproject.io/v1beta1
+          kind: Chart
+          metadata:
+            name: cloud-provider-azure
+            namespace: kube-system
+          spec:
+            {{- if not $global.registry }}
+            repository:
+              url: https://charts.mirantis.com
+            {{- end }}
+            {{- if $global.registryCredentialSecret }}
+            repository:
+              configFrom:
+                secretRef:
+                  name: {{ $global.registryCredentialSecret }}
+            {{- end }}
+            {{- if $global.registry }}
+            chartName: oci://{{ $global.registry }}/charts/cloud-provider-azure
+            {{- else }}
+            chartName: cloud-provider-azure/cloud-provider-azure
+            {{- end }}
+            version: 1.31.2
+            order: 1
+            releaseName: cloud-provider-azure
+            namespace: kube-system
+            values: |
+              cloudControllerManager:
+                cloudConfigSecretName: azure-cloud-provider
+                nodeSelector:
+                  node-role.kubernetes.io/control-plane: "true"
+                {{- if $global.registry }}
+                imageRepository: {{ $global.registry }}
+                {{- end }}
+                imageTag: v1.32.4
+              cloudNodeManager:
+                imageTag: v1.32.4
+              {{- if $global.registry }}
+                imageRepository: {{ $global.registry }}
+              {{- end }}
+      - path: /var/lib/k0s/manifests/kcm/chart-azuredisk-csi-driver.yaml
+        permissions: "0644"
+        content: |
+          apiVersion: helm.k0sproject.io/v1beta1
+          kind: Chart
+          metadata:
+            name: azuredisk-csi-driver
+            namespace: kube-system
+          spec:
+            {{- if not $global.registry }}
+            repository:
+              url: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
+            {{- end }}
+            {{- if $global.registryCredentialSecret }}
+            repository:
+              configFrom:
+                secretRef:
+                  name: {{ $global.registryCredentialSecret }}
+            {{- end }}
+            {{- if $global.registry }}
+            chartName: oci://{{ $global.registry }}/charts/azuredisk-csi-driver
+            {{- else }}
+            chartName: azuredisk-csi-driver/azuredisk-csi-driver
+            {{- end }}
+            version: v1.30.3
+            order: 2
+            releaseName: azuredisk-csi-driver
+            namespace: kube-system
+            values: |
+              {{- if $global.registry }}
+              image:
+                baseRepo: {{ $global.registry }}
+                azuredisk:
+                  repository: /kubernetes-csi/azuredisk-csi
+                csiProvisioner:
+                  repository: /kubernetes-csi/csi-provisioner
+                csiAttacher:
+                  repository: /kubernetes-csi/csi-attacher
+                csiResizer:
+                  repository: /kubernetes-csi/csi-resizer
+                livenessProbe:
+                  repository: /kubernetes-csi/livenessprobe
+                nodeDriverRegistrar:
+                  repository: /kubernetes-csi/csi-node-driver-registrar
+              snapshot:
+                image:
+                  csiSnapshotter:
+                    repository: /kubernetes-csi/csi-snapshotter
+                  csiSnapshotController:
+                    repository: /kubernetes-csi/snapshot-controller
+              {{- end }}
+              controller:
+                cloudConfigSecretName: azure-cloud-provider
+              node:
+                cloudConfigSecretName: azure-cloud-provider
+              linux:
+                kubelet: "/var/lib/k0s/kubelet"
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
     preStartCommands:
     - "sudo update-ca-certificates"
@@ -68,77 +179,6 @@ spec:
         images:
           repository: "{{ $global.registry }}"
         {{- end }}
-        extensions:
-          helm:
-            {{- if not $global.registry }}
-            repositories:
-              - name: mirantis
-                url: https://charts.mirantis.com
-              - name: azuredisk-csi-driver
-                url: https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/charts
-            {{- end }}
-            charts:
-              - name: cloud-provider-azure
-                namespace: kube-system
-                {{- if $global.registry }}
-                chartname: oci://{{ $global.registry }}/charts/cloud-provider-azure
-                {{- else }}
-                chartname: mirantis/cloud-provider-azure
-                {{- end }}
-                version: 1.31.2
-                order: 1
-                values: |
-                  cloudControllerManager:
-                    cloudConfigSecretName: azure-cloud-provider
-                    nodeSelector:
-                      node-role.kubernetes.io/control-plane: "true"
-                    {{- if $global.registry }}
-                    imageRepository: {{ $global.registry }}
-                    {{- end }}
-                    imageTag: v1.32.4
-                  cloudNodeManager:
-                    imageTag: v1.32.4
-                  {{- if $global.registry }}
-                    imageRepository: {{ $global.registry }}
-                  {{- end }}
-              - name: azuredisk-csi-driver
-                namespace: kube-system
-                {{- if $global.registry }}
-                chartname: oci://{{ $global.registry }}/charts/azuredisk-csi-driver
-                {{- else }}
-                chartname: azuredisk-csi-driver/azuredisk-csi-driver
-                {{- end }}
-                version: v1.30.3
-                order: 2
-                values: |
-                  {{- if $global.registry }}
-                  image:
-                    baseRepo: {{ $global.registry }}
-                    azuredisk:
-                      repository: /kubernetes-csi/azuredisk-csi
-                    csiProvisioner:
-                      repository: /kubernetes-csi/csi-provisioner
-                    csiAttacher:
-                      repository: /kubernetes-csi/csi-attacher
-                    csiResizer:
-                      repository: /kubernetes-csi/csi-resizer
-                    livenessProbe:
-                      repository: /kubernetes-csi/livenessprobe
-                    nodeDriverRegistrar:
-                      repository: /kubernetes-csi/csi-node-driver-registrar
-                  snapshot:
-                    image:
-                      csiSnapshotter:
-                        repository: /kubernetes-csi/csi-snapshotter
-                      csiSnapshotController:
-                        repository: /kubernetes-csi/snapshot-controller
-                  {{- end }}
-                  controller:
-                    cloudConfigSecretName: azure-cloud-provider
-                  node:
-                    cloudConfigSecretName: azure-cloud-provider
-                  linux:
-                    kubelet: "/var/lib/k0s/kubelet"
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
       {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
@@ -22,6 +22,16 @@ spec:
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}
         {{- end }}
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
+      {{- end }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -48,6 +48,18 @@ spec:
   {{- if .Values.dataSource.kineDataSourceSecretName }}
   kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
   {{- end }}
+  manifests:
+    - name: manifests
+      configMap:
+        name: {{ include "k0smotroncontrolplane.name" . }}-manifests
+    {{- if $global.registryCredentialSecret }}
+    - name: helm-registry-credentials
+      secret:
+        secretName: {{ $global.registryCredentialSecret }}
+        items:
+          - key: registryCredential
+            path: helm-registry-credentials.yaml
+    {{- end }}
   controllerPlaneFlags:
     - --enable-cloud-provider=true
     - --debug=true
@@ -75,91 +87,123 @@ spec:
       images:
         repository: "{{ $global.registry }}"
       {{- end }}
-      extensions:
-        helm:
-          repositories:
-          {{- if not $global.registry }}
-            - name: mirantis
-              url: https://charts.mirantis.com
-          {{- else }}
-            - name: global-registry
-              url: oci://{{ regexReplaceAll "/.*" $global.registry "" }}
-              {{- if $global.registryCertSecret }}
-              caFile: /usr/local/share/ca-certificates/registry/ca.crt
-              {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "k0smotroncontrolplane.name" . }}-manifests
+data:
+  chart-gcp-cloud-controller-manager.yaml: |
+    apiVersion: helm.k0sproject.io/v1beta1
+    kind: Chart
+    metadata:
+      name: gcp-cloud-controller-manager
+      namespace: kube-system
+    spec:
+      {{- if not $global.registry }}
+      repository:
+        url: https://charts.mirantis.com
+      {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      repository:
+        configFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+        {{- if $global.registryCertSecret }}
+        caFile: /usr/local/share/ca-certificates/registry/ca.crt
+        {{- end }}
+      {{- end }}
+      {{- if $global.registry }}
+      chartName: oci://{{ $global.registry }}/charts/gcp-cloud-controller-manager
+      {{- else }}
+      chartName: gcp-cloud-controller-manager/gcp-cloud-controller-manager
+      {{- end }}
+      version: 0.0.1
+      releaseName: gcp-cloud-controller-manager
+      namespace: kube-system
+      values: |
+        cloudConfig:
+          enabled: true
+          data: W0dsb2JhbF0KbXVsdGl6b25lPXRydWUK
+        cloudCredentials:
+          secretName: gcp-cloud-sa
+          secretKey: cloud-sa.json
+        clusterCIDR: {{ first .Values.clusterNetwork.pods.cidrBlocks }}
+        image:
+          {{- if $global.registry }}
+          repository: {{ $global.registry }}/k8s-staging-cloud-provider-gcp/cloud-controller-manager
           {{- end }}
-          charts:
-            - name: gcp-cloud-controller-manager
-              namespace: kube-system
-              {{- if $global.registry }}
-              chartname: oci://{{ $global.registry }}/charts/gcp-cloud-controller-manager
-              {{- else }}
-              chartname: mirantis/gcp-cloud-controller-manager
-              {{- end }}
-              version: "0.0.1"
-              values: |
-                cloudConfig:
-                  enabled: true
-                  data: W0dsb2JhbF0KbXVsdGl6b25lPXRydWUK
-                cloudCredentials:
-                  secretName: gcp-cloud-sa
-                  secretKey: cloud-sa.json
-                clusterCIDR: {{ first .Values.clusterNetwork.pods.cidrBlocks }}
-                image:
-                  {{- if $global.registry }}
-                  repository: {{ $global.registry }}/k8s-staging-cloud-provider-gcp/cloud-controller-manager
-                  {{- end }}
-                  tag: v32.2.3
-                args:
-                  - --cloud-provider=gce
-                  - --leader-elect=true
-                  - --use-service-account-credentials=true
-                  - --allocate-node-cidrs=true
-                  - --configure-cloud-routes=false
-                  - --v=2
-            - name: gcp-compute-persistent-disk-csi-driver
-              namespace: kube-system
-              {{- if $global.registry }}
-              chartname: oci://{{ $global.registry }}/charts/gcp-compute-persistent-disk-csi-driver
-              {{- else }}
-              chartname: mirantis/gcp-compute-persistent-disk-csi-driver
-              {{- end }}
-              version: "0.0.2"
-              values: |
-                cloudCredentials:
-                  secretName: gcp-cloud-sa
-                  secretKey: cloud-sa.json
-                node:
-                  linux:
-                    enabled: true
-                    kubeletPath: /var/lib/k0s/kubelet
-                    {{- if $global.registry }}
-                    registrar:
-                      image:
-                        repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
-                    driver:
-                      image:
-                        repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-                    {{- end }}
-                  windows:
-                    enabled: false
-                defaultStorageClass:
-                  enabled: true
-                  {{- if $global.registry }}
-                controller:
-                  provisioner:
-                    image:
-                      repository: {{ $global.registry }}/sig-storage/csi-provisioner
-                  attacher:
-                    image:
-                      repository: {{ $global.registry }}/sig-storage/csi-attacher
-                  resizer:
-                    image:
-                      repository: {{ $global.registry }}/sig-storage/csi-resizer
-                  snapshotter:
-                    image:
-                      repository: {{ $global.registry }}/sig-storage/csi-snapshotter
-                  driver:
-                    image:
-                      repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-                {{- end }}
+          tag: v32.2.3
+        args:
+          - --cloud-provider=gce
+          - --leader-elect=true
+          - --use-service-account-credentials=true
+          - --allocate-node-cidrs=true
+          - --configure-cloud-routes=false
+          - --v=2
+  chart-gcp-compute-persistent-disk-csi-driver.yaml: |
+    apiVersion: helm.k0sproject.io/v1beta1
+    kind: Chart
+    metadata:
+      name: gcp-compute-persistent-disk-csi-driver
+      namespace: kube-system
+    spec:
+      {{- if not $global.registry }}
+      repository:
+        url: https://charts.mirantis.com
+      {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      repository:
+        configFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+        {{- if $global.registryCertSecret }}
+        caFile: /usr/local/share/ca-certificates/registry/ca.crt
+        {{- end }}
+      {{- end }}
+      {{- if $global.registry }}
+      chartName: oci://{{ $global.registry }}/charts/gcp-compute-persistent-disk-csi-driver
+      {{- else }}
+      chartName: gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver
+      {{- end }}
+      version: 0.0.2
+      releaseName: gcp-compute-persistent-disk-csi-driver
+      namespace: kube-system
+      values: |
+        cloudCredentials:
+          secretName: gcp-cloud-sa
+          secretKey: cloud-sa.json
+        node:
+          linux:
+            enabled: true
+            kubeletPath: /var/lib/k0s/kubelet
+            {{- if $global.registry }}
+            registrar:
+              image:
+                repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
+            driver:
+              image:
+                repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+            {{- end }}
+          windows:
+            enabled: false
+        defaultStorageClass:
+          enabled: true
+          {{- if $global.registry }}
+        controller:
+          provisioner:
+            image:
+              repository: {{ $global.registry }}/sig-storage/csi-provisioner
+          attacher:
+            image:
+              repository: {{ $global.registry }}/sig-storage/csi-attacher
+          resizer:
+            image:
+              repository: {{ $global.registry }}/sig-storage/csi-resizer
+          snapshotter:
+            image:
+              repository: {{ $global.registry }}/sig-storage/csi-snapshotter
+          driver:
+            image:
+              repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+        {{- end }}

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
       {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
@@ -22,6 +22,16 @@ spec:
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}
         {{- end }}
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
+      {{- end }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.22
+version: 1.0.23
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -10,9 +10,8 @@ spec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
     {{- end }}
-    {{- if or $global.registryCertSecret $global.k0sURLCertSecret .Values.auth.configSecret.name }}
-    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     files:
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- range $path, $secret := $certs }}
       {{- if $secret }}
       - contentFrom:
@@ -31,7 +30,134 @@ spec:
         permissions: "0644"
         path: {{ include "authentication-config.fullpath" . }}
       {{- end }}
-    {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      - contentFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+            key: registryCredential
+        permissions: "0644"
+        path: /var/lib/k0s/manifests/kcm/helm-registry-credentials.yaml
+      - contentFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+            key: containerdAuth
+        permissions: "0664"
+        path: /etc/k0s/containerd.d/registry-auth.toml
+      {{- end }}
+      - path: /var/lib/k0s/manifests/kcm/chart-gcp-cloud-controller-manager.yaml
+        permissions: "0644"
+        content: |
+          apiVersion: helm.k0sproject.io/v1beta1
+          kind: Chart
+          metadata:
+            name: gcp-cloud-controller-manager
+            namespace: kube-system
+          spec:
+            {{- if not $global.registry }}
+            repository:
+              url: https://charts.mirantis.com
+            {{- end }}
+            {{- if $global.registryCredentialSecret }}
+            repository:
+              configFrom:
+                secretRef:
+                  name: {{ $global.registryCredentialSecret }}
+            {{- end }}
+            {{- if $global.registry }}
+            chartName: oci://{{ $global.registry }}/charts/gcp-cloud-controller-manager
+            {{- else }}
+            chartName: gcp-cloud-controller-manager/gcp-cloud-controller-manager
+            {{- end }}
+            version: 0.0.1
+            releaseName: gcp-cloud-controller-manager
+            namespace: kube-system
+            values: |
+              cloudConfig:
+                enabled: true
+                data: W0dsb2JhbF0KbXVsdGl6b25lPXRydWUK
+              apiServer:
+                port: 6443
+              cloudCredentials:
+                secretName: gcp-cloud-sa
+                secretKey: cloud-sa.json
+              clusterCIDR: {{ first .Values.clusterNetwork.pods.cidrBlocks }}
+              image:
+                {{- if $global.registry }}
+                repository: {{ $global.registry }}/k8s-staging-cloud-provider-gcp/cloud-controller-manager
+                {{- end }}
+                tag: v32.2.3
+              args:
+                - --cloud-provider=gce
+                - --leader-elect=true
+                - --use-service-account-credentials=true
+                - --allocate-node-cidrs=true
+                - --configure-cloud-routes=false
+                - --v=2
+      - path: /var/lib/k0s/manifests/kcm/chart-gcp-compute-persistent-disk-csi-driver.yaml
+        permissions: "0644"
+        content: |
+          apiVersion: helm.k0sproject.io/v1beta1
+          kind: Chart
+          metadata:
+            name: gcp-compute-persistent-disk-csi-driver
+            namespace: kube-system
+          spec:
+            {{- if not $global.registry }}
+            repository:
+              url: https://charts.mirantis.com
+            {{- end }}
+            {{- if $global.registryCredentialSecret }}
+            repository:
+              configFrom:
+                secretRef:
+                  name: {{ $global.registryCredentialSecret }}
+            {{- end }}
+            {{- if $global.registry }}
+            chartName: oci://{{ $global.registry }}/charts/gcp-compute-persistent-disk-csi-driver
+            {{- else }}
+            chartName: gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver
+            {{- end }}
+            version: 0.0.2
+            releaseName: gcp-compute-persistent-disk-csi-driver
+            namespace: kube-system
+            values: |
+              cloudCredentials:
+                secretName: gcp-cloud-sa
+                secretKey: cloud-sa.json
+              node:
+                linux:
+                  enabled: true
+                  kubeletPath: /var/lib/k0s/kubelet
+                  {{- if $global.registry }}
+                  registrar:
+                    image:
+                      repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
+                  driver:
+                    image:
+                      repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+                  {{- end }}
+                windows:
+                  enabled: false
+              defaultStorageClass:
+                enabled: true
+              {{- if $global.registry }}
+              controller:
+                provisioner:
+                  image:
+                    repository: {{ $global.registry }}/sig-storage/csi-provisioner
+                attacher:
+                  image:
+                    repository: {{ $global.registry }}/sig-storage/csi-attacher
+                resizer:
+                  image:
+                    repository: {{ $global.registry }}/sig-storage/csi-resizer
+                snapshotter:
+                  image:
+                    repository: {{ $global.registry }}/sig-storage/csi-snapshotter
+                driver:
+                  image:
+                    repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+              {{- end }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
     preStartCommands:
     - "sudo update-ca-certificates"

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
       {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
@@ -22,6 +22,16 @@ spec:
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}
         {{- end }}
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
+      {{- end }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
       {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
@@ -22,6 +22,16 @@ spec:
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}
         {{- end }}
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
+      {{- end }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
@@ -10,7 +10,7 @@ spec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
     {{- end }}
-    {{- if or $global.registryCertSecret $global.k0sURLCertSecret .Values.auth.configSecret.name }}
+    {{- if or $global.registryCertSecret $global.k0sURLCertSecret .Values.auth.configSecret.name $global.registryCredentialSecret }}
     {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     files:
       {{- range $path, $secret := $certs }}
@@ -30,6 +30,20 @@ spec:
             key: {{ default "config" .Values.auth.configSecret.key }}
         permissions: "0644"
         path: {{ include "authentication-config.fullpath" . }}
+      {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      - contentFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+            key: registryCredential
+        permissions: "0644"
+        path: /var/lib/k0s/manifests/kcm/helm-registry-credentials.yaml
+      - contentFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+            key: containerdAuth
+        permissions: "0664"
+        path: /etc/k0s/containerd.d/registry-auth.toml
       {{- end }}
     {{- end }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
       {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
@@ -22,6 +22,16 @@ spec:
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}
         {{- end }}
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
+      {{- end }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.17
+version: 1.0.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -48,6 +48,18 @@ spec:
   {{- if .Values.dataSource.kineDataSourceSecretName }}
   kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
   {{- end }}
+  manifests:
+    - name: manifests
+      configMap:
+        name: {{ include "k0smotroncontrolplane.name" . }}-manifests
+    {{- if $global.registryCredentialSecret }}
+    - name: helm-registry-credentials
+      secret:
+        secretName: {{ $global.registryCredentialSecret }}
+        items:
+          - key: registryCredential
+            path: helm-registry-credentials.yaml
+    {{- end }}
   controllerPlaneFlags:
     - --enable-cloud-provider=true
     - --debug=true
@@ -75,132 +87,164 @@ spec:
       images:
         repository: "{{ $global.registry }}"
       {{- end }}
-      extensions:
-        helm:
-          repositories:
-          {{- if not $global.registry }}
-            - name: openstack
-              url: https://kubernetes.github.io/cloud-provider-openstack/
-          {{- else }}
-            - name: global-registry
-              url: oci://{{ regexReplaceAll "/.*" $global.registry "" }}
-              {{- if $global.registryCertSecret }}
-              caFile: /usr/local/share/ca-certificates/registry/ca.crt
-              {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "k0smotroncontrolplane.name" . }}-manifests
+data:
+  chart-openstack-cloud-controller-manager.yaml: |
+    apiVersion: helm.k0sproject.io/v1beta1
+    kind: Chart
+    metadata:
+      name: openstack-cloud-controller-manager
+      namespace: kube-system
+    spec:
+      {{- if not $global.registry }}
+      repository:
+        url: https://kubernetes.github.io/cloud-provider-openstack/
+      {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      repository:
+        configFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+        {{- if $global.registryCertSecret }}
+        caFile: /usr/local/share/ca-certificates/registry/ca.crt
+        {{- end }}
+      {{- end }}
+      {{- if $global.registry }}
+      chartName: oci://{{ $global.registry }}/charts/openstack-cloud-controller-manager
+      {{- else }}
+      chartName: openstack-cloud-controller-manager/openstack-cloud-controller-manager
+      {{- end }}
+      version: 2.31.1
+      order: 1
+      releaseName: openstack-cloud-controller-manager
+      namespace: kube-system
+      values: |
+        {{- if $global.registry }}
+        image:
+          repository: {{ $global.registry }}/provider-os/openstack-cloud-controller-manager
+        {{- end }}
+        secret:
+          enabled: true
+          name: openstack-cloud-config
+          create: false
+        nodeSelector: null
+        tolerations:
+          - key: node.cloudprovider.kubernetes.io/uninitialized
+            value: "true"
+            effect: NoSchedule
+          - key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
+          - key: node-role.kubernetes.io/master
+            effect: NoSchedule
+        extraEnv:
+          - name: OS_CCM_REGIONAL
+            value: {{ .Values.ccmRegional | quote }}
+        extraVolumes:
+          - name: flexvolume-dir
+            hostPath:
+              path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+          - name: k8s-certs
+            hostPath:
+              path: /etc/kubernetes/pki
+          {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
+          - name: cloud-ca-cert
+            secret:
+              secretName: {{ .Values.identityRef.caCert.secretName }}
           {{- end }}
-          charts:
-            - name: openstack-ccm
-              {{- if $global.registry }}
-              chartname: oci://{{ $global.registry }}/charts/openstack-cloud-controller-manager
-              {{- else }}
-              chartname: openstack/openstack-cloud-controller-manager
-              {{- end }}
-              version: 2.31.1
-              order: 1
-              namespace: kube-system
-              values: |
-                {{- if $global.registry }}
-                image:
-                  repository: {{ $global.registry }}/provider-os/openstack-cloud-controller-manager
-                {{- end }}
-                secret:
-                  enabled: true
-                  name: openstack-cloud-config
-                  create: false
-                nodeSelector: null
-                tolerations:
-                  - key: node.cloudprovider.kubernetes.io/uninitialized
-                    value: "true"
-                    effect: NoSchedule
-                  - key: node-role.kubernetes.io/control-plane
-                    effect: NoSchedule
-                  - key: node-role.kubernetes.io/master
-                    effect: NoSchedule   
-                extraEnv:
-                  - name: OS_CCM_REGIONAL
-                    value: {{ .Values.ccmRegional | quote }}
-                extraVolumes:
-                  - name: flexvolume-dir
-                    hostPath:
-                      path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-                  - name: k8s-certs
-                    hostPath:
-                      path: /etc/kubernetes/pki
-                  {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
-                  - name: cloud-ca-cert
-                    secret:
-                      secretName: {{ .Values.identityRef.caCert.secretName }}
-                  {{- end }}
-                extraVolumeMounts:
-                  - name: flexvolume-dir
-                    mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-                    readOnly: true
-                  - name: k8s-certs
-                    mountPath: /etc/kubernetes/pki
-                    readOnly: true
-                  {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
-                  - name: cloud-ca-cert
-                    mountPath: {{ .Values.identityRef.caCert.path }}
-                  {{- end }}
-            - name: openstack-csi
-              {{- if $global.registry }}
-              chartname: oci://{{ $global.registry }}/charts/openstack-cinder-csi
-              {{- else }}
-              chartname: openstack/openstack-cinder-csi
-              {{- end }}
-              version: 2.31.2
-              order: 2
-              namespace: kube-system
-              values: |
-                storageClass:
-                  enabled: true
-                  delete:
-                    isDefault: true
-                    allowVolumeExpansion: true
-                  retain:
-                    isDefault: false
-                    allowVolumeExpansion: false
-                secret:
-                  enabled: true
-                  name: openstack-cloud-config
-                  create: false
-                csi:
-                  {{- if $global.registry }}
-                  attacher:
-                    image:
-                      repository: {{ $global.registry }}/sig-storage/csi-attacher
-                  provisioner:
-                    image:
-                      repository: {{ $global.registry }}/sig-storage/csi-provisioner
-                  snapshotter:
-                    image:
-                      repository: {{ $global.registry }}/sig-storage/csi-snapshotter
-                  resizer:
-                    image:
-                      repository: {{ $global.registry }}/sig-storage/csi-resizer
-                  livenessprobe:
-                    image:
-                      repository: {{ $global.registry }}/sig-storage/livenessprobe
-                  nodeDriverRegistrar:
-                    image:
-                      repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
-                  {{- end }}
-                  plugin:
-                    {{- if $global.registry }}
-                    image:
-                      repository: {{ $global.registry }}/provider-os/cinder-csi-plugin
-                    {{- end }}
-                    nodePlugin:
-                      kubeletDir: /var/lib/k0s/kubelet
-                    {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
-                    volumes:
-                    - name: cloud-ca-cert
-                      secret:
-                        secretName: {{ .Values.identityRef.caCert.secretName }}
-                    volumeMounts:
-                    - name: cloud-config
-                      mountPath: /etc/kubernetes
-                      readOnly: true
-                    - name: cloud-ca-cert
-                      mountPath: {{ .Values.identityRef.caCert.path }}
-                   {{- end }}
+        extraVolumeMounts:
+          - name: flexvolume-dir
+            mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+            readOnly: true
+          - name: k8s-certs
+            mountPath: /etc/kubernetes/pki
+            readOnly: true
+          {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
+          - name: cloud-ca-cert
+            mountPath: {{ .Values.identityRef.caCert.path }}
+          {{- end }}
+  chart-openstack-cinder-csi.yaml: |
+    apiVersion: helm.k0sproject.io/v1beta1
+    kind: Chart
+    metadata:
+      name: openstack-cinder-csi
+      namespace: kube-system
+    spec:
+      {{- if not $global.registry }}
+      repository:
+        url: https://kubernetes.github.io/cloud-provider-openstack/
+      {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      repository:
+        configFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+        {{- if $global.registryCertSecret }}
+        caFile: /usr/local/share/ca-certificates/registry/ca.crt
+        {{- end }}
+      {{- end }}
+      {{- if $global.registry }}
+      chartName: oci://{{ $global.registry }}/charts/openstack-cinder-csi
+      {{- else }}
+      chartName: openstack-cinder-csi/openstack-cinder-csi
+      {{- end }}
+      version: 2.31.2
+      order: 2
+      releaseName: openstack-cinder-csi
+      namespace: kube-system
+      values: |
+        storageClass:
+          enabled: true
+          delete:
+            isDefault: true
+            allowVolumeExpansion: true
+          retain:
+            isDefault: false
+            allowVolumeExpansion: false
+        secret:
+          enabled: true
+          name: openstack-cloud-config
+          create: false
+        csi:
+          {{- if $global.registry }}
+          attacher:
+            image:
+              repository: {{ $global.registry }}/sig-storage/csi-attacher
+          provisioner:
+            image:
+              repository: {{ $global.registry }}/sig-storage/csi-provisioner
+          snapshotter:
+            image:
+              repository: {{ $global.registry }}/sig-storage/csi-snapshotter
+          resizer:
+            image:
+              repository: {{ $global.registry }}/sig-storage/csi-resizer
+          livenessprobe:
+            image:
+              repository: {{ $global.registry }}/sig-storage/livenessprobe
+          nodeDriverRegistrar:
+            image:
+              repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
+          {{- end }}
+          plugin:
+            {{- if $global.registry }}
+            image:
+              repository: {{ $global.registry }}/provider-os/cinder-csi-plugin
+            {{- end }}
+            nodePlugin:
+              kubeletDir: /var/lib/k0s/kubelet
+            {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
+            volumes:
+            - name: cloud-ca-cert
+              secret:
+                secretName: {{ .Values.identityRef.caCert.secretName }}
+            volumeMounts:
+            - name: cloud-config
+              mountPath: /etc/kubernetes
+              readOnly: true
+            - name: cloud-ca-cert
+              mountPath: {{ .Values.identityRef.caCert.path }}
+           {{- end }}

--- a/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
       {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
@@ -22,6 +22,16 @@ spec:
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}
         {{- end }}
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
+      {{- end }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -10,9 +10,8 @@ spec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
     {{- end }}
-    {{- if or $global.registryCertSecret $global.k0sURLCertSecret .Values.auth.configSecret.name }}
-    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
     files:
+      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       {{- range $path, $secret := $certs }}
       {{- if $secret }}
       - contentFrom:
@@ -31,7 +30,178 @@ spec:
         permissions: "0644"
         path: {{ include "authentication-config.fullpath" . }}
       {{- end }}
-    {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      - contentFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+            key: registryCredential
+        permissions: "0644"
+        path: /var/lib/k0s/manifests/kcm/helm-registry-credentials.yaml
+      - contentFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+            key: containerdAuth
+        permissions: "0664"
+        path: /etc/k0s/containerd.d/registry-auth.toml
+      {{- end }}
+      - path: /var/lib/k0s/manifests/kcm/chart-openstack-cloud-controller-manager.yaml
+        permissions: "0644"
+        content: |
+          apiVersion: helm.k0sproject.io/v1beta1
+          kind: Chart
+          metadata:
+            name: openstack-cloud-controller-manager
+            namespace: kube-system
+          spec:
+            {{- if not $global.registry }}
+            repository:
+              url: https://kubernetes.github.io/cloud-provider-openstack/
+            {{- end }}
+            {{- if $global.registryCredentialSecret }}
+            repository:
+              configFrom:
+                secretRef:
+                  name: {{ $global.registryCredentialSecret }}
+            {{- end }}
+            {{- if $global.registry }}
+            chartName: oci://{{ $global.registry }}/charts/openstack-cloud-controller-manager
+            {{- else }}
+            chartName: openstack-cloud-controller-manager/openstack-cloud-controller-manager
+            {{- end }}
+            version: 2.31.1
+            order: 1
+            releaseName: openstack-cloud-controller-manager
+            namespace: kube-system
+            values: |
+              {{- if .Values.ccmEnableUniqueClusterName }}
+              cluster:
+                name: {{ include "ccm-cluster.name" . }}
+              {{- end }}
+              {{- if $global.registry }}
+              image:
+                repository: {{ $global.registry }}/provider-os/openstack-cloud-controller-manager
+              {{- end }}
+              secret:
+                enabled: true
+                name: openstack-cloud-config
+                create: false
+              nodeSelector:
+                node-role.kubernetes.io/control-plane: "true"
+              tolerations:
+                - key: node.cloudprovider.kubernetes.io/uninitialized
+                  value: "true"
+                  effect: NoSchedule
+                - key: node-role.kubernetes.io/control-plane
+                  effect: NoSchedule
+                - key: node-role.kubernetes.io/master
+                  effect: NoSchedule
+              extraEnv:
+                - name: OS_CCM_REGIONAL
+                  value: {{ .Values.ccmRegional | quote }}
+              extraVolumes:
+                - name: flexvolume-dir
+                  hostPath:
+                    path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+                - name: k8s-certs
+                  hostPath:
+                    path: /etc/kubernetes/pki
+                {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
+                - name: cloud-ca-cert
+                  secret:
+                    secretName: {{ .Values.identityRef.caCert.secretName }}
+                {{- end }}
+              extraVolumeMounts:
+                - name: flexvolume-dir
+                  mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+                  readOnly: true
+                - name: k8s-certs
+                  mountPath: /etc/kubernetes/pki
+                  readOnly: true
+                {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
+                - name: cloud-ca-cert
+                  mountPath: {{ .Values.identityRef.caCert.path }}
+                {{- end }}
+      - path: /var/lib/k0s/manifests/kcm/chart-openstack-cinder-csi.yaml
+        permissions: "0644"
+        content: |
+          apiVersion: helm.k0sproject.io/v1beta1
+          kind: Chart
+          metadata:
+            name: openstack-cinder-csi
+            namespace: kube-system
+          spec:
+            {{- if not $global.registry }}
+            repository:
+              url: https://kubernetes.github.io/cloud-provider-openstack/
+            {{- end }}
+            {{- if $global.registryCredentialSecret }}
+            repository:
+              configFrom:
+                secretRef:
+                  name: {{ $global.registryCredentialSecret }}
+            {{- end }}
+            {{- if $global.registry }}
+            chartName: oci://{{ $global.registry }}/charts/openstack-cinder-csi
+            {{- else }}
+            chartName: openstack-cinder-csi/openstack-cinder-csi
+            {{- end }}
+            version: 2.31.2
+            order: 2
+            releaseName: openstack-cinder-csi
+            namespace: kube-system
+            values: |
+              storageClass:
+                enabled: true
+                delete:
+                  isDefault: true
+                  allowVolumeExpansion: true
+                retain:
+                  isDefault: false
+                  allowVolumeExpansion: false
+              secret:
+                enabled: true
+                name: openstack-cloud-config
+                create: false
+              csi:
+                {{- if $global.registry }}
+                attacher:
+                  image:
+                    repository: {{ $global.registry }}/sig-storage/csi-attacher
+                provisioner:
+                  image:
+                    repository: {{ $global.registry }}/sig-storage/csi-provisioner
+                snapshotter:
+                  image:
+                    repository: {{ $global.registry }}/sig-storage/csi-snapshotter
+                resizer:
+                  image:
+                    repository: {{ $global.registry }}/sig-storage/csi-resizer
+                livenessprobe:
+                  image:
+                    repository: {{ $global.registry }}/sig-storage/livenessprobe
+                nodeDriverRegistrar:
+                  image:
+                    repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
+                {{- end }}
+                plugin:
+                  {{- if $global.registry }}
+                  image:
+                    repository: {{ $global.registry }}/provider-os/cinder-csi-plugin
+                  {{- end }}
+                  nodePlugin:
+                    kubeletDir: /var/lib/k0s/kubelet
+                  {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
+                  volumes:
+                  - name: cloud-ca-cert
+                    secret:
+                      secretName: {{ .Values.identityRef.caCert.secretName }}
+                  volumeMounts:
+                  - name: cloud-config
+                    mountPath: /etc/kubernetes
+                    readOnly: true
+                  - name: cloud-ca-cert
+                    mountPath: {{ .Values.identityRef.caCert.path }}
+                 {{- end }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
     preStartCommands:
     - "sudo update-ca-certificates"
@@ -68,134 +238,6 @@ spec:
         images:
           repository: "{{ $global.registry }}"
         {{- end }}
-        extensions:
-          helm:
-            {{- if not $global.registry }}
-            repositories:
-              - name: openstack
-                url: https://kubernetes.github.io/cloud-provider-openstack/
-            {{- end }}
-            charts:
-              - name: openstack-ccm
-                {{- if $global.registry }}
-                chartname: oci://{{ $global.registry }}/charts/openstack-cloud-controller-manager
-                {{- else }}
-                chartname: openstack/openstack-cloud-controller-manager
-                {{- end }}
-                version: 2.31.1
-                order: 1
-                namespace: kube-system
-                values: |
-                  {{- if .Values.ccmEnableUniqueClusterName }}
-                  cluster:
-                    name: {{ include "ccm-cluster.name" . }}
-                  {{- end }}
-                  {{- if $global.registry }}
-                  image:
-                    repository: {{ $global.registry }}/provider-os/openstack-cloud-controller-manager
-                  {{- end }}
-                  secret:
-                    enabled: true
-                    name: openstack-cloud-config
-                    create: false
-                  nodeSelector:
-                    node-role.kubernetes.io/control-plane: "true"
-                  tolerations:
-                    - key: node.cloudprovider.kubernetes.io/uninitialized
-                      value: "true"
-                      effect: NoSchedule
-                    - key: node-role.kubernetes.io/control-plane
-                      effect: NoSchedule
-                    - key: node-role.kubernetes.io/master
-                      effect: NoSchedule
-                  extraEnv:
-                    - name: OS_CCM_REGIONAL
-                      value: {{ .Values.ccmRegional | quote }}
-                  extraVolumes:
-                    - name: flexvolume-dir
-                      hostPath:
-                        path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-                    - name: k8s-certs
-                      hostPath:
-                        path: /etc/kubernetes/pki
-                    {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
-                    - name: cloud-ca-cert
-                      secret:
-                        secretName: {{ .Values.identityRef.caCert.secretName }}
-                    {{- end }}
-                  extraVolumeMounts:
-                    - name: flexvolume-dir
-                      mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-                      readOnly: true
-                    - name: k8s-certs
-                      mountPath: /etc/kubernetes/pki
-                      readOnly: true
-                    {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
-                    - name: cloud-ca-cert
-                      mountPath: {{ .Values.identityRef.caCert.path }}
-                    {{- end }}
-              - name: openstack-csi
-                {{- if $global.registry }}
-                chartname: oci://{{ $global.registry }}/charts/openstack-cinder-csi
-                {{- else }}
-                chartname: openstack/openstack-cinder-csi
-                {{- end }}
-                version: 2.31.2
-                order: 2
-                namespace: kube-system
-                values: |
-                  storageClass:
-                    enabled: true
-                    delete:
-                      isDefault: true
-                      allowVolumeExpansion: true
-                    retain:
-                      isDefault: false
-                      allowVolumeExpansion: false
-                  secret:
-                    enabled: true
-                    name: openstack-cloud-config
-                    create: false
-                  csi:
-                    {{- if $global.registry }}
-                    attacher:
-                      image:
-                        repository: {{ $global.registry }}/sig-storage/csi-attacher
-                    provisioner:
-                      image:
-                        repository: {{ $global.registry }}/sig-storage/csi-provisioner
-                    snapshotter:
-                      image:
-                        repository: {{ $global.registry }}/sig-storage/csi-snapshotter
-                    resizer:
-                      image:
-                        repository: {{ $global.registry }}/sig-storage/csi-resizer
-                    livenessprobe:
-                      image:
-                        repository: {{ $global.registry }}/sig-storage/livenessprobe
-                    nodeDriverRegistrar:
-                      image:
-                        repository: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
-                    {{- end }}
-                    plugin:
-                      {{- if $global.registry }}
-                      image:
-                        repository: {{ $global.registry }}/provider-os/cinder-csi-plugin
-                      {{- end }}
-                      nodePlugin:
-                        kubeletDir: /var/lib/k0s/kubelet
-                      {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
-                      volumes:
-                      - name: cloud-ca-cert
-                        secret:
-                          secretName: {{ .Values.identityRef.caCert.secretName }}
-                      volumeMounts:
-                      - name: cloud-config
-                        mountPath: /etc/kubernetes
-                        readOnly: true
-                      - name: cloud-ca-cert
-                        mountPath: {{ .Values.identityRef.caCert.path }}
-                     {{- end }}
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
       {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
       files:
         {{- range $path, $secret := $certs }}
@@ -22,6 +22,16 @@ spec:
           path: /usr/local/share/ca-certificates/{{ $path }}
         {{- end }}
         {{- end }}
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
+      {{- end }}
+      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.23
+version: 1.0.24
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -32,7 +32,7 @@ spec:
   {{- if $global.k0sURL }}
   downloadURL: "{{ $global.k0sURL }}/k0s-{{ $.Values.k0s.version }}-{{ $.Values.k0s.arch }}"
   {{- end }}
-  {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+  {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
   {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
   files:
     {{- range $path, $secret := $certs }}
@@ -45,6 +45,16 @@ spec:
       path: /usr/local/share/ca-certificates/{{ $path }}
     {{- end }}
     {{- end }}
+    {{- if $global.registryCredentialSecret }}
+    - contentFrom:
+        secretRef:
+          name: {{ $global.registryCredentialSecret }}
+          key: containerdAuth
+      permissions: "0664"
+      path: /etc/k0s/containerd.d/registry-auth.toml
+    {{- end }}
+  {{- end }}
+  {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
   preStartCommands:
     - {{ printf "%supdate-ca-certificates" (ternary "sudo " "" $machine.useSudo) | quote }}
   {{- end }}

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.23
+version: 1.0.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -48,6 +48,18 @@ spec:
   {{- if .Values.dataSource.kineDataSourceSecretName }}
   kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
   {{- end }}
+  manifests:
+    - name: manifests
+      configMap:
+        name: {{ include "k0smotroncontrolplane.name" . }}-manifests
+    {{- if $global.registryCredentialSecret }}
+    - name: helm-registry-credentials
+      secret:
+        secretName: {{ $global.registryCredentialSecret }}
+        items:
+          - key: registryCredential
+            path: helm-registry-credentials.yaml
+    {{- end }}
   controllerPlaneFlags:
     - --enable-cloud-provider=true
     - --debug=true
@@ -75,95 +87,125 @@ spec:
       images:
         repository: "{{ $global.registry }}"
       {{- end }}
-      extensions:
-        helm:
-          repositories:
-          {{- if not $global.registry }}
-            - name: vsphere-cpi
-              url: https://kubernetes.github.io/cloud-provider-vsphere
-            - name: mirantis
-              url: https://charts.mirantis.com
-          {{- else }}
-            - name: global-registry
-              url: oci://{{ regexReplaceAll "/.*" $global.registry "" }}
-              {{- if $global.registryCertSecret }}
-              caFile: /usr/local/share/ca-certificates/registry/ca.crt
-              {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "k0smotroncontrolplane.name" . }}-manifests
+data:
+  chart-vsphere-cpi.yaml: |
+    apiVersion: helm.k0sproject.io/v1beta1
+    kind: Chart
+    metadata:
+      name: vsphere-cpi
+      namespace: kube-system
+    spec:
+      {{- if not $global.registry }}
+      repository:
+        url: https://kubernetes.github.io/cloud-provider-vsphere
+      {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      repository:
+        configFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+        {{- if $global.registryCertSecret }}
+        caFile: /usr/local/share/ca-certificates/registry/ca.crt
+        {{- end }}
+      {{- end }}
+      {{- if $global.registry }}
+      chartName: oci://{{ $global.registry }}/charts/vsphere-cpi
+      {{- else }}
+      chartName: vsphere-cpi/vsphere-cpi
+      {{- end }}
+      version: 1.31.0
+      releaseName: vsphere-cpi
+      namespace: kube-system
+      order: 1
+      values: |
+        config:
+          enabled: false
+        daemonset:
+          affinity: null
+          {{- if $global.registry }}
+          image: {{ $global.registry }}/cloud-pv-vsphere/cloud-provider-vsphere
           {{- end }}
-          charts:
-          - name: vsphere-cpi
+          tolerations:
+            - effect: NoSchedule
+              key: node.cloudprovider.kubernetes.io/uninitialized
+              value: "true"
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+              operator: Exists
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/control-plane
+              operator: Exists
+            - effect: NoSchedule
+              key: node.kubernetes.io/not-ready
+              operator: Exists
+            - key: CriticalAddonsOnly
+              effect: NoExecute
+              operator: Exists
+  chart-vsphere-csi-driver.yaml: |
+    apiVersion: helm.k0sproject.io/v1beta1
+    kind: Chart
+    metadata:
+      name: vsphere-csi-driver
+      namespace: kube-system
+    spec:
+      {{- if not $global.registry }}
+      repository:
+        url: https://charts.mirantis.com
+      {{- end }}
+      {{- if and $global.registry $global.registryCredentialSecret }}
+      repository:
+        configFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+        {{- if $global.registryCertSecret }}
+        caFile: /usr/local/share/ca-certificates/registry/ca.crt
+        {{- end }}
+      {{- end }}
+      {{- if $global.registry }}
+      chartName: oci://{{ $global.registry }}/charts/vsphere-csi-driver
+      {{- else }}
+      chartName: vsphere-csi-driver/vsphere-csi-driver
+      {{- end }}
+      version: 0.0.3
+      releaseName: vsphere-csi-driver
+      namespace: kube-system
+      order: 2
+      values: |
+        vcenterConfig:
+          enabled: false
+        controller:
+          nodeAffinity: null
+        node:
+          kubeletPath: /var/lib/k0s/kubelet
+        defaultStorageClass:
+          enabled: true
+        images:
+          driver:
             {{- if $global.registry }}
-            chartname: oci://{{ $global.registry }}/charts/vsphere-cpi
-            {{- else }}
-            chartname: vsphere-cpi/vsphere-cpi
+            repo: {{ $global.registry }}/csi-vsphere/driver
             {{- end }}
-            version: 1.31.0
-            order: 1
-            namespace: kube-system
-            values: |
-              config:
-                enabled: false
-              daemonset:
-                affinity: null
-                {{- if $global.registry }}
-                image: {{ $global.registry }}/cloud-pv-vsphere/cloud-provider-vsphere
-                {{- end }}
-                tolerations:
-                  - effect: NoSchedule
-                    key: node.cloudprovider.kubernetes.io/uninitialized
-                    value: "true"
-                  - effect: NoSchedule
-                    key: node-role.kubernetes.io/master
-                    operator: Exists
-                  - effect: NoSchedule
-                    key: node-role.kubernetes.io/control-plane
-                    operator: Exists
-                  - effect: NoSchedule
-                    key: node.kubernetes.io/not-ready
-                    operator: Exists
-                  - key: CriticalAddonsOnly
-                    effect: NoExecute
-                    operator: Exists
-          - name: vsphere-csi-driver
+            tag: v3.1.2
+          syncer:
             {{- if $global.registry }}
-            chartname: oci://{{ $global.registry }}/charts/vsphere-csi-driver
-            {{- else }}
-            chartname: mirantis/vsphere-csi-driver
+            repo: {{ $global.registry }}/csi-vsphere/syncer
             {{- end }}
-            version: 0.0.3
-            order: 2
-            namespace: kube-system
-            values: |
-              vcenterConfig:
-                enabled: false
-              controller:
-                nodeAffinity: null
-              node:
-                kubeletPath: /var/lib/k0s/kubelet
-              defaultStorageClass:
-                enabled: true
-              images:
-                driver:
-                  {{- if $global.registry }}
-                  repo: {{ $global.registry }}/csi-vsphere/driver
-                  {{- end }}
-                  tag: v3.1.2
-                syncer:
-                  {{- if $global.registry }}
-                  repo: {{ $global.registry }}/csi-vsphere/syncer
-                  {{- end }}
-                  tag: v3.1.2
-                {{- if $global.registry }}
-                nodeDriverRegistrar:
-                  repo: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
-                csiAttacher:
-                  repo: {{ $global.registry }}/sig-storage/csi-attacher
-                csiResizer:
-                  repo: {{ $global.registry }}/sig-storage/csi-resizer
-                csiProvisioner:
-                  repo: {{ $global.registry }}/sig-storage/csi-provisioner
-                csiSnapshotter:
-                  repo: {{ $global.registry }}/sig-storage/csi-snapshotter
-                livenessProbe:
-                  repo: {{ $global.registry }}/sig-storage/livenessprobe
-                {{- end }}
+            tag: v3.1.2
+          {{- if $global.registry }}
+          nodeDriverRegistrar:
+            repo: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
+          csiAttacher:
+            repo: {{ $global.registry }}/sig-storage/csi-attacher
+          csiResizer:
+            repo: {{ $global.registry }}/sig-storage/csi-resizer
+          csiProvisioner:
+            repo: {{ $global.registry }}/sig-storage/csi-provisioner
+          csiSnapshotter:
+            repo: {{ $global.registry }}/sig-storage/csi-snapshotter
+          livenessProbe:
+            repo: {{ $global.registry }}/sig-storage/livenessprobe
+          {{- end }}

--- a/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -19,6 +19,14 @@ spec:
         - path: /home/{{ .Values.ssh.user }}/.ssh/authorized_keys
           permissions: "0600"
           content: "{{ trim .Values.ssh.publicKey }}"
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
         {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
         {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
         {{- range $path, $secret := $certs }}

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.22
+version: 1.0.23
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -35,6 +35,182 @@ spec:
         permissions: "0644"
         path: {{ include "authentication-config.fullpath" . }}
       {{- end }}
+      {{- if $global.registryCredentialSecret }}
+      - contentFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+            key: registryCredential
+        permissions: "0644"
+        path: /var/lib/k0s/manifests/kcm/helm-registry-credentials.yaml
+      - contentFrom:
+          secretRef:
+            name: {{ $global.registryCredentialSecret }}
+            key: containerdAuth
+        permissions: "0664"
+        path: /etc/k0s/containerd.d/registry-auth.toml
+      {{- end }}
+      - path: /var/lib/k0s/manifests/kcm/chart-kube-vip.yaml
+        permissions: "0644"
+        content: |
+          apiVersion: helm.k0sproject.io/v1beta1
+          kind: Chart
+          metadata:
+            name: kube-vip
+            namespace: kube-system
+          spec:
+            {{- if not $global.registry }}
+            repository:
+              url: https://kube-vip.github.io/helm-charts
+            {{- end }}
+            {{- if $global.registryCredentialSecret }}
+            repository:
+              configFrom:
+                secretRef:
+                  name: {{ $global.registryCredentialSecret }}
+            {{- end }}
+            {{- if $global.registry }}
+            chartName: oci://{{ $global.registry }}/charts/kube-vip
+            {{- else }}
+            chartName: kube-vip/kube-vip
+            {{- end }}
+            version: 0.6.1
+            releaseName: kube-vip
+            namespace: kube-system
+            order: 1
+            values: |
+              {{- if $global.registry }}
+              image:
+                repository: {{ $global.registry }}/kube-vip/kube-vip
+              {{- end }}
+              config:
+                address: {{ .Values.controlPlaneEndpointIP }}
+              env:
+                svc_enable: "true"
+                cp_enable: "true"
+                lb_enable: "false"
+              nodeSelector:
+                node-role.kubernetes.io/control-plane: "true"
+              tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/master
+                  operator: Exists
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+                - effect: NoSchedule
+                  key: node.cloudprovider.kubernetes.io/uninitialized
+                  value: "true"
+      - path: /var/lib/k0s/manifests/kcm/chart-vsphere-cpi.yaml
+        permissions: "0644"
+        content: |
+          apiVersion: helm.k0sproject.io/v1beta1
+          kind: Chart
+          metadata:
+            name: vsphere-cpi
+            namespace: kube-system
+          spec:
+            {{- if not $global.registry }}
+            repository:
+              url: https://kubernetes.github.io/cloud-provider-vsphere
+            {{- end }}
+            {{- if $global.registryCredentialSecret }}
+            repository:
+              configFrom:
+                secretRef:
+                  name: {{ $global.registryCredentialSecret }}
+            {{- end }}
+            {{- if $global.registry }}
+            chartName: oci://{{ $global.registry }}/charts/vsphere-cpi
+            {{- else }}
+            chartName: vsphere-cpi/vsphere-cpi
+            {{- end }}
+            version: 1.31.0
+            releaseName: vsphere-cpi
+            namespace: kube-system
+            order: 2
+            values: |
+              config:
+                enabled: false
+              daemonset:
+                {{- if $global.registry }}
+                image: {{ $global.registry }}/cloud-pv-vsphere/cloud-provider-vsphere
+                {{- end }}
+                tolerations:
+                  - effect: NoSchedule
+                    key: node.cloudprovider.kubernetes.io/uninitialized
+                    value: "true"
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/master
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node.kubernetes.io/not-ready
+                    operator: Exists
+                  - key: CriticalAddonsOnly
+                    effect: NoExecute
+                    operator: Exists
+      - path: /var/lib/k0s/manifests/kcm/chart-vsphere-csi-driver.yaml
+        permissions: "0644"
+        content: |
+          apiVersion: helm.k0sproject.io/v1beta1
+          kind: Chart
+          metadata:
+            name: vsphere-csi-driver
+            namespace: kube-system
+          spec:
+            {{- if not $global.registry }}
+            repository:
+              url: https://charts.mirantis.com
+            {{- end }}
+            {{- if and $global.registry $global.registryCredentialSecret }}
+            repository:
+              configFrom:
+                secretRef:
+                  name: {{ $global.registryCredentialSecret }}
+            {{- end }}
+            {{- if $global.registry }}
+            chartName: oci://{{ $global.registry }}/charts/vsphere-csi-driver
+            {{- else }}
+            chartName: vsphere-csi-driver/vsphere-csi-driver
+            {{- end }}
+            version: 0.0.3
+            releaseName: vsphere-csi-driver
+            namespace: kube-system
+            order: 3
+            values: |
+              vcenterConfig:
+                enabled: false
+              node:
+                kubeletPath: /var/lib/k0s/kubelet
+              defaultStorageClass:
+                enabled: true
+              images:
+                driver:
+                  {{- if $global.registry }}
+                  repo: {{ $global.registry }}/csi-vsphere/driver
+                  {{- end }}
+                  tag: v3.1.2
+                syncer:
+                  {{- if $global.registry }}
+                  repo: {{ $global.registry }}/csi-vsphere/syncer
+                  {{- end }}
+                  tag: v3.1.2
+                {{- if $global.registry }}
+                nodeDriverRegistrar:
+                  repo: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
+                csiAttacher:
+                  repo: {{ $global.registry }}/sig-storage/csi-attacher
+                csiResizer:
+                  repo: {{ $global.registry }}/sig-storage/csi-resizer
+                csiProvisioner:
+                  repo: {{ $global.registry }}/sig-storage/csi-provisioner
+                csiSnapshotter:
+                  repo: {{ $global.registry }}/sig-storage/csi-snapshotter
+                livenessProbe:
+                  repo: {{ $global.registry }}/sig-storage/livenessprobe
+                {{- end }}
     preStartCommands:
       - chown {{ .Values.controlPlane.ssh.user }} /home/{{ .Values.controlPlane.ssh.user }}/.ssh/authorized_keys
       - sed -i 's/"externalAddress":"{{ .Values.controlPlaneEndpointIP }}",//' /etc/k0s.yaml
@@ -74,123 +250,6 @@ spec:
         images:
           repository: "{{ $global.registry }}"
         {{- end }}
-        extensions:
-          helm:
-            {{- if not $global.registry }}
-            repositories:
-            - name: kube-vip
-              url: https://kube-vip.github.io/helm-charts
-            - name: vsphere-cpi
-              url: https://kubernetes.github.io/cloud-provider-vsphere
-            - name: mirantis
-              url: https://charts.mirantis.com
-            {{- end }}
-            charts:
-            - name: kube-vip
-              {{- if $global.registry }}
-              chartname: oci://{{ $global.registry }}/charts/kube-vip
-              {{- else }}
-              chartname: kube-vip/kube-vip
-              {{- end }}
-              version: 0.6.1
-              order: 1
-              namespace: kube-system
-              values: |
-                {{- if $global.registry }}
-                image:
-                  repository: {{ $global.registry }}/kube-vip/kube-vip
-                {{- end }}
-                config:
-                  address: {{ .Values.controlPlaneEndpointIP }}
-                env:
-                  svc_enable: "true"
-                  cp_enable: "true"
-                  lb_enable: "false"
-                nodeSelector:
-                  node-role.kubernetes.io/control-plane: "true"
-                tolerations:
-                  - effect: NoSchedule
-                    key: node-role.kubernetes.io/master
-                    operator: Exists
-                  - effect: NoSchedule
-                    key: node-role.kubernetes.io/control-plane
-                    operator: Exists
-                  - effect: NoSchedule
-                    key: node.cloudprovider.kubernetes.io/uninitialized
-                    value: "true"
-            - name: vsphere-cpi
-              {{- if $global.registry }}
-              chartname: oci://{{ $global.registry }}/charts/vsphere-cpi
-              {{- else }}
-              chartname: vsphere-cpi/vsphere-cpi
-              {{- end }}
-              version: 1.31.0
-              order: 2
-              namespace: kube-system
-              values: |
-                config:
-                  enabled: false
-                daemonset:
-                  {{- if $global.registry }}
-                  image: {{ $global.registry }}/cloud-pv-vsphere/cloud-provider-vsphere
-                  {{- end }}
-                  tolerations:
-                    - effect: NoSchedule
-                      key: node.cloudprovider.kubernetes.io/uninitialized
-                      value: "true"
-                    - effect: NoSchedule
-                      key: node-role.kubernetes.io/master
-                      operator: Exists
-                    - effect: NoSchedule
-                      key: node-role.kubernetes.io/control-plane
-                      operator: Exists
-                    - effect: NoSchedule
-                      key: node.kubernetes.io/not-ready
-                      operator: Exists
-                    - key: CriticalAddonsOnly
-                      effect: NoExecute
-                      operator: Exists
-            - name: vsphere-csi-driver
-              {{- if $global.registry }}
-              chartname: oci://{{ $global.registry }}/charts/vsphere-csi-driver
-              {{- else }}
-              chartname: mirantis/vsphere-csi-driver
-              {{- end }}
-              version: 0.0.3
-              order: 3
-              namespace: kube-system
-              values: |
-                vcenterConfig:
-                  enabled: false
-                node:
-                  kubeletPath: /var/lib/k0s/kubelet
-                defaultStorageClass:
-                  enabled: true
-                images:
-                  driver:
-                    {{- if $global.registry }}
-                    repo: {{ $global.registry }}/csi-vsphere/driver
-                    {{- end }}
-                    tag: v3.1.2
-                  syncer:
-                    {{- if $global.registry }}
-                    repo: {{ $global.registry }}/csi-vsphere/syncer
-                    {{- end }}
-                    tag: v3.1.2
-                  {{- if $global.registry }}
-                  nodeDriverRegistrar:
-                    repo: {{ $global.registry }}/sig-storage/csi-node-driver-registrar
-                  csiAttacher:
-                    repo: {{ $global.registry }}/sig-storage/csi-attacher
-                  csiResizer:
-                    repo: {{ $global.registry }}/sig-storage/csi-resizer
-                  csiProvisioner:
-                    repo: {{ $global.registry }}/sig-storage/csi-provisioner
-                  csiSnapshotter:
-                    repo: {{ $global.registry }}/sig-storage/csi-snapshotter
-                  livenessProbe:
-                    repo: {{ $global.registry }}/sig-storage/livenessprobe
-                  {{- end }}
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -19,6 +19,14 @@ spec:
         - path: /home/{{ .Values.worker.ssh.user }}/.ssh/authorized_keys
           permissions: "0600"
           content: "{{ trim .Values.worker.ssh.publicKey }}"
+        {{- if $global.registryCredentialSecret }}
+        - contentFrom:
+            secretRef:
+              name: {{ $global.registryCredentialSecret }}
+              key: containerdAuth
+          permissions: "0664"
+          path: /etc/k0s/containerd.d/registry-auth.toml
+        {{- end }}
         {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
         {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
         {{- range $path, $secret := $certs }}

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.16
+version: 1.0.17
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/templates/orc.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/orc.yaml
@@ -1,13 +1,4 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: orc
-    control-plane: controller-manager
-  name: orc-system
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -19,368 +10,352 @@ spec:
   group: openstack.k-orc.cloud
   names:
     categories:
-    - openstack
+      - openstack
     kind: Flavor
     listKind: FlavorList
     plural: flavors
     singular: flavor
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Resource ID
-      jsonPath: .status.id
-      name: ID
-      type: string
-    - description: Availability status of resource
-      jsonPath: .status.conditions[?(@.type=='Available')].status
-      name: Available
-      type: string
-    - description: Message describing current progress status
-      jsonPath: .status.conditions[?(@.type=='Progressing')].message
-      name: Message
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Flavor is the Schema for an ORC resource.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec specifies the desired state of the resource.
-            properties:
-              cloudCredentialsRef:
-                description: cloudCredentialsRef points to a secret containing OpenStack
-                  credentials
-                properties:
-                  cloudName:
-                    description: cloudName specifies the name of the entry in the
-                      clouds.yaml file to use.
-                    maxLength: 256
-                    minLength: 1
-                    type: string
-                  secretName:
-                    description: |-
-                      secretName is the name of a secret in the same namespace as the resource being provisioned.
-                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
-                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                required:
-                - cloudName
-                - secretName
-                type: object
-              import:
-                description: |-
-                  import refers to an existing OpenStack resource which will be imported instead of
-                  creating a new one.
-                maxProperties: 1
-                minProperties: 1
-                properties:
-                  filter:
-                    description: |-
-                      filter contains a resource query which is expected to return a single
-                      result. The controller will continue to retry if filter returns no
-                      results. If filter returns multiple results the controller will set an
-                      error state and will not continue to retry.
-                    minProperties: 1
-                    properties:
-                      disk:
-                        description: disk is the size of the root disk in GiB.
-                        format: int32
-                        minimum: 0
-                        type: integer
-                      name:
-                        description: name of the existing resource
-                        maxLength: 255
-                        minLength: 1
-                        pattern: ^[^,]+$
-                        type: string
-                      ram:
-                        description: ram is the memory of the flavor, measured in
-                          MB.
-                        format: int32
-                        minimum: 1
-                        type: integer
-                      vcpus:
-                        description: vcpus is the number of vcpus for the flavor.
-                        format: int32
-                        minimum: 1
-                        type: integer
-                    type: object
-                  id:
-                    description: |-
-                      id contains the unique identifier of an existing OpenStack resource. Note
-                      that when specifying an import by ID, the resource MUST already exist.
-                      The ORC object will enter an error state if the resource does not exist.
-                    format: uuid
-                    type: string
-                type: object
-              managedOptions:
-                description: managedOptions specifies options which may be applied
-                  to managed objects.
-                properties:
-                  onDelete:
-                    default: delete
-                    description: |-
-                      onDelete specifies the behaviour of the controller when the ORC
-                      object is deleted. Options are `delete` - delete the OpenStack resource;
-                      `detach` - do not delete the OpenStack resource. If not specified, the
-                      default is `delete`.
-                    enum:
-                    - delete
-                    - detach
-                    type: string
-                type: object
-              managementPolicy:
-                default: managed
-                description: |-
-                  managementPolicy defines how ORC will treat the object. Valid values are
-                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
-                  ORC will import an existing resource, and will not apply updates to it or
-                  delete it.
-                enum:
-                - managed
-                - unmanaged
-                type: string
-                x-kubernetes-validations:
-                - message: managementPolicy is immutable
-                  rule: self == oldSelf
-              resource:
-                description: |-
-                  resource specifies the desired state of the resource.
-
-                  resource may not be specified if the management policy is `unmanaged`.
-
-                  resource must be specified if the management policy is `managed`.
-                properties:
-                  description:
-                    description: description contains a free form description of the
-                      flavor.
-                    maxLength: 65535
-                    minLength: 1
-                    type: string
-                  disk:
-                    description: |-
-                      disk is the size of the root disk that will be created in GiB. If 0
-                      the root disk will be set to exactly the size of the image used to
-                      deploy the instance. However, in this case the scheduler cannot
-                      select the compute host based on the virtual image size. Therefore,
-                      0 should only be used for volume booted instances or for testing
-                      purposes. Volume-backed instances can be enforced for flavors with
-                      zero root disk via the
-                      os_compute_api:servers:create:zero_disk_flavor policy rule.
-                    format: int32
-                    minimum: 0
-                    type: integer
-                  ephemeral:
-                    description: |-
-                      ephemeral is the size of the ephemeral disk that will be created, in GiB.
-                      Ephemeral disks may be written over on server state changes. So should only
-                      be used as a scratch space for applications that are aware of its
-                      limitations. Defaults to 0.
-                    format: int32
-                    minimum: 0
-                    type: integer
-                  isPublic:
-                    description: isPublic flags a flavor as being available to all
-                      projects or not.
-                    type: boolean
-                  name:
-                    description: |-
-                      name will be the name of the created resource. If not specified, the
-                      name of the ORC object will be used.
-                    maxLength: 255
-                    minLength: 1
-                    pattern: ^[^,]+$
-                    type: string
-                  ram:
-                    description: ram is the memory of the flavor, measured in MB.
-                    format: int32
-                    minimum: 1
-                    type: integer
-                  swap:
-                    description: |-
-                      swap is the size of a dedicated swap disk that will be allocated, in
-                      MiB. If 0 (the default), no dedicated swap disk will be created.
-                    format: int32
-                    minimum: 0
-                    type: integer
-                  vcpus:
-                    description: vcpus is the number of vcpus for the flavor.
-                    format: int32
-                    minimum: 1
-                    type: integer
-                required:
-                - disk
-                - ram
-                - vcpus
-                type: object
-                x-kubernetes-validations:
-                - message: FlavorResourceSpec is immutable
-                  rule: self == oldSelf
-            required:
-            - cloudCredentialsRef
-            type: object
-            x-kubernetes-validations:
-            - message: resource must be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
-            - message: import may not be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
-                : true'
-            - message: resource may not be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
-                : true'
-            - message: import must be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
-                : true'
-            - message: managedOptions may only be provided when policy is managed
-              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
-                : true'
-          status:
-            description: status defines the observed state of the resource.
-            properties:
-              conditions:
-                description: |-
-                  conditions represents the observed status of the object.
-                  Known .status.conditions.type are: "Available", "Progressing"
-
-                  Available represents the availability of the OpenStack resource. If it is
-                  true then the resource is ready for use.
-
-                  Progressing indicates whether the controller is still attempting to
-                  reconcile the current state of the OpenStack resource to the desired
-                  state. Progressing will be False either because the desired state has
-                  been achieved, or because some terminal error prevents it from ever being
-                  achieved and the controller is no longer attempting to reconcile. If
-                  Progressing is True, an observer waiting on the resource should continue
-                  to wait.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+    - additionalPrinterColumns:
+        - description: Resource ID
+          jsonPath: .status.id
+          name: ID
+          type: string
+        - description: Availability status of resource
+          jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: Available
+          type: string
+        - description: Message describing current progress status
+          jsonPath: .status.conditions[?(@.type=='Progressing')].message
+          name: Message
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Flavor is the Schema for an ORC resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec specifies the desired state of the resource.
+              properties:
+                cloudCredentialsRef:
+                  description: cloudCredentialsRef points to a secret containing OpenStack credentials
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
+                    cloudName:
+                      description: cloudName specifies the name of the entry in the clouds.yaml file to use.
+                      maxLength: 256
                       minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    secretName:
+                      description: |-
+                        secretName is the name of a secret in the same namespace as the resource being provisioned.
+                        The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                        The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                      maxLength: 253
+                      minLength: 1
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - cloudName
+                    - secretName
                   type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              id:
-                description: id is the unique identifier of the OpenStack resource.
-                type: string
-              resource:
-                description: resource contains the observed state of the OpenStack
-                  resource.
-                properties:
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 65535
-                    type: string
-                  disk:
-                    description: disk is the size of the root disk that will be created
-                      in GiB.
-                    format: int32
-                    type: integer
-                  ephemeral:
-                    description: ephemeral is the size of the ephemeral disk, in GiB.
-                    format: int32
-                    type: integer
-                  isPublic:
-                    description: isPublic flags a flavor as being available to all
-                      projects or not.
-                    type: boolean
-                  name:
-                    description: name is a Human-readable name for the flavor. Might
-                      not be unique.
-                    maxLength: 1024
-                    type: string
-                  ram:
-                    description: ram is the memory of the flavor, measured in MB.
-                    format: int32
-                    type: integer
-                  swap:
-                    description: |-
-                      swap is the size of a dedicated swap disk that will be allocated, in
-                      MiB.
-                    format: int32
-                    type: integer
-                  vcpus:
-                    description: vcpus is the number of vcpus for the flavor.
-                    format: int32
-                    type: integer
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                import:
+                  description: |-
+                    import refers to an existing OpenStack resource which will be imported instead of
+                    creating a new one.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: |-
+                        filter contains a resource query which is expected to return a single
+                        result. The controller will continue to retry if filter returns no
+                        results. If filter returns multiple results the controller will set an
+                        error state and will not continue to retry.
+                      minProperties: 1
+                      properties:
+                        disk:
+                          description: disk is the size of the root disk in GiB.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        name:
+                          description: name of the existing resource
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        ram:
+                          description: ram is the memory of the flavor, measured in MB.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        vcpus:
+                          description: vcpus is the number of vcpus for the flavor.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                      type: object
+                    id:
+                      description: |-
+                        id contains the unique identifier of an existing OpenStack resource. Note
+                        that when specifying an import by ID, the resource MUST already exist.
+                        The ORC object will enter an error state if the resource does not exist.
+                      format: uuid
+                      type: string
+                  type: object
+                managedOptions:
+                  description: managedOptions specifies options which may be applied to managed objects.
+                  properties:
+                    onDelete:
+                      default: delete
+                      description: |-
+                        onDelete specifies the behaviour of the controller when the ORC
+                        object is deleted. Options are `delete` - delete the OpenStack resource;
+                        `detach` - do not delete the OpenStack resource. If not specified, the
+                        default is `delete`.
+                      enum:
+                        - delete
+                        - detach
+                      type: string
+                  type: object
+                managementPolicy:
+                  default: managed
+                  description: |-
+                    managementPolicy defines how ORC will treat the object. Valid values are
+                    `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                    ORC will import an existing resource, and will not apply updates to it or
+                    delete it.
+                  enum:
+                    - managed
+                    - unmanaged
+                  type: string
+                  x-kubernetes-validations:
+                    - message: managementPolicy is immutable
+                      rule: self == oldSelf
+                resource:
+                  description: |-
+                    resource specifies the desired state of the resource.
+
+                    resource may not be specified if the management policy is `unmanaged`.
+
+                    resource must be specified if the management policy is `managed`.
+                  properties:
+                    description:
+                      description: description contains a free form description of the flavor.
+                      maxLength: 65535
+                      minLength: 1
+                      type: string
+                    disk:
+                      description: |-
+                        disk is the size of the root disk that will be created in GiB. If 0
+                        the root disk will be set to exactly the size of the image used to
+                        deploy the instance. However, in this case the scheduler cannot
+                        select the compute host based on the virtual image size. Therefore,
+                        0 should only be used for volume booted instances or for testing
+                        purposes. Volume-backed instances can be enforced for flavors with
+                        zero root disk via the
+                        os_compute_api:servers:create:zero_disk_flavor policy rule.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    ephemeral:
+                      description: |-
+                        ephemeral is the size of the ephemeral disk that will be created, in GiB.
+                        Ephemeral disks may be written over on server state changes. So should only
+                        be used as a scratch space for applications that are aware of its
+                        limitations. Defaults to 0.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    isPublic:
+                      description: isPublic flags a flavor as being available to all projects or not.
+                      type: boolean
+                    name:
+                      description: |-
+                        name will be the name of the created resource. If not specified, the
+                        name of the ORC object will be used.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[^,]+$
+                      type: string
+                    ram:
+                      description: ram is the memory of the flavor, measured in MB.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    swap:
+                      description: |-
+                        swap is the size of a dedicated swap disk that will be allocated, in
+                        MiB. If 0 (the default), no dedicated swap disk will be created.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    vcpus:
+                      description: vcpus is the number of vcpus for the flavor.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                  required:
+                    - disk
+                    - ram
+                    - vcpus
+                  type: object
+                  x-kubernetes-validations:
+                    - message: FlavorResourceSpec is immutable
+                      rule: self == oldSelf
+              required:
+                - cloudCredentialsRef
+              type: object
+              x-kubernetes-validations:
+                - message: resource must be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+                - message: import may not be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__) : true'
+                - message: resource may not be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource) : true'
+                - message: import must be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__) : true'
+                - message: managedOptions may only be provided when policy is managed
+                  rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed'' : true'
+            status:
+              description: status defines the observed state of the resource.
+              properties:
+                conditions:
+                  description: |-
+                    conditions represents the observed status of the object.
+                    Known .status.conditions.type are: "Available", "Progressing"
+
+                    Available represents the availability of the OpenStack resource. If it is
+                    true then the resource is ready for use.
+
+                    Progressing indicates whether the controller is still attempting to
+                    reconcile the current state of the OpenStack resource to the desired
+                    state. Progressing will be False either because the desired state has
+                    been achieved, or because some terminal error prevents it from ever being
+                    achieved and the controller is no longer attempting to reconcile. If
+                    Progressing is True, an observer waiting on the resource should continue
+                    to wait.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                id:
+                  description: id is the unique identifier of the OpenStack resource.
+                  type: string
+                resource:
+                  description: resource contains the observed state of the OpenStack resource.
+                  properties:
+                    description:
+                      description: description is a human-readable description for the resource.
+                      maxLength: 65535
+                      type: string
+                    disk:
+                      description: disk is the size of the root disk that will be created in GiB.
+                      format: int32
+                      type: integer
+                    ephemeral:
+                      description: ephemeral is the size of the ephemeral disk, in GiB.
+                      format: int32
+                      type: integer
+                    isPublic:
+                      description: isPublic flags a flavor as being available to all projects or not.
+                      type: boolean
+                    name:
+                      description: name is a Human-readable name for the flavor. Might not be unique.
+                      maxLength: 1024
+                      type: string
+                    ram:
+                      description: ram is the memory of the flavor, measured in MB.
+                      format: int32
+                      type: integer
+                    swap:
+                      description: |-
+                        swap is the size of a dedicated swap disk that will be allocated, in
+                        MiB.
+                      format: int32
+                      type: integer
+                    vcpus:
+                      description: vcpus is the number of vcpus for the flavor.
+                      format: int32
+                      type: integer
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -393,722 +368,689 @@ spec:
   group: openstack.k-orc.cloud
   names:
     categories:
-    - openstack
+      - openstack
     kind: Image
     listKind: ImageList
     plural: images
     singular: image
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Resource ID
-      jsonPath: .status.id
-      name: ID
-      type: string
-    - description: Availability status of resource
-      jsonPath: .status.conditions[?(@.type=='Available')].status
-      name: Available
-      type: string
-    - description: Message describing current progress status
-      jsonPath: .status.conditions[?(@.type=='Progressing')].message
-      name: Message
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Image is the Schema for an ORC resource.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec specifies the desired state of the resource.
-            properties:
-              cloudCredentialsRef:
-                description: cloudCredentialsRef points to a secret containing OpenStack
-                  credentials
-                properties:
-                  cloudName:
-                    description: cloudName specifies the name of the entry in the
-                      clouds.yaml file to use.
-                    maxLength: 256
-                    minLength: 1
-                    type: string
-                  secretName:
-                    description: |-
-                      secretName is the name of a secret in the same namespace as the resource being provisioned.
-                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
-                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                required:
-                - cloudName
-                - secretName
-                type: object
-              import:
-                description: |-
-                  import refers to an existing OpenStack resource which will be imported instead of
-                  creating a new one.
-                maxProperties: 1
-                minProperties: 1
-                properties:
-                  filter:
-                    description: |-
-                      filter contains a resource query which is expected to return a single
-                      result. The controller will continue to retry if filter returns no
-                      results. If filter returns multiple results the controller will set an
-                      error state and will not continue to retry.
-                    minProperties: 1
-                    properties:
-                      name:
-                        description: name specifies the name of a Glance image
-                        maxLength: 255
-                        minLength: 1
-                        pattern: ^[^,]+$
-                        type: string
-                      tags:
-                        description: tags is the list of tags on the resource.
-                        items:
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                    type: object
-                  id:
-                    description: |-
-                      id contains the unique identifier of an existing OpenStack resource. Note
-                      that when specifying an import by ID, the resource MUST already exist.
-                      The ORC object will enter an error state if the resource does not exist.
-                    format: uuid
-                    type: string
-                type: object
-              managedOptions:
-                description: managedOptions specifies options which may be applied
-                  to managed objects.
-                properties:
-                  onDelete:
-                    default: delete
-                    description: |-
-                      onDelete specifies the behaviour of the controller when the ORC
-                      object is deleted. Options are `delete` - delete the OpenStack resource;
-                      `detach` - do not delete the OpenStack resource. If not specified, the
-                      default is `delete`.
-                    enum:
-                    - delete
-                    - detach
-                    type: string
-                type: object
-              managementPolicy:
-                default: managed
-                description: |-
-                  managementPolicy defines how ORC will treat the object. Valid values are
-                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
-                  ORC will import an existing resource, and will not apply updates to it or
-                  delete it.
-                enum:
-                - managed
-                - unmanaged
-                type: string
-                x-kubernetes-validations:
-                - message: managementPolicy is immutable
-                  rule: self == oldSelf
-              resource:
-                description: |-
-                  resource specifies the desired state of the resource.
-
-                  resource may not be specified if the management policy is `unmanaged`.
-
-                  resource must be specified if the management policy is `managed`.
-                properties:
-                  content:
-                    description: content specifies how to obtain the image content.
-                    properties:
-                      containerFormat:
-                        default: bare
-                        description: |-
-                          containerFormat is the format of the image container.
-                          qcow2 and raw images do not usually have a container. This is specified as "bare", which is also the default.
-                          Permitted values are ami, ari, aki, bare, compressed, ovf, ova, and docker.
-                        enum:
-                        - ami
-                        - ari
-                        - aki
-                        - bare
-                        - ovf
-                        - ova
-                        - docker
-                        - compressed
-                        type: string
-                      diskFormat:
-                        description: |-
-                          diskFormat is the format of the disk image.
-                          Normal values are "qcow2", or "raw". Glance may be configured to support others.
-                        enum:
-                        - ami
-                        - ari
-                        - aki
-                        - vhd
-                        - vhdx
-                        - vmdk
-                        - raw
-                        - qcow2
-                        - vdi
-                        - ploop
-                        - iso
-                        type: string
-                      download:
-                        description: |-
-                          download describes how to obtain image data by downloading it from a URL.
-                          Must be set when creating a managed image.
-                        properties:
-                          decompress:
-                            description: |-
-                              decompress specifies that the source data must be decompressed with the
-                              given compression algorithm before being stored. Specifying Decompress
-                              will disable the use of Glance's web-download, as web-download cannot
-                              currently deterministically decompress downloaded content.
-                            enum:
-                            - xz
-                            - gz
-                            - bz2
-                            type: string
-                          hash:
-                            description: |-
-                              hash is a hash which will be used to verify downloaded data, i.e.
-                              before any decompression. If not specified, no hash verification will be
-                              performed. Specifying a Hash will disable the use of Glance's
-                              web-download, as web-download cannot currently deterministically verify
-                              the hash of downloaded content.
-                            properties:
-                              algorithm:
-                                description: algorithm is the hash algorithm used
-                                  to generate value.
-                                enum:
-                                - md5
-                                - sha1
-                                - sha256
-                                - sha512
-                                type: string
-                              value:
-                                description: value is the hash of the image data using
-                                  Algorithm. It must be hex encoded using lowercase
-                                  letters.
-                                maxLength: 1024
-                                minLength: 1
-                                pattern: ^[0-9a-f]+$
-                                type: string
-                            required:
-                            - algorithm
-                            - value
-                            type: object
-                            x-kubernetes-validations:
-                            - message: hash is immutable
-                              rule: self == oldSelf
-                          url:
-                            description: url containing image data
-                            format: uri
-                            maxLength: 2048
-                            type: string
-                        required:
-                        - url
-                        type: object
-                    required:
-                    - diskFormat
-                    - download
-                    type: object
-                    x-kubernetes-validations:
-                    - message: content is immutable
-                      rule: self == oldSelf
-                  name:
-                    description: |-
-                      name will be the name of the created Glance image. If not specified, the
-                      name of the Image object will be used.
-                    maxLength: 255
-                    minLength: 1
-                    pattern: ^[^,]+$
-                    type: string
+    - additionalPrinterColumns:
+        - description: Resource ID
+          jsonPath: .status.id
+          name: ID
+          type: string
+        - description: Availability status of resource
+          jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: Available
+          type: string
+        - description: Message describing current progress status
+          jsonPath: .status.conditions[?(@.type=='Progressing')].message
+          name: Message
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Image is the Schema for an ORC resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec specifies the desired state of the resource.
+              properties:
+                cloudCredentialsRef:
+                  description: cloudCredentialsRef points to a secret containing OpenStack credentials
                   properties:
-                    description: properties is metadata available to consumers of
-                      the image
-                    properties:
-                      architecture:
-                        description: architecture is the CPU architecture that must
-                          be supported by the hypervisor.
-                        enum:
-                        - aarch64
-                        - alpha
-                        - armv7l
-                        - cris
-                        - i686
-                        - ia64
-                        - lm32
-                        - m68k
-                        - microblaze
-                        - microblazeel
-                        - mips
-                        - mipsel
-                        - mips64
-                        - mips64el
-                        - openrisc
-                        - parisc
-                        - parisc64
-                        - ppc
-                        - ppc64
-                        - ppcemb
-                        - s390
-                        - s390x
-                        - sh4
-                        - sh4eb
-                        - sparc
-                        - sparc64
-                        - unicore32
-                        - x86_64
-                        - xtensa
-                        - xtensaeb
-                        type: string
-                      hardware:
-                        description: |-
-                          hardware is a set of properties which control the virtual hardware
-                          created by Nova.
-                        properties:
-                          cdromBus:
-                            description: cdromBus specifies the type of disk controller
-                              to attach CD-ROM devices to.
-                            enum:
-                            - scsi
-                            - virtio
-                            - uml
-                            - xen
-                            - ide
-                            - usb
-                            - lxc
-                            type: string
-                          cpuCores:
-                            description: cpuCores is the preferred number of cores
-                              to expose to the guest
-                            format: int32
-                            minimum: 1
-                            type: integer
-                          cpuPolicy:
-                            description: |-
-                              cpuPolicy is used to pin the virtual CPUs (vCPUs) of instances to the
-                              host's physical CPU cores (pCPUs). Host aggregates should be used to
-                              separate these pinned instances from unpinned instances as the latter
-                              will not respect the resourcing requirements of the former.
-
-                              Permitted values are shared (the default), and dedicated.
-
-                              shared: The guest vCPUs will be allowed to freely float across host
-                              pCPUs, albeit potentially constrained by NUMA policy.
-
-                              dedicated: The guest vCPUs will be strictly pinned to a set of host
-                              pCPUs. In the absence of an explicit vCPU topology request, the
-                              drivers typically expose all vCPUs as sockets with one core and one
-                              thread. When strict CPU pinning is in effect the guest CPU topology
-                              will be setup to match the topology of the CPUs to which it is
-                              pinned. This option implies an overcommit ratio of 1.0. For example,
-                              if a two vCPU guest is pinned to a single host core with two threads,
-                              then the guest will get a topology of one socket, one core, two
-                              threads.
-                            enum:
-                            - shared
-                            - dedicated
-                            type: string
-                          cpuSockets:
-                            description: cpuSockets is the preferred number of sockets
-                              to expose to the guest
-                            format: int32
-                            minimum: 1
-                            type: integer
-                          cpuThreadPolicy:
-                            description: |-
-                              cpuThreadPolicy further refines a CPUPolicy of 'dedicated' by stating
-                              how hardware CPU threads in a simultaneous multithreading-based (SMT)
-                              architecture be used. SMT-based architectures include Intel
-                              processors with Hyper-Threading technology. In these architectures,
-                              processor cores share a number of components with one or more other
-                              cores. Cores in such architectures are commonly referred to as
-                              hardware threads, while the cores that a given core share components
-                              with are known as thread siblings.
-
-                              Permitted values are prefer (the default), isolate, and require.
-
-                              prefer: The host may or may not have an SMT architecture. Where an
-                              SMT architecture is present, thread siblings are preferred.
-
-                              isolate: The host must not have an SMT architecture or must emulate a
-                              non-SMT architecture. If the host does not have an SMT architecture,
-                              each vCPU is placed on a different core as expected. If the host does
-                              have an SMT architecture - that is, one or more cores have thread
-                              siblings - then each vCPU is placed on a different physical core. No
-                              vCPUs from other guests are placed on the same core. All but one
-                              thread sibling on each utilized core is therefore guaranteed to be
-                              unusable.
-
-                              require: The host must have an SMT architecture. Each vCPU is
-                              allocated on thread siblings. If the host does not have an SMT
-                              architecture, then it is not used. If the host has an SMT
-                              architecture, but not enough cores with free thread siblings are
-                              available, then scheduling fails.
-                            enum:
-                            - prefer
-                            - isolate
-                            - require
-                            type: string
-                          cpuThreads:
-                            description: cpuThreads is the preferred number of threads
-                              to expose to the guest
-                            format: int32
-                            minimum: 1
-                            type: integer
-                          diskBus:
-                            description: diskBus specifies the type of disk controller
-                              to attach disk devices to.
-                            enum:
-                            - scsi
-                            - virtio
-                            - uml
-                            - xen
-                            - ide
-                            - usb
-                            - lxc
-                            type: string
-                          qemuGuestAgent:
-                            description: qemuGuestAgent enables QEMU guest agent.
-                            type: boolean
-                          rngModel:
-                            description: |-
-                              rngModel adds a random-number generator device to the image’s instances.
-                              This image property by itself does not guarantee that a hardware RNG will be used;
-                              it expresses a preference that may or may not be satisfied depending upon Nova configuration.
-                            maxLength: 255
-                            type: string
-                          scsiModel:
-                            description: |-
-                              scsiModel enables the use of VirtIO SCSI (virtio-scsi) to provide
-                              block device access for compute instances; by default, instances use
-                              VirtIO Block (virtio-blk). VirtIO SCSI is a para-virtualized SCSI
-                              controller device that provides improved scalability and performance,
-                              and supports advanced SCSI hardware.
-
-                              The only permitted value is virtio-scsi.
-                            enum:
-                            - virtio-scsi
-                            type: string
-                          vifModel:
-                            description: |-
-                              vifModel specifies the model of virtual network interface device to use.
-
-                              Permitted values are e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio,
-                              and vmxnet3.
-                            enum:
-                            - e1000
-                            - e1000e
-                            - ne2k_pci
-                            - pcnet
-                            - rtl8139
-                            - virtio
-                            - vmxnet3
-                            type: string
-                        type: object
-                      hypervisorType:
-                        description: hypervisorType is the hypervisor type
-                        enum:
-                        - hyperv
-                        - ironic
-                        - lxc
-                        - qemu
-                        - uml
-                        - vmware
-                        - xen
-                        type: string
-                      minDiskGB:
-                        description: minDiskGB is the minimum amount of disk space
-                          in GB that is required to boot the image
-                        format: int32
-                        minimum: 1
-                        type: integer
-                      minMemoryMB:
-                        description: minMemoryMB is the minimum amount of RAM in MB
-                          that is required to boot the image.
-                        format: int32
-                        minimum: 1
-                        type: integer
-                      operatingSystem:
-                        description: |-
-                          operatingSystem is a set of properties that specify and influence the behavior
-                          of the operating system within the virtual machine.
-                        properties:
-                          distro:
-                            description: distro is the common name of the operating
-                              system distribution in lowercase.
-                            enum:
-                            - arch
-                            - centos
-                            - debian
-                            - fedora
-                            - freebsd
-                            - gentoo
-                            - mandrake
-                            - mandriva
-                            - mes
-                            - msdos
-                            - netbsd
-                            - netware
-                            - openbsd
-                            - opensolaris
-                            - opensuse
-                            - rocky
-                            - rhel
-                            - sled
-                            - ubuntu
-                            - windows
-                            type: string
-                          version:
-                            description: version is the operating system version as
-                              specified by the distributor.
-                            maxLength: 255
-                            type: string
-                        type: object
-                    type: object
-                  protected:
-                    description: |-
-                      protected specifies that the image is protected from deletion.
-                      If not specified, the default is false.
-                    type: boolean
-                  tags:
-                    description: tags is a list of tags which will be applied to the
-                      image. A tag has a maximum length of 255 characters.
-                    items:
-                      maxLength: 255
+                    cloudName:
+                      description: cloudName specifies the name of the entry in the clouds.yaml file to use.
+                      maxLength: 256
                       minLength: 1
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: set
-                  visibility:
-                    description: visibility of the image
-                    enum:
-                    - public
-                    - private
-                    - shared
-                    - community
-                    type: string
-                    x-kubernetes-validations:
-                    - message: visibility is immutable
-                      rule: self == oldSelf
-                type: object
-                x-kubernetes-validations:
-                - message: name is immutable
-                  rule: 'has(self.name) ? self.name == oldSelf.name : !has(oldSelf.name)'
-                - message: name is immutable
-                  rule: 'has(self.protected) ? self.protected == oldSelf.protected
-                    : !has(oldSelf.protected)'
-                - message: tags is immutable
-                  rule: 'has(self.tags) ? self.tags == oldSelf.tags : !has(oldSelf.tags)'
-                - message: visibility is immutable
-                  rule: 'has(self.visibility) ? self.visibility == oldSelf.visibility
-                    : !has(oldSelf.visibility)'
-                - message: properties is immutable
-                  rule: 'has(self.properties) ? self.properties == oldSelf.properties
-                    : !has(oldSelf.properties)'
-                - message: ImageResourceSpec is immutable
-                  rule: self == oldSelf
-            required:
-            - cloudCredentialsRef
-            type: object
-            x-kubernetes-validations:
-            - message: resource must be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
-            - message: import may not be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
-                : true'
-            - message: resource may not be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
-                : true'
-            - message: import must be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
-                : true'
-            - message: managedOptions may only be provided when policy is managed
-              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
-                : true'
-            - message: resource content must be specified when not importing
-              rule: '!has(self.__import__) ? has(self.resource.content) : true'
-          status:
-            description: status defines the observed state of the resource.
-            properties:
-              conditions:
-                description: |-
-                  conditions represents the observed status of the object.
-                  Known .status.conditions.type are: "Available", "Progressing"
-
-                  Available represents the availability of the OpenStack resource. If it is
-                  true then the resource is ready for use.
-
-                  Progressing indicates whether the controller is still attempting to
-                  reconcile the current state of the OpenStack resource to the desired
-                  state. Progressing will be False either because the desired state has
-                  been achieved, or because some terminal error prevents it from ever being
-                  achieved and the controller is no longer attempting to reconcile. If
-                  Progressing is True, an observer waiting on the resource should continue
-                  to wait.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
+                    secretName:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
+                        secretName is the name of a secret in the same namespace as the resource being provisioned.
+                        The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                        The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                      maxLength: 253
                       minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - cloudName
+                    - secretName
                   type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              downloadAttempts:
-                description: downloadAttempts is the number of times the controller
-                  has attempted to download the image contents
-                format: int32
-                type: integer
-              id:
-                description: id is the unique identifier of the OpenStack resource.
-                type: string
-              resource:
-                description: resource contains the observed state of the OpenStack
-                  resource.
-                properties:
-                  hash:
-                    description: |-
-                      hash is the hash of the image data published by Glance. Note that this is
-                      a hash of the data stored internally by Glance, which will have been
-                      decompressed and potentially format converted depending on server-side
-                      configuration which is not visible to clients. It is expected that this
-                      hash will usually differ from the download hash.
+                import:
+                  description: |-
+                    import refers to an existing OpenStack resource which will be imported instead of
+                    creating a new one.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: |-
+                        filter contains a resource query which is expected to return a single
+                        result. The controller will continue to retry if filter returns no
+                        results. If filter returns multiple results the controller will set an
+                        error state and will not continue to retry.
+                      minProperties: 1
+                      properties:
+                        name:
+                          description: name specifies the name of a Glance image
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        tags:
+                          description: tags is the list of tags on the resource.
+                          items:
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                      type: object
+                    id:
+                      description: |-
+                        id contains the unique identifier of an existing OpenStack resource. Note
+                        that when specifying an import by ID, the resource MUST already exist.
+                        The ORC object will enter an error state if the resource does not exist.
+                      format: uuid
+                      type: string
+                  type: object
+                managedOptions:
+                  description: managedOptions specifies options which may be applied to managed objects.
+                  properties:
+                    onDelete:
+                      default: delete
+                      description: |-
+                        onDelete specifies the behaviour of the controller when the ORC
+                        object is deleted. Options are `delete` - delete the OpenStack resource;
+                        `detach` - do not delete the OpenStack resource. If not specified, the
+                        default is `delete`.
+                      enum:
+                        - delete
+                        - detach
+                      type: string
+                  type: object
+                managementPolicy:
+                  default: managed
+                  description: |-
+                    managementPolicy defines how ORC will treat the object. Valid values are
+                    `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                    ORC will import an existing resource, and will not apply updates to it or
+                    delete it.
+                  enum:
+                    - managed
+                    - unmanaged
+                  type: string
+                  x-kubernetes-validations:
+                    - message: managementPolicy is immutable
+                      rule: self == oldSelf
+                resource:
+                  description: |-
+                    resource specifies the desired state of the resource.
+
+                    resource may not be specified if the management policy is `unmanaged`.
+
+                    resource must be specified if the management policy is `managed`.
+                  properties:
+                    content:
+                      description: content specifies how to obtain the image content.
+                      properties:
+                        containerFormat:
+                          default: bare
+                          description: |-
+                            containerFormat is the format of the image container.
+                            qcow2 and raw images do not usually have a container. This is specified as "bare", which is also the default.
+                            Permitted values are ami, ari, aki, bare, compressed, ovf, ova, and docker.
+                          enum:
+                            - ami
+                            - ari
+                            - aki
+                            - bare
+                            - ovf
+                            - ova
+                            - docker
+                            - compressed
+                          type: string
+                        diskFormat:
+                          description: |-
+                            diskFormat is the format of the disk image.
+                            Normal values are "qcow2", or "raw". Glance may be configured to support others.
+                          enum:
+                            - ami
+                            - ari
+                            - aki
+                            - vhd
+                            - vhdx
+                            - vmdk
+                            - raw
+                            - qcow2
+                            - vdi
+                            - ploop
+                            - iso
+                          type: string
+                        download:
+                          description: |-
+                            download describes how to obtain image data by downloading it from a URL.
+                            Must be set when creating a managed image.
+                          properties:
+                            decompress:
+                              description: |-
+                                decompress specifies that the source data must be decompressed with the
+                                given compression algorithm before being stored. Specifying Decompress
+                                will disable the use of Glance's web-download, as web-download cannot
+                                currently deterministically decompress downloaded content.
+                              enum:
+                                - xz
+                                - gz
+                                - bz2
+                              type: string
+                            hash:
+                              description: |-
+                                hash is a hash which will be used to verify downloaded data, i.e.
+                                before any decompression. If not specified, no hash verification will be
+                                performed. Specifying a Hash will disable the use of Glance's
+                                web-download, as web-download cannot currently deterministically verify
+                                the hash of downloaded content.
+                              properties:
+                                algorithm:
+                                  description: algorithm is the hash algorithm used to generate value.
+                                  enum:
+                                    - md5
+                                    - sha1
+                                    - sha256
+                                    - sha512
+                                  type: string
+                                value:
+                                  description: value is the hash of the image data using Algorithm. It must be hex encoded using lowercase letters.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  pattern: ^[0-9a-f]+$
+                                  type: string
+                              required:
+                                - algorithm
+                                - value
+                              type: object
+                              x-kubernetes-validations:
+                                - message: hash is immutable
+                                  rule: self == oldSelf
+                            url:
+                              description: url containing image data
+                              format: uri
+                              maxLength: 2048
+                              type: string
+                          required:
+                            - url
+                          type: object
+                      required:
+                        - diskFormat
+                        - download
+                      type: object
+                      x-kubernetes-validations:
+                        - message: content is immutable
+                          rule: self == oldSelf
+                    name:
+                      description: |-
+                        name will be the name of the created Glance image. If not specified, the
+                        name of the Image object will be used.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[^,]+$
+                      type: string
                     properties:
-                      algorithm:
-                        description: algorithm is the hash algorithm used to generate
-                          value.
-                        enum:
-                        - md5
-                        - sha1
-                        - sha256
-                        - sha512
+                      description: properties is metadata available to consumers of the image
+                      properties:
+                        architecture:
+                          description: architecture is the CPU architecture that must be supported by the hypervisor.
+                          enum:
+                            - aarch64
+                            - alpha
+                            - armv7l
+                            - cris
+                            - i686
+                            - ia64
+                            - lm32
+                            - m68k
+                            - microblaze
+                            - microblazeel
+                            - mips
+                            - mipsel
+                            - mips64
+                            - mips64el
+                            - openrisc
+                            - parisc
+                            - parisc64
+                            - ppc
+                            - ppc64
+                            - ppcemb
+                            - s390
+                            - s390x
+                            - sh4
+                            - sh4eb
+                            - sparc
+                            - sparc64
+                            - unicore32
+                            - x86_64
+                            - xtensa
+                            - xtensaeb
+                          type: string
+                        hardware:
+                          description: |-
+                            hardware is a set of properties which control the virtual hardware
+                            created by Nova.
+                          properties:
+                            cdromBus:
+                              description: cdromBus specifies the type of disk controller to attach CD-ROM devices to.
+                              enum:
+                                - scsi
+                                - virtio
+                                - uml
+                                - xen
+                                - ide
+                                - usb
+                                - lxc
+                              type: string
+                            cpuCores:
+                              description: cpuCores is the preferred number of cores to expose to the guest
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            cpuPolicy:
+                              description: |-
+                                cpuPolicy is used to pin the virtual CPUs (vCPUs) of instances to the
+                                host's physical CPU cores (pCPUs). Host aggregates should be used to
+                                separate these pinned instances from unpinned instances as the latter
+                                will not respect the resourcing requirements of the former.
+
+                                Permitted values are shared (the default), and dedicated.
+
+                                shared: The guest vCPUs will be allowed to freely float across host
+                                pCPUs, albeit potentially constrained by NUMA policy.
+
+                                dedicated: The guest vCPUs will be strictly pinned to a set of host
+                                pCPUs. In the absence of an explicit vCPU topology request, the
+                                drivers typically expose all vCPUs as sockets with one core and one
+                                thread. When strict CPU pinning is in effect the guest CPU topology
+                                will be setup to match the topology of the CPUs to which it is
+                                pinned. This option implies an overcommit ratio of 1.0. For example,
+                                if a two vCPU guest is pinned to a single host core with two threads,
+                                then the guest will get a topology of one socket, one core, two
+                                threads.
+                              enum:
+                                - shared
+                                - dedicated
+                              type: string
+                            cpuSockets:
+                              description: cpuSockets is the preferred number of sockets to expose to the guest
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            cpuThreadPolicy:
+                              description: |-
+                                cpuThreadPolicy further refines a CPUPolicy of 'dedicated' by stating
+                                how hardware CPU threads in a simultaneous multithreading-based (SMT)
+                                architecture be used. SMT-based architectures include Intel
+                                processors with Hyper-Threading technology. In these architectures,
+                                processor cores share a number of components with one or more other
+                                cores. Cores in such architectures are commonly referred to as
+                                hardware threads, while the cores that a given core share components
+                                with are known as thread siblings.
+
+                                Permitted values are prefer (the default), isolate, and require.
+
+                                prefer: The host may or may not have an SMT architecture. Where an
+                                SMT architecture is present, thread siblings are preferred.
+
+                                isolate: The host must not have an SMT architecture or must emulate a
+                                non-SMT architecture. If the host does not have an SMT architecture,
+                                each vCPU is placed on a different core as expected. If the host does
+                                have an SMT architecture - that is, one or more cores have thread
+                                siblings - then each vCPU is placed on a different physical core. No
+                                vCPUs from other guests are placed on the same core. All but one
+                                thread sibling on each utilized core is therefore guaranteed to be
+                                unusable.
+
+                                require: The host must have an SMT architecture. Each vCPU is
+                                allocated on thread siblings. If the host does not have an SMT
+                                architecture, then it is not used. If the host has an SMT
+                                architecture, but not enough cores with free thread siblings are
+                                available, then scheduling fails.
+                              enum:
+                                - prefer
+                                - isolate
+                                - require
+                              type: string
+                            cpuThreads:
+                              description: cpuThreads is the preferred number of threads to expose to the guest
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            diskBus:
+                              description: diskBus specifies the type of disk controller to attach disk devices to.
+                              enum:
+                                - scsi
+                                - virtio
+                                - uml
+                                - xen
+                                - ide
+                                - usb
+                                - lxc
+                              type: string
+                            qemuGuestAgent:
+                              description: qemuGuestAgent enables QEMU guest agent.
+                              type: boolean
+                            rngModel:
+                              description: |-
+                                rngModel adds a random-number generator device to the image’s instances.
+                                This image property by itself does not guarantee that a hardware RNG will be used;
+                                it expresses a preference that may or may not be satisfied depending upon Nova configuration.
+                              maxLength: 255
+                              type: string
+                            scsiModel:
+                              description: |-
+                                scsiModel enables the use of VirtIO SCSI (virtio-scsi) to provide
+                                block device access for compute instances; by default, instances use
+                                VirtIO Block (virtio-blk). VirtIO SCSI is a para-virtualized SCSI
+                                controller device that provides improved scalability and performance,
+                                and supports advanced SCSI hardware.
+
+                                The only permitted value is virtio-scsi.
+                              enum:
+                                - virtio-scsi
+                              type: string
+                            vifModel:
+                              description: |-
+                                vifModel specifies the model of virtual network interface device to use.
+
+                                Permitted values are e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio,
+                                and vmxnet3.
+                              enum:
+                                - e1000
+                                - e1000e
+                                - ne2k_pci
+                                - pcnet
+                                - rtl8139
+                                - virtio
+                                - vmxnet3
+                              type: string
+                          type: object
+                        hypervisorType:
+                          description: hypervisorType is the hypervisor type
+                          enum:
+                            - hyperv
+                            - ironic
+                            - lxc
+                            - qemu
+                            - uml
+                            - vmware
+                            - xen
+                          type: string
+                        minDiskGB:
+                          description: minDiskGB is the minimum amount of disk space in GB that is required to boot the image
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        minMemoryMB:
+                          description: minMemoryMB is the minimum amount of RAM in MB that is required to boot the image.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        operatingSystem:
+                          description: |-
+                            operatingSystem is a set of properties that specify and influence the behavior
+                            of the operating system within the virtual machine.
+                          properties:
+                            distro:
+                              description: distro is the common name of the operating system distribution in lowercase.
+                              enum:
+                                - arch
+                                - centos
+                                - debian
+                                - fedora
+                                - freebsd
+                                - gentoo
+                                - mandrake
+                                - mandriva
+                                - mes
+                                - msdos
+                                - netbsd
+                                - netware
+                                - openbsd
+                                - opensolaris
+                                - opensuse
+                                - rocky
+                                - rhel
+                                - sled
+                                - ubuntu
+                                - windows
+                              type: string
+                            version:
+                              description: version is the operating system version as specified by the distributor.
+                              maxLength: 255
+                              type: string
+                          type: object
+                      type: object
+                    protected:
+                      description: |-
+                        protected specifies that the image is protected from deletion.
+                        If not specified, the default is false.
+                      type: boolean
+                    tags:
+                      description: tags is a list of tags which will be applied to the image. A tag has a maximum length of 255 characters.
+                      items:
+                        maxLength: 255
+                        minLength: 1
                         type: string
-                      value:
-                        description: value is the hash of the image data using Algorithm.
-                          It must be hex encoded using lowercase letters.
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: set
+                    visibility:
+                      description: visibility of the image
+                      enum:
+                        - public
+                        - private
+                        - shared
+                        - community
+                      type: string
+                      x-kubernetes-validations:
+                        - message: visibility is immutable
+                          rule: self == oldSelf
+                  type: object
+                  x-kubernetes-validations:
+                    - message: name is immutable
+                      rule: 'has(self.name) ? self.name == oldSelf.name : !has(oldSelf.name)'
+                    - message: name is immutable
+                      rule: 'has(self.protected) ? self.protected == oldSelf.protected : !has(oldSelf.protected)'
+                    - message: tags is immutable
+                      rule: 'has(self.tags) ? self.tags == oldSelf.tags : !has(oldSelf.tags)'
+                    - message: visibility is immutable
+                      rule: 'has(self.visibility) ? self.visibility == oldSelf.visibility : !has(oldSelf.visibility)'
+                    - message: properties is immutable
+                      rule: 'has(self.properties) ? self.properties == oldSelf.properties : !has(oldSelf.properties)'
+                    - message: ImageResourceSpec is immutable
+                      rule: self == oldSelf
+              required:
+                - cloudCredentialsRef
+              type: object
+              x-kubernetes-validations:
+                - message: resource must be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+                - message: import may not be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__) : true'
+                - message: resource may not be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource) : true'
+                - message: import must be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__) : true'
+                - message: managedOptions may only be provided when policy is managed
+                  rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed'' : true'
+                - message: resource content must be specified when not importing
+                  rule: '!has(self.__import__) ? has(self.resource.content) : true'
+            status:
+              description: status defines the observed state of the resource.
+              properties:
+                conditions:
+                  description: |-
+                    conditions represents the observed status of the object.
+                    Known .status.conditions.type are: "Available", "Progressing"
+
+                    Available represents the availability of the OpenStack resource. If it is
+                    true then the resource is ready for use.
+
+                    Progressing indicates whether the controller is still attempting to
+                    reconcile the current state of the OpenStack resource to the desired
+                    state. Progressing will be False either because the desired state has
+                    been achieved, or because some terminal error prevents it from ever being
+                    achieved and the controller is no longer attempting to reconcile. If
+                    Progressing is True, an observer waiting on the resource should continue
+                    to wait.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
                         maxLength: 1024
                         minLength: 1
-                        pattern: ^[0-9a-f]+$
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
-                    - algorithm
-                    - value
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
                     type: object
-                  name:
-                    description: name is a Human-readable name for the image. Might
-                      not be unique.
-                    maxLength: 1024
-                    type: string
-                  protected:
-                    description: protected specifies that the image is protected from
-                      deletion.
-                    type: boolean
-                  sizeB:
-                    description: sizeB is the size of the image data, in bytes
-                    format: int64
-                    type: integer
-                  status:
-                    description: status is the image status as reported by Glance
-                    maxLength: 1024
-                    type: string
-                  tags:
-                    description: tags is the list of tags on the resource.
-                    items:
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                downloadAttempts:
+                  description: downloadAttempts is the number of times the controller has attempted to download the image contents
+                  format: int32
+                  type: integer
+                id:
+                  description: id is the unique identifier of the OpenStack resource.
+                  type: string
+                resource:
+                  description: resource contains the observed state of the OpenStack resource.
+                  properties:
+                    hash:
+                      description: |-
+                        hash is the hash of the image data published by Glance. Note that this is
+                        a hash of the data stored internally by Glance, which will have been
+                        decompressed and potentially format converted depending on server-side
+                        configuration which is not visible to clients. It is expected that this
+                        hash will usually differ from the download hash.
+                      properties:
+                        algorithm:
+                          description: algorithm is the hash algorithm used to generate value.
+                          enum:
+                            - md5
+                            - sha1
+                            - sha256
+                            - sha512
+                          type: string
+                        value:
+                          description: value is the hash of the image data using Algorithm. It must be hex encoded using lowercase letters.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[0-9a-f]+$
+                          type: string
+                      required:
+                        - algorithm
+                        - value
+                      type: object
+                    name:
+                      description: name is a Human-readable name for the image. Might not be unique.
                       maxLength: 1024
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  virtualSizeB:
-                    description: virtualSizeB is the size of the disk the image data
-                      represents, in bytes
-                    format: int64
-                    type: integer
-                  visibility:
-                    description: visibility of the image
-                    maxLength: 1024
-                    type: string
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    protected:
+                      description: protected specifies that the image is protected from deletion.
+                      type: boolean
+                    sizeB:
+                      description: sizeB is the size of the image data, in bytes
+                      format: int64
+                      type: integer
+                    status:
+                      description: status is the image status as reported by Glance
+                      maxLength: 1024
+                      type: string
+                    tags:
+                      description: tags is the list of tags on the resource.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    virtualSizeB:
+                      description: virtualSizeB is the size of the disk the image data represents, in bytes
+                      format: int64
+                      type: integer
+                    visibility:
+                      description: visibility of the image
+                      maxLength: 1024
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1121,522 +1063,505 @@ spec:
   group: openstack.k-orc.cloud
   names:
     categories:
-    - openstack
+      - openstack
     kind: Network
     listKind: NetworkList
     plural: networks
     singular: network
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Resource ID
-      jsonPath: .status.id
-      name: ID
-      type: string
-    - description: Availability status of resource
-      jsonPath: .status.conditions[?(@.type=='Available')].status
-      name: Available
-      type: string
-    - description: Message describing current progress status
-      jsonPath: .status.conditions[?(@.type=='Progressing')].message
-      name: Message
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Network is the Schema for an ORC resource.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec specifies the desired state of the resource.
-            properties:
-              cloudCredentialsRef:
-                description: cloudCredentialsRef points to a secret containing OpenStack
-                  credentials
-                properties:
-                  cloudName:
-                    description: cloudName specifies the name of the entry in the
-                      clouds.yaml file to use.
-                    maxLength: 256
-                    minLength: 1
-                    type: string
-                  secretName:
-                    description: |-
-                      secretName is the name of a secret in the same namespace as the resource being provisioned.
-                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
-                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                required:
-                - cloudName
-                - secretName
-                type: object
-              import:
-                description: |-
-                  import refers to an existing OpenStack resource which will be imported instead of
-                  creating a new one.
-                maxProperties: 1
-                minProperties: 1
-                properties:
-                  filter:
-                    description: |-
-                      filter contains a resource query which is expected to return a single
-                      result. The controller will continue to retry if filter returns no
-                      results. If filter returns multiple results the controller will set an
-                      error state and will not continue to retry.
-                    minProperties: 1
-                    properties:
-                      description:
-                        description: description of the existing resource
-                        maxLength: 255
-                        minLength: 1
-                        type: string
-                      external:
-                        description: |-
-                          external indicates whether the network has an external routing
-                          facility that’s not managed by the networking service.
-                        type: boolean
-                      name:
-                        description: name of the existing resource
-                        maxLength: 255
-                        minLength: 1
-                        pattern: ^[^,]+$
-                        type: string
-                      notTags:
-                        description: |-
-                          notTags is a list of tags to filter by. If specified, resources which
-                          contain all of the given tags will be excluded from the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      notTagsAny:
-                        description: |-
-                          notTagsAny is a list of tags to filter by. If specified, resources
-                          which contain any of the given tags will be excluded from the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tags:
-                        description: |-
-                          tags is a list of tags to filter by. If specified, the resource must
-                          have all of the tags specified to be included in the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tagsAny:
-                        description: |-
-                          tagsAny is a list of tags to filter by. If specified, the resource
-                          must have at least one of the tags specified to be included in the
-                          result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                    type: object
-                  id:
-                    description: |-
-                      id contains the unique identifier of an existing OpenStack resource. Note
-                      that when specifying an import by ID, the resource MUST already exist.
-                      The ORC object will enter an error state if the resource does not exist.
-                    format: uuid
-                    type: string
-                type: object
-              managedOptions:
-                description: managedOptions specifies options which may be applied
-                  to managed objects.
-                properties:
-                  onDelete:
-                    default: delete
-                    description: |-
-                      onDelete specifies the behaviour of the controller when the ORC
-                      object is deleted. Options are `delete` - delete the OpenStack resource;
-                      `detach` - do not delete the OpenStack resource. If not specified, the
-                      default is `delete`.
-                    enum:
-                    - delete
-                    - detach
-                    type: string
-                type: object
-              managementPolicy:
-                default: managed
-                description: |-
-                  managementPolicy defines how ORC will treat the object. Valid values are
-                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
-                  ORC will import an existing resource, and will not apply updates to it or
-                  delete it.
-                enum:
-                - managed
-                - unmanaged
-                type: string
-                x-kubernetes-validations:
-                - message: managementPolicy is immutable
-                  rule: self == oldSelf
-              resource:
-                description: |-
-                  resource specifies the desired state of the resource.
-
-                  resource may not be specified if the management policy is `unmanaged`.
-
-                  resource must be specified if the management policy is `managed`.
-                properties:
-                  adminStateUp:
-                    description: adminStateUp is the administrative state of the network,
-                      which is up (true) or down (false)
-                    type: boolean
-                  availabilityZoneHints:
-                    description: availabilityZoneHints is the availability zone candidate
-                      for the network.
-                    items:
-                      maxLength: 255
-                      minLength: 1
-                      type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: set
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 255
-                    minLength: 1
-                    type: string
-                  dnsDomain:
-                    description: dnsDomain is the DNS domain of the network
-                    maxLength: 255
-                    minLength: 1
-                    pattern: ^[A-Za-z0-9]{1,63}(.[A-Za-z0-9-]{1,63})*(.[A-Za-z]{2,63})*.?$
-                    type: string
-                  external:
-                    description: |-
-                      external indicates whether the network has an external routing
-                      facility that’s not managed by the networking service.
-                    type: boolean
-                  mtu:
-                    description: |-
-                      mtu is the the maximum transmission unit value to address
-                      fragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.
-                      Defaults to 1500.
-                    format: int32
-                    maximum: 9216
-                    minimum: 68
-                    type: integer
-                  name:
-                    description: |-
-                      name will be the name of the created resource. If not specified, the
-                      name of the ORC object will be used.
-                    maxLength: 255
-                    minLength: 1
-                    pattern: ^[^,]+$
-                    type: string
-                  portSecurityEnabled:
-                    description: |-
-                      portSecurityEnabled is the port security status of the network.
-                      Valid values are enabled (true) and disabled (false). This value is
-                      used as the default value of port_security_enabled field of a newly
-                      created port.
-                    type: boolean
-                  shared:
-                    description: |-
-                      shared indicates whether this resource is shared across all
-                      projects. By default, only administrative users can change this
-                      value.
-                    type: boolean
-                  tags:
-                    description: tags is a list of tags which will be applied to the
-                      network.
-                    items:
-                      description: |-
-                        NeutronTag represents a tag on a Neutron resource.
-                        It may not be empty and may not contain commas.
-                      maxLength: 255
-                      minLength: 1
-                      type: string
-                    maxItems: 64
-                    type: array
-                    x-kubernetes-list-type: set
-                type: object
-                x-kubernetes-validations:
-                - message: NetworkResourceSpec is immutable
-                  rule: self == oldSelf
-            required:
-            - cloudCredentialsRef
-            type: object
-            x-kubernetes-validations:
-            - message: resource must be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
-            - message: import may not be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
-                : true'
-            - message: resource may not be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
-                : true'
-            - message: import must be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
-                : true'
-            - message: managedOptions may only be provided when policy is managed
-              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
-                : true'
-          status:
-            description: status defines the observed state of the resource.
-            properties:
-              conditions:
-                description: |-
-                  conditions represents the observed status of the object.
-                  Known .status.conditions.type are: "Available", "Progressing"
-
-                  Available represents the availability of the OpenStack resource. If it is
-                  true then the resource is ready for use.
-
-                  Progressing indicates whether the controller is still attempting to
-                  reconcile the current state of the OpenStack resource to the desired
-                  state. Progressing will be False either because the desired state has
-                  been achieved, or because some terminal error prevents it from ever being
-                  achieved and the controller is no longer attempting to reconcile. If
-                  Progressing is True, an observer waiting on the resource should continue
-                  to wait.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+    - additionalPrinterColumns:
+        - description: Resource ID
+          jsonPath: .status.id
+          name: ID
+          type: string
+        - description: Availability status of resource
+          jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: Available
+          type: string
+        - description: Message describing current progress status
+          jsonPath: .status.conditions[?(@.type=='Progressing')].message
+          name: Message
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Network is the Schema for an ORC resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec specifies the desired state of the resource.
+              properties:
+                cloudCredentialsRef:
+                  description: cloudCredentialsRef points to a secret containing OpenStack credentials
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
+                    cloudName:
+                      description: cloudName specifies the name of the entry in the clouds.yaml file to use.
+                      maxLength: 256
                       minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    secretName:
+                      description: |-
+                        secretName is the name of a secret in the same namespace as the resource being provisioned.
+                        The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                        The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                      maxLength: 253
+                      minLength: 1
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - cloudName
+                    - secretName
                   type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              id:
-                description: id is the unique identifier of the OpenStack resource.
-                type: string
-              resource:
-                description: resource contains the observed state of the OpenStack
-                  resource.
-                properties:
-                  adminStateUp:
-                    description: |-
-                      adminStateUp is the administrative state of the network,
-                      which is up (true) or down (false).
-                    type: boolean
-                  availabilityZoneHints:
-                    description: |-
-                      availabilityZoneHints is the availability zone candidate for the
-                      network.
-                    items:
-                      maxLength: 1024
+                import:
+                  description: |-
+                    import refers to an existing OpenStack resource which will be imported instead of
+                    creating a new one.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: |-
+                        filter contains a resource query which is expected to return a single
+                        result. The controller will continue to retry if filter returns no
+                        results. If filter returns multiple results the controller will set an
+                        error state and will not continue to retry.
+                      minProperties: 1
+                      properties:
+                        description:
+                          description: description of the existing resource
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        external:
+                          description: |-
+                            external indicates whether the network has an external routing
+                            facility that’s not managed by the networking service.
+                          type: boolean
+                        name:
+                          description: name of the existing resource
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        notTags:
+                          description: |-
+                            notTags is a list of tags to filter by. If specified, resources which
+                            contain all of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        notTagsAny:
+                          description: |-
+                            notTagsAny is a list of tags to filter by. If specified, resources
+                            which contain any of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tags:
+                          description: |-
+                            tags is a list of tags to filter by. If specified, the resource must
+                            have all of the tags specified to be included in the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tagsAny:
+                          description: |-
+                            tagsAny is a list of tags to filter by. If specified, the resource
+                            must have at least one of the tags specified to be included in the
+                            result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                      type: object
+                    id:
+                      description: |-
+                        id contains the unique identifier of an existing OpenStack resource. Note
+                        that when specifying an import by ID, the resource MUST already exist.
+                        The ORC object will enter an error state if the resource does not exist.
+                      format: uuid
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  createdAt:
-                    description: createdAt shows the date and time when the resource
-                      was created. The date and time stamp format is ISO 8601
-                    format: date-time
-                    type: string
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 1024
-                    type: string
-                  dnsDomain:
-                    description: dnsDomain is the DNS domain of the network
-                    maxLength: 1024
-                    type: string
-                  external:
-                    description: |-
-                      external defines whether the network may be used for creation of
-                      floating IPs. Only networks with this flag may be an external
-                      gateway for routers. The network must have an external routing
-                      facility that is not managed by the networking service. If the
-                      network is updated from external to internal the unused floating IPs
-                      of this network are automatically deleted when extension
-                      floatingip-autodelete-internal is present.
-                    type: boolean
-                  mtu:
-                    description: |-
-                      mtu is the the maximum transmission unit value to address
-                      fragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.
-                    format: int32
-                    type: integer
-                  name:
-                    description: name is a Human-readable name for the network. Might
-                      not be unique.
-                    maxLength: 1024
-                    type: string
-                  portSecurityEnabled:
-                    description: |-
-                      portSecurityEnabled is the port security status of the network.
-                      Valid values are enabled (true) and disabled (false). This value is
-                      used as the default value of port_security_enabled field of a newly
-                      created port.
-                    type: boolean
-                  projectID:
-                    description: projectID is the project owner of the network.
-                    maxLength: 1024
-                    type: string
-                  provider:
-                    description: provider contains provider-network properties.
+                  type: object
+                managedOptions:
+                  description: managedOptions specifies options which may be applied to managed objects.
+                  properties:
+                    onDelete:
+                      default: delete
+                      description: |-
+                        onDelete specifies the behaviour of the controller when the ORC
+                        object is deleted. Options are `delete` - delete the OpenStack resource;
+                        `detach` - do not delete the OpenStack resource. If not specified, the
+                        default is `delete`.
+                      enum:
+                        - delete
+                        - detach
+                      type: string
+                  type: object
+                managementPolicy:
+                  default: managed
+                  description: |-
+                    managementPolicy defines how ORC will treat the object. Valid values are
+                    `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                    ORC will import an existing resource, and will not apply updates to it or
+                    delete it.
+                  enum:
+                    - managed
+                    - unmanaged
+                  type: string
+                  x-kubernetes-validations:
+                    - message: managementPolicy is immutable
+                      rule: self == oldSelf
+                resource:
+                  description: |-
+                    resource specifies the desired state of the resource.
+
+                    resource may not be specified if the management policy is `unmanaged`.
+
+                    resource must be specified if the management policy is `managed`.
+                  properties:
+                    adminStateUp:
+                      description: adminStateUp is the administrative state of the network, which is up (true) or down (false)
+                      type: boolean
+                    availabilityZoneHints:
+                      description: availabilityZoneHints is the availability zone candidate for the network.
+                      items:
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: set
+                    description:
+                      description: description is a human-readable description for the resource.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    dnsDomain:
+                      description: dnsDomain is the DNS domain of the network
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[A-Za-z0-9]{1,63}(.[A-Za-z0-9-]{1,63})*(.[A-Za-z]{2,63})*.?$
+                      type: string
+                    external:
+                      description: |-
+                        external indicates whether the network has an external routing
+                        facility that’s not managed by the networking service.
+                      type: boolean
+                    mtu:
+                      description: |-
+                        mtu is the the maximum transmission unit value to address
+                        fragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.
+                        Defaults to 1500.
+                      format: int32
+                      maximum: 9216
+                      minimum: 68
+                      type: integer
+                    name:
+                      description: |-
+                        name will be the name of the created resource. If not specified, the
+                        name of the ORC object will be used.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[^,]+$
+                      type: string
+                    portSecurityEnabled:
+                      description: |-
+                        portSecurityEnabled is the port security status of the network.
+                        Valid values are enabled (true) and disabled (false). This value is
+                        used as the default value of port_security_enabled field of a newly
+                        created port.
+                      type: boolean
+                    shared:
+                      description: |-
+                        shared indicates whether this resource is shared across all
+                        projects. By default, only administrative users can change this
+                        value.
+                      type: boolean
+                    tags:
+                      description: tags is a list of tags which will be applied to the network.
+                      items:
+                        description: |-
+                          NeutronTag represents a tag on a Neutron resource.
+                          It may not be empty and may not contain commas.
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      maxItems: 64
+                      type: array
+                      x-kubernetes-list-type: set
+                  type: object
+                  x-kubernetes-validations:
+                    - message: NetworkResourceSpec is immutable
+                      rule: self == oldSelf
+              required:
+                - cloudCredentialsRef
+              type: object
+              x-kubernetes-validations:
+                - message: resource must be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+                - message: import may not be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__) : true'
+                - message: resource may not be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource) : true'
+                - message: import must be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__) : true'
+                - message: managedOptions may only be provided when policy is managed
+                  rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed'' : true'
+            status:
+              description: status defines the observed state of the resource.
+              properties:
+                conditions:
+                  description: |-
+                    conditions represents the observed status of the object.
+                    Known .status.conditions.type are: "Available", "Progressing"
+
+                    Available represents the availability of the OpenStack resource. If it is
+                    true then the resource is ready for use.
+
+                    Progressing indicates whether the controller is still attempting to
+                    reconcile the current state of the OpenStack resource to the desired
+                    state. Progressing will be False either because the desired state has
+                    been achieved, or because some terminal error prevents it from ever being
+                    achieved and the controller is no longer attempting to reconcile. If
+                    Progressing is True, an observer waiting on the resource should continue
+                    to wait.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
-                      networkType:
+                      lastTransitionTime:
                         description: |-
-                          networkType is the type of physical network that this
-                          network should be mapped to. Supported values are flat, vlan, vxlan, and gre.
-                          Valid values depend on the networking back-end.
-                        maxLength: 1024
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
                         type: string
-                      physicalNetwork:
+                      message:
                         description: |-
-                          physicalNetwork is the physical network where this network
-                          should be implemented. The Networking API v2.0 does not provide a
-                          way to list available physical networks. For example, the Open
-                          vSwitch plug-in configuration file defines a symbolic name that maps
-                          to specific bridges on each compute host.
-                        maxLength: 1024
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
                         type: string
-                      segmentationID:
+                      observedGeneration:
                         description: |-
-                          segmentationID is the ID of the isolated segment on the
-                          physical network. The network_type attribute defines the
-                          segmentation model. For example, if the network_type value is vlan,
-                          this ID is a vlan identifier. If the network_type value is gre, this
-                          ID is a gre key.
-                        format: int32
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
                         type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
                     type: object
-                  revisionNumber:
-                    description: revisionNumber optionally set via extensions/standard-attr-revisions
-                    format: int64
-                    type: integer
-                  shared:
-                    description: |-
-                      shared specifies whether the network resource can be accessed by any
-                      tenant.
-                    type: boolean
-                  status:
-                    description: |-
-                      status indicates whether network is currently operational. Possible values
-                      include `ACTIVE', `DOWN', `BUILD', or `ERROR'. Plug-ins might define
-                      additional values.
-                    maxLength: 1024
-                    type: string
-                  subnets:
-                    description: subnets associated with this network.
-                    items:
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                id:
+                  description: id is the unique identifier of the OpenStack resource.
+                  type: string
+                resource:
+                  description: resource contains the observed state of the OpenStack resource.
+                  properties:
+                    adminStateUp:
+                      description: |-
+                        adminStateUp is the administrative state of the network,
+                        which is up (true) or down (false).
+                      type: boolean
+                    availabilityZoneHints:
+                      description: |-
+                        availabilityZoneHints is the availability zone candidate for the
+                        network.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    createdAt:
+                      description: createdAt shows the date and time when the resource was created. The date and time stamp format is ISO 8601
+                      format: date-time
+                      type: string
+                    description:
+                      description: description is a human-readable description for the resource.
                       maxLength: 1024
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  tags:
-                    description: tags is the list of tags on the resource.
-                    items:
+                    dnsDomain:
+                      description: dnsDomain is the DNS domain of the network
                       maxLength: 1024
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  updatedAt:
-                    description: updatedAt shows the date and time when the resource
-                      was updated. The date and time stamp format is ISO 8601
-                    format: date-time
-                    type: string
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    external:
+                      description: |-
+                        external defines whether the network may be used for creation of
+                        floating IPs. Only networks with this flag may be an external
+                        gateway for routers. The network must have an external routing
+                        facility that is not managed by the networking service. If the
+                        network is updated from external to internal the unused floating IPs
+                        of this network are automatically deleted when extension
+                        floatingip-autodelete-internal is present.
+                      type: boolean
+                    mtu:
+                      description: |-
+                        mtu is the the maximum transmission unit value to address
+                        fragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.
+                      format: int32
+                      type: integer
+                    name:
+                      description: name is a Human-readable name for the network. Might not be unique.
+                      maxLength: 1024
+                      type: string
+                    portSecurityEnabled:
+                      description: |-
+                        portSecurityEnabled is the port security status of the network.
+                        Valid values are enabled (true) and disabled (false). This value is
+                        used as the default value of port_security_enabled field of a newly
+                        created port.
+                      type: boolean
+                    projectID:
+                      description: projectID is the project owner of the network.
+                      maxLength: 1024
+                      type: string
+                    provider:
+                      description: provider contains provider-network properties.
+                      properties:
+                        networkType:
+                          description: |-
+                            networkType is the type of physical network that this
+                            network should be mapped to. Supported values are flat, vlan, vxlan, and gre.
+                            Valid values depend on the networking back-end.
+                          maxLength: 1024
+                          type: string
+                        physicalNetwork:
+                          description: |-
+                            physicalNetwork is the physical network where this network
+                            should be implemented. The Networking API v2.0 does not provide a
+                            way to list available physical networks. For example, the Open
+                            vSwitch plug-in configuration file defines a symbolic name that maps
+                            to specific bridges on each compute host.
+                          maxLength: 1024
+                          type: string
+                        segmentationID:
+                          description: |-
+                            segmentationID is the ID of the isolated segment on the
+                            physical network. The network_type attribute defines the
+                            segmentation model. For example, if the network_type value is vlan,
+                            this ID is a vlan identifier. If the network_type value is gre, this
+                            ID is a gre key.
+                          format: int32
+                          type: integer
+                      type: object
+                    revisionNumber:
+                      description: revisionNumber optionally set via extensions/standard-attr-revisions
+                      format: int64
+                      type: integer
+                    shared:
+                      description: |-
+                        shared specifies whether the network resource can be accessed by any
+                        tenant.
+                      type: boolean
+                    status:
+                      description: |-
+                        status indicates whether network is currently operational. Possible values
+                        include `ACTIVE', `DOWN', `BUILD', or `ERROR'. Plug-ins might define
+                        additional values.
+                      maxLength: 1024
+                      type: string
+                    subnets:
+                      description: subnets associated with this network.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    tags:
+                      description: tags is the list of tags on the resource.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    updatedAt:
+                      description: updatedAt shows the date and time when the resource was updated. The date and time stamp format is ISO 8601
+                      format: date-time
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1649,583 +1574,555 @@ spec:
   group: openstack.k-orc.cloud
   names:
     categories:
-    - openstack
+      - openstack
     kind: Port
     listKind: PortList
     plural: ports
     singular: port
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Resource ID
-      jsonPath: .status.id
-      name: ID
-      type: string
-    - description: Availability status of resource
-      jsonPath: .status.conditions[?(@.type=='Available')].status
-      name: Available
-      type: string
-    - description: Allocated IP addresses
-      jsonPath: .status.resource.fixedIPs[*].ip
-      name: Addresses
-      type: string
-    - description: Message describing current progress status
-      jsonPath: .status.conditions[?(@.type=='Progressing')].message
-      name: Message
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Port is the Schema for an ORC resource.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec specifies the desired state of the resource.
-            properties:
-              cloudCredentialsRef:
-                description: cloudCredentialsRef points to a secret containing OpenStack
-                  credentials
-                properties:
-                  cloudName:
-                    description: cloudName specifies the name of the entry in the
-                      clouds.yaml file to use.
-                    maxLength: 256
-                    minLength: 1
-                    type: string
-                  secretName:
-                    description: |-
-                      secretName is the name of a secret in the same namespace as the resource being provisioned.
-                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
-                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                required:
-                - cloudName
-                - secretName
-                type: object
-              import:
-                description: |-
-                  import refers to an existing OpenStack resource which will be imported instead of
-                  creating a new one.
-                maxProperties: 1
-                minProperties: 1
-                properties:
-                  filter:
-                    description: |-
-                      filter contains a resource query which is expected to return a single
-                      result. The controller will continue to retry if filter returns no
-                      results. If filter returns multiple results the controller will set an
-                      error state and will not continue to retry.
-                    minProperties: 1
-                    properties:
-                      description:
-                        description: description of the existing resource
-                        maxLength: 255
-                        minLength: 1
-                        type: string
-                      name:
-                        description: name of the existing resource
-                        maxLength: 255
-                        minLength: 1
-                        pattern: ^[^,]+$
-                        type: string
-                      networkRef:
-                        description: networkRef is a reference to the ORC Network
-                          which this port is associated with.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      notTags:
-                        description: |-
-                          notTags is a list of tags to filter by. If specified, resources which
-                          contain all of the given tags will be excluded from the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      notTagsAny:
-                        description: |-
-                          notTagsAny is a list of tags to filter by. If specified, resources
-                          which contain any of the given tags will be excluded from the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tags:
-                        description: |-
-                          tags is a list of tags to filter by. If specified, the resource must
-                          have all of the tags specified to be included in the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tagsAny:
-                        description: |-
-                          tagsAny is a list of tags to filter by. If specified, the resource
-                          must have at least one of the tags specified to be included in the
-                          result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                    type: object
-                  id:
-                    description: |-
-                      id contains the unique identifier of an existing OpenStack resource. Note
-                      that when specifying an import by ID, the resource MUST already exist.
-                      The ORC object will enter an error state if the resource does not exist.
-                    format: uuid
-                    type: string
-                type: object
-              managedOptions:
-                description: managedOptions specifies options which may be applied
-                  to managed objects.
-                properties:
-                  onDelete:
-                    default: delete
-                    description: |-
-                      onDelete specifies the behaviour of the controller when the ORC
-                      object is deleted. Options are `delete` - delete the OpenStack resource;
-                      `detach` - do not delete the OpenStack resource. If not specified, the
-                      default is `delete`.
-                    enum:
-                    - delete
-                    - detach
-                    type: string
-                type: object
-              managementPolicy:
-                default: managed
-                description: |-
-                  managementPolicy defines how ORC will treat the object. Valid values are
-                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
-                  ORC will import an existing resource, and will not apply updates to it or
-                  delete it.
-                enum:
-                - managed
-                - unmanaged
-                type: string
-                x-kubernetes-validations:
-                - message: managementPolicy is immutable
-                  rule: self == oldSelf
-              resource:
-                description: |-
-                  resource specifies the desired state of the resource.
-
-                  resource may not be specified if the management policy is `unmanaged`.
-
-                  resource must be specified if the management policy is `managed`.
-                properties:
-                  addresses:
-                    description: addresses are the IP addresses for the port.
-                    items:
+    - additionalPrinterColumns:
+        - description: Resource ID
+          jsonPath: .status.id
+          name: ID
+          type: string
+        - description: Availability status of resource
+          jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: Available
+          type: string
+        - description: Allocated IP addresses
+          jsonPath: .status.resource.fixedIPs[*].ip
+          name: Addresses
+          type: string
+        - description: Message describing current progress status
+          jsonPath: .status.conditions[?(@.type=='Progressing')].message
+          name: Message
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Port is the Schema for an ORC resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec specifies the desired state of the resource.
+              properties:
+                cloudCredentialsRef:
+                  description: cloudCredentialsRef points to a secret containing OpenStack credentials
+                  properties:
+                    cloudName:
+                      description: cloudName specifies the name of the entry in the clouds.yaml file to use.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    secretName:
+                      description: |-
+                        secretName is the name of a secret in the same namespace as the resource being provisioned.
+                        The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                        The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                    - cloudName
+                    - secretName
+                  type: object
+                import:
+                  description: |-
+                    import refers to an existing OpenStack resource which will be imported instead of
+                    creating a new one.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: |-
+                        filter contains a resource query which is expected to return a single
+                        result. The controller will continue to retry if filter returns no
+                        results. If filter returns multiple results the controller will set an
+                        error state and will not continue to retry.
+                      minProperties: 1
                       properties:
-                        ip:
-                          description: |-
-                            ip contains a fixed IP address assigned to the port. It must belong
-                            to the referenced subnet's CIDR. If not specified, OpenStack
-                            allocates an available IP from the referenced subnet.
-                          maxLength: 45
+                        description:
+                          description: description of the existing resource
+                          maxLength: 255
                           minLength: 1
                           type: string
-                        subnetRef:
-                          description: |-
-                            subnetRef references the subnet from which to allocate the IP
-                            address.
+                        name:
+                          description: name of the existing resource
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        networkRef:
+                          description: networkRef is a reference to the ORC Network which this port is associated with.
                           maxLength: 253
                           minLength: 1
                           type: string
-                      required:
-                      - subnetRef
-                      type: object
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  allowedAddressPairs:
-                    description: allowedAddressPairs are allowed addresses associated
-                      with this port.
-                    items:
-                      properties:
-                        ip:
+                        notTags:
                           description: |-
-                            ip contains an IP address which a server connected to the port can
-                            send packets with. It can be an IP Address or a CIDR (if supported
-                            by the underlying extension plugin).
-                          maxLength: 45
-                          minLength: 1
-                          type: string
-                        mac:
+                            notTags is a list of tags to filter by. If specified, resources which
+                            contain all of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        notTagsAny:
                           description: |-
-                            mac contains a MAC address which a server connected to the port can
-                            send packets with. Defaults to the MAC address of the port.
-                          maxLength: 17
-                          minLength: 1
-                          type: string
-                      required:
-                      - ip
+                            notTagsAny is a list of tags to filter by. If specified, resources
+                            which contain any of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tags:
+                          description: |-
+                            tags is a list of tags to filter by. If specified, the resource must
+                            have all of the tags specified to be included in the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tagsAny:
+                          description: |-
+                            tagsAny is a list of tags to filter by. If specified, the resource
+                            must have at least one of the tags specified to be included in the
+                            result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
                       type: object
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 255
-                    minLength: 1
-                    type: string
-                  name:
-                    description: name is a human-readable name of the port. If not
-                      set, the object's name will be used.
-                    maxLength: 255
-                    minLength: 1
-                    pattern: ^[^,]+$
-                    type: string
-                  networkRef:
-                    description: networkRef is a reference to the ORC Network which
-                      this port is associated with.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  portSecurity:
-                    default: Inherit
-                    description: |-
-                      portSecurity controls port security for this port.
-                      When set to Enabled, port security is enabled.
-                      When set to Disabled, port security is disabled and SecurityGroupRefs must be empty.
-                      When set to Inherit (default), it takes the value from the network level.
-                    enum:
-                    - Enabled
-                    - Disabled
-                    - Inherit
-                    type: string
-                  securityGroupRefs:
-                    description: |-
-                      securityGroupRefs are the names of the security groups associated
-                      with this port.
-                    items:
+                    id:
+                      description: |-
+                        id contains the unique identifier of an existing OpenStack resource. Note
+                        that when specifying an import by ID, the resource MUST already exist.
+                        The ORC object will enter an error state if the resource does not exist.
+                      format: uuid
+                      type: string
+                  type: object
+                managedOptions:
+                  description: managedOptions specifies options which may be applied to managed objects.
+                  properties:
+                    onDelete:
+                      default: delete
+                      description: |-
+                        onDelete specifies the behaviour of the controller when the ORC
+                        object is deleted. Options are `delete` - delete the OpenStack resource;
+                        `detach` - do not delete the OpenStack resource. If not specified, the
+                        default is `delete`.
+                      enum:
+                        - delete
+                        - detach
+                      type: string
+                  type: object
+                managementPolicy:
+                  default: managed
+                  description: |-
+                    managementPolicy defines how ORC will treat the object. Valid values are
+                    `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                    ORC will import an existing resource, and will not apply updates to it or
+                    delete it.
+                  enum:
+                    - managed
+                    - unmanaged
+                  type: string
+                  x-kubernetes-validations:
+                    - message: managementPolicy is immutable
+                      rule: self == oldSelf
+                resource:
+                  description: |-
+                    resource specifies the desired state of the resource.
+
+                    resource may not be specified if the management policy is `unmanaged`.
+
+                    resource must be specified if the management policy is `managed`.
+                  properties:
+                    addresses:
+                      description: addresses are the IP addresses for the port.
+                      items:
+                        properties:
+                          ip:
+                            description: |-
+                              ip contains a fixed IP address assigned to the port. It must belong
+                              to the referenced subnet's CIDR. If not specified, OpenStack
+                              allocates an available IP from the referenced subnet.
+                            maxLength: 45
+                            minLength: 1
+                            type: string
+                          subnetRef:
+                            description: |-
+                              subnetRef references the subnet from which to allocate the IP
+                              address.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        required:
+                          - subnetRef
+                        type: object
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    allowedAddressPairs:
+                      description: allowedAddressPairs are allowed addresses associated with this port.
+                      items:
+                        properties:
+                          ip:
+                            description: |-
+                              ip contains an IP address which a server connected to the port can
+                              send packets with. It can be an IP Address or a CIDR (if supported
+                              by the underlying extension plugin).
+                            maxLength: 45
+                            minLength: 1
+                            type: string
+                          mac:
+                            description: |-
+                              mac contains a MAC address which a server connected to the port can
+                              send packets with. Defaults to the MAC address of the port.
+                            maxLength: 17
+                            minLength: 1
+                            type: string
+                        required:
+                          - ip
+                        type: object
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    description:
+                      description: description is a human-readable description for the resource.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    name:
+                      description: name is a human-readable name of the port. If not set, the object's name will be used.
                       maxLength: 255
                       minLength: 1
                       pattern: ^[^,]+$
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: set
-                  tags:
-                    description: tags is a list of tags which will be applied to the
-                      port.
-                    items:
-                      description: |-
-                        NeutronTag represents a tag on a Neutron resource.
-                        It may not be empty and may not contain commas.
-                      maxLength: 255
+                    networkRef:
+                      description: networkRef is a reference to the ORC Network which this port is associated with.
+                      maxLength: 253
                       minLength: 1
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: set
-                  vnicType:
-                    description: |-
-                      vnicType specifies the type of vNIC which this port should be
-                      attached to. This is used to determine which mechanism driver(s) to
-                      be used to bind the port. The valid values are normal, macvtap,
-                      direct, baremetal, direct-physical, virtio-forwarder, smart-nic and
-                      remote-managed, although these values will not be validated in this
-                      API to ensure compatibility with future neutron changes or custom
-                      implementations. What type of vNIC is actually available depends on
-                      deployments. If not specified, the Neutron default value is used.
-                    maxLength: 64
-                    type: string
-                required:
-                - networkRef
-                type: object
-                x-kubernetes-validations:
-                - message: PortResourceSpec is immutable
-                  rule: self == oldSelf
-                - message: securityGroupRefs must be empty when portSecurity is set
-                    to Disabled
-                  rule: 'has(self.portSecurity) && self.portSecurity == ''Disabled''
-                    ? !has(self.securityGroupRefs) : true'
-                - message: allowedAddressPairs must be empty when portSecurity is
-                    set to Disabled
-                  rule: 'has(self.portSecurity) && self.portSecurity == ''Disabled''
-                    ? !has(self.allowedAddressPairs) : true'
-            required:
-            - cloudCredentialsRef
-            type: object
-            x-kubernetes-validations:
-            - message: resource must be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
-            - message: import may not be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
-                : true'
-            - message: resource may not be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
-                : true'
-            - message: import must be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
-                : true'
-            - message: managedOptions may only be provided when policy is managed
-              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
-                : true'
-          status:
-            description: status defines the observed state of the resource.
-            properties:
-              conditions:
-                description: |-
-                  conditions represents the observed status of the object.
-                  Known .status.conditions.type are: "Available", "Progressing"
-
-                  Available represents the availability of the OpenStack resource. If it is
-                  true then the resource is ready for use.
-
-                  Progressing indicates whether the controller is still attempting to
-                  reconcile the current state of the OpenStack resource to the desired
-                  state. Progressing will be False either because the desired state has
-                  been achieved, or because some terminal error prevents it from ever being
-                  achieved and the controller is no longer attempting to reconcile. If
-                  Progressing is True, an observer waiting on the resource should continue
-                  to wait.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
+                    portSecurity:
+                      default: Inherit
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
+                        portSecurity controls port security for this port.
+                        When set to Enabled, port security is enabled.
+                        When set to Disabled, port security is disabled and SecurityGroupRefs must be empty.
+                        When set to Inherit (default), it takes the value from the network level.
                       enum:
-                      - "True"
-                      - "False"
-                      - Unknown
+                        - Enabled
+                        - Disabled
+                        - Inherit
                       type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    securityGroupRefs:
+                      description: |-
+                        securityGroupRefs are the names of the security groups associated
+                        with this port.
+                      items:
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[^,]+$
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: set
+                    tags:
+                      description: tags is a list of tags which will be applied to the port.
+                      items:
+                        description: |-
+                          NeutronTag represents a tag on a Neutron resource.
+                          It may not be empty and may not contain commas.
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: set
+                    vnicType:
+                      description: |-
+                        vnicType specifies the type of vNIC which this port should be
+                        attached to. This is used to determine which mechanism driver(s) to
+                        be used to bind the port. The valid values are normal, macvtap,
+                        direct, baremetal, direct-physical, virtio-forwarder, smart-nic and
+                        remote-managed, although these values will not be validated in this
+                        API to ensure compatibility with future neutron changes or custom
+                        implementations. What type of vNIC is actually available depends on
+                        deployments. If not specified, the Neutron default value is used.
+                      maxLength: 64
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - networkRef
                   type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              id:
-                description: id is the unique identifier of the OpenStack resource.
-                type: string
-              resource:
-                description: resource contains the observed state of the OpenStack
-                  resource.
-                properties:
-                  adminStateUp:
-                    description: |-
-                      adminStateUp is the administrative state of the port,
-                      which is up (true) or down (false).
-                    type: boolean
-                  allowedAddressPairs:
-                    description: |-
-                      allowedAddressPairs is a set of zero or more allowed address pair
-                      objects each where address pair object contains an IP address and
-                      MAC address.
-                    items:
-                      properties:
-                        ip:
-                          description: |-
-                            ip contains an IP address which a server connected to the port can
-                            send packets with.
-                          maxLength: 1024
-                          type: string
-                        mac:
-                          description: |-
-                            mac contains a MAC address which a server connected to the port can
-                            send packets with.
-                          maxLength: 1024
-                          type: string
-                      type: object
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  createdAt:
-                    description: createdAt shows the date and time when the resource
-                      was created. The date and time stamp format is ISO 8601
-                    format: date-time
-                    type: string
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 1024
-                    type: string
-                  deviceID:
-                    description: deviceID is the ID of the device that uses this port.
-                    maxLength: 1024
-                    type: string
-                  deviceOwner:
-                    description: deviceOwner is the entity type that uses this port.
-                    maxLength: 1024
-                    type: string
-                  fixedIPs:
-                    description: |-
-                      fixedIPs is a set of zero or more fixed IP objects each where fixed
-                      IP object contains an IP address and subnet ID from which the IP
-                      address is assigned.
-                    items:
-                      properties:
-                        ip:
-                          description: ip contains a fixed IP address assigned to
-                            the port.
-                          maxLength: 1024
-                          type: string
-                        subnetID:
-                          description: subnetID is the ID of the subnet this IP is
-                            allocated from.
-                          maxLength: 1024
-                          type: string
-                      type: object
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  macAddress:
-                    description: macAddress is the MAC address of the port.
-                    maxLength: 1024
-                    type: string
-                  name:
-                    description: name is the human-readable name of the resource.
-                      Might not be unique.
-                    maxLength: 1024
-                    type: string
-                  networkID:
-                    description: networkID is the ID of the attached network.
-                    maxLength: 1024
-                    type: string
-                  portSecurityEnabled:
-                    description: portSecurityEnabled indicates whether port security
-                      is enabled or not.
-                    type: boolean
-                  projectID:
-                    description: projectID is the project owner of the resource.
-                    maxLength: 1024
-                    type: string
-                  propagateUplinkStatus:
-                    description: |-
-                      propagateUplinkStatus represents the uplink status propagation of
-                      the port.
-                    type: boolean
-                  revisionNumber:
-                    description: revisionNumber optionally set via extensions/standard-attr-revisions
-                    format: int64
-                    type: integer
-                  securityGroups:
-                    description: securityGroups contains the IDs of security groups
-                      applied to the port.
-                    items:
+                  x-kubernetes-validations:
+                    - message: PortResourceSpec is immutable
+                      rule: self == oldSelf
+                    - message: securityGroupRefs must be empty when portSecurity is set to Disabled
+                      rule: 'has(self.portSecurity) && self.portSecurity == ''Disabled'' ? !has(self.securityGroupRefs) : true'
+                    - message: allowedAddressPairs must be empty when portSecurity is set to Disabled
+                      rule: 'has(self.portSecurity) && self.portSecurity == ''Disabled'' ? !has(self.allowedAddressPairs) : true'
+              required:
+                - cloudCredentialsRef
+              type: object
+              x-kubernetes-validations:
+                - message: resource must be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+                - message: import may not be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__) : true'
+                - message: resource may not be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource) : true'
+                - message: import must be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__) : true'
+                - message: managedOptions may only be provided when policy is managed
+                  rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed'' : true'
+            status:
+              description: status defines the observed state of the resource.
+              properties:
+                conditions:
+                  description: |-
+                    conditions represents the observed status of the object.
+                    Known .status.conditions.type are: "Available", "Progressing"
+
+                    Available represents the availability of the OpenStack resource. If it is
+                    true then the resource is ready for use.
+
+                    Progressing indicates whether the controller is still attempting to
+                    reconcile the current state of the OpenStack resource to the desired
+                    state. Progressing will be False either because the desired state has
+                    been achieved, or because some terminal error prevents it from ever being
+                    achieved and the controller is no longer attempting to reconcile. If
+                    Progressing is True, an observer waiting on the resource should continue
+                    to wait.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                id:
+                  description: id is the unique identifier of the OpenStack resource.
+                  type: string
+                resource:
+                  description: resource contains the observed state of the OpenStack resource.
+                  properties:
+                    adminStateUp:
+                      description: |-
+                        adminStateUp is the administrative state of the port,
+                        which is up (true) or down (false).
+                      type: boolean
+                    allowedAddressPairs:
+                      description: |-
+                        allowedAddressPairs is a set of zero or more allowed address pair
+                        objects each where address pair object contains an IP address and
+                        MAC address.
+                      items:
+                        properties:
+                          ip:
+                            description: |-
+                              ip contains an IP address which a server connected to the port can
+                              send packets with.
+                            maxLength: 1024
+                            type: string
+                          mac:
+                            description: |-
+                              mac contains a MAC address which a server connected to the port can
+                              send packets with.
+                            maxLength: 1024
+                            type: string
+                        type: object
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    createdAt:
+                      description: createdAt shows the date and time when the resource was created. The date and time stamp format is ISO 8601
+                      format: date-time
+                      type: string
+                    description:
+                      description: description is a human-readable description for the resource.
                       maxLength: 1024
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  status:
-                    description: status indicates the current status of the resource.
-                    maxLength: 1024
-                    type: string
-                  tags:
-                    description: tags is the list of tags on the resource.
-                    items:
+                    deviceID:
+                      description: deviceID is the ID of the device that uses this port.
                       maxLength: 1024
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  updatedAt:
-                    description: updatedAt shows the date and time when the resource
-                      was updated. The date and time stamp format is ISO 8601
-                    format: date-time
-                    type: string
-                  vnicType:
-                    description: vnicType is the type of vNIC which this port is attached
-                      to.
-                    maxLength: 64
-                    type: string
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    deviceOwner:
+                      description: deviceOwner is the entity type that uses this port.
+                      maxLength: 1024
+                      type: string
+                    fixedIPs:
+                      description: |-
+                        fixedIPs is a set of zero or more fixed IP objects each where fixed
+                        IP object contains an IP address and subnet ID from which the IP
+                        address is assigned.
+                      items:
+                        properties:
+                          ip:
+                            description: ip contains a fixed IP address assigned to the port.
+                            maxLength: 1024
+                            type: string
+                          subnetID:
+                            description: subnetID is the ID of the subnet this IP is allocated from.
+                            maxLength: 1024
+                            type: string
+                        type: object
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    macAddress:
+                      description: macAddress is the MAC address of the port.
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: name is the human-readable name of the resource. Might not be unique.
+                      maxLength: 1024
+                      type: string
+                    networkID:
+                      description: networkID is the ID of the attached network.
+                      maxLength: 1024
+                      type: string
+                    portSecurityEnabled:
+                      description: portSecurityEnabled indicates whether port security is enabled or not.
+                      type: boolean
+                    projectID:
+                      description: projectID is the project owner of the resource.
+                      maxLength: 1024
+                      type: string
+                    propagateUplinkStatus:
+                      description: |-
+                        propagateUplinkStatus represents the uplink status propagation of
+                        the port.
+                      type: boolean
+                    revisionNumber:
+                      description: revisionNumber optionally set via extensions/standard-attr-revisions
+                      format: int64
+                      type: integer
+                    securityGroups:
+                      description: securityGroups contains the IDs of security groups applied to the port.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    status:
+                      description: status indicates the current status of the resource.
+                      maxLength: 1024
+                      type: string
+                    tags:
+                      description: tags is the list of tags on the resource.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    updatedAt:
+                      description: updatedAt shows the date and time when the resource was updated. The date and time stamp format is ISO 8601
+                      format: date-time
+                      type: string
+                    vnicType:
+                      description: vnicType is the type of vNIC which this port is attached to.
+                      maxLength: 64
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2238,348 +2135,334 @@ spec:
   group: openstack.k-orc.cloud
   names:
     categories:
-    - openstack
+      - openstack
     kind: Project
     listKind: ProjectList
     plural: projects
     singular: project
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Resource ID
-      jsonPath: .status.id
-      name: ID
-      type: string
-    - description: Availability status of resource
-      jsonPath: .status.conditions[?(@.type=='Available')].status
-      name: Available
-      type: string
-    - description: Message describing current progress status
-      jsonPath: .status.conditions[?(@.type=='Progressing')].message
-      name: Message
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Project is the Schema for an ORC resource.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec specifies the desired state of the resource.
-            properties:
-              cloudCredentialsRef:
-                description: cloudCredentialsRef points to a secret containing OpenStack
-                  credentials
-                properties:
-                  cloudName:
-                    description: cloudName specifies the name of the entry in the
-                      clouds.yaml file to use.
-                    maxLength: 256
-                    minLength: 1
-                    type: string
-                  secretName:
-                    description: |-
-                      secretName is the name of a secret in the same namespace as the resource being provisioned.
-                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
-                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                required:
-                - cloudName
-                - secretName
-                type: object
-              import:
-                description: |-
-                  import refers to an existing OpenStack resource which will be imported instead of
-                  creating a new one.
-                maxProperties: 1
-                minProperties: 1
-                properties:
-                  filter:
-                    description: |-
-                      filter contains a resource query which is expected to return a single
-                      result. The controller will continue to retry if filter returns no
-                      results. If filter returns multiple results the controller will set an
-                      error state and will not continue to retry.
-                    minProperties: 1
-                    properties:
-                      name:
-                        description: name of the existing resource
-                        maxLength: 64
-                        minLength: 1
-                        type: string
-                      notTags:
-                        description: |-
-                          notTags is a list of tags to filter by. If specified, resources which
-                          contain all of the given tags will be excluded from the result.
-                        items:
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 80
-                        type: array
-                        x-kubernetes-list-type: set
-                      notTagsAny:
-                        description: |-
-                          notTagsAny is a list of tags to filter by. If specified, resources
-                          which contain any of the given tags will be excluded from the result.
-                        items:
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 80
-                        type: array
-                        x-kubernetes-list-type: set
-                      tags:
-                        description: |-
-                          tags is a list of tags to filter by. If specified, the resource must
-                          have all of the tags specified to be included in the result.
-                        items:
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 80
-                        type: array
-                        x-kubernetes-list-type: set
-                      tagsAny:
-                        description: |-
-                          tagsAny is a list of tags to filter by. If specified, the resource
-                          must have at least one of the tags specified to be included in the
-                          result.
-                        items:
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 80
-                        type: array
-                        x-kubernetes-list-type: set
-                    type: object
-                  id:
-                    description: |-
-                      id contains the unique identifier of an existing OpenStack resource. Note
-                      that when specifying an import by ID, the resource MUST already exist.
-                      The ORC object will enter an error state if the resource does not exist.
-                    format: uuid
-                    type: string
-                type: object
-              managedOptions:
-                description: managedOptions specifies options which may be applied
-                  to managed objects.
-                properties:
-                  onDelete:
-                    default: delete
-                    description: |-
-                      onDelete specifies the behaviour of the controller when the ORC
-                      object is deleted. Options are `delete` - delete the OpenStack resource;
-                      `detach` - do not delete the OpenStack resource. If not specified, the
-                      default is `delete`.
-                    enum:
-                    - delete
-                    - detach
-                    type: string
-                type: object
-              managementPolicy:
-                default: managed
-                description: |-
-                  managementPolicy defines how ORC will treat the object. Valid values are
-                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
-                  ORC will import an existing resource, and will not apply updates to it or
-                  delete it.
-                enum:
-                - managed
-                - unmanaged
-                type: string
-                x-kubernetes-validations:
-                - message: managementPolicy is immutable
-                  rule: self == oldSelf
-              resource:
-                description: |-
-                  resource specifies the desired state of the resource.
-
-                  resource may not be specified if the management policy is `unmanaged`.
-
-                  resource must be specified if the management policy is `managed`.
-                properties:
-                  description:
-                    description: description contains a free form description of the
-                      project.
-                    maxLength: 65535
-                    minLength: 1
-                    type: string
-                  enabled:
-                    description: enabled defines whether a project is enabled or not.
-                      Default is true.
-                    type: boolean
-                  name:
-                    description: |-
-                      name will be the name of the created resource. If not specified, the
-                      name of the ORC object will be used.
-                    maxLength: 64
-                    minLength: 1
-                    type: string
-                  tags:
-                    description: |-
-                      tags is list of simple strings assigned to a project.
-                      Tags can be used to classify projects into groups.
-                    items:
-                      maxLength: 255
-                      minLength: 1
-                      type: string
-                    maxItems: 80
-                    type: array
-                    x-kubernetes-list-type: set
-                type: object
-                x-kubernetes-validations:
-                - message: ProjectResourceSpec is immutable
-                  rule: self == oldSelf
-            required:
-            - cloudCredentialsRef
-            type: object
-            x-kubernetes-validations:
-            - message: resource must be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
-            - message: import may not be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
-                : true'
-            - message: resource may not be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
-                : true'
-            - message: import must be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
-                : true'
-            - message: managedOptions may only be provided when policy is managed
-              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
-                : true'
-          status:
-            description: status defines the observed state of the resource.
-            properties:
-              conditions:
-                description: |-
-                  conditions represents the observed status of the object.
-                  Known .status.conditions.type are: "Available", "Progressing"
-
-                  Available represents the availability of the OpenStack resource. If it is
-                  true then the resource is ready for use.
-
-                  Progressing indicates whether the controller is still attempting to
-                  reconcile the current state of the OpenStack resource to the desired
-                  state. Progressing will be False either because the desired state has
-                  been achieved, or because some terminal error prevents it from ever being
-                  achieved and the controller is no longer attempting to reconcile. If
-                  Progressing is True, an observer waiting on the resource should continue
-                  to wait.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+    - additionalPrinterColumns:
+        - description: Resource ID
+          jsonPath: .status.id
+          name: ID
+          type: string
+        - description: Availability status of resource
+          jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: Available
+          type: string
+        - description: Message describing current progress status
+          jsonPath: .status.conditions[?(@.type=='Progressing')].message
+          name: Message
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Project is the Schema for an ORC resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec specifies the desired state of the resource.
+              properties:
+                cloudCredentialsRef:
+                  description: cloudCredentialsRef points to a secret containing OpenStack credentials
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
+                    cloudName:
+                      description: cloudName specifies the name of the entry in the clouds.yaml file to use.
+                      maxLength: 256
                       minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    secretName:
+                      description: |-
+                        secretName is the name of a secret in the same namespace as the resource being provisioned.
+                        The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                        The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                      maxLength: 253
+                      minLength: 1
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - cloudName
+                    - secretName
                   type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              id:
-                description: id is the unique identifier of the OpenStack resource.
-                type: string
-              resource:
-                description: resource contains the observed state of the OpenStack
-                  resource.
-                properties:
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 65535
-                    type: string
-                  enabled:
-                    description: enabled represents whether a project is enabled or
-                      not.
-                    type: boolean
-                  name:
-                    description: name is a Human-readable name for the project. Might
-                      not be unique.
-                    maxLength: 1024
-                    type: string
-                  tags:
-                    description: tags is the list of tags on the resource.
-                    items:
+                import:
+                  description: |-
+                    import refers to an existing OpenStack resource which will be imported instead of
+                    creating a new one.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: |-
+                        filter contains a resource query which is expected to return a single
+                        result. The controller will continue to retry if filter returns no
+                        results. If filter returns multiple results the controller will set an
+                        error state and will not continue to retry.
+                      minProperties: 1
+                      properties:
+                        name:
+                          description: name of the existing resource
+                          maxLength: 64
+                          minLength: 1
+                          type: string
+                        notTags:
+                          description: |-
+                            notTags is a list of tags to filter by. If specified, resources which
+                            contain all of the given tags will be excluded from the result.
+                          items:
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 80
+                          type: array
+                          x-kubernetes-list-type: set
+                        notTagsAny:
+                          description: |-
+                            notTagsAny is a list of tags to filter by. If specified, resources
+                            which contain any of the given tags will be excluded from the result.
+                          items:
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 80
+                          type: array
+                          x-kubernetes-list-type: set
+                        tags:
+                          description: |-
+                            tags is a list of tags to filter by. If specified, the resource must
+                            have all of the tags specified to be included in the result.
+                          items:
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 80
+                          type: array
+                          x-kubernetes-list-type: set
+                        tagsAny:
+                          description: |-
+                            tagsAny is a list of tags to filter by. If specified, the resource
+                            must have at least one of the tags specified to be included in the
+                            result.
+                          items:
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 80
+                          type: array
+                          x-kubernetes-list-type: set
+                      type: object
+                    id:
+                      description: |-
+                        id contains the unique identifier of an existing OpenStack resource. Note
+                        that when specifying an import by ID, the resource MUST already exist.
+                        The ORC object will enter an error state if the resource does not exist.
+                      format: uuid
+                      type: string
+                  type: object
+                managedOptions:
+                  description: managedOptions specifies options which may be applied to managed objects.
+                  properties:
+                    onDelete:
+                      default: delete
+                      description: |-
+                        onDelete specifies the behaviour of the controller when the ORC
+                        object is deleted. Options are `delete` - delete the OpenStack resource;
+                        `detach` - do not delete the OpenStack resource. If not specified, the
+                        default is `delete`.
+                      enum:
+                        - delete
+                        - detach
+                      type: string
+                  type: object
+                managementPolicy:
+                  default: managed
+                  description: |-
+                    managementPolicy defines how ORC will treat the object. Valid values are
+                    `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                    ORC will import an existing resource, and will not apply updates to it or
+                    delete it.
+                  enum:
+                    - managed
+                    - unmanaged
+                  type: string
+                  x-kubernetes-validations:
+                    - message: managementPolicy is immutable
+                      rule: self == oldSelf
+                resource:
+                  description: |-
+                    resource specifies the desired state of the resource.
+
+                    resource may not be specified if the management policy is `unmanaged`.
+
+                    resource must be specified if the management policy is `managed`.
+                  properties:
+                    description:
+                      description: description contains a free form description of the project.
+                      maxLength: 65535
+                      minLength: 1
+                      type: string
+                    enabled:
+                      description: enabled defines whether a project is enabled or not. Default is true.
+                      type: boolean
+                    name:
+                      description: |-
+                        name will be the name of the created resource. If not specified, the
+                        name of the ORC object will be used.
+                      maxLength: 64
+                      minLength: 1
+                      type: string
+                    tags:
+                      description: |-
+                        tags is list of simple strings assigned to a project.
+                        Tags can be used to classify projects into groups.
+                      items:
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      maxItems: 80
+                      type: array
+                      x-kubernetes-list-type: set
+                  type: object
+                  x-kubernetes-validations:
+                    - message: ProjectResourceSpec is immutable
+                      rule: self == oldSelf
+              required:
+                - cloudCredentialsRef
+              type: object
+              x-kubernetes-validations:
+                - message: resource must be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+                - message: import may not be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__) : true'
+                - message: resource may not be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource) : true'
+                - message: import must be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__) : true'
+                - message: managedOptions may only be provided when policy is managed
+                  rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed'' : true'
+            status:
+              description: status defines the observed state of the resource.
+              properties:
+                conditions:
+                  description: |-
+                    conditions represents the observed status of the object.
+                    Known .status.conditions.type are: "Available", "Progressing"
+
+                    Available represents the availability of the OpenStack resource. If it is
+                    true then the resource is ready for use.
+
+                    Progressing indicates whether the controller is still attempting to
+                    reconcile the current state of the OpenStack resource to the desired
+                    state. Progressing will be False either because the desired state has
+                    been achieved, or because some terminal error prevents it from ever being
+                    achieved and the controller is no longer attempting to reconcile. If
+                    Progressing is True, an observer waiting on the resource should continue
+                    to wait.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                id:
+                  description: id is the unique identifier of the OpenStack resource.
+                  type: string
+                resource:
+                  description: resource contains the observed state of the OpenStack resource.
+                  properties:
+                    description:
+                      description: description is a human-readable description for the resource.
+                      maxLength: 65535
+                      type: string
+                    enabled:
+                      description: enabled represents whether a project is enabled or not.
+                      type: boolean
+                    name:
+                      description: name is a Human-readable name for the project. Might not be unique.
                       maxLength: 1024
                       type: string
-                    maxItems: 80
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    tags:
+                      description: tags is the list of tags on the resource.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 80
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2592,164 +2475,159 @@ spec:
   group: openstack.k-orc.cloud
   names:
     categories:
-    - openstack
+      - openstack
     kind: RouterInterface
     listKind: RouterInterfaceList
     plural: routerinterfaces
     singular: routerinterface
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Availability status of resource
-      jsonPath: .status.conditions[?(@.type=='Available')].status
-      name: Available
-      type: string
-    - description: Message describing current progress status
-      jsonPath: .status.conditions[?(@.type=='Progressing')].message
-      name: Message
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: RouterInterface is the Schema for an ORC resource.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec specifies the desired state of the resource.
-            properties:
-              routerRef:
-                description: routerRef references the router to which this interface
-                  belongs.
-                maxLength: 253
-                minLength: 1
-                type: string
-              subnetRef:
-                description: subnetRef references the subnet the router interface
-                  is created on.
-                maxLength: 253
-                minLength: 1
-                type: string
-              type:
-                description: type specifies the type of the router interface.
-                enum:
-                - Subnet
-                maxLength: 8
-                minLength: 1
-                type: string
-            required:
-            - routerRef
-            - type
-            type: object
-            x-kubernetes-validations:
-            - message: subnetRef is required when type is 'Subnet' and not permitted
-                otherwise
-              rule: 'self.type == ''Subnet'' ? has(self.subnetRef) : !has(self.subnetRef)'
-            - message: RouterInterfaceResourceSpec is immutable
-              rule: self == oldSelf
-          status:
-            description: status defines the observed state of the resource.
-            properties:
-              conditions:
-                description: |-
-                  conditions represents the observed status of the object.
-                  Known .status.conditions.type are: "Available", "Progressing"
-
-                  Available represents the availability of the OpenStack resource. If it is
-                  true then the resource is ready for use.
-
-                  Progressing indicates whether the controller is still attempting to
-                  reconcile the current state of the OpenStack resource to the desired
-                  state. Progressing will be False either because the desired state has
-                  been achieved, or because some terminal error prevents it from ever being
-                  achieved and the controller is no longer attempting to reconcile. If
-                  Progressing is True, an observer waiting on the resource should continue
-                  to wait.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
+    - additionalPrinterColumns:
+        - description: Availability status of resource
+          jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: Available
+          type: string
+        - description: Message describing current progress status
+          jsonPath: .status.conditions[?(@.type=='Progressing')].message
+          name: Message
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: RouterInterface is the Schema for an ORC resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec specifies the desired state of the resource.
+              properties:
+                routerRef:
+                  description: routerRef references the router to which this interface belongs.
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+                subnetRef:
+                  description: subnetRef references the subnet the router interface is created on.
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+                type:
+                  description: type specifies the type of the router interface.
+                  enum:
+                    - Subnet
+                  maxLength: 8
+                  minLength: 1
+                  type: string
+              required:
+                - routerRef
                 - type
-                x-kubernetes-list-type: map
-              id:
-                description: id is the unique identifier of the port created for the
-                  router interface
-                maxLength: 1024
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              type: object
+              x-kubernetes-validations:
+                - message: subnetRef is required when type is 'Subnet' and not permitted otherwise
+                  rule: 'self.type == ''Subnet'' ? has(self.subnetRef) : !has(self.subnetRef)'
+                - message: RouterInterfaceResourceSpec is immutable
+                  rule: self == oldSelf
+            status:
+              description: status defines the observed state of the resource.
+              properties:
+                conditions:
+                  description: |-
+                    conditions represents the observed status of the object.
+                    Known .status.conditions.type are: "Available", "Progressing"
+
+                    Available represents the availability of the OpenStack resource. If it is
+                    true then the resource is ready for use.
+
+                    Progressing indicates whether the controller is still attempting to
+                    reconcile the current state of the OpenStack resource to the desired
+                    state. Progressing will be False either because the desired state has
+                    been achieved, or because some terminal error prevents it from ever being
+                    achieved and the controller is no longer attempting to reconcile. If
+                    Progressing is True, an observer waiting on the resource should continue
+                    to wait.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                id:
+                  description: id is the unique identifier of the port created for the router interface
+                  maxLength: 1024
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2762,436 +2640,419 @@ spec:
   group: openstack.k-orc.cloud
   names:
     categories:
-    - openstack
+      - openstack
     kind: Router
     listKind: RouterList
     plural: routers
     singular: router
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Resource ID
-      jsonPath: .status.id
-      name: ID
-      type: string
-    - description: Availability status of resource
-      jsonPath: .status.conditions[?(@.type=='Available')].status
-      name: Available
-      type: string
-    - description: Message describing current progress status
-      jsonPath: .status.conditions[?(@.type=='Progressing')].message
-      name: Message
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Router is the Schema for an ORC resource.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec specifies the desired state of the resource.
-            properties:
-              cloudCredentialsRef:
-                description: cloudCredentialsRef points to a secret containing OpenStack
-                  credentials
-                properties:
-                  cloudName:
-                    description: cloudName specifies the name of the entry in the
-                      clouds.yaml file to use.
-                    maxLength: 256
-                    minLength: 1
-                    type: string
-                  secretName:
-                    description: |-
-                      secretName is the name of a secret in the same namespace as the resource being provisioned.
-                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
-                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                required:
-                - cloudName
-                - secretName
-                type: object
-              import:
-                description: |-
-                  import refers to an existing OpenStack resource which will be imported instead of
-                  creating a new one.
-                maxProperties: 1
-                minProperties: 1
-                properties:
-                  filter:
-                    description: |-
-                      filter contains a resource query which is expected to return a single
-                      result. The controller will continue to retry if filter returns no
-                      results. If filter returns multiple results the controller will set an
-                      error state and will not continue to retry.
-                    minProperties: 1
-                    properties:
-                      description:
-                        description: description of the existing resource
-                        maxLength: 255
-                        minLength: 1
-                        type: string
-                      name:
-                        description: name of the existing resource
-                        maxLength: 255
-                        minLength: 1
-                        pattern: ^[^,]+$
-                        type: string
-                      notTags:
-                        description: |-
-                          notTags is a list of tags to filter by. If specified, resources which
-                          contain all of the given tags will be excluded from the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      notTagsAny:
-                        description: |-
-                          notTagsAny is a list of tags to filter by. If specified, resources
-                          which contain any of the given tags will be excluded from the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tags:
-                        description: |-
-                          tags is a list of tags to filter by. If specified, the resource must
-                          have all of the tags specified to be included in the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tagsAny:
-                        description: |-
-                          tagsAny is a list of tags to filter by. If specified, the resource
-                          must have at least one of the tags specified to be included in the
-                          result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                    type: object
-                  id:
-                    description: |-
-                      id contains the unique identifier of an existing OpenStack resource. Note
-                      that when specifying an import by ID, the resource MUST already exist.
-                      The ORC object will enter an error state if the resource does not exist.
-                    format: uuid
-                    type: string
-                type: object
-              managedOptions:
-                description: managedOptions specifies options which may be applied
-                  to managed objects.
-                properties:
-                  onDelete:
-                    default: delete
-                    description: |-
-                      onDelete specifies the behaviour of the controller when the ORC
-                      object is deleted. Options are `delete` - delete the OpenStack resource;
-                      `detach` - do not delete the OpenStack resource. If not specified, the
-                      default is `delete`.
-                    enum:
-                    - delete
-                    - detach
-                    type: string
-                type: object
-              managementPolicy:
-                default: managed
-                description: |-
-                  managementPolicy defines how ORC will treat the object. Valid values are
-                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
-                  ORC will import an existing resource, and will not apply updates to it or
-                  delete it.
-                enum:
-                - managed
-                - unmanaged
-                type: string
-                x-kubernetes-validations:
-                - message: managementPolicy is immutable
-                  rule: self == oldSelf
-              resource:
-                description: |-
-                  resource specifies the desired state of the resource.
-
-                  resource may not be specified if the management policy is `unmanaged`.
-
-                  resource must be specified if the management policy is `managed`.
-                properties:
-                  adminStateUp:
-                    description: |-
-                      adminStateUp represents the administrative state of the resource,
-                      which is up (true) or down (false). Default is true.
-                    type: boolean
-                  availabilityZoneHints:
-                    description: availabilityZoneHints is the availability zone candidate
-                      for the router.
-                    items:
-                      maxLength: 255
-                      minLength: 1
-                      type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: set
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 255
-                    minLength: 1
-                    type: string
-                  distributed:
-                    description: |-
-                      distributed indicates whether the router is distributed or not. It
-                      is available when dvr extension is enabled.
-                    type: boolean
-                  externalGateways:
-                    description: externalGateways is a list of external gateways for
-                      the router.
-                    items:
-                      properties:
-                        networkRef:
-                          description: |-
-                            networkRef is a reference to the ORC Network which the external
-                            gateway is on.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                      required:
-                      - networkRef
-                      type: object
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  name:
-                    description: |-
-                      name is a human-readable name of the router. If not set, the
-                      object's name will be used.
-                    maxLength: 255
-                    minLength: 1
-                    pattern: ^[^,]+$
-                    type: string
-                  tags:
-                    description: tags is a list of tags which will be applied to the
-                      router.
-                    items:
-                      description: |-
-                        NeutronTag represents a tag on a Neutron resource.
-                        It may not be empty and may not contain commas.
-                      maxLength: 255
-                      minLength: 1
-                      type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: set
-                type: object
-                x-kubernetes-validations:
-                - message: RouterResourceSpec is immutable
-                  rule: self == oldSelf
-            required:
-            - cloudCredentialsRef
-            type: object
-            x-kubernetes-validations:
-            - message: resource must be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
-            - message: import may not be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
-                : true'
-            - message: resource may not be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
-                : true'
-            - message: import must be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
-                : true'
-            - message: managedOptions may only be provided when policy is managed
-              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
-                : true'
-          status:
-            description: status defines the observed state of the resource.
-            properties:
-              conditions:
-                description: |-
-                  conditions represents the observed status of the object.
-                  Known .status.conditions.type are: "Available", "Progressing"
-
-                  Available represents the availability of the OpenStack resource. If it is
-                  true then the resource is ready for use.
-
-                  Progressing indicates whether the controller is still attempting to
-                  reconcile the current state of the OpenStack resource to the desired
-                  state. Progressing will be False either because the desired state has
-                  been achieved, or because some terminal error prevents it from ever being
-                  achieved and the controller is no longer attempting to reconcile. If
-                  Progressing is True, an observer waiting on the resource should continue
-                  to wait.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+    - additionalPrinterColumns:
+        - description: Resource ID
+          jsonPath: .status.id
+          name: ID
+          type: string
+        - description: Availability status of resource
+          jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: Available
+          type: string
+        - description: Message describing current progress status
+          jsonPath: .status.conditions[?(@.type=='Progressing')].message
+          name: Message
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Router is the Schema for an ORC resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec specifies the desired state of the resource.
+              properties:
+                cloudCredentialsRef:
+                  description: cloudCredentialsRef points to a secret containing OpenStack credentials
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
+                    cloudName:
+                      description: cloudName specifies the name of the entry in the clouds.yaml file to use.
+                      maxLength: 256
                       minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    secretName:
+                      description: |-
+                        secretName is the name of a secret in the same namespace as the resource being provisioned.
+                        The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                        The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                      maxLength: 253
+                      minLength: 1
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - cloudName
+                    - secretName
                   type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              id:
-                description: id is the unique identifier of the OpenStack resource.
-                type: string
-              resource:
-                description: resource contains the observed state of the OpenStack
-                  resource.
-                properties:
-                  adminStateUp:
-                    description: |-
-                      adminStateUp is the administrative state of the router,
-                      which is up (true) or down (false).
-                    type: boolean
-                  availabilityZoneHints:
-                    description: |-
-                      availabilityZoneHints is the availability zone candidate for the
-                      router.
-                    items:
-                      maxLength: 1024
-                      type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 1024
-                    type: string
-                  externalGateways:
-                    description: externalGateways is a list of external gateways for
-                      the router.
-                    items:
+                import:
+                  description: |-
+                    import refers to an existing OpenStack resource which will be imported instead of
+                    creating a new one.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: |-
+                        filter contains a resource query which is expected to return a single
+                        result. The controller will continue to retry if filter returns no
+                        results. If filter returns multiple results the controller will set an
+                        error state and will not continue to retry.
+                      minProperties: 1
                       properties:
-                        networkID:
-                          description: networkID is the ID of the network the gateway
-                            is on.
-                          maxLength: 1024
+                        description:
+                          description: description of the existing resource
+                          maxLength: 255
+                          minLength: 1
                           type: string
+                        name:
+                          description: name of the existing resource
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        notTags:
+                          description: |-
+                            notTags is a list of tags to filter by. If specified, resources which
+                            contain all of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        notTagsAny:
+                          description: |-
+                            notTagsAny is a list of tags to filter by. If specified, resources
+                            which contain any of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tags:
+                          description: |-
+                            tags is a list of tags to filter by. If specified, the resource must
+                            have all of the tags specified to be included in the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tagsAny:
+                          description: |-
+                            tagsAny is a list of tags to filter by. If specified, the resource
+                            must have at least one of the tags specified to be included in the
+                            result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
                       type: object
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  name:
-                    description: name is the human-readable name of the resource.
-                      Might not be unique.
-                    maxLength: 1024
-                    type: string
-                  projectID:
-                    description: projectID is the project owner of the resource.
-                    maxLength: 1024
-                    type: string
-                  status:
-                    description: status indicates the current status of the resource.
-                    maxLength: 1024
-                    type: string
-                  tags:
-                    description: tags is the list of tags on the resource.
-                    items:
+                    id:
+                      description: |-
+                        id contains the unique identifier of an existing OpenStack resource. Note
+                        that when specifying an import by ID, the resource MUST already exist.
+                        The ORC object will enter an error state if the resource does not exist.
+                      format: uuid
+                      type: string
+                  type: object
+                managedOptions:
+                  description: managedOptions specifies options which may be applied to managed objects.
+                  properties:
+                    onDelete:
+                      default: delete
+                      description: |-
+                        onDelete specifies the behaviour of the controller when the ORC
+                        object is deleted. Options are `delete` - delete the OpenStack resource;
+                        `detach` - do not delete the OpenStack resource. If not specified, the
+                        default is `delete`.
+                      enum:
+                        - delete
+                        - detach
+                      type: string
+                  type: object
+                managementPolicy:
+                  default: managed
+                  description: |-
+                    managementPolicy defines how ORC will treat the object. Valid values are
+                    `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                    ORC will import an existing resource, and will not apply updates to it or
+                    delete it.
+                  enum:
+                    - managed
+                    - unmanaged
+                  type: string
+                  x-kubernetes-validations:
+                    - message: managementPolicy is immutable
+                      rule: self == oldSelf
+                resource:
+                  description: |-
+                    resource specifies the desired state of the resource.
+
+                    resource may not be specified if the management policy is `unmanaged`.
+
+                    resource must be specified if the management policy is `managed`.
+                  properties:
+                    adminStateUp:
+                      description: |-
+                        adminStateUp represents the administrative state of the resource,
+                        which is up (true) or down (false). Default is true.
+                      type: boolean
+                    availabilityZoneHints:
+                      description: availabilityZoneHints is the availability zone candidate for the router.
+                      items:
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: set
+                    description:
+                      description: description is a human-readable description for the resource.
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    distributed:
+                      description: |-
+                        distributed indicates whether the router is distributed or not. It
+                        is available when dvr extension is enabled.
+                      type: boolean
+                    externalGateways:
+                      description: externalGateways is a list of external gateways for the router.
+                      items:
+                        properties:
+                          networkRef:
+                            description: |-
+                              networkRef is a reference to the ORC Network which the external
+                              gateway is on.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        required:
+                          - networkRef
+                        type: object
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: |-
+                        name is a human-readable name of the router. If not set, the
+                        object's name will be used.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[^,]+$
+                      type: string
+                    tags:
+                      description: tags is a list of tags which will be applied to the router.
+                      items:
+                        description: |-
+                          NeutronTag represents a tag on a Neutron resource.
+                          It may not be empty and may not contain commas.
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: set
+                  type: object
+                  x-kubernetes-validations:
+                    - message: RouterResourceSpec is immutable
+                      rule: self == oldSelf
+              required:
+                - cloudCredentialsRef
+              type: object
+              x-kubernetes-validations:
+                - message: resource must be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+                - message: import may not be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__) : true'
+                - message: resource may not be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource) : true'
+                - message: import must be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__) : true'
+                - message: managedOptions may only be provided when policy is managed
+                  rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed'' : true'
+            status:
+              description: status defines the observed state of the resource.
+              properties:
+                conditions:
+                  description: |-
+                    conditions represents the observed status of the object.
+                    Known .status.conditions.type are: "Available", "Progressing"
+
+                    Available represents the availability of the OpenStack resource. If it is
+                    true then the resource is ready for use.
+
+                    Progressing indicates whether the controller is still attempting to
+                    reconcile the current state of the OpenStack resource to the desired
+                    state. Progressing will be False either because the desired state has
+                    been achieved, or because some terminal error prevents it from ever being
+                    achieved and the controller is no longer attempting to reconcile. If
+                    Progressing is True, an observer waiting on the resource should continue
+                    to wait.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                id:
+                  description: id is the unique identifier of the OpenStack resource.
+                  type: string
+                resource:
+                  description: resource contains the observed state of the OpenStack resource.
+                  properties:
+                    adminStateUp:
+                      description: |-
+                        adminStateUp is the administrative state of the router,
+                        which is up (true) or down (false).
+                      type: boolean
+                    availabilityZoneHints:
+                      description: |-
+                        availabilityZoneHints is the availability zone candidate for the
+                        router.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    description:
+                      description: description is a human-readable description for the resource.
                       maxLength: 1024
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    externalGateways:
+                      description: externalGateways is a list of external gateways for the router.
+                      items:
+                        properties:
+                          networkID:
+                            description: networkID is the ID of the network the gateway is on.
+                            maxLength: 1024
+                            type: string
+                        type: object
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: name is the human-readable name of the resource. Might not be unique.
+                      maxLength: 1024
+                      type: string
+                    projectID:
+                      description: projectID is the project owner of the resource.
+                      maxLength: 1024
+                      type: string
+                    status:
+                      description: status indicates the current status of the resource.
+                      maxLength: 1024
+                      type: string
+                    tags:
+                      description: tags is the list of tags on the resource.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3204,582 +3065,549 @@ spec:
   group: openstack.k-orc.cloud
   names:
     categories:
-    - openstack
+      - openstack
     kind: SecurityGroup
     listKind: SecurityGroupList
     plural: securitygroups
     singular: securitygroup
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Resource ID
-      jsonPath: .status.id
-      name: ID
-      type: string
-    - description: Availability status of resource
-      jsonPath: .status.conditions[?(@.type=='Available')].status
-      name: Available
-      type: string
-    - description: Message describing current progress status
-      jsonPath: .status.conditions[?(@.type=='Progressing')].message
-      name: Message
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: SecurityGroup is the Schema for an ORC resource.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec specifies the desired state of the resource.
-            properties:
-              cloudCredentialsRef:
-                description: cloudCredentialsRef points to a secret containing OpenStack
-                  credentials
-                properties:
-                  cloudName:
-                    description: cloudName specifies the name of the entry in the
-                      clouds.yaml file to use.
-                    maxLength: 256
-                    minLength: 1
-                    type: string
-                  secretName:
-                    description: |-
-                      secretName is the name of a secret in the same namespace as the resource being provisioned.
-                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
-                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                required:
-                - cloudName
-                - secretName
-                type: object
-              import:
-                description: |-
-                  import refers to an existing OpenStack resource which will be imported instead of
-                  creating a new one.
-                maxProperties: 1
-                minProperties: 1
-                properties:
-                  filter:
-                    description: |-
-                      filter contains a resource query which is expected to return a single
-                      result. The controller will continue to retry if filter returns no
-                      results. If filter returns multiple results the controller will set an
-                      error state and will not continue to retry.
-                    minProperties: 1
-                    properties:
-                      description:
-                        description: description of the existing resource
-                        maxLength: 255
-                        minLength: 1
-                        type: string
-                      name:
-                        description: name of the existing resource
-                        maxLength: 255
-                        minLength: 1
-                        pattern: ^[^,]+$
-                        type: string
-                      notTags:
-                        description: |-
-                          notTags is a list of tags to filter by. If specified, resources which
-                          contain all of the given tags will be excluded from the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      notTagsAny:
-                        description: |-
-                          notTagsAny is a list of tags to filter by. If specified, resources
-                          which contain any of the given tags will be excluded from the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tags:
-                        description: |-
-                          tags is a list of tags to filter by. If specified, the resource must
-                          have all of the tags specified to be included in the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tagsAny:
-                        description: |-
-                          tagsAny is a list of tags to filter by. If specified, the resource
-                          must have at least one of the tags specified to be included in the
-                          result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                    type: object
-                  id:
-                    description: |-
-                      id contains the unique identifier of an existing OpenStack resource. Note
-                      that when specifying an import by ID, the resource MUST already exist.
-                      The ORC object will enter an error state if the resource does not exist.
-                    format: uuid
-                    type: string
-                type: object
-              managedOptions:
-                description: managedOptions specifies options which may be applied
-                  to managed objects.
-                properties:
-                  onDelete:
-                    default: delete
-                    description: |-
-                      onDelete specifies the behaviour of the controller when the ORC
-                      object is deleted. Options are `delete` - delete the OpenStack resource;
-                      `detach` - do not delete the OpenStack resource. If not specified, the
-                      default is `delete`.
-                    enum:
-                    - delete
-                    - detach
-                    type: string
-                type: object
-              managementPolicy:
-                default: managed
-                description: |-
-                  managementPolicy defines how ORC will treat the object. Valid values are
-                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
-                  ORC will import an existing resource, and will not apply updates to it or
-                  delete it.
-                enum:
-                - managed
-                - unmanaged
-                type: string
-                x-kubernetes-validations:
-                - message: managementPolicy is immutable
-                  rule: self == oldSelf
-              resource:
-                description: |-
-                  resource specifies the desired state of the resource.
-
-                  resource may not be specified if the management policy is `unmanaged`.
-
-                  resource must be specified if the management policy is `managed`.
-                properties:
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 255
-                    minLength: 1
-                    type: string
-                    x-kubernetes-validations:
-                    - message: Property is immutable
-                      rule: self == oldSelf
-                  name:
-                    description: |-
-                      name will be the name of the created resource. If not specified, the
-                      name of the ORC object will be used.
-                    maxLength: 255
-                    minLength: 1
-                    pattern: ^[^,]+$
-                    type: string
-                    x-kubernetes-validations:
-                    - message: Property is immutable
-                      rule: self == oldSelf
-                  rules:
-                    description: rules is a list of security group rules belonging
-                      to this SG.
-                    items:
-                      description: SecurityGroupRule defines a Security Group rule
+    - additionalPrinterColumns:
+        - description: Resource ID
+          jsonPath: .status.id
+          name: ID
+          type: string
+        - description: Availability status of resource
+          jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: Available
+          type: string
+        - description: Message describing current progress status
+          jsonPath: .status.conditions[?(@.type=='Progressing')].message
+          name: Message
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: SecurityGroup is the Schema for an ORC resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec specifies the desired state of the resource.
+              properties:
+                cloudCredentialsRef:
+                  description: cloudCredentialsRef points to a secret containing OpenStack credentials
+                  properties:
+                    cloudName:
+                      description: cloudName specifies the name of the entry in the clouds.yaml file to use.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    secretName:
+                      description: |-
+                        secretName is the name of a secret in the same namespace as the resource being provisioned.
+                        The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                        The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                    - cloudName
+                    - secretName
+                  type: object
+                import:
+                  description: |-
+                    import refers to an existing OpenStack resource which will be imported instead of
+                    creating a new one.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: |-
+                        filter contains a resource query which is expected to return a single
+                        result. The controller will continue to retry if filter returns no
+                        results. If filter returns multiple results the controller will set an
+                        error state and will not continue to retry.
                       minProperties: 1
                       properties:
                         description:
-                          description: description is a human-readable description
-                            for the resource.
+                          description: description of the existing resource
                           maxLength: 255
                           minLength: 1
                           type: string
-                        direction:
-                          description: |-
-                            direction represents the direction in which the security group rule
-                            is applied. Can be ingress or egress.
-                          enum:
-                          - ingress
-                          - egress
-                          type: string
-                        ethertype:
-                          description: |-
-                            ethertype must be IPv4 or IPv6, and addresses represented in CIDR
-                            must match the ingress or egress rules.
-                          enum:
-                          - IPv4
-                          - IPv6
-                          type: string
-                        portRange:
-                          description: |-
-                            portRange sets the minimum and maximum ports range that the security group rule
-                            matches. If the protocol is [tcp, udp, dccp sctp,udplite] PortRange.Min must be less than
-                            or equal to the PortRange.Max attribute value.
-                            If the protocol is ICMP, this PortRamge.Min must be an ICMP code and PortRange.Max
-                            should be an ICMP type
-                          properties:
-                            max:
-                              description: |-
-                                max is the maximum port number in the range that is matched by the security group rule.
-                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be greater than or equal
-                                to the port_range_min attribute value. If the protocol is ICMP, this value must be an ICMP code.
-                              format: int32
-                              maximum: 65535
-                              minimum: 0
-                              type: integer
-                            min:
-                              description: |-
-                                min is the minimum port number in the range that is matched by the security group rule.
-                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be less than or equal
-                                to the port_range_max attribute value. If the protocol is ICMP, this value must be an ICMP type
-                              format: int32
-                              maximum: 65535
-                              minimum: 0
-                              type: integer
-                          required:
-                          - max
-                          - min
-                          type: object
-                        protocol:
-                          description: protocol is the IP protocol is represented
-                            by a string
-                          enum:
-                          - ah
-                          - dccp
-                          - egp
-                          - esp
-                          - gre
-                          - icmp
-                          - icmpv6
-                          - igmp
-                          - ipip
-                          - ipv6-encap
-                          - ipv6-frag
-                          - ipv6-icmp
-                          - ipv6-nonxt
-                          - ipv6-opts
-                          - ipv6-route
-                          - ospf
-                          - pgm
-                          - rsvp
-                          - sctp
-                          - tcp
-                          - udp
-                          - udplite
-                          - vrrp
-                          type: string
-                        remoteIPPrefix:
-                          description: remoteIPPrefix is an IP address block. Should
-                            match the Ethertype (IPv4 or IPv6)
-                          format: cidr
-                          maxLength: 49
+                        name:
+                          description: name of the existing resource
+                          maxLength: 255
                           minLength: 1
+                          pattern: ^[^,]+$
                           type: string
-                      required:
-                      - ethertype
+                        notTags:
+                          description: |-
+                            notTags is a list of tags to filter by. If specified, resources which
+                            contain all of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        notTagsAny:
+                          description: |-
+                            notTagsAny is a list of tags to filter by. If specified, resources
+                            which contain any of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tags:
+                          description: |-
+                            tags is a list of tags to filter by. If specified, the resource must
+                            have all of the tags specified to be included in the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tagsAny:
+                          description: |-
+                            tagsAny is a list of tags to filter by. If specified, the resource
+                            must have at least one of the tags specified to be included in the
+                            result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
                       type: object
-                      x-kubernetes-validations:
-                      - message: portRangeMax should be equal or greater than portRange.min
-                        rule: (!has(self.portRange)|| !(self.protocol == 'tcp'|| self.protocol
-                          == 'udp' || self.protocol == 'dccp' || self.protocol ==
-                          'sctp' || self.protocol == 'udplite') || (self.portRange.min
-                          <= self.portRange.max))
-                      - message: When protocol is ICMP or ICMPv6 portRange.min should
-                          be between 0 and 255
-                        rule: '!(self.protocol == ''icmp'' || self.protocol == ''icmpv6'')
-                          || !has(self.portRange)|| (self.portRange.min >= 0 && self.portRange.min
-                          <= 255)'
-                      - message: When protocol is ICMP or ICMPv6 portRange.max should
-                          be between 0 and 255
-                        rule: '!(self.protocol == ''icmp'' || self.protocol == ''icmpv6'')
-                          || !has(self.portRange)|| (self.portRange.max >= 0 && self.portRange.max
-                          <= 255)'
-                    maxItems: 256
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  stateful:
-                    description: stateful indicates if the security group is stateful
-                      or stateless.
-                    type: boolean
-                    x-kubernetes-validations:
-                    - message: Property is immutable
-                      rule: self == oldSelf
-                  tags:
-                    description: tags is a list of tags which will be applied to the
-                      security group.
-                    items:
+                    id:
                       description: |-
-                        NeutronTag represents a tag on a Neutron resource.
-                        It may not be empty and may not contain commas.
+                        id contains the unique identifier of an existing OpenStack resource. Note
+                        that when specifying an import by ID, the resource MUST already exist.
+                        The ORC object will enter an error state if the resource does not exist.
+                      format: uuid
+                      type: string
+                  type: object
+                managedOptions:
+                  description: managedOptions specifies options which may be applied to managed objects.
+                  properties:
+                    onDelete:
+                      default: delete
+                      description: |-
+                        onDelete specifies the behaviour of the controller when the ORC
+                        object is deleted. Options are `delete` - delete the OpenStack resource;
+                        `detach` - do not delete the OpenStack resource. If not specified, the
+                        default is `delete`.
+                      enum:
+                        - delete
+                        - detach
+                      type: string
+                  type: object
+                managementPolicy:
+                  default: managed
+                  description: |-
+                    managementPolicy defines how ORC will treat the object. Valid values are
+                    `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                    ORC will import an existing resource, and will not apply updates to it or
+                    delete it.
+                  enum:
+                    - managed
+                    - unmanaged
+                  type: string
+                  x-kubernetes-validations:
+                    - message: managementPolicy is immutable
+                      rule: self == oldSelf
+                resource:
+                  description: |-
+                    resource specifies the desired state of the resource.
+
+                    resource may not be specified if the management policy is `unmanaged`.
+
+                    resource must be specified if the management policy is `managed`.
+                  properties:
+                    description:
+                      description: description is a human-readable description for the resource.
                       maxLength: 255
                       minLength: 1
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: set
-                    x-kubernetes-validations:
-                    - message: Property is immutable
-                      rule: self == oldSelf
-                type: object
-            required:
-            - cloudCredentialsRef
-            type: object
-            x-kubernetes-validations:
-            - message: resource must be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
-            - message: import may not be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
-                : true'
-            - message: resource may not be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
-                : true'
-            - message: import must be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
-                : true'
-            - message: managedOptions may only be provided when policy is managed
-              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
-                : true'
-          status:
-            description: status defines the observed state of the resource.
-            properties:
-              conditions:
-                description: |-
-                  conditions represents the observed status of the object.
-                  Known .status.conditions.type are: "Available", "Progressing"
-
-                  Available represents the availability of the OpenStack resource. If it is
-                  true then the resource is ready for use.
-
-                  Progressing indicates whether the controller is still attempting to
-                  reconcile the current state of the OpenStack resource to the desired
-                  state. Progressing will be False either because the desired state has
-                  been achieved, or because some terminal error prevents it from ever being
-                  achieved and the controller is no longer attempting to reconcile. If
-                  Progressing is True, an observer waiting on the resource should continue
-                  to wait.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
+                      x-kubernetes-validations:
+                        - message: Property is immutable
+                          rule: self == oldSelf
+                    name:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        name will be the name of the created resource. If not specified, the
+                        name of the ORC object will be used.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[^,]+$
+                      type: string
+                      x-kubernetes-validations:
+                        - message: Property is immutable
+                          rule: self == oldSelf
+                    rules:
+                      description: rules is a list of security group rules belonging to this SG.
+                      items:
+                        description: SecurityGroupRule defines a Security Group rule
+                        minProperties: 1
+                        properties:
+                          description:
+                            description: description is a human-readable description for the resource.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          direction:
+                            description: |-
+                              direction represents the direction in which the security group rule
+                              is applied. Can be ingress or egress.
+                            enum:
+                              - ingress
+                              - egress
+                            type: string
+                          ethertype:
+                            description: |-
+                              ethertype must be IPv4 or IPv6, and addresses represented in CIDR
+                              must match the ingress or egress rules.
+                            enum:
+                              - IPv4
+                              - IPv6
+                            type: string
+                          portRange:
+                            description: |-
+                              portRange sets the minimum and maximum ports range that the security group rule
+                              matches. If the protocol is [tcp, udp, dccp sctp,udplite] PortRange.Min must be less than
+                              or equal to the PortRange.Max attribute value.
+                              If the protocol is ICMP, this PortRamge.Min must be an ICMP code and PortRange.Max
+                              should be an ICMP type
+                            properties:
+                              max:
+                                description: |-
+                                  max is the maximum port number in the range that is matched by the security group rule.
+                                  If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be greater than or equal
+                                  to the port_range_min attribute value. If the protocol is ICMP, this value must be an ICMP code.
+                                format: int32
+                                maximum: 65535
+                                minimum: 0
+                                type: integer
+                              min:
+                                description: |-
+                                  min is the minimum port number in the range that is matched by the security group rule.
+                                  If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be less than or equal
+                                  to the port_range_max attribute value. If the protocol is ICMP, this value must be an ICMP type
+                                format: int32
+                                maximum: 65535
+                                minimum: 0
+                                type: integer
+                            required:
+                              - max
+                              - min
+                            type: object
+                          protocol:
+                            description: protocol is the IP protocol is represented by a string
+                            enum:
+                              - ah
+                              - dccp
+                              - egp
+                              - esp
+                              - gre
+                              - icmp
+                              - icmpv6
+                              - igmp
+                              - ipip
+                              - ipv6-encap
+                              - ipv6-frag
+                              - ipv6-icmp
+                              - ipv6-nonxt
+                              - ipv6-opts
+                              - ipv6-route
+                              - ospf
+                              - pgm
+                              - rsvp
+                              - sctp
+                              - tcp
+                              - udp
+                              - udplite
+                              - vrrp
+                            type: string
+                          remoteIPPrefix:
+                            description: remoteIPPrefix is an IP address block. Should match the Ethertype (IPv4 or IPv6)
+                            format: cidr
+                            maxLength: 49
+                            minLength: 1
+                            type: string
+                        required:
+                          - ethertype
+                        type: object
+                        x-kubernetes-validations:
+                          - message: portRangeMax should be equal or greater than portRange.min
+                            rule: (!has(self.portRange)|| !(self.protocol == 'tcp'|| self.protocol == 'udp' || self.protocol == 'dccp' || self.protocol == 'sctp' || self.protocol == 'udplite') || (self.portRange.min <= self.portRange.max))
+                          - message: When protocol is ICMP or ICMPv6 portRange.min should be between 0 and 255
+                            rule: '!(self.protocol == ''icmp'' || self.protocol == ''icmpv6'') || !has(self.portRange)|| (self.portRange.min >= 0 && self.portRange.min <= 255)'
+                          - message: When protocol is ICMP or ICMPv6 portRange.max should be between 0 and 255
+                            rule: '!(self.protocol == ''icmp'' || self.protocol == ''icmpv6'') || !has(self.portRange)|| (self.portRange.max >= 0 && self.portRange.max <= 255)'
+                      maxItems: 256
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    stateful:
+                      description: stateful indicates if the security group is stateful or stateless.
+                      type: boolean
+                      x-kubernetes-validations:
+                        - message: Property is immutable
+                          rule: self == oldSelf
+                    tags:
+                      description: tags is a list of tags which will be applied to the security group.
+                      items:
+                        description: |-
+                          NeutronTag represents a tag on a Neutron resource.
+                          It may not be empty and may not contain commas.
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: set
+                      x-kubernetes-validations:
+                        - message: Property is immutable
+                          rule: self == oldSelf
+                  type: object
+              required:
+                - cloudCredentialsRef
+              type: object
+              x-kubernetes-validations:
+                - message: resource must be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+                - message: import may not be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__) : true'
+                - message: resource may not be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource) : true'
+                - message: import must be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__) : true'
+                - message: managedOptions may only be provided when policy is managed
+                  rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed'' : true'
+            status:
+              description: status defines the observed state of the resource.
+              properties:
+                conditions:
+                  description: |-
+                    conditions represents the observed status of the object.
+                    Known .status.conditions.type are: "Available", "Progressing"
+
+                    Available represents the availability of the OpenStack resource. If it is
+                    true then the resource is ready for use.
+
+                    Progressing indicates whether the controller is still attempting to
+                    reconcile the current state of the OpenStack resource to the desired
+                    state. Progressing will be False either because the desired state has
+                    been achieved, or because some terminal error prevents it from ever being
+                    achieved and the controller is no longer attempting to reconcile. If
+                    Progressing is True, an observer waiting on the resource should continue
+                    to wait.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                id:
+                  description: id is the unique identifier of the OpenStack resource.
+                  type: string
+                resource:
+                  description: resource contains the observed state of the OpenStack resource.
+                  properties:
+                    createdAt:
+                      description: createdAt shows the date and time when the resource was created. The date and time stamp format is ISO 8601
                       format: date-time
                       type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
+                    description:
+                      description: description is a human-readable description for the resource.
+                      maxLength: 1024
                       type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
+                    name:
+                      description: name is a Human-readable name for the security group. Might not be unique.
+                      maxLength: 1024
+                      type: string
+                    projectID:
+                      description: projectID is the project owner of the security group.
+                      maxLength: 1024
+                      type: string
+                    revisionNumber:
+                      description: revisionNumber optionally set via extensions/standard-attr-revisions
                       format: int64
-                      minimum: 0
                       type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    rules:
+                      description: rules is a list of security group rules belonging to this SG.
+                      items:
+                        properties:
+                          description:
+                            description: description is a human-readable description for the resource.
+                            maxLength: 1024
+                            type: string
+                          direction:
+                            description: |-
+                              direction represents the direction in which the security group rule
+                              is applied. Can be ingress or egress.
+                            maxLength: 1024
+                            type: string
+                          ethertype:
+                            description: |-
+                              ethertype must be IPv4 or IPv6, and addresses represented in CIDR
+                              must match the ingress or egress rules.
+                            maxLength: 1024
+                            type: string
+                          id:
+                            description: id is the ID of the security group rule.
+                            maxLength: 1024
+                            type: string
+                          portRange:
+                            description: |-
+                              portRange sets the minimum and maximum ports range that the security group rule
+                              matches. If the protocol is [tcp, udp, dccp sctp,udplite] PortRange.Min must be less than
+                              or equal to the PortRange.Max attribute value.
+                              If the protocol is ICMP, this PortRamge.Min must be an ICMP code and PortRange.Max
+                              should be an ICMP type
+                            properties:
+                              max:
+                                description: |-
+                                  max is the maximum port number in the range that is matched by the security group rule.
+                                  If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be greater than or equal
+                                  to the port_range_min attribute value. If the protocol is ICMP, this value must be an ICMP code.
+                                format: int32
+                                type: integer
+                              min:
+                                description: |-
+                                  min is the minimum port number in the range that is matched by the security group rule.
+                                  If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be less than or equal
+                                  to the port_range_max attribute value. If the protocol is ICMP, this value must be an ICMP type
+                                format: int32
+                                type: integer
+                            type: object
+                          protocol:
+                            description: |-
+                              protocol is the IP protocol can be represented by a string, an
+                              integer, or null
+                            maxLength: 1024
+                            type: string
+                          remoteGroupID:
+                            description: |-
+                              remoteGroupID is the remote group UUID to associate with this security group rule
+                              RemoteGroupID
+                            maxLength: 1024
+                            type: string
+                          remoteIPPrefix:
+                            description: remoteIPPrefix is an IP address block. Should match the Ethertype (IPv4 or IPv6)
+                            maxLength: 1024
+                            type: string
+                        type: object
+                      maxItems: 256
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    stateful:
+                      description: stateful indicates if the security group is stateful or stateless.
+                      type: boolean
+                    tags:
+                      description: tags is the list of tags on the resource.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    updatedAt:
+                      description: updatedAt shows the date and time when the resource was updated. The date and time stamp format is ISO 8601
+                      format: date-time
                       type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
                   type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              id:
-                description: id is the unique identifier of the OpenStack resource.
-                type: string
-              resource:
-                description: resource contains the observed state of the OpenStack
-                  resource.
-                properties:
-                  createdAt:
-                    description: createdAt shows the date and time when the resource
-                      was created. The date and time stamp format is ISO 8601
-                    format: date-time
-                    type: string
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 1024
-                    type: string
-                  name:
-                    description: name is a Human-readable name for the security group.
-                      Might not be unique.
-                    maxLength: 1024
-                    type: string
-                  projectID:
-                    description: projectID is the project owner of the security group.
-                    maxLength: 1024
-                    type: string
-                  revisionNumber:
-                    description: revisionNumber optionally set via extensions/standard-attr-revisions
-                    format: int64
-                    type: integer
-                  rules:
-                    description: rules is a list of security group rules belonging
-                      to this SG.
-                    items:
-                      properties:
-                        description:
-                          description: description is a human-readable description
-                            for the resource.
-                          maxLength: 1024
-                          type: string
-                        direction:
-                          description: |-
-                            direction represents the direction in which the security group rule
-                            is applied. Can be ingress or egress.
-                          maxLength: 1024
-                          type: string
-                        ethertype:
-                          description: |-
-                            ethertype must be IPv4 or IPv6, and addresses represented in CIDR
-                            must match the ingress or egress rules.
-                          maxLength: 1024
-                          type: string
-                        id:
-                          description: id is the ID of the security group rule.
-                          maxLength: 1024
-                          type: string
-                        portRange:
-                          description: |-
-                            portRange sets the minimum and maximum ports range that the security group rule
-                            matches. If the protocol is [tcp, udp, dccp sctp,udplite] PortRange.Min must be less than
-                            or equal to the PortRange.Max attribute value.
-                            If the protocol is ICMP, this PortRamge.Min must be an ICMP code and PortRange.Max
-                            should be an ICMP type
-                          properties:
-                            max:
-                              description: |-
-                                max is the maximum port number in the range that is matched by the security group rule.
-                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be greater than or equal
-                                to the port_range_min attribute value. If the protocol is ICMP, this value must be an ICMP code.
-                              format: int32
-                              type: integer
-                            min:
-                              description: |-
-                                min is the minimum port number in the range that is matched by the security group rule.
-                                If the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be less than or equal
-                                to the port_range_max attribute value. If the protocol is ICMP, this value must be an ICMP type
-                              format: int32
-                              type: integer
-                          type: object
-                        protocol:
-                          description: |-
-                            protocol is the IP protocol can be represented by a string, an
-                            integer, or null
-                          maxLength: 1024
-                          type: string
-                        remoteGroupID:
-                          description: |-
-                            remoteGroupID is the remote group UUID to associate with this security group rule
-                            RemoteGroupID
-                          maxLength: 1024
-                          type: string
-                        remoteIPPrefix:
-                          description: remoteIPPrefix is an IP address block. Should
-                            match the Ethertype (IPv4 or IPv6)
-                          maxLength: 1024
-                          type: string
-                      type: object
-                    maxItems: 256
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  stateful:
-                    description: stateful indicates if the security group is stateful
-                      or stateless.
-                    type: boolean
-                  tags:
-                    description: tags is the list of tags on the resource.
-                    items:
-                      maxLength: 1024
-                      type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  updatedAt:
-                    description: updatedAt shows the date and time when the resource
-                      was updated. The date and time stamp format is ISO 8601
-                    format: date-time
-                    type: string
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3792,396 +3620,380 @@ spec:
   group: openstack.k-orc.cloud
   names:
     categories:
-    - openstack
+      - openstack
     kind: Server
     listKind: ServerList
     plural: servers
     singular: server
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Resource ID
-      jsonPath: .status.id
-      name: ID
-      type: string
-    - description: Availability status of resource
-      jsonPath: .status.conditions[?(@.type=='Available')].status
-      name: Available
-      type: string
-    - description: Message describing current progress status
-      jsonPath: .status.conditions[?(@.type=='Progressing')].message
-      name: Message
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Server is the Schema for an ORC resource.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec specifies the desired state of the resource.
-            properties:
-              cloudCredentialsRef:
-                description: cloudCredentialsRef points to a secret containing OpenStack
-                  credentials
-                properties:
-                  cloudName:
-                    description: cloudName specifies the name of the entry in the
-                      clouds.yaml file to use.
-                    maxLength: 256
-                    minLength: 1
-                    type: string
-                  secretName:
-                    description: |-
-                      secretName is the name of a secret in the same namespace as the resource being provisioned.
-                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
-                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                required:
-                - cloudName
-                - secretName
-                type: object
-              import:
-                description: |-
-                  import refers to an existing OpenStack resource which will be imported instead of
-                  creating a new one.
-                maxProperties: 1
-                minProperties: 1
-                properties:
-                  filter:
-                    description: |-
-                      filter contains a resource query which is expected to return a single
-                      result. The controller will continue to retry if filter returns no
-                      results. If filter returns multiple results the controller will set an
-                      error state and will not continue to retry.
-                    minProperties: 1
-                    properties:
-                      name:
-                        description: name of the existing resource
-                        maxLength: 255
+    - additionalPrinterColumns:
+        - description: Resource ID
+          jsonPath: .status.id
+          name: ID
+          type: string
+        - description: Availability status of resource
+          jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: Available
+          type: string
+        - description: Message describing current progress status
+          jsonPath: .status.conditions[?(@.type=='Progressing')].message
+          name: Message
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Server is the Schema for an ORC resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec specifies the desired state of the resource.
+              properties:
+                cloudCredentialsRef:
+                  description: cloudCredentialsRef points to a secret containing OpenStack credentials
+                  properties:
+                    cloudName:
+                      description: cloudName specifies the name of the entry in the clouds.yaml file to use.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    secretName:
+                      description: |-
+                        secretName is the name of a secret in the same namespace as the resource being provisioned.
+                        The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                        The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                    - cloudName
+                    - secretName
+                  type: object
+                import:
+                  description: |-
+                    import refers to an existing OpenStack resource which will be imported instead of
+                    creating a new one.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: |-
+                        filter contains a resource query which is expected to return a single
+                        result. The controller will continue to retry if filter returns no
+                        results. If filter returns multiple results the controller will set an
+                        error state and will not continue to retry.
+                      minProperties: 1
+                      properties:
+                        name:
+                          description: name of the existing resource
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        notTags:
+                          description: |-
+                            notTags is a list of tags to filter by. If specified, resources which
+                            contain all of the given tags will be excluded from the result.
+                          items:
+                            maxLength: 80
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        notTagsAny:
+                          description: |-
+                            notTagsAny is a list of tags to filter by. If specified, resources
+                            which contain any of the given tags will be excluded from the result.
+                          items:
+                            maxLength: 80
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tags:
+                          description: |-
+                            tags is a list of tags to filter by. If specified, the resource must
+                            have all of the tags specified to be included in the result.
+                          items:
+                            maxLength: 80
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tagsAny:
+                          description: |-
+                            tagsAny is a list of tags to filter by. If specified, the resource
+                            must have at least one of the tags specified to be included in the
+                            result.
+                          items:
+                            maxLength: 80
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                      type: object
+                    id:
+                      description: |-
+                        id contains the unique identifier of an existing OpenStack resource. Note
+                        that when specifying an import by ID, the resource MUST already exist.
+                        The ORC object will enter an error state if the resource does not exist.
+                      format: uuid
+                      type: string
+                  type: object
+                managedOptions:
+                  description: managedOptions specifies options which may be applied to managed objects.
+                  properties:
+                    onDelete:
+                      default: delete
+                      description: |-
+                        onDelete specifies the behaviour of the controller when the ORC
+                        object is deleted. Options are `delete` - delete the OpenStack resource;
+                        `detach` - do not delete the OpenStack resource. If not specified, the
+                        default is `delete`.
+                      enum:
+                        - delete
+                        - detach
+                      type: string
+                  type: object
+                managementPolicy:
+                  default: managed
+                  description: |-
+                    managementPolicy defines how ORC will treat the object. Valid values are
+                    `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                    ORC will import an existing resource, and will not apply updates to it or
+                    delete it.
+                  enum:
+                    - managed
+                    - unmanaged
+                  type: string
+                  x-kubernetes-validations:
+                    - message: managementPolicy is immutable
+                      rule: self == oldSelf
+                resource:
+                  description: |-
+                    resource specifies the desired state of the resource.
+
+                    resource may not be specified if the management policy is `unmanaged`.
+
+                    resource must be specified if the management policy is `managed`.
+                  properties:
+                    flavorRef:
+                      description: flavorRef references the flavor to use for the server instance.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    imageRef:
+                      description: |-
+                        imageRef references the image to use for the server instance.
+                        NOTE: This is not required in case of boot from volume.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    name:
+                      description: |-
+                        name will be the name of the created resource. If not specified, the
+                        name of the ORC object will be used.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[^,]+$
+                      type: string
+                    ports:
+                      description: ports defines a list of ports which will be attached to the server.
+                      items:
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          portRef:
+                            description: |-
+                              portRef is a reference to a Port object. Server creation will wait for
+                              this port to be created and available.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        type: object
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    tags:
+                      description: tags is a list of tags which will be applied to the server.
+                      items:
+                        maxLength: 80
                         minLength: 1
-                        pattern: ^[^,]+$
                         type: string
-                      notTags:
-                        description: |-
-                          notTags is a list of tags to filter by. If specified, resources which
-                          contain all of the given tags will be excluded from the result.
-                        items:
-                          maxLength: 80
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      notTagsAny:
-                        description: |-
-                          notTagsAny is a list of tags to filter by. If specified, resources
-                          which contain any of the given tags will be excluded from the result.
-                        items:
-                          maxLength: 80
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tags:
-                        description: |-
-                          tags is a list of tags to filter by. If specified, the resource must
-                          have all of the tags specified to be included in the result.
-                        items:
-                          maxLength: 80
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tagsAny:
-                        description: |-
-                          tagsAny is a list of tags to filter by. If specified, the resource
-                          must have at least one of the tags specified to be included in the
-                          result.
-                        items:
-                          maxLength: 80
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                    type: object
-                  id:
-                    description: |-
-                      id contains the unique identifier of an existing OpenStack resource. Note
-                      that when specifying an import by ID, the resource MUST already exist.
-                      The ORC object will enter an error state if the resource does not exist.
-                    format: uuid
-                    type: string
-                type: object
-              managedOptions:
-                description: managedOptions specifies options which may be applied
-                  to managed objects.
-                properties:
-                  onDelete:
-                    default: delete
-                    description: |-
-                      onDelete specifies the behaviour of the controller when the ORC
-                      object is deleted. Options are `delete` - delete the OpenStack resource;
-                      `detach` - do not delete the OpenStack resource. If not specified, the
-                      default is `delete`.
-                    enum:
-                    - delete
-                    - detach
-                    type: string
-                type: object
-              managementPolicy:
-                default: managed
-                description: |-
-                  managementPolicy defines how ORC will treat the object. Valid values are
-                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
-                  ORC will import an existing resource, and will not apply updates to it or
-                  delete it.
-                enum:
-                - managed
-                - unmanaged
-                type: string
-                x-kubernetes-validations:
-                - message: managementPolicy is immutable
-                  rule: self == oldSelf
-              resource:
-                description: |-
-                  resource specifies the desired state of the resource.
-
-                  resource may not be specified if the management policy is `unmanaged`.
-
-                  resource must be specified if the management policy is `managed`.
-                properties:
-                  flavorRef:
-                    description: flavorRef references the flavor to use for the server
-                      instance.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  imageRef:
-                    description: |-
-                      imageRef references the image to use for the server instance.
-                      NOTE: This is not required in case of boot from volume.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  name:
-                    description: |-
-                      name will be the name of the created resource. If not specified, the
-                      name of the ORC object will be used.
-                    maxLength: 255
-                    minLength: 1
-                    pattern: ^[^,]+$
-                    type: string
-                  ports:
-                    description: ports defines a list of ports which will be attached
-                      to the server.
-                    items:
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: set
+                    userData:
+                      description: |-
+                        userData specifies data which will be made available to the server at
+                        boot time, either via the metadata service or a config drive. It is
+                        typically read by a configuration service such as cloud-init or ignition.
                       maxProperties: 1
                       minProperties: 1
                       properties:
-                        portRef:
-                          description: |-
-                            portRef is a reference to a Port object. Server creation will wait for
-                            this port to be created and available.
+                        secretRef:
+                          description: secretRef is a reference to a Secret containing the user data for this server.
                           maxLength: 253
                           minLength: 1
                           type: string
                       type: object
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  tags:
-                    description: tags is a list of tags which will be applied to the
-                      server.
-                    items:
-                      maxLength: 80
-                      minLength: 1
-                      type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: set
-                  userData:
-                    description: |-
-                      userData specifies data which will be made available to the server at
-                      boot time, either via the metadata service or a config drive. It is
-                      typically read by a configuration service such as cloud-init or ignition.
-                    maxProperties: 1
-                    minProperties: 1
+                  required:
+                    - flavorRef
+                    - imageRef
+                    - ports
+                  type: object
+                  x-kubernetes-validations:
+                    - message: ServerResourceSpec is immutable
+                      rule: self == oldSelf
+              required:
+                - cloudCredentialsRef
+              type: object
+              x-kubernetes-validations:
+                - message: resource must be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+                - message: import may not be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__) : true'
+                - message: resource may not be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource) : true'
+                - message: import must be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__) : true'
+                - message: managedOptions may only be provided when policy is managed
+                  rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed'' : true'
+            status:
+              description: status defines the observed state of the resource.
+              properties:
+                conditions:
+                  description: |-
+                    conditions represents the observed status of the object.
+                    Known .status.conditions.type are: "Available", "Progressing"
+
+                    Available represents the availability of the OpenStack resource. If it is
+                    true then the resource is ready for use.
+
+                    Progressing indicates whether the controller is still attempting to
+                    reconcile the current state of the OpenStack resource to the desired
+                    state. Progressing will be False either because the desired state has
+                    been achieved, or because some terminal error prevents it from ever being
+                    achieved and the controller is no longer attempting to reconcile. If
+                    Progressing is True, an observer waiting on the resource should continue
+                    to wait.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
-                      secretRef:
-                        description: secretRef is a reference to a Secret containing
-                          the user data for this server.
-                        maxLength: 253
-                        minLength: 1
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
                         type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
                     type: object
-                required:
-                - flavorRef
-                - imageRef
-                - ports
-                type: object
-                x-kubernetes-validations:
-                - message: ServerResourceSpec is immutable
-                  rule: self == oldSelf
-            required:
-            - cloudCredentialsRef
-            type: object
-            x-kubernetes-validations:
-            - message: resource must be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
-            - message: import may not be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
-                : true'
-            - message: resource may not be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
-                : true'
-            - message: import must be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
-                : true'
-            - message: managedOptions may only be provided when policy is managed
-              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
-                : true'
-          status:
-            description: status defines the observed state of the resource.
-            properties:
-              conditions:
-                description: |-
-                  conditions represents the observed status of the object.
-                  Known .status.conditions.type are: "Available", "Progressing"
-
-                  Available represents the availability of the OpenStack resource. If it is
-                  true then the resource is ready for use.
-
-                  Progressing indicates whether the controller is still attempting to
-                  reconcile the current state of the OpenStack resource to the desired
-                  state. Progressing will be False either because the desired state has
-                  been achieved, or because some terminal error prevents it from ever being
-                  achieved and the controller is no longer attempting to reconcile. If
-                  Progressing is True, an observer waiting on the resource should continue
-                  to wait.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                id:
+                  description: id is the unique identifier of the OpenStack resource.
+                  type: string
+                resource:
+                  description: resource contains the observed state of the OpenStack resource.
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
+                    hostID:
+                      description: hostID is the host where the server is located in the cloud.
                       maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    imageID:
+                      description: imageID indicates the OS image used to deploy the server.
+                      maxLength: 1024
+                      type: string
+                    name:
+                      description: name is the human-readable name of the resource. Might not be unique.
+                      maxLength: 1024
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              id:
-                description: id is the unique identifier of the OpenStack resource.
-                type: string
-              resource:
-                description: resource contains the observed state of the OpenStack
-                  resource.
-                properties:
-                  hostID:
-                    description: hostID is the host where the server is located in
-                      the cloud.
-                    maxLength: 1024
-                    type: string
-                  imageID:
-                    description: imageID indicates the OS image used to deploy the
-                      server.
-                    maxLength: 1024
-                    type: string
-                  name:
-                    description: name is the human-readable name of the resource.
-                      Might not be unique.
-                    maxLength: 1024
-                    type: string
-                  status:
-                    description: |-
-                      status contains the current operational status of the server,
-                      such as IN_PROGRESS or ACTIVE.
-                    maxLength: 1024
-                    type: string
-                  tags:
-                    description: tags is the list of tags on the resource.
-                    items:
+                      description: |-
+                        status contains the current operational status of the server,
+                        such as IN_PROGRESS or ACTIVE.
                       maxLength: 1024
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    tags:
+                      description: tags is the list of tags on the resource.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4194,665 +4006,626 @@ spec:
   group: openstack.k-orc.cloud
   names:
     categories:
-    - openstack
+      - openstack
     kind: Subnet
     listKind: SubnetList
     plural: subnets
     singular: subnet
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Resource ID
-      jsonPath: .status.id
-      name: ID
-      type: string
-    - description: Availability status of resource
-      jsonPath: .status.conditions[?(@.type=='Available')].status
-      name: Available
-      type: string
-    - description: Message describing current progress status
-      jsonPath: .status.conditions[?(@.type=='Progressing')].message
-      name: Message
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Subnet is the Schema for an ORC resource.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec specifies the desired state of the resource.
-            properties:
-              cloudCredentialsRef:
-                description: cloudCredentialsRef points to a secret containing OpenStack
-                  credentials
-                properties:
-                  cloudName:
-                    description: cloudName specifies the name of the entry in the
-                      clouds.yaml file to use.
-                    maxLength: 256
-                    minLength: 1
-                    type: string
-                  secretName:
-                    description: |-
-                      secretName is the name of a secret in the same namespace as the resource being provisioned.
-                      The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
-                      The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                required:
-                - cloudName
-                - secretName
-                type: object
-              import:
-                description: |-
-                  import refers to an existing OpenStack resource which will be imported instead of
-                  creating a new one.
-                maxProperties: 1
-                minProperties: 1
-                properties:
-                  filter:
-                    description: |-
-                      filter contains a resource query which is expected to return a single
-                      result. The controller will continue to retry if filter returns no
-                      results. If filter returns multiple results the controller will set an
-                      error state and will not continue to retry.
-                    minProperties: 1
-                    properties:
-                      cidr:
-                        description: cidr of the existing resource
-                        format: cidr
-                        maxLength: 49
-                        minLength: 1
-                        type: string
-                      description:
-                        description: description of the existing resource
-                        maxLength: 255
-                        minLength: 1
-                        type: string
-                      gatewayIP:
-                        description: gatewayIP is the IP address of the gateway of
-                          the existing resource
-                        maxLength: 45
-                        minLength: 1
-                        type: string
-                      ipVersion:
-                        description: ipVersion of the existing resource
-                        enum:
-                        - 4
-                        - 6
-                        format: int32
-                        type: integer
-                      ipv6:
-                        description: ipv6 options of the existing resource
-                        minProperties: 1
-                        properties:
-                          addressMode:
-                            description: addressMode specifies mechanisms for assigning
-                              IPv6 IP addresses.
-                            enum:
-                            - slaac
-                            - dhcpv6-stateful
-                            - dhcpv6-stateless
-                            type: string
-                          raMode:
-                            description: |-
-                              raMode specifies the IPv6 router advertisement mode. It specifies whether
-                              the networking service should transmit ICMPv6 packets.
-                            enum:
-                            - slaac
-                            - dhcpv6-stateful
-                            - dhcpv6-stateless
-                            type: string
-                        type: object
-                      name:
-                        description: name of the existing resource
-                        maxLength: 255
-                        minLength: 1
-                        pattern: ^[^,]+$
-                        type: string
-                      networkRef:
-                        description: networkRef is a reference to the ORC Network
-                          which this subnet is associated with.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      notTags:
-                        description: |-
-                          notTags is a list of tags to filter by. If specified, resources which
-                          contain all of the given tags will be excluded from the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      notTagsAny:
-                        description: |-
-                          notTagsAny is a list of tags to filter by. If specified, resources
-                          which contain any of the given tags will be excluded from the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tags:
-                        description: |-
-                          tags is a list of tags to filter by. If specified, the resource must
-                          have all of the tags specified to be included in the result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                      tagsAny:
-                        description: |-
-                          tagsAny is a list of tags to filter by. If specified, the resource
-                          must have at least one of the tags specified to be included in the
-                          result.
-                        items:
-                          description: |-
-                            NeutronTag represents a tag on a Neutron resource.
-                            It may not be empty and may not contain commas.
-                          maxLength: 255
-                          minLength: 1
-                          type: string
-                        maxItems: 32
-                        type: array
-                        x-kubernetes-list-type: set
-                    type: object
-                  id:
-                    description: |-
-                      id contains the unique identifier of an existing OpenStack resource. Note
-                      that when specifying an import by ID, the resource MUST already exist.
-                      The ORC object will enter an error state if the resource does not exist.
-                    format: uuid
-                    type: string
-                type: object
-              managedOptions:
-                description: managedOptions specifies options which may be applied
-                  to managed objects.
-                properties:
-                  onDelete:
-                    default: delete
-                    description: |-
-                      onDelete specifies the behaviour of the controller when the ORC
-                      object is deleted. Options are `delete` - delete the OpenStack resource;
-                      `detach` - do not delete the OpenStack resource. If not specified, the
-                      default is `delete`.
-                    enum:
-                    - delete
-                    - detach
-                    type: string
-                type: object
-              managementPolicy:
-                default: managed
-                description: |-
-                  managementPolicy defines how ORC will treat the object. Valid values are
-                  `managed`: ORC will create, update, and delete the resource; `unmanaged`:
-                  ORC will import an existing resource, and will not apply updates to it or
-                  delete it.
-                enum:
-                - managed
-                - unmanaged
-                type: string
-                x-kubernetes-validations:
-                - message: managementPolicy is immutable
-                  rule: self == oldSelf
-              resource:
-                description: |-
-                  resource specifies the desired state of the resource.
-
-                  resource may not be specified if the management policy is `unmanaged`.
-
-                  resource must be specified if the management policy is `managed`.
-                properties:
-                  allocationPools:
-                    description: |-
-                      allocationPools are IP Address pools that will be available for DHCP. IP
-                      addresses must be in CIDR.
-                    items:
-                      properties:
-                        end:
-                          description: end is the last IP address in the allocation
-                            pool.
-                          maxLength: 45
-                          minLength: 1
-                          type: string
-                        start:
-                          description: start is the first IP address in the allocation
-                            pool.
-                          maxLength: 45
-                          minLength: 1
-                          type: string
-                      required:
-                      - end
-                      - start
-                      type: object
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  cidr:
-                    description: cidr is the address CIDR of the subnet. It must match
-                      the IP version specified in IPVersion.
-                    format: cidr
-                    maxLength: 49
-                    minLength: 1
-                    type: string
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 255
-                    minLength: 1
-                    type: string
-                  dnsNameservers:
-                    description: dnsNameservers are the nameservers to be set via
-                      DHCP.
-                    items:
-                      maxLength: 45
+    - additionalPrinterColumns:
+        - description: Resource ID
+          jsonPath: .status.id
+          name: ID
+          type: string
+        - description: Availability status of resource
+          jsonPath: .status.conditions[?(@.type=='Available')].status
+          name: Available
+          type: string
+        - description: Message describing current progress status
+          jsonPath: .status.conditions[?(@.type=='Progressing')].message
+          name: Message
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Subnet is the Schema for an ORC resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec specifies the desired state of the resource.
+              properties:
+                cloudCredentialsRef:
+                  description: cloudCredentialsRef points to a secret containing OpenStack credentials
+                  properties:
+                    cloudName:
+                      description: cloudName specifies the name of the entry in the clouds.yaml file to use.
+                      maxLength: 256
                       minLength: 1
                       type: string
-                    maxItems: 16
-                    type: array
-                    x-kubernetes-list-type: set
-                  dnsPublishFixedIP:
-                    description: |-
-                      dnsPublishFixedIP will either enable or disable the publication of
-                      fixed IPs to the DNS. Defaults to false.
-                    type: boolean
-                  enableDHCP:
-                    description: enableDHCP will either enable to disable the DHCP
-                      service.
-                    type: boolean
-                  gateway:
-                    description: |-
-                      gateway specifies the default gateway of the subnet. If not specified,
-                      neutron will add one automatically. To disable this behaviour, specify a
-                      gateway with a type of None.
-                    properties:
-                      ip:
-                        description: |-
-                          ip is the IP address of the default gateway, which must be specified if
-                          Type is `IP`. It must be a valid IP address, either IPv4 or IPv6,
-                          matching the IPVersion in SubnetResourceSpec.
-                        maxLength: 45
-                        minLength: 1
-                        type: string
-                      type:
-                        description: |-
-                          type specifies how the default gateway will be created. `Automatic`
-                          specifies that neutron will automatically add a default gateway. This is
-                          also the default if no Gateway is specified. `None` specifies that the
-                          subnet will not have a default gateway. `IP` specifies that the subnet
-                          will use a specific address as the default gateway, which must be
-                          specified in `IP`.
-                        enum:
-                        - None
-                        - Automatic
-                        - IP
-                        type: string
-                    required:
-                    - type
-                    type: object
-                  hostRoutes:
-                    description: hostRoutes are any static host routes to be set via
-                      DHCP.
-                    items:
+                    secretName:
+                      description: |-
+                        secretName is the name of a secret in the same namespace as the resource being provisioned.
+                        The secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.
+                        The secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                    - cloudName
+                    - secretName
+                  type: object
+                import:
+                  description: |-
+                    import refers to an existing OpenStack resource which will be imported instead of
+                    creating a new one.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    filter:
+                      description: |-
+                        filter contains a resource query which is expected to return a single
+                        result. The controller will continue to retry if filter returns no
+                        results. If filter returns multiple results the controller will set an
+                        error state and will not continue to retry.
+                      minProperties: 1
                       properties:
-                        destination:
-                          description: destination for the additional route.
+                        cidr:
+                          description: cidr of the existing resource
                           format: cidr
                           maxLength: 49
                           minLength: 1
                           type: string
-                        nextHop:
-                          description: nextHop for the additional route.
+                        description:
+                          description: description of the existing resource
+                          maxLength: 255
+                          minLength: 1
+                          type: string
+                        gatewayIP:
+                          description: gatewayIP is the IP address of the gateway of the existing resource
                           maxLength: 45
                           minLength: 1
                           type: string
-                      required:
-                      - destination
-                      - nextHop
+                        ipVersion:
+                          description: ipVersion of the existing resource
+                          enum:
+                            - 4
+                            - 6
+                          format: int32
+                          type: integer
+                        ipv6:
+                          description: ipv6 options of the existing resource
+                          minProperties: 1
+                          properties:
+                            addressMode:
+                              description: addressMode specifies mechanisms for assigning IPv6 IP addresses.
+                              enum:
+                                - slaac
+                                - dhcpv6-stateful
+                                - dhcpv6-stateless
+                              type: string
+                            raMode:
+                              description: |-
+                                raMode specifies the IPv6 router advertisement mode. It specifies whether
+                                the networking service should transmit ICMPv6 packets.
+                              enum:
+                                - slaac
+                                - dhcpv6-stateful
+                                - dhcpv6-stateless
+                              type: string
+                          type: object
+                        name:
+                          description: name of the existing resource
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[^,]+$
+                          type: string
+                        networkRef:
+                          description: networkRef is a reference to the ORC Network which this subnet is associated with.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        notTags:
+                          description: |-
+                            notTags is a list of tags to filter by. If specified, resources which
+                            contain all of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        notTagsAny:
+                          description: |-
+                            notTagsAny is a list of tags to filter by. If specified, resources
+                            which contain any of the given tags will be excluded from the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tags:
+                          description: |-
+                            tags is a list of tags to filter by. If specified, the resource must
+                            have all of the tags specified to be included in the result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
+                        tagsAny:
+                          description: |-
+                            tagsAny is a list of tags to filter by. If specified, the resource
+                            must have at least one of the tags specified to be included in the
+                            result.
+                          items:
+                            description: |-
+                              NeutronTag represents a tag on a Neutron resource.
+                              It may not be empty and may not contain commas.
+                            maxLength: 255
+                            minLength: 1
+                            type: string
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-type: set
                       type: object
-                    maxItems: 256
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  ipVersion:
-                    description: ipVersion is the IP version for the subnet.
-                    enum:
-                    - 4
-                    - 6
-                    format: int32
-                    type: integer
-                  ipv6:
-                    description: ipv6 contains IPv6-specific options. It may only
-                      be set if IPVersion is 6.
-                    minProperties: 1
-                    properties:
-                      addressMode:
-                        description: addressMode specifies mechanisms for assigning
-                          IPv6 IP addresses.
-                        enum:
-                        - slaac
-                        - dhcpv6-stateful
-                        - dhcpv6-stateless
-                        type: string
-                      raMode:
-                        description: |-
-                          raMode specifies the IPv6 router advertisement mode. It specifies whether
-                          the networking service should transmit ICMPv6 packets.
-                        enum:
-                        - slaac
-                        - dhcpv6-stateful
-                        - dhcpv6-stateless
-                        type: string
-                    type: object
-                  name:
-                    description: name is a human-readable name of the subnet. If not
-                      set, the object's name will be used.
-                    maxLength: 255
-                    minLength: 1
-                    pattern: ^[^,]+$
-                    type: string
-                  networkRef:
-                    description: networkRef is a reference to the ORC Network which
-                      this subnet is associated with.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  routerRef:
-                    description: routerRef specifies a router to attach the subnet
-                      to
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  tags:
-                    description: tags is a list of tags which will be applied to the
-                      subnet.
-                    items:
+                    id:
                       description: |-
-                        NeutronTag represents a tag on a Neutron resource.
-                        It may not be empty and may not contain commas.
+                        id contains the unique identifier of an existing OpenStack resource. Note
+                        that when specifying an import by ID, the resource MUST already exist.
+                        The ORC object will enter an error state if the resource does not exist.
+                      format: uuid
+                      type: string
+                  type: object
+                managedOptions:
+                  description: managedOptions specifies options which may be applied to managed objects.
+                  properties:
+                    onDelete:
+                      default: delete
+                      description: |-
+                        onDelete specifies the behaviour of the controller when the ORC
+                        object is deleted. Options are `delete` - delete the OpenStack resource;
+                        `detach` - do not delete the OpenStack resource. If not specified, the
+                        default is `delete`.
+                      enum:
+                        - delete
+                        - detach
+                      type: string
+                  type: object
+                managementPolicy:
+                  default: managed
+                  description: |-
+                    managementPolicy defines how ORC will treat the object. Valid values are
+                    `managed`: ORC will create, update, and delete the resource; `unmanaged`:
+                    ORC will import an existing resource, and will not apply updates to it or
+                    delete it.
+                  enum:
+                    - managed
+                    - unmanaged
+                  type: string
+                  x-kubernetes-validations:
+                    - message: managementPolicy is immutable
+                      rule: self == oldSelf
+                resource:
+                  description: |-
+                    resource specifies the desired state of the resource.
+
+                    resource may not be specified if the management policy is `unmanaged`.
+
+                    resource must be specified if the management policy is `managed`.
+                  properties:
+                    allocationPools:
+                      description: |-
+                        allocationPools are IP Address pools that will be available for DHCP. IP
+                        addresses must be in CIDR.
+                      items:
+                        properties:
+                          end:
+                            description: end is the last IP address in the allocation pool.
+                            maxLength: 45
+                            minLength: 1
+                            type: string
+                          start:
+                            description: start is the first IP address in the allocation pool.
+                            maxLength: 45
+                            minLength: 1
+                            type: string
+                        required:
+                          - end
+                          - start
+                        type: object
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    cidr:
+                      description: cidr is the address CIDR of the subnet. It must match the IP version specified in IPVersion.
+                      format: cidr
+                      maxLength: 49
+                      minLength: 1
+                      type: string
+                    description:
+                      description: description is a human-readable description for the resource.
                       maxLength: 255
                       minLength: 1
                       type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: set
-                required:
-                - cidr
-                - ipVersion
-                - networkRef
-                type: object
-                x-kubernetes-validations:
-                - message: SubnetResourceSpec is immutable
-                  rule: self == oldSelf
-            required:
-            - cloudCredentialsRef
-            type: object
-            x-kubernetes-validations:
-            - message: resource must be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
-            - message: import may not be specified when policy is managed
-              rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__)
-                : true'
-            - message: resource may not be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource)
-                : true'
-            - message: import must be specified when policy is unmanaged
-              rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__)
-                : true'
-            - message: managedOptions may only be provided when policy is managed
-              rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed''
-                : true'
-          status:
-            description: status defines the observed state of the resource.
-            properties:
-              conditions:
-                description: |-
-                  conditions represents the observed status of the object.
-                  Known .status.conditions.type are: "Available", "Progressing"
-
-                  Available represents the availability of the OpenStack resource. If it is
-                  true then the resource is ready for use.
-
-                  Progressing indicates whether the controller is still attempting to
-                  reconcile the current state of the OpenStack resource to the desired
-                  state. Progressing will be False either because the desired state has
-                  been achieved, or because some terminal error prevents it from ever being
-                  achieved and the controller is no longer attempting to reconcile. If
-                  Progressing is True, an observer waiting on the resource should continue
-                  to wait.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
+                    dnsNameservers:
+                      description: dnsNameservers are the nameservers to be set via DHCP.
+                      items:
+                        maxLength: 45
+                        minLength: 1
+                        type: string
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-type: set
+                    dnsPublishFixedIP:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        dnsPublishFixedIP will either enable or disable the publication of
+                        fixed IPs to the DNS. Defaults to false.
+                      type: boolean
+                    enableDHCP:
+                      description: enableDHCP will either enable to disable the DHCP service.
+                      type: boolean
+                    gateway:
+                      description: |-
+                        gateway specifies the default gateway of the subnet. If not specified,
+                        neutron will add one automatically. To disable this behaviour, specify a
+                        gateway with a type of None.
+                      properties:
+                        ip:
+                          description: |-
+                            ip is the IP address of the default gateway, which must be specified if
+                            Type is `IP`. It must be a valid IP address, either IPv4 or IPv6,
+                            matching the IPVersion in SubnetResourceSpec.
+                          maxLength: 45
+                          minLength: 1
+                          type: string
+                        type:
+                          description: |-
+                            type specifies how the default gateway will be created. `Automatic`
+                            specifies that neutron will automatically add a default gateway. This is
+                            also the default if no Gateway is specified. `None` specifies that the
+                            subnet will not have a default gateway. `IP` specifies that the subnet
+                            will use a specific address as the default gateway, which must be
+                            specified in `IP`.
+                          enum:
+                            - None
+                            - Automatic
+                            - IP
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    hostRoutes:
+                      description: hostRoutes are any static host routes to be set via DHCP.
+                      items:
+                        properties:
+                          destination:
+                            description: destination for the additional route.
+                            format: cidr
+                            maxLength: 49
+                            minLength: 1
+                            type: string
+                          nextHop:
+                            description: nextHop for the additional route.
+                            maxLength: 45
+                            minLength: 1
+                            type: string
+                        required:
+                          - destination
+                          - nextHop
+                        type: object
+                      maxItems: 256
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ipVersion:
+                      description: ipVersion is the IP version for the subnet.
+                      enum:
+                        - 4
+                        - 6
+                      format: int32
+                      type: integer
+                    ipv6:
+                      description: ipv6 contains IPv6-specific options. It may only be set if IPVersion is 6.
+                      minProperties: 1
+                      properties:
+                        addressMode:
+                          description: addressMode specifies mechanisms for assigning IPv6 IP addresses.
+                          enum:
+                            - slaac
+                            - dhcpv6-stateful
+                            - dhcpv6-stateless
+                          type: string
+                        raMode:
+                          description: |-
+                            raMode specifies the IPv6 router advertisement mode. It specifies whether
+                            the networking service should transmit ICMPv6 packets.
+                          enum:
+                            - slaac
+                            - dhcpv6-stateful
+                            - dhcpv6-stateless
+                          type: string
+                      type: object
+                    name:
+                      description: name is a human-readable name of the subnet. If not set, the object's name will be used.
+                      maxLength: 255
+                      minLength: 1
+                      pattern: ^[^,]+$
+                      type: string
+                    networkRef:
+                      description: networkRef is a reference to the ORC Network which this subnet is associated with.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    routerRef:
+                      description: routerRef specifies a router to attach the subnet to
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    tags:
+                      description: tags is a list of tags which will be applied to the subnet.
+                      items:
+                        description: |-
+                          NeutronTag represents a tag on a Neutron resource.
+                          It may not be empty and may not contain commas.
+                        maxLength: 255
+                        minLength: 1
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: set
+                  required:
+                    - cidr
+                    - ipVersion
+                    - networkRef
+                  type: object
+                  x-kubernetes-validations:
+                    - message: SubnetResourceSpec is immutable
+                      rule: self == oldSelf
+              required:
+                - cloudCredentialsRef
+              type: object
+              x-kubernetes-validations:
+                - message: resource must be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? has(self.resource) : true'
+                - message: import may not be specified when policy is managed
+                  rule: 'self.managementPolicy == ''managed'' ? !has(self.__import__) : true'
+                - message: resource may not be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? !has(self.resource) : true'
+                - message: import must be specified when policy is unmanaged
+                  rule: 'self.managementPolicy == ''unmanaged'' ? has(self.__import__) : true'
+                - message: managedOptions may only be provided when policy is managed
+                  rule: 'has(self.managedOptions) ? self.managementPolicy == ''managed'' : true'
+            status:
+              description: status defines the observed state of the resource.
+              properties:
+                conditions:
+                  description: |-
+                    conditions represents the observed status of the object.
+                    Known .status.conditions.type are: "Available", "Progressing"
+
+                    Available represents the availability of the OpenStack resource. If it is
+                    true then the resource is ready for use.
+
+                    Progressing indicates whether the controller is still attempting to
+                    reconcile the current state of the OpenStack resource to the desired
+                    state. Progressing will be False either because the desired state has
+                    been achieved, or because some terminal error prevents it from ever being
+                    achieved and the controller is no longer attempting to reconcile. If
+                    Progressing is True, an observer waiting on the resource should continue
+                    to wait.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                id:
+                  description: id is the unique identifier of the OpenStack resource.
+                  type: string
+                resource:
+                  description: resource contains the observed state of the OpenStack resource.
+                  properties:
+                    allocationPools:
+                      description: |-
+                        allocationPools is a list of sub-ranges within CIDR available for dynamic
+                        allocation to ports.
+                      items:
+                        properties:
+                          end:
+                            description: end is the last IP address in the allocation pool.
+                            maxLength: 1024
+                            type: string
+                          start:
+                            description: start is the first IP address in the allocation pool.
+                            maxLength: 1024
+                            type: string
+                        type: object
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    cidr:
+                      description: cidr representing IP range for this subnet, based on IP version.
+                      maxLength: 1024
+                      type: string
+                    createdAt:
+                      description: createdAt shows the date and time when the resource was created. The date and time stamp format is ISO 8601
                       format: date-time
                       type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
+                    description:
+                      description: description is a human-readable description for the resource.
+                      maxLength: 1024
                       type: string
-                    observedGeneration:
+                    dnsNameservers:
+                      description: dnsNameservers is a list of name servers used by hosts in this subnet.
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    dnsPublishFixedIP:
+                      description: dnsPublishFixedIP specifies whether the fixed IP addresses are published to the DNS.
+                      type: boolean
+                    enableDHCP:
+                      description: enableDHCP specifies whether DHCP is enabled for this subnet or not.
+                      type: boolean
+                    gatewayIP:
+                      description: gatewayIP is the default gateway used by devices in this subnet, if any.
+                      maxLength: 1024
+                      type: string
+                    hostRoutes:
                       description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
+                        hostRoutes is a list of routes that should be used by devices with IPs
+                        from this subnet (not including local subnet route).
+                      items:
+                        properties:
+                          destination:
+                            description: destination for the additional route.
+                            maxLength: 1024
+                            type: string
+                          nextHop:
+                            description: nextHop for the additional route.
+                            maxLength: 1024
+                            type: string
+                        type: object
+                      maxItems: 256
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ipVersion:
+                      description: ipVersion specifies IP version, either `4' or `6'.
+                      format: int32
                       type: integer
-                    reason:
+                    ipv6AddressMode:
+                      description: ipv6AddressMode specifies mechanisms for assigning IPv6 IP addresses.
+                      maxLength: 1024
+                      type: string
+                    ipv6RAMode:
                       description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
+                        ipv6RAMode is the IPv6 router advertisement mode. It specifies
+                        whether the networking service should transmit ICMPv6 packets.
                       maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
+                    name:
+                      description: name is the human-readable name of the subnet. Might not be unique.
+                      maxLength: 1024
                       type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    networkID:
+                      description: networkID is the ID of the network to which the subnet belongs.
+                      maxLength: 1024
                       type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    projectID:
+                      description: projectID is the project owner of the subnet.
+                      maxLength: 1024
+                      type: string
+                    revisionNumber:
+                      description: revisionNumber optionally set via extensions/standard-attr-revisions
+                      format: int64
+                      type: integer
+                    subnetPoolID:
+                      description: subnetPoolID is the id of the subnet pool associated with the subnet.
+                      maxLength: 1024
+                      type: string
+                    tags:
+                      description: tags optionally set via extensions/attributestags
+                      items:
+                        maxLength: 1024
+                        type: string
+                      maxItems: 32
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    updatedAt:
+                      description: updatedAt shows the date and time when the resource was updated. The date and time stamp format is ISO 8601
+                      format: date-time
+                      type: string
                   type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              id:
-                description: id is the unique identifier of the OpenStack resource.
-                type: string
-              resource:
-                description: resource contains the observed state of the OpenStack
-                  resource.
-                properties:
-                  allocationPools:
-                    description: |-
-                      allocationPools is a list of sub-ranges within CIDR available for dynamic
-                      allocation to ports.
-                    items:
-                      properties:
-                        end:
-                          description: end is the last IP address in the allocation
-                            pool.
-                          maxLength: 1024
-                          type: string
-                        start:
-                          description: start is the first IP address in the allocation
-                            pool.
-                          maxLength: 1024
-                          type: string
-                      type: object
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  cidr:
-                    description: cidr representing IP range for this subnet, based
-                      on IP version.
-                    maxLength: 1024
-                    type: string
-                  createdAt:
-                    description: createdAt shows the date and time when the resource
-                      was created. The date and time stamp format is ISO 8601
-                    format: date-time
-                    type: string
-                  description:
-                    description: description is a human-readable description for the
-                      resource.
-                    maxLength: 1024
-                    type: string
-                  dnsNameservers:
-                    description: dnsNameservers is a list of name servers used by
-                      hosts in this subnet.
-                    items:
-                      maxLength: 1024
-                      type: string
-                    maxItems: 16
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  dnsPublishFixedIP:
-                    description: dnsPublishFixedIP specifies whether the fixed IP
-                      addresses are published to the DNS.
-                    type: boolean
-                  enableDHCP:
-                    description: enableDHCP specifies whether DHCP is enabled for
-                      this subnet or not.
-                    type: boolean
-                  gatewayIP:
-                    description: gatewayIP is the default gateway used by devices
-                      in this subnet, if any.
-                    maxLength: 1024
-                    type: string
-                  hostRoutes:
-                    description: |-
-                      hostRoutes is a list of routes that should be used by devices with IPs
-                      from this subnet (not including local subnet route).
-                    items:
-                      properties:
-                        destination:
-                          description: destination for the additional route.
-                          maxLength: 1024
-                          type: string
-                        nextHop:
-                          description: nextHop for the additional route.
-                          maxLength: 1024
-                          type: string
-                      type: object
-                    maxItems: 256
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  ipVersion:
-                    description: ipVersion specifies IP version, either `4' or `6'.
-                    format: int32
-                    type: integer
-                  ipv6AddressMode:
-                    description: ipv6AddressMode specifies mechanisms for assigning
-                      IPv6 IP addresses.
-                    maxLength: 1024
-                    type: string
-                  ipv6RAMode:
-                    description: |-
-                      ipv6RAMode is the IPv6 router advertisement mode. It specifies
-                      whether the networking service should transmit ICMPv6 packets.
-                    maxLength: 1024
-                    type: string
-                  name:
-                    description: name is the human-readable name of the subnet. Might
-                      not be unique.
-                    maxLength: 1024
-                    type: string
-                  networkID:
-                    description: networkID is the ID of the network to which the subnet
-                      belongs.
-                    maxLength: 1024
-                    type: string
-                  projectID:
-                    description: projectID is the project owner of the subnet.
-                    maxLength: 1024
-                    type: string
-                  revisionNumber:
-                    description: revisionNumber optionally set via extensions/standard-attr-revisions
-                    format: int64
-                    type: integer
-                  subnetPoolID:
-                    description: subnetPoolID is the id of the subnet pool associated
-                      with the subnet.
-                    maxLength: 1024
-                    type: string
-                  tags:
-                    description: tags optionally set via extensions/attributestags
-                    items:
-                      maxLength: 1024
-                      type: string
-                    maxItems: 32
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  updatedAt:
-                    description: updatedAt shows the date and time when the resource
-                      was updated. The date and time stamp format is ISO 8601
-                    format: date-time
-                    type: string
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -4861,7 +4634,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: orc
   name: orc-controller-manager
-  namespace: orc-system
+  namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -4870,39 +4643,39 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: orc
   name: orc-leader-election-role
-  namespace: orc-system
+  namespace: '{{ .Release.Namespace }}'
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -4912,24 +4685,24 @@ metadata:
     app.kubernetes.io/name: orc
   name: orc-image-editor-role
 rules:
-- apiGroups:
-  - openstack.k-orc.cloud
-  resources:
-  - images
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openstack.k-orc.cloud
-  resources:
-  - images/status
-  verbs:
-  - get
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - images
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - images/status
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -4939,102 +4712,102 @@ metadata:
     app.kubernetes.io/name: orc
   name: orc-image-viewer-role
 rules:
-- apiGroups:
-  - openstack.k-orc.cloud
-  resources:
-  - images
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - openstack.k-orc.cloud
-  resources:
-  - images/status
-  verbs:
-  - get
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - images
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - images/status
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: orc-manager-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openstack.k-orc.cloud
-  resources:
-  - flavors
-  - images
-  - networks
-  - ports
-  - projects
-  - routerinterfaces
-  - routers
-  - securitygroups
-  - servers
-  - subnets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - openstack.k-orc.cloud
-  resources:
-  - flavors/status
-  - images/status
-  - networks/status
-  - ports/status
-  - projects/status
-  - routerinterfaces/status
-  - routers/status
-  - securitygroups/status
-  - servers/status
-  - subnets/status
-  verbs:
-  - get
-  - patch
-  - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - flavors
+      - images
+      - networks
+      - ports
+      - projects
+      - routerinterfaces
+      - routers
+      - securitygroups
+      - servers
+      - subnets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - openstack.k-orc.cloud
+    resources:
+      - flavors/status
+      - images/status
+      - networks/status
+      - ports/status
+      - projects/status
+      - routerinterfaces/status
+      - routers/status
+      - securitygroups/status
+      - servers/status
+      - subnets/status
+    verbs:
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: orc-metrics-auth-role
 rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: orc-metrics-reader
 rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -5043,15 +4816,15 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: orc
   name: orc-leader-election-rolebinding
-  namespace: orc-system
+  namespace: '{{ .Release.Namespace }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: orc-leader-election-role
 subjects:
-- kind: ServiceAccount
-  name: orc-controller-manager
-  namespace: orc-system
+  - kind: ServiceAccount
+    name: orc-controller-manager
+    namespace: orc-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -5065,9 +4838,9 @@ roleRef:
   kind: ClusterRole
   name: orc-manager-role
 subjects:
-- kind: ServiceAccount
-  name: orc-controller-manager
-  namespace: orc-system
+  - kind: ServiceAccount
+    name: orc-controller-manager
+    namespace: orc-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -5078,9 +4851,9 @@ roleRef:
   kind: ClusterRole
   name: orc-metrics-auth-role
 subjects:
-- kind: ServiceAccount
-  name: orc-controller-manager
-  namespace: orc-system
+  - kind: ServiceAccount
+    name: orc-controller-manager
+    namespace: orc-system
 ---
 apiVersion: v1
 kind: Service
@@ -5090,13 +4863,13 @@ metadata:
     app.kubernetes.io/name: orc
     control-plane: controller-manager
   name: orc-controller-manager-metrics-service
-  namespace: orc-system
+  namespace: '{{ .Release.Namespace }}'
 spec:
   ports:
-  - name: https
-    port: 8443
-    protocol: TCP
-    targetPort: 8443
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
   selector:
     control-plane: controller-manager
 ---
@@ -5108,7 +4881,7 @@ metadata:
     app.kubernetes.io/name: orc
     control-plane: controller-manager
   name: orc-controller-manager
-  namespace: orc-system
+  namespace: '{{ .Release.Namespace }}'
 spec:
   replicas: 1
   selector:
@@ -5122,53 +4895,53 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - args:
-        - --metrics-bind-address=:8443
-        - --leader-elect
-        - --health-probe-bind-address=:8081
-        command:
-        - /manager
-        image: {{ default "quay.io" $global.registry }}/orc/openstack-resource-controller:v2.1.0
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        name: manager
-        {{- $proxyEnv := include "infrastructureProvider.proxyEnv" . | fromYaml }}
-        {{- if $proxyEnv }}
-        env:
-        {{ toYaml $proxyEnv.env | nindent 8 }}
-        {{- end }}
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          runAsGroup: 65532
-          runAsUser: 65532
-        terminationMessagePolicy: FallbackToLogsOnError
+        - args:
+            - --metrics-bind-address=:8443
+            - --leader-elect
+            - --health-probe-bind-address=:8081
+          command:
+            - /manager
+          image: {{ default "quay.io" $global.registry }}/orc/openstack-resource-controller:v2.1.0
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          {{- $proxyEnv := include "infrastructureProvider.proxyEnv" . | fromYaml }}
+          {{- if $proxyEnv }}
+          env:
+          {{ toYaml $proxyEnv.env | nindent 8 }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            runAsGroup: 65532
+            runAsUser: 65532
+          terminationMessagePolicy: FallbackToLogsOnError
       securityContext:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: orc-controller-manager
-      {{- if $global.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml $global.imagePullSecrets | nindent 8 }}
-      {{- end }}
+        {{- if $global.imagePullSecrets }}
+        imagePullSecrets: {{ toYaml $global.imagePullSecrets | nindent 8 }}
+        {{- end }}
       terminationGracePeriodSeconds: 10

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -22,7 +22,7 @@ spec:
     - name: cluster-api-provider-aws
       template: cluster-api-provider-aws-1-0-14
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-1-0-16
+      template: cluster-api-provider-openstack-1-0-17
     - name: cluster-api-provider-docker
       template: cluster-api-provider-docker-1-0-11
     - name: cluster-api-provider-gcp

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-26.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-26.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-22
+  name: aws-hosted-cp-1-0-26
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.22
+      chart: aws-hosted-cp
+      version: 1.0.26
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-25.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-25.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-5
+  name: aws-standalone-cp-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-standalone-cp
-      version: 1.0.5
+      chart: aws-standalone-cp
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-28.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-28.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-23
+  name: azure-hosted-cp-1-0-28
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.23
+      chart: azure-hosted-cp
+      version: 1.0.28
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-25.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-25.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-27
+  name: azure-standalone-cp-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.27
+      chart: azure-standalone-cp
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-1-0-16
+  name: cluster-api-provider-openstack-1-0-17
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 1.0.16
+      version: 1.0.17
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-25.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-25.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-17
+  name: gcp-hosted-cp-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.17
+      chart: gcp-hosted-cp
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-23.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-23.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-26
+  name: gcp-standalone-cp-1-0-23
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.26
+      chart: gcp-standalone-cp
+      version: 1.0.23
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-24
+  name: kubevirt-hosted-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.24
+      chart: kubevirt-hosted-cp
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-22
+  name: kubevirt-standalone-cp-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.22
+      chart: kubevirt-standalone-cp
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-18.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-18.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-24
+  name: openstack-hosted-cp-1-0-18
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.24
+      chart: openstack-hosted-cp
+      version: 1.0.18
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-27.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-27.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-23
+  name: openstack-standalone-cp-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.23
+      chart: openstack-standalone-cp
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-24.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-24.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-24
+  name: remote-cluster-1-0-24
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
+      chart: remote-cluster
       version: 1.0.24
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-24.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-24.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-hosted-cp-1-0-5
+  name: vsphere-hosted-cp-1-0-24
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-hosted-cp
-      version: 1.0.5
+      chart: vsphere-hosted-cp
+      version: 1.0.24
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-23.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-23.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-25
+  name: vsphere-standalone-cp-1-0-23
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.25
+      chart: vsphere-standalone-cp
+      version: 1.0.23
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds all needed configuration to support registry with authentication when creating child clusters.

Major changes:
- Switch from k0s extension configuration to direct creation of the `Chart` object (now recommended way of using chart installation)
- Additional secret creation to reference credentials from inside cluster templates
- capo-orc installed to the same namespace as all capo components (kcm-system) to avoid additional logic for pull secret propagation to `orc-system` namespace
- https://github.com/k0rdent/kcm/issues/1889 (PR https://github.com/k0rdent/kcm/pull/1890) fix shouldn't be needed, but it should be re-tested


