### PR TITLE
test: increase multicluster service test coverage to include updating helm chart values

### DIFF
--- a/test/e2e/clusterdeployment/clusterdeployment.go
+++ b/test/e2e/clusterdeployment/clusterdeployment.go
@@ -125,6 +125,14 @@ func GenerateClusterName(postfix string) string {
 	return mcPrefix
 }
 
+func GenerateUniqueClusterName(postfix string) string {
+	randomSuffix := uuid.New().String()[:8]
+	if postfix != "" {
+		return GenerateClusterName(fmt.Sprintf("%s-%s", postfix, randomSuffix))
+	}
+	return GenerateClusterName(randomSuffix)
+}
+
 func setClusterName(name string) {
 	GinkgoT().Setenv(EnvVarClusterDeploymentName, name)
 }

--- a/test/e2e/clusterdeployment/providervalidator.go
+++ b/test/e2e/clusterdeployment/providervalidator.go
@@ -178,6 +178,9 @@ func NewProviderValidator(templateType templates.Type, clusterName string, actio
 				"clusters":                  validateClusterDeleted,
 			}
 			resourceOrder = []string{"gcp-managed-machine-pools", "gcp-managed-control-plane", "gcp-managed-cluster", "clusters"}
+		case templates.TemplateDockerCluster:
+			resourcesToValidate["machines"] = validateMachinesDeleted
+			resourceOrder = append(resourceOrder, "machines")
 		case templates.TemplateRemoteCluster:
 			resourcesToValidate = map[string]resourceValidationFunc{
 				"clusters": validateClusterDeleted,

--- a/test/e2e/clusterdeployment/validate_deleted.go
+++ b/test/e2e/clusterdeployment/validate_deleted.go
@@ -20,18 +20,55 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	statusutil "github.com/K0rdent/kcm/internal/util/status"
 	"github.com/K0rdent/kcm/test/e2e/kubeclient"
 	validationutil "github.com/K0rdent/kcm/test/util/validation"
 )
 
