### PR TITLE
fix: quote kubernetes api server port in openstack ccm

### DIFF
--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.19
+version: 1.0.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -160,7 +160,7 @@ data:
           - name: KUBERNETES_SERVICE_HOST
             value: {{ .Values.ingress.apiHost }}
           - name: KUBERNETES_SERVICE_PORT
-            value: {{ .Values.ingress.port }}
+            value: {{ .Values.ingress.port | quote }}
         extraVolumes:
           - name: flexvolume-dir
             hostPath:

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-20.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-20.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-19
+  name: openstack-hosted-cp-1-0-20
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-hosted-cp
-      version: 1.0.19
+      version: 1.0.20
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to quote an integer port value in extra env vars of the `openstack-hosted-cp` template, otherwise the CCM helm chart will not be installed.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Related to #2467

