### PR TITLE
fix(api): cld nullable propagateCredentials

### DIFF
--- a/api/v1beta1/clusterdeployment_types.go
+++ b/api/v1beta1/clusterdeployment_types.go
@@ -65,6 +65,11 @@ type ClusterDeploymentSpec struct {
 	// If no Config provided, the field will be populated with the default values for
 	// the template and DryRun will be enabled.
 	Config *apiextv1.JSON `json:"config,omitempty"`
+	// +kubebuilder:default:=true
+
+	// PropagateCredentials indicates whether credentials should be propagated
+	// for use by CCM (Cloud Controller Manager).
+	PropagateCredentials *bool `json:"propagateCredentials,omitempty"`
 
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
@@ -84,11 +89,6 @@ type ClusterDeploymentSpec struct {
 	ServiceSpec ServiceSpec `json:"serviceSpec,omitempty"`
 	// DryRun specifies whether the template should be applied after validation or only validated.
 	DryRun bool `json:"dryRun,omitempty"`
-	// +kubebuilder:default:=true
-
-	// PropagateCredentials indicates whether credentials should be propagated
-	// for use by CCM (Cloud Controller Manager).
-	PropagateCredentials bool `json:"propagateCredentials,omitempty"`
 
 	// CleanupOnDeletion specifies whether potentially orphaned Services and PVCs
 	// should be removed during the object deletion.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -493,6 +493,11 @@ func (in *ClusterDeploymentSpec) DeepCopyInto(out *ClusterDeploymentSpec) {
 		*out = new(apiextensionsv1.JSON)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PropagateCredentials != nil {
+		in, out := &in.PropagateCredentials, &out.PropagateCredentials
+		*out = new(bool)
+		**out = **in
+	}
 	in.IPAMClaim.DeepCopyInto(&out.IPAMClaim)
 	in.ServiceSpec.DeepCopyInto(&out.ServiceSpec)
 }

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -1398,7 +1398,7 @@ func fillNotDeployedServices(serviceSet *kcmv1.ServiceSet, now func() time.Time)
 
 // TODO: refactor, see: https://github.com/k0rdent/kcm/issues/1586
 func projectTemplateResourceRefs(cd *kcmv1.ClusterDeployment, cred *kcmv1.Credential) []addoncontrollerv1beta1.TemplateResourceRef {
-	if !cd.Spec.PropagateCredentials || cred.Spec.IdentityRef == nil {
+	if cd.Spec.PropagateCredentials == nil || cred.Spec.IdentityRef == nil || !*cd.Spec.PropagateCredentials {
 		return nil
 	}
 
@@ -1426,7 +1426,7 @@ func projectTemplateResourceRefs(cd *kcmv1.ClusterDeployment, cred *kcmv1.Creden
 
 // TODO: refactor, see: https://github.com/k0rdent/kcm/issues/1586
 func projectPolicyRefs(cd *kcmv1.ClusterDeployment, cred *kcmv1.Credential) []addoncontrollerv1beta1.PolicyRef {
-	if !cd.Spec.PropagateCredentials || cred.Spec.IdentityRef == nil {
+	if cd.Spec.PropagateCredentials == nil || cred.Spec.IdentityRef == nil || !*cd.Spec.PropagateCredentials {
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the `.spec.propagateCredentials` of the `clusterdeployments` resource nullable (`bool` -> `*bool`)

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Related: #2554 