### PR TITLE
feat: add ingress support to the openstack hosted template

### DIFF
--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.18
+version: 1.0.19
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -10,6 +10,18 @@ spec:
   service:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if and .Values.ingress.enabled .Values.ingress.apiHost .Values.ingress.konnectivityHost }}
+  ingress:
+    deploy: true
+    className: {{ .Values.ingress.className }}
+    {{- with .Values.ingress.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    port: {{ .Values.ingress.port }}
+    apiHost: {{ .Values.ingress.apiHost }}
+    konnectivityHost: {{ .Values.ingress.konnectivityHost }}
+  {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
   etcd:
@@ -140,9 +152,15 @@ data:
             effect: NoSchedule
           - key: node-role.kubernetes.io/master
             effect: NoSchedule
+          - key: node.kubernetes.io/not-ready
+            effect: NoSchedule
         extraEnv:
           - name: OS_CCM_REGIONAL
             value: {{ .Values.ccmRegional | quote }}
+          - name: KUBERNETES_SERVICE_HOST
+            value: {{ .Values.ingress.apiHost }}
+          - name: KUBERNETES_SERVICE_PORT
+            value: {{ .Values.ingress.port }}
         extraVolumes:
           - name: flexvolume-dir
             hostPath:

--- a/templates/cluster/openstack-hosted-cp/values.schema.json
+++ b/templates/cluster/openstack-hosted-cp/values.schema.json
@@ -266,6 +266,44 @@
         }
       }
     },
+    "ingress": {
+      "description": "Ingress configuration for control plane access via management or regional cluster load balancer",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Ingress annotations (must include SSL passthrough annotation)",
+          "type": "object",
+          "properties": {
+            "haproxy.org/ssl-passthrough": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        },
+        "apiHost": {
+          "description": "Hostname for Kubernetes API (e.g., kube-api.example.com). Required when ingress is enabled",
+          "type": "string"
+        },
+        "className": {
+          "description": "Ingress class name (must support SSL passthrough, e.g., haproxy, nginx, traefik)",
+          "type": "string"
+        },
+        "enabled": {
+          "description": "Enable ingress for control plane access (requires k0s v1.34.1+k0s.0 or later)",
+          "type": "boolean"
+        },
+        "konnectivityHost": {
+          "description": "Hostname for konnectivity server (e.g., konnectivity.example.com). Required when ingress is enabled",
+          "type": "string"
+        },
+        "port": {
+          "description": "The port used by the ingress controller",
+          "type": "integer",
+          "maximum": 65535,
+          "minimum": 1
+        }
+      }
+    },
     "k0s": {
       "description": "K0s parameters",
       "type": "object",

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -13,6 +13,15 @@ clusterNetwork:  # @schema description: The cluster network configuration; type:
 clusterLabels: {} # @schema description: Labels to apply to the cluster; type: object; additionalProperties: true
 clusterAnnotations: {} # @schema description: Annotations to apply to the cluster; type: object; additionalProperties: true
 
+ingress: # @schema description: Ingress configuration for control plane access via management or regional cluster load balancer; type: object
+  enabled: false # @schema description: Enable ingress for control plane access (requires k0s v1.34.1+k0s.0 or later); type: boolean
+  className: "haproxy" # @schema description: Ingress class name (must support SSL passthrough, e.g., haproxy, nginx, traefik); type: string
+  apiHost: "" # @schema description: Hostname for Kubernetes API (e.g., kube-api.example.com). Required when ingress is enabled; type: string
+  konnectivityHost: "" # @schema description: Hostname for konnectivity server (e.g., konnectivity.example.com). Required when ingress is enabled; type: string
+  port: 443 # @schema description: The port used by the ingress controller; type: integer; minimum: 1; maximum: 65535
+  annotations: # @schema description: Ingress annotations (must include SSL passthrough annotation); type: object; additionalProperties: true
+    haproxy.org/ssl-passthrough: "true"
+
 ccmRegional: true # @schema description: Allow OpenStack CCM to set ProviderID with region name; type: boolean
 
 clusterIdentity: # @schema description: The OpenStack credentials secret reference, auto-populated; type: object; required: true

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-19.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-19.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-18
+  name: openstack-hosted-cp-1-0-19
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-hosted-cp
-      version: 1.0.18
+      version: 1.0.19
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables support for ingress configuration in the `openstack-hosted-cp` cluster template. It also includes a workaround for the known issue (https://github.com/k0sproject/k0smotron/issues/1396) by adding additional environment variables to the openstack CCM cluster template.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Related to #2467 
