### PR TITLE
fix: check CredSecretName before passing to globals

### DIFF
--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -843,12 +843,16 @@ func (r *ClusterDeploymentReconciler) fillHelmValues(scope *clusterScope) error 
 		}
 
 		global := map[string]any{
-			"registry":                 r.GlobalRegistry,
-			"k0sURL":                   r.GlobalK0sURL,
-			"registryCertSecret":       r.RegistryCertSecretName,
-			"k0sURLCertSecret":         r.K0sURLCertSecretName,
-			"registryCredentialSecret": r.CldRegistryCredSecretName,
+			"registry":           r.GlobalRegistry,
+			"k0sURL":             r.GlobalK0sURL,
+			"registryCertSecret": r.RegistryCertSecretName,
+			"k0sURLCertSecret":   r.K0sURLCertSecretName,
 		}
+
+		if r.CldRegistryCredSecretName != "" {
+			global["registryCredentialSecret"] = r.CldRegistryCredSecretName
+		}
+
 		for _, v := range global {
 			if v != "" {
 				values["global"] = global


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds additional check for `CldRegistryCredSecretName` existence before passing it to global values to avoid triggering helmrelease reconcile.   
