### PR TITLE
fix: several fixes for cluster deployment reconciler

### DIFF
--- a/api/v1beta1/clusterdeployment_types.go
+++ b/api/v1beta1/clusterdeployment_types.go
@@ -206,6 +206,10 @@ func (in *ClusterDeployment) AddHelmValues(fn func(map[string]any) error) error 
 		return err
 	}
 
+	if values == nil {
+		values = make(map[string]any)
+	}
+
 	if err := fn(values); err != nil {
 		return err
 	}

--- a/api/v1beta1/clusterdeployment_types.go
+++ b/api/v1beta1/clusterdeployment_types.go
@@ -15,7 +15,9 @@
 package v1beta1
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -178,43 +180,77 @@ type ClusterDeployment struct { //nolint:govet // false-positive
 	Status ClusterDeploymentStatus `json:"status,omitempty"`
 }
 
+// HelmValues returns a non-nil map of Helm values from [ClusterDeployment.Spec] Config field.
+// Nil, empty, and "null" payloads are treated as empty values.
 func (in *ClusterDeployment) HelmValues() (map[string]any, error) {
-	var values map[string]any
-
-	if in.Spec.Config != nil {
-		if err := yaml.Unmarshal(in.Spec.Config.Raw, &values); err != nil {
-			return nil, fmt.Errorf("error unmarshalling helm values for clusterTemplate %s: %w", in.Spec.Template, err)
-		}
+	if in == nil {
+		return nil, errors.New("cluster deployment is nil")
 	}
 
-	return values, nil
-}
+	values := make(map[string]any)
 
-func (in *ClusterDeployment) SetHelmValues(values map[string]any) error {
-	b, err := json.Marshal(values)
-	if err != nil {
-		return fmt.Errorf("error marshalling helm values for clusterTemplate %s: %w", in.Spec.Template, err)
+	if in.Spec.Config == nil {
+		return values, nil
 	}
 
-	in.Spec.Config = &apiextv1.JSON{Raw: b}
-	return nil
-}
+	raw := bytes.TrimSpace(in.Spec.Config.Raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return values, nil
+	}
 
-func (in *ClusterDeployment) AddHelmValues(fn func(map[string]any) error) error {
-	values, err := in.HelmValues()
-	if err != nil {
-		return err
+	if err := yaml.Unmarshal(raw, &values); err != nil {
+		return nil, fmt.Errorf("error unmarshalling helm values for ClusterDeployment %s/%s: %w", in.Namespace, in.Name, err)
 	}
 
 	if values == nil {
 		values = make(map[string]any)
 	}
 
-	if err := fn(values); err != nil {
-		return err
+	return values, nil
+}
+
+// SetHelmValues stores Helm values in [ClusterDeployment.Spec] Config field as JSON bytes.
+// Passing nil values clears [ClusterDeployment.Spec] Config field.
+func (in *ClusterDeployment) SetHelmValues(values map[string]any) error {
+	if in == nil {
+		return errors.New("cluster deployment is nil")
 	}
 
-	return in.SetHelmValues(values)
+	if values == nil {
+		in.Spec.Config = nil
+		return nil
+	}
+
+	b, err := json.Marshal(values)
+	if err != nil {
+		return fmt.Errorf("error marshalling helm values for ClusterDeployment %s/%s with ClusterTemplate %s: %w", in.Namespace, in.Name, in.Spec.Template, err)
+	}
+
+	in.Spec.Config = &apiextv1.JSON{Raw: b}
+	return nil
+}
+
+// AddHelmValues loads current values, applies fn, and persists the result.
+// The callback receives a non-nil map.
+func (in *ClusterDeployment) AddHelmValues(fn func(map[string]any) error) error {
+	if fn == nil {
+		return errors.New("helm values mutator is nil")
+	}
+
+	values, err := in.HelmValues()
+	if err != nil {
+		return fmt.Errorf("failed to get helm values: %w", err)
+	}
+
+	if err := fn(values); err != nil {
+		return fmt.Errorf("failed to mutate helm values: %w", err)
+	}
+
+	if err := in.SetHelmValues(values); err != nil {
+		return fmt.Errorf("failed to set helm values: %w", err)
+	}
+
+	return nil
 }
 
 func (in *ClusterDeployment) GetConditions() *[]metav1.Condition {

--- a/api/v1beta1/clusterdeployment_types_test.go
+++ b/api/v1beta1/clusterdeployment_types_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestHelmValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		cd              *ClusterDeployment
+		expectedValues  map[string]any
+		errContainsText string
+	}{
+		{
+			name:            "nil receiver returns error",
+			cd:              nil,
+			errContainsText: "cluster deployment is nil",
+		},
+		{
+			name:           "nil config returns empty map",
+			cd:             &ClusterDeployment{},
+			expectedValues: map[string]any{},
+		},
+		{
+			name: "empty raw returns empty map",
+			cd: &ClusterDeployment{
+				Spec: ClusterDeploymentSpec{Config: &apiextv1.JSON{Raw: []byte("  \n\t  ")}},
+			},
+			expectedValues: map[string]any{},
+		},
+		{
+			name: "null raw returns empty map",
+			cd: &ClusterDeployment{
+				Spec: ClusterDeploymentSpec{Config: &apiextv1.JSON{Raw: []byte("null")}},
+			},
+			expectedValues: map[string]any{},
+		},
+		{
+			name: "json config unmarshals",
+			cd: &ClusterDeployment{
+				Spec: ClusterDeploymentSpec{Config: &apiextv1.JSON{Raw: []byte(`{"region":"eu","nested":{"enabled":true}}`)}},
+			},
+			expectedValues: map[string]any{
+				"region": "eu",
+				"nested": map[string]any{"enabled": true},
+			},
+		},
+		{
+			name: "yaml config unmarshals",
+			cd: &ClusterDeployment{
+				Spec: ClusterDeploymentSpec{Config: &apiextv1.JSON{Raw: []byte("region: eu\nnested:\n  enabled: true\n")}},
+			},
+			expectedValues: map[string]any{
+				"region": "eu",
+				"nested": map[string]any{"enabled": true},
+			},
+		},
+		{
+			name: "invalid config returns error",
+			cd: &ClusterDeployment{
+				Spec: ClusterDeploymentSpec{Config: &apiextv1.JSON{Raw: []byte("{invalid")}},
+			},
+			errContainsText: "error unmarshalling helm values for ClusterDeployment",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			values, err := tc.cd.HelmValues()
+			if tc.errContainsText != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContainsText)
+				require.Nil(t, values)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, values)
+			require.Equal(t, tc.expectedValues, values)
+		})
+	}
+}
+
+func TestSetHelmValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		cd                *ClusterDeployment
+		values            map[string]any
+		errContainsText   string
+		expectConfigNil   bool
+		expectedConfigRaw string
+	}{
+		{
+			name:            "nil receiver returns error",
+			cd:              nil,
+			values:          map[string]any{"region": "eu"},
+			errContainsText: "cluster deployment is nil",
+		},
+		{
+			name: "nil values clear config",
+			cd: &ClusterDeployment{
+				Spec: ClusterDeploymentSpec{Config: &apiextv1.JSON{Raw: []byte(`{"region":"eu"}`)}},
+			},
+			values:          nil,
+			expectConfigNil: true,
+		},
+		{
+			name:              "empty map is persisted as object",
+			cd:                &ClusterDeployment{},
+			values:            map[string]any{},
+			expectedConfigRaw: `{}`,
+		},
+		{
+			name:              "map is marshalled to config",
+			cd:                &ClusterDeployment{},
+			values:            map[string]any{"region": "eu"},
+			expectedConfigRaw: `{"region":"eu"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.cd.SetHelmValues(tc.values)
+			if tc.errContainsText != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContainsText)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.expectConfigNil {
+				require.Nil(t, tc.cd.Spec.Config)
+				return
+			}
+
+			require.NotNil(t, tc.cd.Spec.Config)
+			require.JSONEq(t, tc.expectedConfigRaw, string(tc.cd.Spec.Config.Raw))
+		})
+	}
+}
+
+func TestAddHelmValues(t *testing.T) {
+	t.Parallel()
+
+	mutatorErr := errors.New("boom")
+
+	tests := []struct {
+		name            string
+		cd              *ClusterDeployment
+		mutator         func(map[string]any) error
+		errContainsText string
+		expectedValues  map[string]any
+		expectConfigNil bool
+	}{
+		{
+			name:            "nil mutator returns error",
+			cd:              &ClusterDeployment{},
+			mutator:         nil,
+			errContainsText: "helm values mutator is nil",
+		},
+		{
+			name:            "nil receiver returns error",
+			cd:              nil,
+			mutator:         func(map[string]any) error { return nil },
+			errContainsText: "failed to get helm values: cluster deployment is nil",
+		},
+		{
+			name: "mutator receives and persists values",
+			cd:   &ClusterDeployment{},
+			mutator: func(values map[string]any) error {
+				values["region"] = "eu"
+				values["nested"] = map[string]any{"enabled": true}
+				return nil
+			},
+			expectedValues: map[string]any{
+				"region": "eu",
+				"nested": map[string]any{"enabled": true},
+			},
+		},
+		{
+			name:            "mutator error is returned",
+			cd:              &ClusterDeployment{},
+			mutator:         func(map[string]any) error { return mutatorErr },
+			errContainsText: "failed to mutate helm values: boom",
+			expectConfigNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.cd.AddHelmValues(tc.mutator)
+			if tc.errContainsText != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContainsText)
+				if tc.cd != nil && tc.expectConfigNil {
+					require.Nil(t, tc.cd.Spec.Config)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			values, valuesErr := tc.cd.HelmValues()
+			require.NoError(t, valuesErr)
+			require.Equal(t, tc.expectedValues, values)
+		})
+	}
+}

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -856,6 +856,8 @@ func (r *ClusterDeploymentReconciler) fillHelmValues(scope *clusterScope) error 
 	cd := scope.cd
 	cred := scope.cred
 	if err := cd.AddHelmValues(func(values map[string]any) error {
+		// NOTE: values map is guaranteed to be non-nil by AddHelmValues
+
 		r.fillClusterAuthenticationValues(scope, values)
 		r.fillDataSourceValues(scope, values)
 
@@ -1316,7 +1318,12 @@ func (r *ClusterDeploymentReconciler) reconcileDelete(ctx context.Context, mgmt 
 		}
 
 		r.ensureDeletingCondition(scope, err)
-		err = errors.Join(err, r.updateStatus(ctx, cd, nil))
+
+		// Skip status update if the finalizer has been removed since the object
+		// may already be deleted by the time this defer runs.
+		if controllerutil.ContainsFinalizer(cd, kcmv1.ClusterDeploymentFinalizer) {
+			err = errors.Join(err, r.updateStatus(ctx, cd, nil))
+		}
 	}()
 
 	if r.IsDisabledValidationWH {

--- a/internal/util/kube/secrets.go
+++ b/internal/util/kube/secrets.go
@@ -167,16 +167,16 @@ func CopySecret(
 	newSecret.SetSelfLink("")
 	newSecret.SetUID("")
 
+	newSecret.SetNamespace(toNamespace)
+	if nameOverride != "" {
+		newSecret.SetName(nameOverride)
+	}
+
 	if owner != nil {
 		err := controllerutil.SetOwnerReference(owner, newSecret, targetClient.Scheme())
 		if err != nil {
 			return fmt.Errorf("failed to set owner reference on Secret: %w", err)
 		}
-	}
-
-	newSecret.SetNamespace(toNamespace)
-	if nameOverride != "" {
-		newSecret.SetName(nameOverride)
 	}
 
 	if len(extraLabels) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR contains several fixes for ClusterDeployment reconciliation:
1. Initialize values map in `AddHelmValues` to fix panic when `spec.config` is unset in ClusterDeployment
2. Override the secret namespace prior to SetOwnerReference to avoid cross-namespaced owner reference error
3. Update ClusterDeployment status only when ClusterDeployment has a finalizer to avoid status update errors when the object has been deleted

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
#2619 
