### PR TITLE
test: fix flapping ServiceTemplateChain test

### DIFF
--- a/internal/controller/templatechain_controller_test.go
+++ b/internal/controller/templatechain_controller_test.go
@@ -454,6 +454,20 @@ var _ = Describe("Template Chain Controller", func() {
 		})
 
 		It("should use the chain's namespace as the LocalSourceRef namespace for Secret and ConfigMap sources", func() {
+			// mgrClient is a cache-backed client and preserves TypeMeta on Get responses,
+			// which is required for owner reference population. Wait for its cache to reflect
+			// the status updates made via k8sClient in BeforeEach before reconciling.
+			Eventually(func(g Gomega) {
+				chain := &kcmv1.ServiceTemplateChain{}
+				g.Expect(mgrClient.Get(ctx, types.NamespacedName{Namespace: localRefNamespace.Name, Name: localRefChainName}, chain)).To(Succeed())
+				g.Expect(chain.Status.Valid).To(BeTrue())
+			}, eventuallyTimeout, pollingInterval).Should(Succeed())
+			Eventually(func(g Gomega) {
+				st := &kcmv1.ServiceTemplate{}
+				g.Expect(mgrClient.Get(ctx, types.NamespacedName{Namespace: kubeutil.DefaultSystemNamespace, Name: localRefStName}, st)).To(Succeed())
+				g.Expect(st.Status.Valid).To(BeTrue())
+			}, eventuallyTimeout, pollingInterval).Should(Succeed())
+
 			templateChainReconciler := TemplateChainReconciler{
 				Client:          mgrClient,
 				SystemNamespace: kubeutil.DefaultSystemNamespace,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a flapping test introduced in #2574. The ServiceTemplateChain status was updated via the direct REST client (k8sClient) in BeforeEach, but Reconcile was called immediately after using the cache-backed manager client (mgrClient). If the cache hadn't yet reflected the status update, Reconcile fetched a stale resourceVersion and updateStatus failed with a conflict error. The fix adds Eventually checks to wait for the manager cache to catch up before triggering reconciliation.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
