### PR TITLE
fix: restrict the release name of KCM

### DIFF
--- a/templates/provider/kcm/templates/_helpers.tpl
+++ b/templates/provider/kcm/templates/_helpers.tpl
@@ -11,6 +11,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "kcm.fullname" -}}
+{{- if ne .Release.Name "kcm" }}
+{{- fail "Release name is static and must be 'kcm'" }}
+{{- end }}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, k0rdent doesn't support installation with the release name different from `kcm`. This PR adds a restriction to force installation with the `kcm` name.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
