### PR TITLE
fix(templates): override kube API server only when ingress enabled

### DIFF
--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.20
+version: 1.0.21
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,4 +1,5 @@
 {{- $global := .Values.global | default dict }}
+{{- $ingressEnabled := and .Values.ingress.enabled .Values.ingress.apiHost .Values.ingress.konnectivityHost }}
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: K0smotronControlPlane
 metadata:
@@ -10,7 +11,7 @@ spec:
   service:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if and .Values.ingress.enabled .Values.ingress.apiHost .Values.ingress.konnectivityHost }}
+  {{- if $ingressEnabled }}
   ingress:
     deploy: true
     className: {{ .Values.ingress.className }}
@@ -157,10 +158,12 @@ data:
         extraEnv:
           - name: OS_CCM_REGIONAL
             value: {{ .Values.ccmRegional | quote }}
+          {{- if $ingressEnabled }}
           - name: KUBERNETES_SERVICE_HOST
             value: {{ .Values.ingress.apiHost }}
           - name: KUBERNETES_SERVICE_PORT
             value: {{ .Values.ingress.port | quote }}
+          {{- end }}
         extraVolumes:
           - name: flexvolume-dir
             hostPath:

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-21.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-21.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-20
+  name: openstack-hosted-cp-1-0-21
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-hosted-cp
-      version: 1.0.20
+      version: 1.0.21
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Overriding Kubernetes API server environment variables in CCM is only necessary when ingress is enabled. This PR adds a conditional check to skip the override if ingress is not in use.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Related task: #2467
