### PR TITLE
fix: make version field optional in templatechain available upgrades 

### DIFF
--- a/api/v1beta1/templatechain_common.go
+++ b/api/v1beta1/templatechain_common.go
@@ -54,7 +54,7 @@ type AvailableUpgrade struct {
 	Name string `json:"name"`
 
 	// Version is the version of the Template to which the upgrade is available.
-	Version string `json:"version"`
+	Version string `json:"version,omitempty"`
 }
 
 // IsValid checks if the [TemplateChainSpec] is valid, otherwise provides warning messages.

--- a/api/v1beta1/templatechain_common.go
+++ b/api/v1beta1/templatechain_common.go
@@ -74,6 +74,20 @@ func (s *TemplateChainSpec) IsValid() (warnings []string, ok bool) {
 		}
 	}
 
+	for _, supportedTemplate := range s.SupportedTemplates {
+		upgrades := supportedTemplate.AvailableUpgrades
+		if len(upgrades) == 0 {
+			continue
+		}
+		hasVersion := upgrades[0].Version != ""
+		for _, upgrade := range upgrades[1:] {
+			if (upgrade.Version != "") != hasVersion {
+				warnings = append(warnings, fmt.Sprintf("template %s has mixed version/no-version available upgrades: either all or none should have version set", supportedTemplate.Name))
+				break
+			}
+		}
+	}
+
 	if len(warnings) > 0 {
 		slices.Sort(warnings)
 	}

--- a/api/v1beta1/templatechain_common.go
+++ b/api/v1beta1/templatechain_common.go
@@ -167,6 +167,11 @@ func (s *TemplateChainSpec) UpgradePaths(templateName string) ([]UpgradePath, er
 	// Convert map back to slice
 	result := make([]UpgradePath, 0, len(uniquePaths))
 	for _, path := range uniquePaths {
+		for i := range path {
+			if path[i].Version == "" {
+				path[i].Version = path[i].Name
+			}
+		}
 		sort.Slice(path, func(i, j int) bool {
 			return path[i].Version < path[j].Version
 		})

--- a/api/v1beta1/templatechain_common_test.go
+++ b/api/v1beta1/templatechain_common_test.go
@@ -257,3 +257,68 @@ func TestTemplateChainSpec_TemplateUpgradePath(t *testing.T) {
 		})
 	}
 }
+
+func TestTemplateChainSpec_IsValid(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		spec             TemplateChainSpec
+		expectedWarnings []string
+		expectedValid    bool
+	}{
+		"valid-all-versions-set": {
+			spec: TemplateChainSpec{SupportedTemplates: []SupportedTemplate{
+				{
+					Name: "foo-0-1-0",
+					AvailableUpgrades: []AvailableUpgrade{
+						{Name: "foo-0-2-0", Version: "0.2.0"},
+						{Name: "foo-0-3-0", Version: "0.3.0"},
+					},
+				},
+				{Name: "foo-0-2-0"},
+				{Name: "foo-0-3-0"},
+			}},
+			expectedValid: true,
+		},
+		"valid-no-versions-set": {
+			spec: TemplateChainSpec{SupportedTemplates: []SupportedTemplate{
+				{
+					Name: "foo-0-1-0",
+					AvailableUpgrades: []AvailableUpgrade{
+						{Name: "foo-0-2-0"},
+						{Name: "foo-0-3-0"},
+					},
+				},
+				{Name: "foo-0-2-0"},
+				{Name: "foo-0-3-0"},
+			}},
+			expectedValid: true,
+		},
+		"invalid-mixed-versions": {
+			spec: TemplateChainSpec{SupportedTemplates: []SupportedTemplate{
+				{
+					Name: "foo-0-1-0",
+					AvailableUpgrades: []AvailableUpgrade{
+						{Name: "foo-0-2-0", Version: "0.2.0"},
+						{Name: "foo-0-3-0"},
+					},
+				},
+				{Name: "foo-0-2-0"},
+				{Name: "foo-0-3-0"},
+			}},
+			expectedWarnings: []string{
+				"template foo-0-1-0 has mixed version/no-version available upgrades: either all or none should have version set",
+			},
+			expectedValid: false,
+		},
+	}
+
+	for testName, tc := range tests {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			warnings, ok := tc.spec.IsValid()
+			require.Equal(t, tc.expectedValid, ok)
+			require.Equal(t, tc.expectedWarnings, warnings)
+		})
+	}
+}

--- a/api/v1beta1/templatechain_common_test.go
+++ b/api/v1beta1/templatechain_common_test.go
@@ -166,6 +166,48 @@ func TestTemplateChainSpec_TemplateUpgradePath(t *testing.T) {
 				},
 			},
 		},
+		"upgrade-path-no-version-single": {
+			templateChainSpec: TemplateChainSpec{SupportedTemplates: []SupportedTemplate{
+				{
+					Name: "foo-0-1-0",
+					AvailableUpgrades: []AvailableUpgrade{
+						{Name: "foo-0-2-0"},
+					},
+				},
+				{
+					Name: "foo-0-2-0",
+				},
+			}},
+			templateName: "foo-0-1-0",
+			expectedUpgradePath: []UpgradePath{
+				{Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "foo-0-2-0"}}},
+			},
+		},
+		"upgrade-path-no-version-multi": {
+			templateChainSpec: TemplateChainSpec{SupportedTemplates: []SupportedTemplate{
+				{
+					Name: "foo-0-1-0",
+					AvailableUpgrades: []AvailableUpgrade{
+						{Name: "foo-0-2-0"},
+						{Name: "foo-0-3-0"},
+					},
+				},
+				{
+					Name: "foo-0-2-0",
+					AvailableUpgrades: []AvailableUpgrade{
+						{Name: "foo-0-3-0"},
+					},
+				},
+				{
+					Name: "foo-0-3-0",
+				},
+			}},
+			templateName: "foo-0-1-0",
+			expectedUpgradePath: []UpgradePath{
+				{Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "foo-0-2-0"}}},
+				{Versions: []AvailableUpgrade{{Name: "foo-0-3-0", Version: "foo-0-3-0"}}},
+			},
+		},
 		"upgrade-path-4": {
 			templateChainSpec: TemplateChainSpec{SupportedTemplates: []SupportedTemplate{
 				{

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
@@ -1014,7 +1014,6 @@ spec:
                                     type: string
                                 required:
                                   - name
-                                  - version
                                 type: object
                               type: array
                           type: object

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplatechains.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplatechains.yaml
@@ -67,7 +67,6 @@ spec:
                               type: string
                           required:
                             - name
-                            - version
                           type: object
                         type: array
                       name:

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -970,7 +970,6 @@ spec:
                                     type: string
                                 required:
                                   - name
-                                  - version
                                 type: object
                               type: array
                           type: object

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplatechains.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplatechains.yaml
@@ -67,7 +67,6 @@ spec:
                               type: string
                           required:
                             - name
-                            - version
                           type: object
                         type: array
                       name:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes `version` field in template chain `.spec.availableUpgrades[]` optional

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
