### PR TITLE
fix(templates): specify helm chart order in manifest filename

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-25
+  template: aws-standalone-cp-1-0-26
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-25
+  template: azure-standalone-cp-1-0-26
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-23
+  template: gcp-standalone-cp-1-0-24
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-27
+  template: openstack-standalone-cp-1-0-28
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-23
+  template: vsphere-standalone-cp-1-0-24
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -94,7 +94,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}-manifests
 data:
-  chart-aws-cloud-controller-manager.yaml: |
+  1-chart-aws-cloud-controller-manager.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
     kind: Chart
     metadata:
@@ -142,7 +142,7 @@ data:
         # TODO: it does not work
         nodeSelector:
           node-role.kubernetes.io/control-plane: null
-  chart-aws-ebs-csi-driver.yaml: |
+  2-chart-aws-ebs-csi-driver.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
     kind: Chart
     metadata:

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.25
+version: 1.0.26
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -65,7 +65,7 @@ spec:
       permissions: "0664"
       path: /etc/k0s/containerd.d/registry-auth.toml
     {{- end }}
-    - path: /var/lib/k0s/manifests/kcm/chart-aws-cloud-controller-manager.yaml
+    - path: /var/lib/k0s/manifests/kcm/1-chart-aws-cloud-controller-manager.yaml
       permissions: "0644"
       content: |
         apiVersion: helm.k0sproject.io/v1beta1
@@ -106,7 +106,7 @@ spec:
               - --cluster-cidr={{ first .Values.clusterNetwork.pods.cidrBlocks }}
               - --allocate-node-cidrs=true
               - --cluster-name={{ include "cluster.name" . }}
-    - path: /var/lib/k0s/manifests/kcm/chart-aws-ebs-csi-driver.yaml
+    - path: /var/lib/k0s/manifests/kcm/2-chart-aws-ebs-csi-driver.yaml
       permissions: "0644"
       content: |
         apiVersion: helm.k0sproject.io/v1beta1

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.28
+version: 1.0.29
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -93,7 +93,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}-manifests
 data:
-  chart-cloud-provider-azure.yaml: |
+  1-chart-cloud-provider-azure.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
     kind: Chart
     metadata:
@@ -136,7 +136,7 @@ data:
         {{- if $global.registry }}
           imageRepository: {{ $global.registry }}
         {{- end }}
-  chart-azuredisk-csi-driver.yaml: |
+  2-chart-azuredisk-csi-driver.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
     kind: Chart
     metadata:

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.25
+version: 1.0.26
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -44,7 +44,7 @@ spec:
         permissions: "0664"
         path: /etc/k0s/containerd.d/registry-auth.toml
       {{- end }}
-      - path: /var/lib/k0s/manifests/kcm/chart-cloud-provider-azure.yaml
+      - path: /var/lib/k0s/manifests/kcm/1-chart-cloud-provider-azure.yaml
         permissions: "0644"
         content: |
           apiVersion: helm.k0sproject.io/v1beta1
@@ -86,7 +86,7 @@ spec:
               {{- if $global.registry }}
                 imageRepository: {{ $global.registry }}
               {{- end }}
-      - path: /var/lib/k0s/manifests/kcm/chart-azuredisk-csi-driver.yaml
+      - path: /var/lib/k0s/manifests/kcm/2-chart-azuredisk-csi-driver.yaml
         permissions: "0644"
         content: |
           apiVersion: helm.k0sproject.io/v1beta1

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.25
+version: 1.0.26
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -93,7 +93,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}-manifests
 data:
-  chart-gcp-cloud-controller-manager.yaml: |
+  1-chart-gcp-cloud-controller-manager.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
     kind: Chart
     metadata:
@@ -141,7 +141,7 @@ data:
           - --allocate-node-cidrs=true
           - --configure-cloud-routes=false
           - --v=2
-  chart-gcp-compute-persistent-disk-csi-driver.yaml: |
+  2-chart-gcp-compute-persistent-disk-csi-driver.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
     kind: Chart
     metadata:

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.23
+version: 1.0.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -44,7 +44,7 @@ spec:
         permissions: "0664"
         path: /etc/k0s/containerd.d/registry-auth.toml
       {{- end }}
-      - path: /var/lib/k0s/manifests/kcm/chart-gcp-cloud-controller-manager.yaml
+      - path: /var/lib/k0s/manifests/kcm/1-chart-gcp-cloud-controller-manager.yaml
         permissions: "0644"
         content: |
           apiVersion: helm.k0sproject.io/v1beta1
@@ -93,7 +93,7 @@ spec:
                 - --allocate-node-cidrs=true
                 - --configure-cloud-routes=false
                 - --v=2
-      - path: /var/lib/k0s/manifests/kcm/chart-gcp-compute-persistent-disk-csi-driver.yaml
+      - path: /var/lib/k0s/manifests/kcm/2-chart-gcp-compute-persistent-disk-csi-driver.yaml
         permissions: "0644"
         content: |
           apiVersion: helm.k0sproject.io/v1beta1

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.21
+version: 1.0.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -106,7 +106,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}-manifests
 data:
