### PR TITLE
test(envtest): fix kube-apiserver error

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -101,14 +101,16 @@ jobs:
 
       - name: Validate PR title and commit message
         shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
 
           # Conventional commit regex (simplified)
-          CONVENTIONAL_REGEX='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-zA-Z0-9_-]+\))??!?:.+$'
+          CONVENTIONAL_REGEX='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-zA-Z0-9_-]+\))?!?: .+$'
           REVERT_REGEX='^Revert ".+"$'
 
-          pr_title="${{ github.event.pull_request.title }}"
+          pr_title="$PR_TITLE"
           echo "PR title: $pr_title"
 
           commit_title="$(git log -2 --pretty=%s | tail -n 1)"

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,10 @@ IMG_TELEMETRY ?= localhost/kcm/telemetry:latest
 IMG_TELEMETRY_REPO = $(shell echo $(IMG_TELEMETRY) | cut -d: -f1)
 IMG_TELEMETRY_TAG  = $(shell echo $(IMG_TELEMETRY) | cut -d: -f2)
 
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-# ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}') # TODO: use it when 1.35 properly works with the ginkgo/gomega
-ENVTEST_K8S_VERSION ?= 1.34.1
+#ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
+ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
+  [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
+  printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
 KCM_STABLE_VERSION = $(shell git ls-remote --tags --sort v:refname --exit-code --refs https://github.com/k0rdent/kcm | grep -v -e "-rc[0-9]\+$$" | tail -n1 | cut -d '/' -f3)
 
@@ -807,7 +808,8 @@ SUPPORT_BUNDLE_CLI ?= $(LOCALBIN)/support-bundle-$(SUPPORT_BUNDLE_CLI_VERSION)
 
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
-ENVTEST_VERSION ?= release-0.23
+#ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
+ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; printf '%s\n' "$$v" | sed -E 's/^v?([0-9]+)\.([0-9]+).*/release-\1.\2/')
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_TIMEOUT ?= 1m
 HELM_VERSION ?= v3.18.3
@@ -948,4 +950,8 @@ echo "Downloading $${package}" ;\
 GOBIN=$(LOCALBIN) go install $${package} ;\
 if [ ! -f $(1) ]; then mv -f "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1); fi ;\
 }
+endef
+
+define gomodver
+$(shell go list -m -f '{{if .Replace}}{{.Replace.Version}}{{else}}{{.Version}}{{end}}' $(1) 2>/dev/null)
 endef

--- a/internal/controller/adapters/sveltos/suite_test.go
+++ b/internal/controller/adapters/sveltos/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,6 +90,9 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	Expect(testEnv.Stop()).NotTo(HaveOccurred())
+	By("tearing down the test environment")
 	cancel()
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })

--- a/internal/controller/backup/suite_test.go
+++ b/internal/controller/backup/suite_test.go
@@ -151,6 +151,7 @@ var _ = AfterSuite(func() {
 
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })

--- a/internal/controller/ipam/suite_test.go
+++ b/internal/controller/ipam/suite_test.go
@@ -145,6 +145,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })

--- a/internal/controller/region/suite_test.go
+++ b/internal/controller/region/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -109,9 +110,18 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	Expect(rgnEnv.Stop()).NotTo(HaveOccurred())
-	Expect(mgmtEnv.Stop()).NotTo(HaveOccurred())
+	By("tearing down the test environment")
 	cancel()
+
+	By("tearing down the regional test environment")
+	Eventually(func() error {
+		return rgnEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
+
+	By("tearing down the management test environment")
+	Eventually(func() error {
+		return mgmtEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 func getRegionalClient() (client.Client, []byte) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -214,8 +214,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 func loadWebhooks(path string) ([]*admissionv1.ValidatingWebhookConfiguration, []*admissionv1.MutatingWebhookConfiguration, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes sporadic error when the kube-apiserver is not able lto keep up with tests time expectations (none).

Fixes CI commits/PRs validations allowing automatic revert PRs.

Fixes incorrect quotes escaping in revert PRs.

Auto-set envtest version and envtest assets k8s version.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2505