+func getChildClusterConfig(ctx context.Context, mgmtClient client.Client, namespace, clusterName string) (*rest.Config, error) {
+	secretName := fmt.Sprintf("%s-kubeconfig", clusterName)
+	secret := &corev1.Secret{}
+	err := mgmtClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretName}, secret)
+	if err != nil {
+		return nil, err
+	}
+	kubeconfigBytes, ok := secret.Data["value"]
+	if !ok {
+		return nil, fmt.Errorf("kubeconfig secret missing 'value' key")
+	}
+
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func validateClusterReachable(cfg *rest.Config) error {
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("cluster unreachable: %w", err)
+	}
+	_, err = clientset.Discovery().ServerVersion()
+	if err != nil {
+		return fmt.Errorf("cluster unreachable: %w", err)
+	}
+	return nil
+}
+
 // validateClusterDeleted validates that the Cluster resource has been deleted.
 func validateClusterDeleted(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
 	// Validate that the Cluster resource has been deleted
 	cluster, err := kc.GetCluster(ctx, clusterName)
+
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
@@ -60,7 +97,30 @@ func validateClusterDeleted(ctx context.Context, kc *kubeclient.KubeClient, clus
 		return fmt.Errorf("cluster %q still in 'Deleting' phase with conditions:\n%w", clusterName, errs)
 	}
 
+	cfg, err := getChildClusterConfig(ctx, kc.CrClient, kc.Namespace, clusterName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	err = validateClusterReachable(cfg)
+	if err == nil {
+		return fmt.Errorf("cluster %q is still reachable", clusterName)
+	}
+
 	return nil
+}
+
+// validateMachinesDeleted validates that all Machines have been deleted.
+func validateMachinesDeleted(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
+	machines, err := kc.ListMachines(ctx, clusterName)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return validateObjectsRemoved("Machine", machines)
 }
 
 // validateMachineDeploymentsDeleted validates that all MachineDeployments have

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -59,7 +59,7 @@ const (
 
 var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docker"), Ordered, ContinueOnFailure, func() {
 	var (
-		clusterNames      []string
+		clusterName       string
 		clusterDeleteFunc func() error
 
 		helmRepositorySpec   sourcev1.HelmRepositorySpec
@@ -155,9 +155,12 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 
 	AfterEach(func() {
 		if clusterDeleteFunc != nil {
-			Expect(clusterDeleteFunc()).Error().NotTo(HaveOccurred(), "failed to delete cluster")
+			err := clusterDeleteFunc()
 			clusterDeleteFunc = nil
+			Expect(err).NotTo(HaveOccurred(), "failed to delete cluster")
 		}
+
+		waitForSveltosResourcesDeleted(context.Background(), kc, clusterName)
 	})
 
 	AfterAll(func() {
@@ -187,13 +190,12 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 			cfg.SetDefaults(clusterTemplates, config.TestingProviderDocker)
 
 			By(fmt.Sprintf("Testing configuration:\n%s\n", cfg.String()))
-			clusterName := clusterdeployment.GenerateClusterName(fmt.Sprintf("docker-%d", i))
+			clusterName = clusterdeployment.GenerateUniqueClusterName(fmt.Sprintf("docker-%d", i))
 
 			sd, deleteFn := createAndWaitCluster(ctx, kc, clusterName)
-			clusterNames = append(clusterNames, clusterName)
 			clusterDeleteFunc = deleteFn
 
-			mcs := multiclusterservice.BuildMultiClusterService(sd, multiClusterServiceTemplate, multiClusterServiceMatchLabel, multiClusterServiceName)
+			mcs := multiclusterservice.BuildMultiClusterService(sd, multiClusterServiceTemplate, openCostChartName, multiClusterServiceMatchLabel, multiClusterServiceName)
 			multiclusterservice.CreateMultiClusterService(ctx, kc.CrClient, mcs)
 			multiclusterservice.ValidateMultiClusterService(ctx, kc, multiClusterServiceName, 1)
 
@@ -212,10 +214,9 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 
 			By(fmt.Sprintf("Testing configuration:\n%s\n", cfg.String()))
 
-			clusterName := clusterdeployment.GenerateClusterName(fmt.Sprintf("docker-%d", i))
+			clusterName = clusterdeployment.GenerateUniqueClusterName(fmt.Sprintf("docker-%d", i))
 
 			sd, deleteFn := createAndWaitCluster(ctx, kc, clusterName)
-			clusterNames = append(clusterNames, clusterName)
 			clusterDeleteFunc = deleteFn
 
 			waitForServiceDeployments(ctx, kc, sd, sd.Spec.ServiceSpec.Services)
@@ -251,36 +252,33 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 			cfg.SetDefaults(clusterTemplates, config.TestingProviderDocker)
 
 			By(fmt.Sprintf("Testing configuration:\n%s\n", cfg.String()))
-			clusterName := clusterdeployment.GenerateClusterName(fmt.Sprintf("docker-%d", i))
+			clusterName = clusterdeployment.GenerateUniqueClusterName(fmt.Sprintf("docker-%d", i))
 
 			serviceName := fmt.Sprintf("%s-%s", openCostChartName, strings.ReplaceAll(openCostChartVersion, ".", "-"))
 			sd := clusterdeployment.Generate(templates.TemplateDockerCluster, clusterName, templates.FindLatestTemplatesWithType(clusterTemplates, templates.TemplateDockerCluster, 1)[0])
 			sd.Spec.ServiceSpec.Services[0].TemplateChain = templateChainName
 			sd.Spec.ServiceSpec.Services[0].DependsOn = []kcmv1.ServiceDependsOn{
 				{
-					Name:      serviceName,
-					Namespace: openCostChartName,
+					Name: serviceName,
 				},
 			}
 
 			sd.Spec.ServiceSpec.Services = append(sd.Spec.ServiceSpec.Services,
 				kcmv1.Service{
 					Name:      openWebuiChartName,
-					Namespace: openWebuiChartName,
 					Template:  fmt.Sprintf("%s-%s", openWebuiChartName, strings.ReplaceAll(openWebuiVersion, ".", "-")),
-					DependsOn: []kcmv1.ServiceDependsOn{{Name: serviceName, Namespace: openCostChartName}},
+					DependsOn: []kcmv1.ServiceDependsOn{{Name: serviceName}},
 				})
 
 			sd.Spec.ServiceSpec.Services = append(sd.Spec.ServiceSpec.Services,
 				kcmv1.Service{
-					Name:      serviceName,
-					Namespace: openCostChartName,
-					Template:  fmt.Sprintf("%s-%s", openCostChartName, strings.ReplaceAll(openCostChartVersion, ".", "-")),
+					Name:     serviceName,
+					Template: fmt.Sprintf("%s-%s", openCostChartName, strings.ReplaceAll(openCostChartVersion, ".", "-")),
 				})
 
 			By(fmt.Sprintf("Deploying cluster deployment :%v", sd))
 			deleteFn := clusterdeployment.Create(ctx, kc.CrClient, sd)
-			clusterNames = append(clusterNames, clusterName)
+
 			clusterDeleteFunc = func() error { //nolint:unparam
 				By(fmt.Sprintf("Deleting ClusterDeployment %s", clusterName))
 				Expect(deleteFn()).NotTo(HaveOccurred(), "failed to delete cluster")
@@ -330,10 +328,9 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 
 			By(fmt.Sprintf("Testing configuration:\n%s\n", cfg.String()))
 
-			clusterName := clusterdeployment.GenerateClusterName(fmt.Sprintf("docker-%d", i))
+			clusterName = clusterdeployment.GenerateUniqueClusterName(fmt.Sprintf("docker-%d", i))
 
 			sd, deleteFn := createAndWaitCluster(ctx, kc, clusterName)
-			clusterNames = append(clusterNames, clusterName)
 			clusterDeleteFunc = deleteFn
 
 			waitForServiceDeployments(ctx, kc, sd, sd.Spec.ServiceSpec.Services)
@@ -384,13 +381,12 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 			cfg.SetDefaults(clusterTemplates, config.TestingProviderDocker)
 
 			By(fmt.Sprintf("Testing configuration:\n%s\n", cfg.String()))
-			clusterName := clusterdeployment.GenerateClusterName(fmt.Sprintf("docker-%d", i))
-
+			clusterName = clusterdeployment.GenerateUniqueClusterName(fmt.Sprintf("docker-%d", i))
 			sd, deleteFn := createAndWaitCluster(ctx, kc, clusterName)
 
 			clusterDeleteFunc = deleteFn
 
-			mcs := multiclusterservice.BuildMultiClusterService(sd, multiClusterServiceTemplate, multiClusterServiceMatchLabel, multiClusterServiceName)
+			mcs := multiclusterservice.BuildMultiClusterService(sd, multiClusterServiceTemplate, openCostChartName, multiClusterServiceMatchLabel, multiClusterServiceName)
 			mcsServiceSpec := mcs.Spec.ServiceSpec
 			mcs.Spec.ServiceSpec = kcmv1.ServiceSpec{}
 			multiclusterservice.CreateMultiClusterService(ctx, kc.CrClient, mcs)
@@ -428,13 +424,13 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 			cfg.SetDefaults(clusterTemplates, config.TestingProviderDocker)
 
 			By(fmt.Sprintf("Testing configuration:\n%s\n", cfg.String()))
-			clusterName := clusterdeployment.GenerateClusterName(fmt.Sprintf("docker-%d", i))
+			clusterName = clusterdeployment.GenerateUniqueClusterName(fmt.Sprintf("docker-%d", i))
 
 			sd, deleteFn := createAndWaitCluster(ctx, kc, clusterName)
-
+			waitForServiceDeployments(ctx, kc, sd, sd.Spec.ServiceSpec.Services)
 			clusterDeleteFunc = deleteFn
 
-			mcs := multiclusterservice.BuildMultiClusterService(sd, multiClusterServiceTemplate, multiClusterServiceMatchLabel, multiClusterServiceName)
+			mcs := multiclusterservice.BuildMultiClusterService(sd, multiClusterServiceTemplate, openCostChartName, multiClusterServiceMatchLabel, multiClusterServiceName)
 			mcsServiceSpec := mcs.Spec.ServiceSpec
 			mcs.Spec.ServiceSpec = kcmv1.ServiceSpec{}
 			multiclusterservice.CreateMultiClusterService(ctx, kc.CrClient, mcs)
@@ -445,10 +441,9 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 				return kc.CrClient.Update(ctx, mcs)
 			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 
-			multiclusterservice.ValidateMultiClusterService(ctx, kc, multiClusterServiceName, 1)
-
-			waitForServiceDeployments(ctx, kc, sd, mcs.Spec.ServiceSpec.Services)
 			serviceSetObjectKey := serviceset.ObjectKey(kubeutil.DefaultSystemNamespace, sd, mcs)
+			waitForServiceSetTransition(ctx, kc, serviceSetObjectKey, mcs.Spec.ServiceSpec.Services)
+			multiclusterservice.ValidateMultiClusterService(ctx, kc, multiClusterServiceName, 1)
 			validateClusterProfile(ctx, serviceSetObjectKey, mcs.Spec.ServiceSpec, kc)
 
 			Eventually(func() error {
@@ -467,6 +462,33 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 		})
 	}
 })
+
+func waitForServiceSetTransition(
+	ctx context.Context,
+	kc *kubeclient.KubeClient,
+	key crclient.ObjectKey,
+	expectedServices []kcmv1.Service,
+) {
+	serviceSet := &kcmv1.ServiceSet{}
+	Eventually(func() error {
+		if err := kc.CrClient.Get(ctx, key, serviceSet); err != nil {
+			return fmt.Errorf("failed to get ServiceSet %s: %w", key, err)
+		}
+		trackedNames := make(map[string]struct{}, len(serviceSet.Status.Services))
+		for _, s := range serviceSet.Status.Services {
+			trackedNames[s.Name] = struct{}{}
+		}
+		for _, svc := range expectedServices {
+			if _, ok := trackedNames[svc.Name]; !ok {
+				return fmt.Errorf("service %q not yet tracked in ServiceSet %s", svc.Name, key)
+			}
+		}
+		if !serviceSet.Status.Deployed {
+			return fmt.Errorf("ServiceSet %s services tracked but not yet Deployed=true", key)
+		}
+		return nil
+	}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+}
 
 func validateClusterProfile(ctx context.Context, key crclient.ObjectKey, spec kcmv1.ServiceSpec, kc *kubeclient.KubeClient) {
 	profile := new(addoncontrollerv1beta1.Profile)
@@ -699,4 +721,39 @@ func waitForServiceSetVersions(
 		}
 		return nil
 	}, 10*time.Minute, 10*time.Second).Should(Succeed())
+}
+
+func waitForSveltosResourcesDeleted(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) {
+	GinkgoHelper()
+	Eventually(func() error {
+		ssList := &kcmv1.ServiceSetList{}
+		By(fmt.Sprintf("List servicesets for cluster:%s\n", clusterName))
+		if err := kc.CrClient.List(ctx, ssList, crclient.InNamespace(kc.Namespace),
+			crclient.MatchingLabels{kubeutil.DefaultStateManagementProviderSelectorKey: kubeutil.DefaultStateManagementProviderSelectorValue}); err != nil {
+			return err
+		}
+		if len(ssList.Items) > 0 {
+			return fmt.Errorf("found %d ServiceSet CR(s) for cluster %q", len(ssList.Items), clusterName)
+		}
+
+		By(fmt.Sprintf("List profile for cluster:%s\n", clusterName))
+		profileList := &addoncontrollerv1beta1.ProfileList{}
+		if err := kc.CrClient.List(ctx, profileList, crclient.InNamespace(kc.Namespace), crclient.MatchingLabels{kcmv1.KCMManagedLabelKey: kcmv1.KCMManagedLabelValue}); err != nil {
+			return err
+		}
+		if len(profileList.Items) > 0 {
+			return fmt.Errorf("found %d Profile CR(s) for cluster %q", len(profileList.Items), clusterName)
+		}
+
+		By(fmt.Sprintf("List ClusterSummaries for cluster:%s\n", clusterName))
+		clusterSummaryList := &addoncontrollerv1beta1.ClusterSummaryList{}
+		if err := kc.CrClient.List(ctx, clusterSummaryList, crclient.InNamespace(kc.Namespace)); err != nil {
+			return err
+		}
+		if len(clusterSummaryList.Items) > 0 {
+			return fmt.Errorf("found %d ClusterSummary CR(s) for cluster %q", len(clusterSummaryList.Items), clusterName)
+		}
+
+		return nil
+	}, 10*time.Minute, 15*time.Second).Should(Succeed())
 }

--- a/test/e2e/multiclusterservice/multiclusterservice.go
+++ b/test/e2e/multiclusterservice/multiclusterservice.go
@@ -36,7 +36,7 @@ import (
 )
 
 // BuildMultiClusterService constructs a MultiClusterService spec for the given ClusterDeployment.
-func BuildMultiClusterService(cd *kcmv1.ClusterDeployment, multiClusterServiceTemplate, multiClusterServiceMatchLabel, name string) *kcmv1.MultiClusterService {
+func BuildMultiClusterService(cd *kcmv1.ClusterDeployment, multiClusterServiceTemplate, serviceNamespace, multiClusterServiceMatchLabel, name string) *kcmv1.MultiClusterService {
 	return &kcmv1.MultiClusterService{
 		TypeMeta: metav1.TypeMeta{
 			Kind: kcmv1.MultiClusterServiceKind,
@@ -56,7 +56,7 @@ func BuildMultiClusterService(cd *kcmv1.ClusterDeployment, multiClusterServiceTe
 				Services: []kcmv1.Service{
 					{
 						Name:      multiClusterServiceTemplate,
-						Namespace: cd.Namespace,
+						Namespace: serviceNamespace,
 						Template:  multiClusterServiceTemplate,
 					},
 				},
@@ -105,6 +105,7 @@ func CreateMultiClusterServiceWithDelete(
 }
 
 func DeleteMultiClusterService(ctx context.Context, cl client.Client, mc *kcmv1.MultiClusterService) {
+	mcKey := client.ObjectKeyFromObject(mc)
 	Eventually(func() error {
 		err := client.IgnoreNotFound(cl.Delete(ctx, mc))
 		if err != nil {
@@ -112,6 +113,12 @@ func DeleteMultiClusterService(ctx context.Context, cl client.Client, mc *kcmv1.
 		}
 		return err
 	}, 1*time.Minute, 10*time.Second).Should(Succeed())
+
+	Eventually(func() bool {
+		err := cl.Get(ctx, mcKey, &kcmv1.MultiClusterService{})
+		return apierrors.IsNotFound(err)
+	}).WithTimeout(5 * time.Minute).WithPolling(3 * time.Second).Should(BeTrue())
+	logs.Printf("Deleted MultiClusterService [%s]", mcKey)
 }
 
 func checkClusterReadyConditionInMCS(mcsName string, expectedCount int, conditions []metav1.Condition) (err error) {
@@ -160,7 +167,7 @@ func ValidateMultiClusterService(ctx context.Context, kc *kubeclient.KubeClient,
 		}
 
 		return validationutil.ValidateConditionsTrue(mcs)
-	}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+	}).WithTimeout(20 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 }
 
 func GetMultiClusterService(ctx context.Context, cl client.Client, key client.ObjectKey) (*kcmv1.MultiClusterService, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds some tests for verifying that helm chart value updates work correctly in multicluster services.
**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2434 