-  chart-openstack-cloud-controller-manager.yaml: |
+  1-chart-openstack-cloud-controller-manager.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
     kind: Chart
     metadata:
@@ -187,7 +187,7 @@ data:
           - name: cloud-ca-cert
             mountPath: {{ .Values.identityRef.caCert.path }}
           {{- end }}
-  chart-openstack-cinder-csi.yaml: |
+  2-chart-openstack-cinder-csi.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
     kind: Chart
     metadata:

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.27
+version: 1.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -44,7 +44,7 @@ spec:
         permissions: "0664"
         path: /etc/k0s/containerd.d/registry-auth.toml
       {{- end }}
-      - path: /var/lib/k0s/manifests/kcm/chart-openstack-cloud-controller-manager.yaml
+      - path: /var/lib/k0s/manifests/kcm/1-chart-openstack-cloud-controller-manager.yaml
         permissions: "0644"
         content: |
           apiVersion: helm.k0sproject.io/v1beta1
@@ -121,7 +121,7 @@ spec:
                 - name: cloud-ca-cert
                   mountPath: {{ .Values.identityRef.caCert.path }}
                 {{- end }}
-      - path: /var/lib/k0s/manifests/kcm/chart-openstack-cinder-csi.yaml
+      - path: /var/lib/k0s/manifests/kcm/2-chart-openstack-cinder-csi.yaml
         permissions: "0644"
         content: |
           apiVersion: helm.k0sproject.io/v1beta1

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -93,7 +93,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}-manifests
 data:
-  chart-vsphere-cpi.yaml: |
+  1-chart-vsphere-cpi.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
     kind: Chart
     metadata:
@@ -146,7 +146,7 @@ data:
             - key: CriticalAddonsOnly
               effect: NoExecute
               operator: Exists
-  chart-vsphere-csi-driver.yaml: |
+  2-chart-vsphere-csi-driver.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
     kind: Chart
     metadata:

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.23
+version: 1.0.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -49,7 +49,7 @@ spec:
         permissions: "0664"
         path: /etc/k0s/containerd.d/registry-auth.toml
       {{- end }}
-      - path: /var/lib/k0s/manifests/kcm/chart-kube-vip.yaml
+      - path: /var/lib/k0s/manifests/kcm/1-chart-kube-vip.yaml
         permissions: "0644"
         content: |
           apiVersion: helm.k0sproject.io/v1beta1
@@ -100,7 +100,7 @@ spec:
                 - effect: NoSchedule
                   key: node.cloudprovider.kubernetes.io/uninitialized
                   value: "true"
-      - path: /var/lib/k0s/manifests/kcm/chart-vsphere-cpi.yaml
+      - path: /var/lib/k0s/manifests/kcm/2-chart-vsphere-cpi.yaml
         permissions: "0644"
         content: |
           apiVersion: helm.k0sproject.io/v1beta1
@@ -151,7 +151,7 @@ spec:
                   - key: CriticalAddonsOnly
                     effect: NoExecute
                     operator: Exists
-      - path: /var/lib/k0s/manifests/kcm/chart-vsphere-csi-driver.yaml
+      - path: /var/lib/k0s/manifests/kcm/3-chart-vsphere-csi-driver.yaml
         permissions: "0644"
         content: |
           apiVersion: helm.k0sproject.io/v1beta1

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-27.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-27.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-23
+  name: aws-hosted-cp-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.23
+      chart: aws-hosted-cp
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-26.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-26.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-28
+  name: aws-standalone-cp-1-0-26
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.28
+      chart: aws-standalone-cp
+      version: 1.0.26
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-29.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-29.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-24
+  name: azure-hosted-cp-1-0-29
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.24
+      chart: azure-hosted-cp
+      version: 1.0.29
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-26.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-26.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-26
+  name: azure-standalone-cp-1-0-26
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
+      chart: azure-standalone-cp
       version: 1.0.26
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-26.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-26.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-21
+  name: gcp-hosted-cp-1-0-26
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.21
+      chart: gcp-hosted-cp
+      version: 1.0.26
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-24.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-24.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-25
+  name: gcp-standalone-cp-1-0-24
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.25
+      chart: gcp-standalone-cp
+      version: 1.0.24
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-22.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-22.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-25
+  name: openstack-hosted-cp-1-0-22
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.25
+      chart: openstack-hosted-cp
+      version: 1.0.22
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-28.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-28.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-23
+  name: openstack-standalone-cp-1-0-28
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.23
+      chart: openstack-standalone-cp
+      version: 1.0.28
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-25.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-25.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-25
+  name: vsphere-hosted-cp-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
+      chart: vsphere-hosted-cp
       version: 1.0.25
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-24.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-24.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-27
+  name: vsphere-standalone-cp-1-0-24
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.27
+      chart: vsphere-standalone-cp
+      version: 1.0.24
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
This is needed to ensure proper helm charts installation order (ccm -> csi).

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2542
