### PR TITLE
fix: capo-orc-fetch indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,14 +170,14 @@ capo-orc-fetch: yq
 	    print "          {{- $$proxyEnv := include \"infrastructureProvider.proxyEnv\" . | fromYaml }}"; \
 	    print "          {{- if $$proxyEnv }}"; \
 	    print "          env:"; \
-	    print "          {{ toYaml $$proxyEnv.env | nindent 8 }}"; \
+	    print "          {{ toYaml $$proxyEnv.env | nindent 12 }}"; \
 	    print "          {{- end }}"; \
 	  } \
 \
 	  if ($$0 ~ /serviceAccountName: orc-controller-manager/) { \
-	    print "        {{- if $$global.imagePullSecrets }}"; \
-	    print "        imagePullSecrets: {{ toYaml $$global.imagePullSecrets | nindent 8 }}"; \
-	    print "        {{- end }}"; \
+	    print "      {{- if $$global.imagePullSecrets }}"; \
+	    print "      imagePullSecrets: {{ toYaml $$global.imagePullSecrets | nindent 8 }}"; \
+	    print "      {{- end }}"; \
 	  } \
 	}' > $(CAPO_ORC_TEMPLATE)
 

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.17
+version: 1.0.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/templates/orc.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/orc.yaml
@@ -4912,7 +4912,7 @@ spec:
           {{- $proxyEnv := include "infrastructureProvider.proxyEnv" . | fromYaml }}
           {{- if $proxyEnv }}
           env:
-          {{ toYaml $proxyEnv.env | nindent 8 }}
+          {{ toYaml $proxyEnv.env | nindent 12 }}
           {{- end }}
           readinessProbe:
             httpGet:
@@ -4941,7 +4941,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: orc-controller-manager
-        {{- if $global.imagePullSecrets }}
-        imagePullSecrets: {{ toYaml $global.imagePullSecrets | nindent 8 }}
-        {{- end }}
+      {{- if $global.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml $global.imagePullSecrets | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -22,7 +22,7 @@ spec:
     - name: cluster-api-provider-aws
       template: cluster-api-provider-aws-1-0-14
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-1-0-17
+      template: cluster-api-provider-openstack-1-0-18
     - name: cluster-api-provider-docker
       template: cluster-api-provider-docker-1-0-11
     - name: cluster-api-provider-gcp

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-1-0-17
+  name: cluster-api-provider-openstack-1-0-18
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 1.0.17
+      version: 1.0.18
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes indentation for orc manifest when using proxy or imagepullsecrets values.

Tested with

```
helm template --set global.proxy.secretName="foo" --set global.imagePullSecrets[0].name="pull" . -s templates/orc.yaml
```

Which now results with a correct yaml for deployment for `orc-controller-manager`:

````yaml
# Source: cluster-api-provider-openstack/templates/orc.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: orc
    control-plane: controller-manager
  name: orc-controller-manager
  namespace: 'default'
spec:
  replicas: 1
  selector:
    matchLabels:
      control-plane: controller-manager
  template:
    metadata:
      annotations:
        kubectl.kubernetes.io/default-container: manager
      labels:
        control-plane: controller-manager
    spec:
      containers:
        - args:
            - --metrics-bind-address=:8443
            - --leader-elect
            - --health-probe-bind-address=:8081
          command:
            - /manager
          image: quay.io/orc/openstack-resource-controller:v2.1.0
          livenessProbe:
            httpGet:
              path: /healthz
              port: 8081
            initialDelaySeconds: 15
            periodSeconds: 20
          name: manager
          env:
            - name: HTTP_PROXY
              valueFrom:
                secretKeyRef:
                  key: HTTP_PROXY
                  name: foo
                  optional: true
            - name: http_proxy
              valueFrom:
                secretKeyRef:
                  key: HTTP_PROXY
                  name: foo
                  optional: true
            - name: HTTPS_PROXY
              valueFrom:
                secretKeyRef:
                  key: HTTPS_PROXY
                  name: foo
                  optional: true
            - name: https_proxy
              valueFrom:
                secretKeyRef:
                  key: HTTPS_PROXY
                  name: foo
                  optional: true
            - name: NO_PROXY
              valueFrom:
                secretKeyRef:
                  key: NO_PROXY
                  name: foo
                  optional: true
            - name: no_proxy
              valueFrom:
                secretKeyRef:
                  key: NO_PROXY
                  name: foo
                  optional: true
          readinessProbe:
            httpGet:
              path: /readyz
              port: 8081
            initialDelaySeconds: 5
            periodSeconds: 10
          resources:
            limits:
              cpu: 500m
              memory: 128Mi
            requests:
              cpu: 10m
              memory: 64Mi
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
                - ALL
            privileged: false
            runAsGroup: 65532
            runAsUser: 65532
          terminationMessagePolicy: FallbackToLogsOnError
      securityContext:
        runAsNonRoot: true
        seccompProfile:
          type: RuntimeDefault
      serviceAccountName: orc-controller-manager
      imagePullSecrets:
        - name: pull
      terminationGracePeriodSeconds: 10

```