### PR TITLE
fix: svc status in ServiceSet to consider new FailureMessage field in ClusterSummary

### DIFF
--- a/api/v1beta1/serviceset_types.go
+++ b/api/v1beta1/serviceset_types.go
@@ -38,6 +38,8 @@ const (
 	ServiceStateProvisioning = "Provisioning"
 	// ServiceStateDeleting is the state when the Service is being deleted
 	ServiceStateDeleting = "Deleting"
+	// ServiceStateDeleted is the state when the Service has been deleted
+	ServiceStateDeleted = "Deleted"
 
 	// ServiceTypeHelm is the type for Helm Service
 	ServiceTypeHelm ServiceType = "Helm"
@@ -249,7 +251,7 @@ type ServiceState struct {
 	Version *string `json:"version,omitempty"`
 
 	// State is the state of the Service
-	// +kubebuilder:validation:Enum=Deployed;Provisioning;Failed;Pending;Deleting
+	// +kubebuilder:validation:Enum=Deployed;Provisioning;Failed;Pending;Deleting;Deleted
 	State string `json:"state"`
 
 	// FailureMessage is the reason why the Service failed to deploy

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-	"github.com/go-logr/logr"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/addon-controller/lib/clusterops"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
@@ -51,7 +50,6 @@ import (
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	"github.com/K0rdent/kcm/internal/record"
-	"github.com/K0rdent/kcm/internal/serviceset"
 	helmutil "github.com/K0rdent/kcm/internal/util/helm"
 	kubeutil "github.com/K0rdent/kcm/internal/util/kube"
 	pointerutil "github.com/K0rdent/kcm/internal/util/pointer"
@@ -1520,131 +1518,6 @@ func conditionReasonChanged(conditionOldState, conditionNewState *metav1.Conditi
 		return true
 	}
 	return conditionOldState.Reason != conditionNewState.Reason
-}
-
-func servicesStateFromSummary(
-	logger logr.Logger,
-	summary *addoncontrollerv1beta1.ClusterSummary,
-	serviceSet *kcmv1.ServiceSet,
-) []kcmv1.ServiceState {
-	logger.Info("Collecting services state from ClusterSummary", "cluster_summary", client.ObjectKeyFromObject(summary))
-	// we'll recreate service states list according to the desired services
-	states := make([]kcmv1.ServiceState, 0, len(serviceSet.Spec.Services))
-	servicesMap := make(map[client.ObjectKey]kcmv1.ServiceState)
-	for _, service := range serviceSet.Spec.Services {
-		servicesMap[client.ObjectKey{
-			Namespace: service.Namespace,
-			Name:      service.Name,
-		}] = kcmv1.ServiceState{
-			Type:                    "",
-			LastStateTransitionTime: nil,
-			Name:                    service.Name,
-			Namespace:               service.Namespace,
-			Template:                service.Template,
-			Version:                 service.Version,
-			State:                   kcmv1.ServiceStateProvisioning,
-			FailureMessage:          "",
-		}
-	}
-
-	hasKustomizations := len(summary.Spec.ClusterProfileSpec.KustomizationRefs) > 0
-	hasPolicies := len(summary.Spec.ClusterProfileSpec.PolicyRefs) > 0
-
-	// in case feature is absent we'll treat it as deployed
-	helmChartsFailureMessage := ""
-	kustomizationsDeployed := !hasKustomizations
-	kustomizationsFailed := false
-	kustomizationsFailureMessage := ""
-	policiesDeployed := !hasPolicies
-	policiesFailed := false
-	policiesFailureMessage := ""
-
-	for _, feature := range summary.Status.FeatureSummaries {
-		switch feature.FeatureID {
-		// we'll only lookup for failure message related to helm charts,
-		// because we have better mechanism to determine whether helm release was deployed or not
-		case libsveltosv1beta1.FeatureHelm:
-			if feature.FailureMessage != nil {
-				helmChartsFailureMessage = *feature.FailureMessage
-			}
-		// we cannot determine which kustomizations or policies were failed, hence we'll treat them as failed
-		// in case feature summary contains failure message. This message will be copied to the ServiceSet status
-		// thus user will be able to see the reason of failure.
-		// this is a temporary solution, we'll work with projectsveltos maintainers to improve observability.
-		case libsveltosv1beta1.FeatureKustomize:
-			kustomizationsDeployed = feature.Status == libsveltosv1beta1.FeatureStatusProvisioned
-			if feature.FailureMessage != nil {
-				kustomizationsFailed = true
-				kustomizationsFailureMessage = *feature.FailureMessage
-			}
-		case libsveltosv1beta1.FeatureResources:
-			policiesDeployed = feature.Status == libsveltosv1beta1.FeatureStatusProvisioned
-			if feature.FailureMessage != nil {
-				policiesFailed = true
-				policiesFailureMessage = *feature.FailureMessage
-			}
-		}
-	}
-
-	helmReleaseMap := make(map[client.ObjectKey]bool)
-	for _, helmRelease := range summary.Status.HelmReleaseSummaries {
-		// we'll save true to the helmReleaseMap if values hash is not empty.
-		// This means that the helm release was successfully deployed.
-		helmReleaseMap[client.ObjectKey{
-			Namespace: helmRelease.ReleaseNamespace,
-			Name:      helmRelease.ReleaseName,
-		}] = len(helmRelease.ValuesHash) > 0
-	}
-
-	for _, s := range serviceSet.Status.Services {
-		// we won't save state if the service absent in desired ones
-		newState, ok := servicesMap[client.ObjectKey{
-			Namespace: s.Namespace,
-			Name:      s.Name,
-		}]
-		if !ok {
-			continue
-		}
-		newState.Type = s.Type
-		newState.LastStateTransitionTime = s.LastStateTransitionTime
-
-		switch s.Type {
-		case kcmv1.ServiceTypeHelm:
-			deployed, found := helmReleaseMap[serviceset.ServiceKey(s.Namespace, s.Name)]
-			if !found {
-				newState.State = kcmv1.ServiceStateNotDeployed
-			}
-			if deployed {
-				newState.State = kcmv1.ServiceStateDeployed
-			}
-			if !deployed && helmChartsFailureMessage != "" {
-				newState.State = kcmv1.ServiceStateFailed
-				newState.FailureMessage = helmChartsFailureMessage
-			}
-			if newState.State != s.State {
-				newState.LastStateTransitionTime = new(metav1.Now())
-			}
-		case kcmv1.ServiceTypeKustomize:
-			if kustomizationsDeployed {
-				newState.State = kcmv1.ServiceStateDeployed
-			}
-			if kustomizationsFailed {
-				newState.State = kcmv1.ServiceStateFailed
-				newState.FailureMessage = "One or more Kustomizations failed to deploy:" + kustomizationsFailureMessage
-			}
-		case kcmv1.ServiceTypeResource:
-			if policiesDeployed {
-				newState.State = kcmv1.ServiceStateDeployed
-			}
-			if policiesFailed {
-				newState.State = kcmv1.ServiceStateFailed
-				newState.FailureMessage = "One or more Resources failed to deploy: " + policiesFailureMessage
-			}
-		}
-		states = append(states, newState)
-	}
-	logger.V(1).Info("Collected services state from summary", "states", states)
-	return states
 }
 
 // getRegionalClient returns local or regional kubernetes client depending on the target cluster type.

--- a/internal/controller/adapters/sveltos/state.go
+++ b/internal/controller/adapters/sveltos/state.go
@@ -1,0 +1,442 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sveltos
+
+import (
+	"cmp"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/go-logr/logr"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+	"github.com/K0rdent/kcm/internal/serviceset"
+)
+
+// This is taken from kubernetes defined at:
+// https://github.com/kubernetes/kubernetes/blob/ce14ead/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L222
+const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
+
+var (
+	releaseNameRgx      *regexp.Regexp
+	releaseNamespaceRgx *regexp.Regexp
+)
+
+func init() {
+	releaseNameRgx = regexp.MustCompile("releaseName=(" + dns1035LabelFmt + ")")
+	releaseNamespaceRgx = regexp.MustCompile("releaseNamespace=(" + dns1035LabelFmt + ")")
+}
+
+func servicesStateFromSummary(
+	logger logr.Logger,
+	summary *addoncontrollerv1beta1.ClusterSummary,
+	serviceSet *kcmv1.ServiceSet,
+) []kcmv1.ServiceState {
+	if summary == nil {
+		logger.Info("Could not collect services state because the provided ClusterSummary is nil")
+		return nil
+	}
+	if serviceSet == nil {
+		logger.Info("Could not collect services state because the provided ServiceSet is nil")
+		return nil
+	}
+
+	logger.Info("Collecting services state from ClusterSummary", "cluster_summary", client.ObjectKeyFromObject(summary), "service_set", client.ObjectKeyFromObject(serviceSet))
+
+	// We'll recreate service states list according to the desired services.
+	states := make([]kcmv1.ServiceState, 0, len(serviceSet.Spec.Services))
+	servicesMap := make(map[client.ObjectKey]kcmv1.ServiceState)
+
+	for _, svc := range serviceSet.Spec.Services {
+		servicesMap[serviceset.ServiceKey(svc.Namespace, svc.Name)] = kcmv1.ServiceState{
+			Name:      svc.Name,
+			Namespace: svc.Namespace,
+			Template:  svc.Template,
+			Version:   svc.Version,
+			State:     kcmv1.ServiceStateProvisioning,
+		}
+	}
+
+	/*
+		NOTE: The reason why we can safely iterate over serviceSet's status here is because elsewhere
+		in the code (in getHelmCharts, getKustomizationRefs & getPolicyRefs funcs) we modify the
+		serviceSet object to add an entry (with default values) in its status for any service which
+		exists in its spec but not in its status. This means that we can be sure that the serviceSet's
+		status will already contain an entry for each of the services in the serviceSet's spec.
+	*/
+	for _, svc := range serviceSet.Status.Services {
+		// We won't save state if the service is absent in the spec.
+		newState, ok := servicesMap[serviceset.ServiceKey(svc.Namespace, svc.Name)]
+		if !ok {
+			continue
+		}
+
+		newState.Type = svc.Type
+		newState.LastStateTransitionTime = svc.LastStateTransitionTime
+
+		switch svc.Type {
+		case kcmv1.ServiceTypeKustomize:
+			featureKustomize(&newState, summary)
+		case kcmv1.ServiceTypeResource:
+			featureResources(&newState, summary)
+		case kcmv1.ServiceTypeHelm:
+			featureHelm(&newState, summary)
+		}
+
+		if newState.State != svc.State {
+			now := metav1.Now()
+			newState.LastStateTransitionTime = &now
+		}
+		states = append(states, newState)
+	}
+
+	slices.SortStableFunc(states, func(a, b kcmv1.ServiceState) int {
+		aKey := serviceset.ServiceKey(a.Namespace, a.Name)
+		bKey := serviceset.ServiceKey(b.Namespace, b.Name)
+
+		if n := cmp.Compare(aKey.Namespace, bKey.Namespace); n != 0 {
+			return n
+		}
+		return cmp.Compare(aKey.Name, bKey.Name)
+	})
+
+	logger.V(1).Info("Collected services state from summary", "states", states)
+
+	return states
+}
+
+func featureKustomize(newState *kcmv1.ServiceState, summary *addoncontrollerv1beta1.ClusterSummary) {
+	hasKustomizations := len(summary.Spec.ClusterProfileSpec.KustomizationRefs) > 0
+
+	kustomizationsDeployed := !hasKustomizations // Treat as deployed if feature absent.
+	kustomizationsFailed := false
+	kustomizationsFailureMessage := ""
+
+	for _, feature := range summary.Status.FeatureSummaries {
+		if feature.FeatureID == libsveltosv1beta1.FeatureKustomize {
+			// We cannot determine which kustomizations or policies were failed, hence we'll treat them as failed
+			// in case feature summary contains failure message. This message will be copied to the ServiceSet status
+			// thus user will be able to see the reason of failure.
+			// this is a temporary solution, we'll work with projectsveltos maintainers to improve observability.
+			kustomizationsDeployed = feature.Status == libsveltosv1beta1.FeatureStatusProvisioned
+			if feature.FailureMessage != nil {
+				kustomizationsFailed = true
+				kustomizationsFailureMessage = *feature.FailureMessage
+			}
+			break
+		}
+	}
+
+	if kustomizationsDeployed {
+		newState.State = kcmv1.ServiceStateDeployed
+	}
+	if kustomizationsFailed {
+		newState.State = kcmv1.ServiceStateFailed
+		newState.FailureMessage = "One or more Kustomizations failed to deploy: " + kustomizationsFailureMessage
+	}
+}
+
+func featureResources(newState *kcmv1.ServiceState, summary *addoncontrollerv1beta1.ClusterSummary) {
+	hasPolicies := len(summary.Spec.ClusterProfileSpec.PolicyRefs) > 0
+
+	policiesDeployed := !hasPolicies // Treat as deployed if feature absent.
+	policiesFailed := false
+	policiesFailureMessage := ""
+
+	for _, feature := range summary.Status.FeatureSummaries {
+		if feature.FeatureID == libsveltosv1beta1.FeatureResources {
+			policiesDeployed = feature.Status == libsveltosv1beta1.FeatureStatusProvisioned
+			if feature.FailureMessage != nil {
+				policiesFailed = true
+				policiesFailureMessage = *feature.FailureMessage
+			}
+			break
+		}
+	}
+
+	if policiesDeployed {
+		newState.State = kcmv1.ServiceStateDeployed
+	}
+	if policiesFailed {
+		newState.State = kcmv1.ServiceStateFailed
+		newState.FailureMessage = "One or more Resources failed to deploy: " + policiesFailureMessage
+	}
+}
+
+func featureHelm(
+	newState *kcmv1.ServiceState,
+	summary *addoncontrollerv1beta1.ClusterSummary,
+) {
+	var helmFeatureFailMsg string
+	var helmFeatureStatus libsveltosv1beta1.FeatureStatus
+
+	for _, feature := range summary.Status.FeatureSummaries {
+		if feature.FeatureID == libsveltosv1beta1.FeatureHelm {
+			helmFeatureStatus = feature.Status
+			// NOTE: The FailureMessage for the Helm Feature is simply a concatenation of
+			// each individual `helmReleaseSummaries[].FailureMessage` since Sveltos v1.7.0.
+			if feature.FailureMessage != nil {
+				helmFeatureFailMsg = *feature.FailureMessage
+			}
+			break
+		}
+	}
+
+	// Sometimes the failure message associated with a service is kept in the
+	// Helm Feature's failure message even when it is removed from the service's
+	// `helmReleaseSummaries[].FailureMessage`. For example when a service transitions
+	// from Failed->Provisioning. So we parse the Helm Feature's failure message to
+	// check if a failure message associated with a particular service is present or not.
+	// This helps us in figuring out the proper states for each service in some scenarios.
+	svcInHelmFeatureFailMsg := unpackHelmFailureMsg(helmFeatureFailMsg)
+
+	// Create a helm release map from sveltos clustersummary for quicker lookup.
+	helmReleaseMap := make(map[client.ObjectKey]*addoncontrollerv1beta1.HelmChartSummary)
+	for _, helmRelease := range summary.Status.HelmReleaseSummaries {
+		helmReleaseMap[client.ObjectKey{
+			Namespace: helmRelease.ReleaseNamespace,
+			Name:      helmRelease.ReleaseName,
+		}] = &helmRelease
+	}
+
+	helmRelease := helmReleaseMap[serviceset.ServiceKey(newState.Namespace, newState.Name)]
+	if helmRelease == nil {
+		// Setting as not deployed because the service exists in
+		// ServiceSet spec but not in ClusterSummary status yet.
+		newState.State = kcmv1.ServiceStateNotDeployed
+		return
+	}
+
+	convertedHelmFeatureStatus := featureStatusToServiceState(helmFeatureStatus)
+	if convertedHelmFeatureStatus == kcmv1.ServiceStateDeleting ||
+		convertedHelmFeatureStatus == kcmv1.ServiceStateDeleted {
+		newState.State = convertedHelmFeatureStatus
+		return
+	}
+
+	if helmRelease.Status == addoncontrollerv1beta1.HelmChartStatusConflict {
+		newState.State = kcmv1.ServiceStateFailed
+		// We can ignore `helmRelease.FailureMessage` when there's a conflict because
+		// the ConflictMessage and FailureMessage cannot be both set at the same time.
+		// github.com/projectsveltos/addon-controller/blob/f9b3752/controllers/handlers_helm.go#L2662-L2684
+		newState.FailureMessage = helmRelease.ConflictMessage
+		return
+	}
+
+	// Set the service's state to the status of the entire Helm Feature's status as a fallback.
+	newState.State = convertedHelmFeatureStatus
+
+	isValuesHashSet := len(helmRelease.ValuesHash) > 0
+	isFailureMsgSet := helmRelease.FailureMessage != nil && *helmRelease.FailureMessage != ""
+
+	switch {
+	case !isValuesHashSet && !isFailureMsgSet:
+		if helmFeatureStatus == libsveltosv1beta1.FeatureStatusProvisioning {
+			/*
+				The service could still be Provisioning like in the following example.
+
+					featureSummaries:
+					- featureID: Helm
+						hash: 16CwFOvGTz25T2tUxoruIMDZaqv+AswuQylmSX/wKB8=
+						status: Provisioning
+					helmReleaseSummaries:
+					- releaseName: nginx
+						releaseNamespace: nginx
+						status: Managing
+					- releaseName: postgres-operator
+						releaseNamespace: postgres-operator
+						status: Managing
+			*/
+			newState.State = kcmv1.ServiceStateProvisioning
+		} else {
+			/*
+				Or it could be Pending as below where postgres-operator isn't even attempted
+				because continueOnError was False. One way we know that it is not even
+				attempted is because the Helm Feature has a non-transitory (Failed) status
+				but the postgres-operator has neither valuesHash nor failureMessage set.
+
+					featureSummaries:
+					- consecutiveFailures: 3
+						failureMessage: 'chart: ingress-nginx, releaseNamespace: nginx, release: nginx,
+							context deadline exceeded'
+						featureID: Helm
+						hash: p+CtqayLCV/oE2GmSQVgH/njs+PNS9jPuxK2fBfAA+A=
+						lastAppliedTime: "2026-04-22T21:40:36Z"
+						status: Failed
+					helmReleaseSummaries:
+					- failureMessage: context deadline exceeded
+						releaseName: nginx
+						releaseNamespace: nginx
+						status: Managing
+					- releaseName: postgres-operator
+						releaseNamespace: postgres-operator
+						status: Managing
+			*/
+			newState.State = kcmv1.ServiceStateNotDeployed
+		}
+	case !isValuesHashSet && isFailureMsgSet:
+		// The service has failed to deploy.
+		newState.State = kcmv1.ServiceStateFailed
+		newState.FailureMessage = *helmRelease.FailureMessage
+	case isValuesHashSet && !isFailureMsgSet:
+		if helmFeatureStatus == libsveltosv1beta1.FeatureStatusProvisioning {
+			/*
+					Here the service could either be Provisioning or Deployed and in some cases with
+					multiple services we have no way of knowing which. Like in the example below:
+
+						featureSummaries:
+						- failureMessage: |
+								chart: ingress-nginx, releaseNamespace: nginx, release: nginx, context deadline exceeded
+							featureID: Helm
+							hash: 16CwFOvGTz25T2tUxoruIMDZaqv+AswuQylmSX/wKB8=
+							status: Provisioning
+						helmReleaseSummaries:
+						- releaseName: nginx
+							releaseNamespace: nginx
+							status: Managing
+							valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+						- releaseName: postgres-operator
+							releaseNamespace: postgres-operator
+							status: Managing
+							valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+
+					1) nginx is (Deployed->Provisioning->Failed->Provisioning).
+					   Starting with Deployed because it's valuesHash is set and then
+						 moving on to Failed because the Helm Feature has a failure message for nginx.
+						 Then finally moving on to Provisioning as the current state because it's own
+						 failureMessage is not set, which means the Helm Feature's failureMessage is
+						 from a previous Failed state.
+
+					2) postgres-operator can either be (Deployed) or (Deployed->Provisioning).
+
+					We can't know for sure whether postgres-operator is Deployed or Provisioning.
+					So the best we can do is set the state to Provisioning if the Helm Feature's
+					FailureMessage doesn't have an error belonging to the service. If it does then
+					set the state to the status of the entire Helm Feature as a fallback (done earlier)
+				  by doing nothing. These states would just be transitory because once the entire
+					Helm Feature's status moves on from Provisioning to some other non-transitory value
+					then we will be able to determine the actual state of the services.
+			*/
+			if _, ok := svcInHelmFeatureFailMsg[serviceset.ServiceKey(newState.Namespace, newState.Name)]; !ok {
+				newState.State = kcmv1.ServiceStateProvisioning
+			}
+		}
+
+		if helmFeatureStatus == libsveltosv1beta1.FeatureStatusProvisioned {
+			// If the entire Helm Feature has been Provisioned then so has this service.
+			newState.State = kcmv1.ServiceStateDeployed
+		}
+
+		if helmFeatureStatus == libsveltosv1beta1.FeatureStatusFailed {
+			/*
+				In this case it could be that one service has Failed as nginx has in the example
+				below while the other service (postgres-operator) has successfully Deployed but
+				since one of the services failed the overall status of Helm Feature reports Failed.
+
+					featureSummaries:
+					- failureMessage: |
+							chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+						featureID: Helm
+						hash: 9J6imd1Rsr9faFztMeQDOQthMKWpFk2FyQ0WBm89XNg=
+						status: Failed
+					helmReleaseSummaries:
+					- failureMessage: context deadline exceeded
+						releaseName: nginx
+						releaseNamespace: nginx
+						status: Managing
+					- releaseName: postgres-operator
+						releaseNamespace: postgres-operator
+						status: Managing
+						valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+
+				In such a case, since the Helm Feature's status is a non-transitory one (Failed) yet
+				the postgres-operator service has an empty failureMessage and it's valuesHash set,
+				we can be sure that it has been successfully Deployed.
+			*/
+			newState.State = kcmv1.ServiceStateDeployed
+		}
+
+		if helmFeatureStatus == libsveltosv1beta1.FeatureStatusFailedNonRetriable {
+			/*
+				This usually happens when a service has conflict, or if there are multiple
+				services then at least one has a conflict while the others have been Deployed.
+				If at least one has a conflict while another service has Failed then the overall
+				status of the Helm Feature would be Failed instead of FailedNonRetriable.
+			*/
+			newState.State = kcmv1.ServiceStateDeployed
+		}
+	case isValuesHashSet && isFailureMsgSet:
+		// This just means that the service is currently failing but a
+		// previous version of the service was successfully deployed.
+		newState.State = kcmv1.ServiceStateFailed
+		newState.FailureMessage = *helmRelease.FailureMessage
+	}
+}
+
+func featureStatusToServiceState(featureStatus libsveltosv1beta1.FeatureStatus) string {
+	state := kcmv1.ServiceStateNotDeployed
+
+	switch featureStatus {
+	case libsveltosv1beta1.FeatureStatusProvisioning:
+		state = kcmv1.ServiceStateProvisioning
+	case libsveltosv1beta1.FeatureStatusProvisioned:
+		state = kcmv1.ServiceStateDeployed
+	case libsveltosv1beta1.FeatureStatusFailed:
+		state = kcmv1.ServiceStateFailed
+	case libsveltosv1beta1.FeatureStatusFailedNonRetriable:
+		// If the feature's status is FeatureStatusFailedNonRetriable this does not
+		// mean complete failure. For example in then Helm Feature it could happen
+		// that one service is Deployed successfully while the other has Conflict.
+		// In such a case, the Helm Feature's status will be FeatureStatusFailedNonRetriable.
+		state = kcmv1.ServiceStateFailed
+	case libsveltosv1beta1.FeatureStatusRemoving:
+		state = kcmv1.ServiceStateDeleting
+	case libsveltosv1beta1.FeatureStatusAgentRemoving:
+		state = kcmv1.ServiceStateDeleting
+	case libsveltosv1beta1.FeatureStatusRemoved:
+		state = kcmv1.ServiceStateDeleted
+	}
+
+	return state
+}
+
+// unpackHelmFailureMsg parses provided Helm Feature's failure message
+// and returns a map of service keys that are contained in the message.
+func unpackHelmFailureMsg(msg string) map[client.ObjectKey]struct{} {
+	result := make(map[client.ObjectKey]struct{})
+
+	for line := range strings.SplitSeq(msg, "\n") {
+		releaseName := releaseNameRgx.FindString(line)
+		releaseName, found := strings.CutPrefix(releaseName, "releaseName=")
+		if !found {
+			continue
+		}
+
+		releaseNamespace := releaseNamespaceRgx.FindString(line)
+		releaseNamespace, found = strings.CutPrefix(releaseNamespace, "releaseNamespace=")
+		if !found {
+			continue
+		}
+
+		result[serviceset.ServiceKey(releaseNamespace, releaseName)] = struct{}{}
+	}
+
+	return result
+}

--- a/internal/controller/adapters/sveltos/state.go
+++ b/internal/controller/adapters/sveltos/state.go
@@ -209,6 +209,13 @@ func featureHelm(
 		}
 	}
 
+	convertedHelmFeatureStatus := featureStatusToServiceState(helmFeatureStatus)
+	if convertedHelmFeatureStatus == kcmv1.ServiceStateDeleting ||
+		convertedHelmFeatureStatus == kcmv1.ServiceStateDeleted {
+		newState.State = convertedHelmFeatureStatus
+		return
+	}
+
 	// Sometimes the failure message associated with a service is kept in the
 	// Helm Feature's failure message even when it is removed from the service's
 	// `helmReleaseSummaries[].FailureMessage`. For example when a service transitions
@@ -231,13 +238,6 @@ func featureHelm(
 		// Setting as not deployed because the service exists in
 		// ServiceSet spec but not in ClusterSummary status yet.
 		newState.State = kcmv1.ServiceStateNotDeployed
-		return
-	}
-
-	convertedHelmFeatureStatus := featureStatusToServiceState(helmFeatureStatus)
-	if convertedHelmFeatureStatus == kcmv1.ServiceStateDeleting ||
-		convertedHelmFeatureStatus == kcmv1.ServiceStateDeleted {
-		newState.State = convertedHelmFeatureStatus
 		return
 	}
 

--- a/internal/controller/adapters/sveltos/state.go
+++ b/internal/controller/adapters/sveltos/state.go
@@ -30,9 +30,17 @@ import (
 	"github.com/K0rdent/kcm/internal/serviceset"
 )
 
-// This is taken from kubernetes defined at:
-// https://github.com/kubernetes/kubernetes/blob/ce14ead/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L222
-const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
+const (
+	// dns1035LabelFmt is the regex format for release names.
+	// Taken from kubernetes defined at:
+	// https://github.com/kubernetes/kubernetes/blob/ce14ead/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L222
+	dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
+
+	// dns1123LabelFmt is the regex format for release namespaces.
+	// Taken from kubernetes defined at:
+	// https://github.com/kubernetes/kubernetes/blob/ce14ead/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L155
+	dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+)
 
 var (
 	releaseNameRgx      *regexp.Regexp
@@ -40,8 +48,10 @@ var (
 )
 
 func init() {
+	// These regexes used to extract the release name and release namespace from `featureSummaries[].FailureMessage`
+	// for the Helm Feature are only applicable in Sveltos >= 1.9.0 when the error format which these match was applied.
 	releaseNameRgx = regexp.MustCompile("releaseName=(" + dns1035LabelFmt + ")")
-	releaseNamespaceRgx = regexp.MustCompile("releaseNamespace=(" + dns1035LabelFmt + ")")
+	releaseNamespaceRgx = regexp.MustCompile("releaseNamespace=(" + dns1123LabelFmt + ")")
 }
 
 func servicesStateFromSummary(

--- a/internal/controller/adapters/sveltos/state_test.go
+++ b/internal/controller/adapters/sveltos/state_test.go
@@ -1,0 +1,1459 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sveltos
+
+import (
+	"bytes"
+	"testing"
+
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+)
+
+func Test_servicesStateFromSummary_Helm(t *testing.T) {
+	type testCase struct {
+		description string
+		summary     string
+		serviceSet  *kcmv1.ServiceSet
+		expected    []kcmv1.ServiceState
+	}
+
+	cases := []testCase{
+		{
+			description: "empty status with no services",
+		},
+		{
+			description: "empty status with services",
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateNotDeployed,
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateNotDeployed,
+				},
+			},
+		},
+		{
+			description: "nginx Failed",
+			summary: `
+  status:
+    dependencies: no dependencies
+    featureSummaries:
+    - consecutiveFailures: 1
+      failureMessage: |
+        chart: ingress-nginx, releaseNamespace: nginx, release: nginx, context deadline exceeded
+      featureID: Helm
+      hash: r3heWCzDuieATqLebzLZqzkIU6JqVY2+pUnrNfplcLM=
+      lastAppliedTime: "2026-04-23T06:08:08Z"
+      status: Failed
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+			},
+		},
+		{
+			description: "nginx Failed->Provisioning",
+			summary: `
+  status:
+    dependencies: no dependencies
+    featureSummaries:
+    - failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+      featureID: Helm
+      hash: 9uIsgqogeawbyindlsMevgCxjOoYRtTurwUU1aVDeBA=
+      lastAppliedTime: "2026-04-23T08:28:19Z"
+      status: Provisioning
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+			},
+		},
+		{
+			description: "nginx Deployed",
+			summary: `
+  status:
+    dependencies: no dependencies
+    featureSummaries:
+    - featureID: Helm
+      hash: RrRcFPXyTypTdFD3d8q7emG92cPZfUrI7djagQI8/K8=
+      lastAppliedTime: "2024-10-01T02:58:32Z"
+      status: Provisioned
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: Eq4yyx7ALQHto1gbEnwf7jsNxTVy7WuvI5choD2C4SY=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateDeployed,
+				},
+			},
+		},
+		{
+			description: "nginx Deployed->Provisioning",
+			summary: `
+  status:
+    dependencies: no dependencies
+    featureSummaries:
+    - featureID: Helm
+      hash: XEqVbp+3j+cNDb+oJGfsQW6+3w6vLuYIXkcn6xsKLbo=
+      lastAppliedTime: "2026-04-23T08:28:39Z"
+      status: Provisioning
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: RTxW4tOWWuPqhKwLwZ8935jZY/koONmlkiGx3l14SQs=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+			},
+		},
+		{
+			description: "nginx Deployed->Provisioning->Failed",
+			summary: `
+  status:
+    dependencies: no dependencies
+    featureSummaries:
+    - consecutiveFailures: 1
+      failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+      featureID: Helm
+      hash: r3heWCzDuieATqLebzLZqzkIU6JqVY2+pUnrNfplcLM=
+      lastAppliedTime: "2026-04-23T10:12:22Z"
+      status: Failed
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+			},
+		},
+		{
+			description: "nginx Failed & postgres Failed",
+			summary: `
+  status:
+    dependencies: no dependencies
+    featureSummaries:
+    - failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+        chart=postgres-operator, releaseNamespace=postgres-operator, releaseName=postgres-operator: context deadline exceeded
+      featureID: Helm
+      hash: +OIMqZZ3LuRy6P8yCT45zb92Y6i4BAj1W94pMGq9wfk=
+      lastAppliedTime: "2026-03-25T13:45:16Z"
+      status: Failed
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+    - failureMessage: context deadline exceeded
+      releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "postgres-operator",
+					Namespace:      "postgres-operator",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+			},
+		},
+		{
+			description: "nginx Failed & postgres Failed->Provisioning",
+			summary: `
+  status:
+    dependencies: no dependencies
+    featureSummaries:
+    - failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+        chart=postgres-operator, releaseNamespace=postgres-operator, releaseName=postgres-operator: context deadline exceeded
+      featureID: Helm
+      hash: 9J6imd1Rsr9faFztMeQDOQthMKWpFk2FyQ0WBm89XNg=
+      lastAppliedTime: "2026-04-24T21:02:44Z"
+      status: Provisioning
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+			},
+		},
+		{
+			description: "nginx Failed & postgres Failed->Provisioning->Deployed",
+			summary: `
+  status:
+    dependencies: no dependencies
+    featureSummaries:
+    - consecutiveFailures: 31
+      failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+      featureID: Helm
+      hash: 9J6imd1Rsr9faFztMeQDOQthMKWpFk2FyQ0WBm89XNg=
+      lastAppliedTime: "2026-04-24T21:18:50Z"
+      status: Failed
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateDeployed,
+				},
+			},
+		},
+		{
+			// In this case the valuesHash for each service is set even though the
+			// previous state was Failed because during provisioning Sveltos sets
+			// the valuesHash before it updates the Helm Feature's FailureMessage.
+			description: "nginx Failed->Provisioning & postgres Failed->Provisioning",
+			summary: `
+  status:
+    featureSummaries:
+    - failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+        chart=postgres-operator, releaseNamespace=postgres-operator, releaseName=postgres-operator: context deadline exceeded
+      featureID: Helm
+      hash: mBh74LoXFwbhno8ShBxkx8C0+L7qYvsL3L1Mj0P/BQw=
+      lastAppliedTime: "2026-04-24T21:32:14Z"
+      status: Provisioning
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+			},
+		},
+		{
+			description: "nginx Provisioning & postgres Provisioning",
+			summary: `
+  status:
+    featureSummaries:
+    - featureID: Helm
+      hash: mBh74LoXFwbhno8ShBxkx8C0+L7qYvsL3L1Mj0P/BQw=
+      status: Provisioning
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+			},
+		},
+		{
+			description: "nginx Deployed & postgres Deployed",
+			summary: `
+  status:
+    featureSummaries:
+    - featureID: Helm
+      hash: mBh74LoXFwbhno8ShBxkx8C0+L7qYvsL3L1Mj0P/BQw=
+      lastAppliedTime: "2026-04-24T21:41:08Z"
+      status: Provisioned
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateDeployed,
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateDeployed,
+				},
+			},
+		},
+		{
+			// When creating this case, I updated the values of nginx to 3 replicas so
+			// that nginx would enter the Provisioning state. The postgres-operator
+			// service was unchanged, however, looking at the ClusterSummary's status
+			// there is no way to know which of the services is Provisioning or Deployed
+			// or both because both have valuesHash set and no failure message and the
+			// Helm Feature's FailureMessage is also empty. So the best we can do in this
+			// transitionary period is set the status for both services to Provisioning and
+			// once nginx transitions from Provisioning to either Failed or Deployed,
+			// the status will be updated to capture the correct state for each service.
+			description: "nginx Deployed->Provisioning & postgres Deployed",
+			summary: `
+  status:
+    featureSummaries:
+    - featureID: Helm
+      hash: a28oOzTRQxNGS+4N3349+goL8MKG+GjOLoza0spa7uo=
+      lastAppliedTime: "2026-04-24T21:41:08Z"
+      status: Provisioning
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+			},
+		},
+		{
+			description: "nginx Deployed->Provisioning & postgres Deployed->Provisioning",
+			summary: `
+  status:
+    featureSummaries:
+    - featureID: Helm
+      hash: dFJHYOa9fQO15cZjkLTgKmxXpz0dBuRvb1qc7ccMGW8=
+      lastAppliedTime: "2026-04-24T21:52:14Z"
+      status: Provisioning
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+			},
+		},
+		{
+			description: "nginx Deployed->Provisioning->Failed & postgres Deployed",
+			summary: `
+  status:
+    featureSummaries:
+    - consecutiveFailures: 2
+      failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+      featureID: Helm
+      hash: 0DxX3s8cx9qPS+0hcC+LZizjB0u1SNNIgSgG8fv+o4k=
+      lastAppliedTime: "2026-04-24T21:56:03Z"
+      status: Failed
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: RTxW4tOWWuPqhKwLwZ8935jZY/koONmlkiGx3l14SQs=
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+      valuesHash: ++UQu2VpyN9315nhoxA3kxUpkqroDv/32xGowdzQwrA=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateDeployed,
+				},
+			},
+		},
+		{
+			description: "nginx Deployed->Provisioning->Failed & postgres Deployed->Provisioning",
+			summary: `
+  status:
+    featureSummaries:
+    - failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+      featureID: Helm
+      hash: 9J6imd1Rsr9faFztMeQDOQthMKWpFk2FyQ0WBm89XNg=
+      lastAppliedTime: "2026-04-24T21:58:33Z"
+      status: Provisioning
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: RTxW4tOWWuPqhKwLwZ8935jZY/koONmlkiGx3l14SQs=
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+			},
+		},
+		{
+			description: "nginx Deployed->Provisioning->Failed & postgres Deployed->Provisioning->Failed",
+			summary: `
+  status:
+    featureSummaries:
+    - failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+        chart=postgres-operator, releaseNamespace=postgres-operator, releaseName=postgres-operator: context deadline exceeded
+      featureID: Helm
+      hash: +OIMqZZ3LuRy6P8yCT45zb92Y6i4BAj1W94pMGq9wfk=
+      lastAppliedTime: "2026-03-25T13:45:16Z"
+      status: Failed
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: RTxW4tOWWuPqhKwLwZ8935jZY/koONmlkiGx3l14SQs=
+    - failureMessage: context deadline exceeded
+      releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "postgres-operator",
+					Namespace:      "postgres-operator",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+			},
+		},
+		{
+			description: "nginx Failed->Provisioning->Deployed & postgres Failed->Provisioning->Deployed",
+			summary: `
+  status:
+    featureSummaries:
+    - featureID: Helm
+      hash: mBh74LoXFwbhno8ShBxkx8C0+L7qYvsL3L1Mj0P/BQw=
+      lastAppliedTime: "2026-04-24T22:35:48Z"
+      status: Provisioned
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateDeployed,
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateDeployed,
+				},
+			},
+		},
+		{
+			description: "nginx Deployed->Provisioning->Failed->Provisioning & postgres Deployed",
+			summary: `
+  status:
+    featureSummaries:
+    - failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+      featureID: Helm
+      hash: mBh74LoXFwbhno8ShBxkx8C0+L7qYvsL3L1Mj0P/BQw=
+      lastAppliedTime: "2026-04-24T22:38:38Z"
+      status: Provisioning
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+			},
+		},
+		{
+			// nginx failed & postgres isn't even attempted because continueOnError=false
+			description: "nginx Failed & Postgres Pending because continueOnError=False",
+			summary: `
+  status:
+    dependencies: no dependencies
+    featureSummaries:
+    - consecutiveFailures: 3
+      failureMessage: 'chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx:
+        context deadline exceeded'
+      featureID: Helm
+      hash: p+CtqayLCV/oE2GmSQVgH/njs+PNS9jPuxK2fBfAA+A=
+      lastAppliedTime: "2026-04-22T21:40:36Z"
+      status: Failed
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateNotDeployed,
+				},
+			},
+		},
+		{
+			description: "nginx Failed->Removing & postgres Deployed->Removing",
+			summary: `
+  status:
+    featureSummaries:
+    - consecutiveFailures: 9
+      failureMessage: 'chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx:
+        context deadline exceeded'
+      featureID: Helm
+      lastAppliedTime: "2026-04-24T22:48:42Z"
+      status: Removing
+    - featureID: Resources
+      status: Removing
+    - featureID: Kustomize
+      status: Removing
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+    - releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Managing
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateDeleting,
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateDeleting,
+				},
+			},
+		},
+		{
+			description: "nginx Failed->Provisioning & postgres Conflict",
+			summary: `
+  status:
+    featureSummaries:
+    - failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+      featureID: Helm
+      hash: mBh74LoXFwbhno8ShBxkx8C0+L7qYvsL3L1Mj0P/BQw=
+      lastAppliedTime: "2026-04-25T00:07:31Z"
+      status: Provisioning
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+    - conflictMessage: ClusterSummary management-3556efa5-sveltos-mgmt managing it
+      releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Conflict
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "postgres-operator",
+					Namespace:      "postgres-operator",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "ClusterSummary management-3556efa5-sveltos-mgmt managing it",
+				},
+			},
+		},
+		{
+			description: "nginx Failed & postgres Conflict",
+			summary: `
+  status:
+    featureSummaries:
+    - consecutiveFailures: 6
+      failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+      featureID: Helm
+      hash: 9J6imd1Rsr9faFztMeQDOQthMKWpFk2FyQ0WBm89XNg=
+      lastAppliedTime: "2026-04-25T00:02:11Z"
+      status: Failed
+    helmReleaseSummaries:
+    - failureMessage: context deadline exceeded
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+    - conflictMessage: ClusterSummary management-3556efa5-sveltos-mgmt managing it
+      releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Conflict
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "context deadline exceeded",
+				},
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "postgres-operator",
+					Namespace:      "postgres-operator",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "ClusterSummary management-3556efa5-sveltos-mgmt managing it",
+				},
+			},
+		},
+		{
+			description: "nginx Failed->Provisioning & postgres Conflict",
+			summary: `
+  status:
+    featureSummaries:
+    - failureMessage: |
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
+      featureID: Helm
+      hash: mBh74LoXFwbhno8ShBxkx8C0+L7qYvsL3L1Mj0P/BQw=
+      lastAppliedTime: "2026-04-25T00:07:31Z"
+      status: Provisioning
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+    - conflictMessage: ClusterSummary management-3556efa5-sveltos-mgmt managing it
+      releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Conflict
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "postgres-operator",
+					Namespace:      "postgres-operator",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "ClusterSummary management-3556efa5-sveltos-mgmt managing it",
+				},
+			},
+		},
+		{
+			description: "nginx Failed->Provisioning->Deployed & postgres Conflict",
+			summary: `
+  status:
+    featureSummaries:
+    - consecutiveFailures: 2
+      failureMessage: |
+        cannot manage chart postgres-operator/postgres-operator. ClusterSummary management-3556efa5-sveltos-mgmt managing it.
+      featureID: Helm
+      hash: mBh74LoXFwbhno8ShBxkx8C0+L7qYvsL3L1Mj0P/BQw=
+      lastAppliedTime: "2026-04-25T00:07:48Z"
+      status: FailedNonRetriable
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+    - conflictMessage: ClusterSummary management-3556efa5-sveltos-mgmt managing it
+      releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Conflict
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateDeployed,
+				},
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "postgres-operator",
+					Namespace:      "postgres-operator",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "ClusterSummary management-3556efa5-sveltos-mgmt managing it",
+				},
+			},
+		},
+		{
+			description: "nginx Deployed & postgres Conflict",
+			summary: `
+  status:
+    featureSummaries:
+    - consecutiveFailures: 2
+      failureMessage: |
+        cannot manage chart postgres-operator/postgres-operator. ClusterSummary management-3556efa5-sveltos-mgmt managing it.
+      featureID: Helm
+      hash: mBh74LoXFwbhno8ShBxkx8C0+L7qYvsL3L1Mj0P/BQw=
+      lastAppliedTime: "2026-04-25T00:22:22Z"
+      status: FailedNonRetriable
+    helmReleaseSummaries:
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+    - conflictMessage: ClusterSummary management-3556efa5-sveltos-mgmt managing it
+      releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Conflict
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateDeployed,
+				},
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "postgres-operator",
+					Namespace:      "postgres-operator",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "ClusterSummary management-3556efa5-sveltos-mgmt managing it",
+				},
+			},
+		},
+		{
+			description: "nginx Deployed->Provisioning & postgres Conflict",
+			summary: `
+  status:
+    featureSummaries:
+    - failureMessage: |
+        cannot manage chart postgres-operator/postgres-operator. ClusterSummary management-3556efa5-sveltos-mgmt managing it.
+      featureID: Helm
+      hash: a28oOzTRQxNGS+4N3349+goL8MKG+GjOLoza0spa7uo=
+      lastAppliedTime: "2026-04-25T00:22:22Z"
+      status: Provisioning
+    helmReleaseSummaries:
+    - conflictMessage: ClusterSummary management-3556efa5-sveltos-mgmt managing it
+      releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Conflict
+    - releaseName: nginx
+      releaseNamespace: nginx
+      status: Managing
+      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateProvisioning,
+				},
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "postgres-operator",
+					Namespace:      "postgres-operator",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "ClusterSummary management-3556efa5-sveltos-mgmt managing it",
+				},
+			},
+		},
+		{
+			description: "nginx Conflict & postgres Conflict",
+			summary: `
+  status:
+    dependencies: no dependencies
+    featureSummaries:
+    - consecutiveFailures: 2
+    failureMessage: |
+      cannot manage chart nginx/nginx. ClusterSummary management-3556efa5-sveltos-mgmt managing it.
+      cannot manage chart postgres-operator/postgres-operator. ClusterSummary management-3556efa5-sveltos-mgmt managing it.
+    featureID: Helm
+    hash: 16CwFOvGTz25T2tUxoruIMDZaqv+AswuQylmSX/wKB8=
+    lastAppliedTime: "2026-04-22T10:25:45Z"
+    status: FailedNonRetriable
+    helmReleaseSummaries:
+    - conflictMessage: ClusterSummary management-3556efa5-sveltos-mgmt managing it
+      releaseName: nginx
+      releaseNamespace: nginx
+      status: Conflict
+    - conflictMessage: ClusterSummary management-3556efa5-sveltos-mgmt managing it
+      releaseName: postgres-operator
+      releaseNamespace: postgres-operator
+      status: Conflict
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "nginx",
+					Namespace:      "nginx",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "ClusterSummary management-3556efa5-sveltos-mgmt managing it",
+				},
+				{
+					Type:           kcmv1.ServiceTypeHelm,
+					Name:           "postgres-operator",
+					Namespace:      "postgres-operator",
+					State:          kcmv1.ServiceStateFailed,
+					FailureMessage: "ClusterSummary management-3556efa5-sveltos-mgmt managing it",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			logger := ctrl.LoggerFrom(t.Context()).WithName("test")
+			summary := &addoncontrollerv1beta1.ClusterSummary{}
+			err := yaml.Unmarshal(bytes.TrimSpace([]byte(tc.summary)), summary)
+			require.NoError(t, err)
+			servicesState := servicesStateFromSummary(logger, summary, tc.serviceSet)
+			compareStates(t, tc.description, tc.expected, servicesState)
+		})
+	}
+}
+
+func compareStates(t *testing.T, description string, expected, actual []kcmv1.ServiceState) {
+	t.Helper()
+
+	type projectedState struct {
+		Name           string
+		Namespace      string
+		Type           kcmv1.ServiceType
+		State          string
+		FailureMessage string
+	}
+
+	expectedProjected := make([]projectedState, len(expected))
+	for i, ex := range expected {
+		expectedProjected[i] = projectedState{
+			Name:           ex.Name,
+			Namespace:      ex.Namespace,
+			Type:           ex.Type,
+			State:          ex.State,
+			FailureMessage: ex.FailureMessage,
+		}
+	}
+
+	actualProjected := make([]projectedState, len(actual))
+	for i, ac := range actual {
+		actualProjected[i] = projectedState{
+			Name:           ac.Name,
+			Namespace:      ac.Namespace,
+			Type:           ac.Type,
+			State:          ac.State,
+			FailureMessage: ac.FailureMessage,
+		}
+	}
+
+	require.ElementsMatch(t, expectedProjected, actualProjected, description)
+}

--- a/internal/controller/adapters/sveltos/state_test.go
+++ b/internal/controller/adapters/sveltos/state_test.go
@@ -77,7 +77,7 @@ func Test_servicesStateFromSummary_Helm(t *testing.T) {
     featureSummaries:
     - consecutiveFailures: 1
       failureMessage: |
-        chart: ingress-nginx, releaseNamespace: nginx, release: nginx, context deadline exceeded
+        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
       featureID: Helm
       hash: r3heWCzDuieATqLebzLZqzkIU6JqVY2+pUnrNfplcLM=
       lastAppliedTime: "2026-04-23T06:08:08Z"
@@ -1044,57 +1044,6 @@ func Test_servicesStateFromSummary_Helm(t *testing.T) {
 			},
 		},
 		{
-			description: "nginx Failed->Provisioning & postgres Conflict",
-			summary: `
-  status:
-    featureSummaries:
-    - failureMessage: |
-        chart=ingress-nginx, releaseNamespace=nginx, releaseName=nginx: context deadline exceeded
-      featureID: Helm
-      hash: mBh74LoXFwbhno8ShBxkx8C0+L7qYvsL3L1Mj0P/BQw=
-      lastAppliedTime: "2026-04-25T00:07:31Z"
-      status: Provisioning
-    helmReleaseSummaries:
-    - releaseName: nginx
-      releaseNamespace: nginx
-      status: Managing
-      valuesHash: yj0WO6sFU4GCciYUBWjzvvfqrBh869doeOC2Pp5EI1Y=
-    - conflictMessage: ClusterSummary management-3556efa5-sveltos-mgmt managing it
-      releaseName: postgres-operator
-      releaseNamespace: postgres-operator
-      status: Conflict
-`,
-			serviceSet: &kcmv1.ServiceSet{
-				Spec: kcmv1.ServiceSetSpec{
-					Services: []kcmv1.ServiceWithValues{
-						{Name: "nginx", Namespace: "nginx"},
-						{Name: "postgres-operator", Namespace: "postgres-operator"},
-					},
-				},
-				Status: kcmv1.ServiceSetStatus{
-					Services: []kcmv1.ServiceState{
-						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
-						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
-					},
-				},
-			},
-			expected: []kcmv1.ServiceState{
-				{
-					Type:      kcmv1.ServiceTypeHelm,
-					Name:      "nginx",
-					Namespace: "nginx",
-					State:     kcmv1.ServiceStateProvisioning,
-				},
-				{
-					Type:           kcmv1.ServiceTypeHelm,
-					Name:           "postgres-operator",
-					Namespace:      "postgres-operator",
-					State:          kcmv1.ServiceStateFailed,
-					FailureMessage: "ClusterSummary management-3556efa5-sveltos-mgmt managing it",
-				},
-			},
-		},
-		{
 			description: "nginx Failed & postgres Conflict",
 			summary: `
   status:
@@ -1360,13 +1309,13 @@ func Test_servicesStateFromSummary_Helm(t *testing.T) {
     dependencies: no dependencies
     featureSummaries:
     - consecutiveFailures: 2
-    failureMessage: |
-      cannot manage chart nginx/nginx. ClusterSummary management-3556efa5-sveltos-mgmt managing it.
-      cannot manage chart postgres-operator/postgres-operator. ClusterSummary management-3556efa5-sveltos-mgmt managing it.
-    featureID: Helm
-    hash: 16CwFOvGTz25T2tUxoruIMDZaqv+AswuQylmSX/wKB8=
-    lastAppliedTime: "2026-04-22T10:25:45Z"
-    status: FailedNonRetriable
+      failureMessage: |
+        cannot manage chart nginx/nginx. ClusterSummary management-3556efa5-sveltos-mgmt managing it.
+        cannot manage chart postgres-operator/postgres-operator. ClusterSummary management-3556efa5-sveltos-mgmt managing it.
+      featureID: Helm
+      hash: 16CwFOvGTz25T2tUxoruIMDZaqv+AswuQylmSX/wKB8=
+      lastAppliedTime: "2026-04-22T10:25:45Z"
+      status: FailedNonRetriable
     helmReleaseSummaries:
     - conflictMessage: ClusterSummary management-3556efa5-sveltos-mgmt managing it
       releaseName: nginx

--- a/internal/controller/adapters/sveltos/state_test.go
+++ b/internal/controller/adapters/sveltos/state_test.go
@@ -1044,6 +1044,50 @@ func Test_servicesStateFromSummary_Helm(t *testing.T) {
 			},
 		},
 		{
+			description: "nginx Removed & postgres Removed",
+			summary: `
+  status:
+    dependencies: no dependencies
+    featureSummaries:
+    - featureID: Helm
+      lastAppliedTime: "2026-06-02T20:41:38Z"
+      resourceSummaryDeployed: false
+      status: Removed
+    - featureID: Resources
+      status: Removed
+    - featureID: Kustomize
+      status: Removed
+`,
+			serviceSet: &kcmv1.ServiceSet{
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "nginx", Namespace: "nginx"},
+						{Name: "postgres-operator", Namespace: "postgres-operator"},
+					},
+				},
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: "nginx", Namespace: "nginx", Type: kcmv1.ServiceTypeHelm},
+						{Name: "postgres-operator", Namespace: "postgres-operator", Type: kcmv1.ServiceTypeHelm},
+					},
+				},
+			},
+			expected: []kcmv1.ServiceState{
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "nginx",
+					Namespace: "nginx",
+					State:     kcmv1.ServiceStateDeleted,
+				},
+				{
+					Type:      kcmv1.ServiceTypeHelm,
+					Name:      "postgres-operator",
+					Namespace: "postgres-operator",
+					State:     kcmv1.ServiceStateDeleted,
+				},
+			},
+		},
+		{
 			description: "nginx Failed & postgres Conflict",
 			summary: `
   status:

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -362,10 +362,13 @@ func FilterServiceDependencies(
 
 	// Sort for deterministic ordering across reconcile cycles.
 	slices.SortFunc(filtered, func(a, b kcmv1.Service) int {
-		if n := cmp.Compare(effectiveNamespace(a.Namespace), effectiveNamespace(b.Namespace)); n != 0 {
+		aKey := ServiceKey(a.Namespace, a.Name)
+		bKey := ServiceKey(b.Namespace, b.Name)
+
+		if n := cmp.Compare(aKey.Namespace, bKey.Namespace); n != 0 {
 			return n
 		}
-		return cmp.Compare(a.Name, b.Name)
+		return cmp.Compare(aKey.Name, bKey.Name)
 	})
 
 	return filtered, nil

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
@@ -1031,6 +1031,7 @@ spec:
                           - Failed
                           - Pending
                           - Deleting
+                          - Deleted
                         type: string
                       template:
                         description: Template is the name of the ServiceTemplate used to deploy the Service

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -987,6 +987,7 @@ spec:
                           - Failed
                           - Pending
                           - Deleting
+                          - Deleted
                         type: string
                       template:
                         description: Template is the name of the ServiceTemplate used to deploy the Service

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
@@ -525,6 +525,7 @@ spec:
                           - Failed
                           - Pending
                           - Deleting
+                          - Deleted
                         type: string
                       template:
                         description: Template is the name of the ServiceTemplate used to deploy the Service


### PR DESCRIPTION
# Description

The new field [`helmReleaseSummaries[].FailureMessage`](https://github.com/projectsveltos/addon-controller/blob/f9b3752ffd6a565bc58fb1add028711ba3fb0aa2/api/v1beta1/clustersummary_types.go#L124) has been introduced since Sveltos 1.7.0. With its introduction we need to change the logic of how we fetch each individual service's status from ClusterSummary for Helm.

Fixes https://github.com/k0rdent/kcm/issues/2564.