### PR TITLE
fix(templates): helm extensions caFile configuration

### DIFF
--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.27
+version: 1.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -105,11 +105,13 @@ data:
       repository:
         url: https://charts.mirantis.com
       {{- end }}
-      {{- if $global.registryCredentialSecret }}
+      {{- if or $global.registryCredentialSecret $global.registryCertSecret }}
       repository:
+        {{- if $global.registryCredentialSecret }}
         configFrom:
           secretRef:
             name: {{ $global.registryCredentialSecret }}
+        {{- end }}
         {{- if $global.registryCertSecret }}
         caFile: /usr/local/share/ca-certificates/registry/ca.crt
         {{- end }}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.29
+version: 1.0.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -104,11 +104,13 @@ data:
       repository:
         url: https://charts.mirantis.com
       {{- end }}
-      {{- if $global.registryCredentialSecret }}
+      {{- if or $global.registryCredentialSecret $global.registryCertSecret }}
       repository:
+        {{- if $global.registryCredentialSecret }}
         configFrom:
           secretRef:
             name: {{ $global.registryCredentialSecret }}
+        {{- end }}
         {{- if $global.registryCertSecret }}
         caFile: /usr/local/share/ca-certificates/registry/ca.crt
         {{- end }}

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -104,11 +104,13 @@ data:
       repository:
         url: https://charts.mirantis.com
       {{- end }}
-      {{- if $global.registryCredentialSecret }}
+      {{- if or $global.registryCredentialSecret $global.registryCertSecret }}
       repository:
+        {{- if $global.registryCredentialSecret }}
         configFrom:
           secretRef:
             name: {{ $global.registryCredentialSecret }}
+        {{- end }}
         {{- if $global.registryCertSecret }}
         caFile: /usr/local/share/ca-certificates/registry/ca.crt
         {{- end }}

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.22
+version: 1.0.23
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -117,11 +117,13 @@ data:
       repository:
         url: https://kubernetes.github.io/cloud-provider-openstack/
       {{- end }}
-      {{- if $global.registryCredentialSecret }}
+      {{- if or $global.registryCredentialSecret $global.registryCertSecret }}
       repository:
+        {{- if $global.registryCredentialSecret }}
         configFrom:
           secretRef:
             name: {{ $global.registryCredentialSecret }}
+        {{- end }}
         {{- if $global.registryCertSecret }}
         caFile: /usr/local/share/ca-certificates/registry/ca.crt
         {{- end }}

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.25
+version: 1.0.26
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -104,11 +104,13 @@ data:
       repository:
         url: https://kubernetes.github.io/cloud-provider-vsphere
       {{- end }}
-      {{- if $global.registryCredentialSecret }}
+      {{- if or $global.registryCredentialSecret $global.registryCertSecret }}
       repository:
+        {{- if $global.registryCredentialSecret }}
         configFrom:
           secretRef:
             name: {{ $global.registryCredentialSecret }}
+        {{- end }}
         {{- if $global.registryCertSecret }}
         caFile: /usr/local/share/ca-certificates/registry/ca.crt
         {{- end }}

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-28.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-28.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-22
+  name: aws-hosted-cp-1-0-28
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.22
+      chart: aws-hosted-cp
+      version: 1.0.28
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-30.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-30.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-26
+  name: azure-hosted-cp-1-0-30
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.26
+      chart: azure-hosted-cp
+      version: 1.0.30
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-27.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-27.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-29
+  name: gcp-hosted-cp-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.29
+      chart: gcp-hosted-cp
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-23.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-23.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-27
+  name: openstack-hosted-cp-1-0-23
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.27
+      chart: openstack-hosted-cp
+      version: 1.0.23
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-26.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-26.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-25
+  name: vsphere-hosted-cp-1-0-26
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: vsphere-hosted-cp
-      version: 1.0.25
+      version: 1.0.26
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the `caFile` is configured only if `global.registryCredentialSecret` is set, but it should be propagated when `global.registryCertSecret` is set.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2557
