### PR TITLE
fix: don't use empty selector when matching CD in MCS controller

### DIFF
--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -155,9 +155,17 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 	r.setCondition(mcs, kcmv1.MultiClusterServiceDependencyValidationCondition, nil)
 
-	l.V(1).Info("Cleaning up ServiceSets for ClusterDeployments that are no longer match")
+	l.V(1).Info("Cleaning up ServiceSets for ClusterDeployments that no longer match")
 	if err = r.cleanup(ctx, mcs); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile cleanup: %w", err)
+	}
+
+	var errs error
+	// if selfManagement flag is set, then we'll need to create serviceSet which does not refer
+	// any clusterDeployment, but also has selfManagement flag set to true.
+	if mcs.Spec.ServiceSpec.Provider.SelfManagement {
+		l.V(1).Info("Ensuring ServiceSet for the management cluster")
+		errs = errors.Join(r.createOrUpdateServiceSet(ctx, mcs, nil))
 	}
 
 	l.V(1).Info("Ensuring ServiceSets for matching ClusterDeployments")
@@ -166,16 +174,12 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 		return ctrl.Result{}, fmt.Errorf("failed to convert ClusterSelector to selector: %w", err)
 	}
 
-	var errs error
-	// if selfManagement flag is set, then we'll need to create serviceSet which does not refer
-	// any clusterDeployment, but also has selfManagement flag set to true.
-	if mcs.Spec.ServiceSpec.Provider.SelfManagement {
-		errs = errors.Join(r.createOrUpdateServiceSet(ctx, mcs, nil))
-	}
-
 	clusters := new(kcmv1.ClusterDeploymentList)
-	if err := r.Client.List(ctx, clusters, client.MatchingLabelsSelector{Selector: selector}); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to list ClusterDeployments: %w", err)
+
+	if !selector.Empty() {
+		if err := r.Client.List(ctx, clusters, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to list ClusterDeployments: %w", err)
+		}
 	}
 
 	l.V(1).Info("Matching ClusterDeployments found", "count", len(clusters.Items))

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -531,16 +531,25 @@ func (r *MultiClusterServiceReconciler) cleanupServiceSets(ctx context.Context, 
 			continue
 		}
 
+		if selector.Empty() {
+			// since selector is empty it will not match any ServiceSet so deleting the
+			// ServiceSet without checking if its ClusterDeployment's labels match the selector
+			if err := r.Client.Delete(ctx, &serviceSet); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("failed to delete ServiceSet %s/%s: %w", serviceSet.Namespace, serviceSet.Name, err))
+			}
+			continue
+		}
+
 		cd := new(kcmv1.ClusterDeployment)
 		key := client.ObjectKey{Namespace: serviceSet.Namespace, Name: serviceSet.Spec.Cluster}
 		if err := r.Client.Get(ctx, key, cd); err != nil {
 			return fmt.Errorf("failed to get ClusterDeployment %s: %w", key.String(), err)
 		}
 
-		if selector.Empty() || !selector.Matches(labels.Set(cd.Labels)) {
-			// we want to delete serviceSet since clusterDeployment does not match selector anymore
+		if !selector.Matches(labels.Set(cd.Labels)) {
+			// delete the ServiceSet since it's ClusterDeployment's labels don't match selector anymore
 			if err := r.Client.Delete(ctx, &serviceSet); err != nil {
-				errs = errors.Join(errs, fmt.Errorf("failed to delete ServiceSet %s: %w", key.String(), err))
+				errs = errors.Join(errs, fmt.Errorf("failed to delete ServiceSet %s/%s: %w", serviceSet.Namespace, serviceSet.Name, err))
 			}
 		}
 	}

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -156,8 +156,14 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	r.setCondition(mcs, kcmv1.MultiClusterServiceDependencyValidationCondition, nil)
 
 	l.V(1).Info("Cleaning up ServiceSets for ClusterDeployments that no longer match")
-	if err = r.cleanup(ctx, mcs); err != nil {
+	if err = r.cleanupServiceSets(ctx, mcs); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile cleanup: %w", err)
+	}
+
+	l.V(1).Info("Ensuring ServiceSets for matching ClusterDeployments")
+	selector, err := metav1.LabelSelectorAsSelector(&mcs.Spec.ClusterSelector)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to convert ClusterSelector to selector: %w", err)
 	}
 
 	var errs error
@@ -168,14 +174,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 		errs = errors.Join(r.createOrUpdateServiceSet(ctx, mcs, nil))
 	}
 
-	l.V(1).Info("Ensuring ServiceSets for matching ClusterDeployments")
-	selector, err := metav1.LabelSelectorAsSelector(&mcs.Spec.ClusterSelector)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to convert ClusterSelector to selector: %w", err)
-	}
-
 	clusters := new(kcmv1.ClusterDeploymentList)
-
 	if !selector.Empty() {
 		if err := r.Client.List(ctx, clusters, client.MatchingLabelsSelector{Selector: selector}); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to list ClusterDeployments: %w", err)
@@ -506,7 +505,7 @@ func (r *MultiClusterServiceReconciler) createOrUpdateServiceSet(
 	return serviceset.NewProcessor(r.Client).CreateOrUpdateServiceSet(ctx, op, serviceSet)
 }
 
-func (r *MultiClusterServiceReconciler) cleanup(ctx context.Context, mcs *kcmv1.MultiClusterService) error {
+func (r *MultiClusterServiceReconciler) cleanupServiceSets(ctx context.Context, mcs *kcmv1.MultiClusterService) error {
 	serviceSets := new(kcmv1.ServiceSetList)
 	// we'll list all ServiceSets which have .spec.multiClusterService defined and match
 	// current MultiClusterService object being reconciled
@@ -538,16 +537,14 @@ func (r *MultiClusterServiceReconciler) cleanup(ctx context.Context, mcs *kcmv1.
 			return fmt.Errorf("failed to get ClusterDeployment %s: %w", key.String(), err)
 		}
 
-		// ClusterDeployment labels match selector, skipping
-		if selector.Matches(labels.Set(cd.Labels)) {
-			continue
-		}
-
-		// we want to delete serviceSet since clusterDeployment does not match selector anymore
-		if err := r.Client.Delete(ctx, &serviceSet); err != nil {
-			errs = errors.Join(errs, fmt.Errorf("failed to delete ServiceSet %s: %w", key.String(), err))
+		if selector.Empty() || !selector.Matches(labels.Set(cd.Labels)) {
+			// we want to delete serviceSet since clusterDeployment does not match selector anymore
+			if err := r.Client.Delete(ctx, &serviceSet); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("failed to delete ServiceSet %s: %w", key.String(), err))
+			}
 		}
 	}
+
 	return errs
 }
 

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -31,6 +31,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
@@ -69,6 +70,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 		multiClusterService := &kcmv1.MultiClusterService{}
 		clusterDeployment := kcmv1.ClusterDeployment{}
 		serviceSet := kcmv1.ServiceSet{}
+		mgmtServiceSet := kcmv1.ServiceSet{}
 
 		helmRepositoryRef := types.NamespacedName{Namespace: testSystemNamespace, Name: helmRepoName}
 		helmChartRef := types.NamespacedName{Namespace: testSystemNamespace, Name: helmChartName}
@@ -76,6 +78,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 		serviceTemplate2Ref := types.NamespacedName{Namespace: testSystemNamespace, Name: serviceTemplate2Name}
 		multiClusterServiceRef := types.NamespacedName{Name: multiClusterServiceName}
 		serviceSetKey := types.NamespacedName{}
+		mgmtServiceSetKey := types.NamespacedName{}
 
 		BeforeEach(func() {
 			By("creating Namespace")
@@ -217,6 +220,10 @@ var _ = Describe("MultiClusterService Controller", func() {
 					Namespace: clusterDeployment.Namespace,
 					Name:      fmt.Sprintf("%s-%x", clusterDeployment.Name, mcsNameHash[:4]),
 				}
+				mgmtServiceSetKey = types.NamespacedName{
+					Namespace: testSystemNamespace,
+					Name:      fmt.Sprintf("management-%x", mcsNameHash[:4]),
+				}
 			})
 
 			// NOTE: ServiceTemplate2 doesn't need to be reconciled
@@ -279,29 +286,30 @@ var _ = Describe("MultiClusterService Controller", func() {
 		})
 
 		AfterEach(func() {
+			deleteIfNotFound := func(ctx context.Context, key client.ObjectKey, obj client.Object) {
+				if err := k8sClient.Get(ctx, key, obj); err == nil {
+					Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
+				} else if !apierrors.IsNotFound(err) { // ignore not found error
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
+
 			By("cleaning up")
 			multiClusterServiceResource := &kcmv1.MultiClusterService{}
-			Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterServiceResource)).NotTo(HaveOccurred())
-			Expect(k8sClient.Delete(ctx, multiClusterService)).To(Succeed())
+			deleteIfNotFound(ctx, multiClusterServiceRef, multiClusterServiceResource)
 
 			serviceTemplateResource := &kcmv1.ServiceTemplate{}
-			Expect(k8sClient.Get(ctx, serviceTemplate1Ref, serviceTemplateResource)).NotTo(HaveOccurred())
-			Expect(k8sClient.Delete(ctx, serviceTemplateResource)).To(Succeed())
-
-			Expect(k8sClient.Get(ctx, serviceTemplate2Ref, serviceTemplateResource)).NotTo(HaveOccurred())
-			Expect(k8sClient.Delete(ctx, serviceTemplateResource)).To(Succeed())
+			deleteIfNotFound(ctx, serviceTemplate1Ref, serviceTemplateResource)
+			deleteIfNotFound(ctx, serviceTemplate2Ref, serviceTemplateResource)
 
 			helmChartResource := &sourcev1.HelmChart{}
-			Expect(k8sClient.Get(ctx, helmChartRef, helmChartResource)).NotTo(HaveOccurred())
-			Expect(k8sClient.Delete(ctx, helmChartResource)).To(Succeed())
+			deleteIfNotFound(ctx, helmChartRef, helmChartResource)
 
 			helmRepositoryResource := &sourcev1.HelmRepository{}
-			Expect(k8sClient.Get(ctx, helmRepositoryRef, helmRepositoryResource)).NotTo(HaveOccurred())
-			Expect(k8sClient.Delete(ctx, helmRepositoryResource)).To(Succeed())
+			deleteIfNotFound(ctx, helmRepositoryRef, helmRepositoryResource)
 
 			serviceSet := &kcmv1.ServiceSet{}
-			Expect(k8sClient.Get(ctx, serviceSetKey, serviceSet)).NotTo(HaveOccurred())
-			Expect(k8sClient.Delete(ctx, serviceSet)).To(Succeed())
+			deleteIfNotFound(ctx, serviceSetKey, serviceSet)
 		})
 
 		It("should successfully reconcile the resource", func() {
@@ -316,6 +324,61 @@ var _ = Describe("MultiClusterService Controller", func() {
 				_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(k8sClient.Get(ctx, serviceSetKey, &serviceSet)).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("updating MutliClusterService to remove cluster selector")
+			Eventually(func(g Gomega) {
+				// Update the MCS
+				g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).NotTo(HaveOccurred())
+				multiClusterService.Spec.ClusterSelector = metav1.LabelSelector{}
+				g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+
+				// Reconcile the MCS
+				_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Verify that the ServiceSet for CD (via MCS) no longer exists
+				err = k8sClient.Get(ctx, serviceSetKey, &serviceSet)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+
+			By("updating MultiClusterService to set selfManagement")
+			Eventually(func(g Gomega) {
+				// Update the MCS
+				g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).NotTo(HaveOccurred())
+				multiClusterService.Spec.ServiceSpec.Provider.SelfManagement = true
+				g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+
+				// Reconcile the MCS
+				_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Verify the ServiceSet for Management is created
+				g.Expect(k8sClient.Get(ctx, mgmtServiceSetKey, &mgmtServiceSet)).ToNot(HaveOccurred())
+
+				// Verify the ServiceSet for CD (via MCS) still doesn't exist
+				err = k8sClient.Get(ctx, serviceSetKey, &serviceSet)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).Should(Succeed())
+
+			By("updating MutliClusterService to re-add cluster selector")
+			Eventually(func(g Gomega) {
+				// Update the MCS
+				g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).NotTo(HaveOccurred())
+				multiClusterService.Spec.ClusterSelector = metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"test": "true",
+					},
+				}
+				g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+
+				// Reconcile the MCS
+				_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Verify that the ServiceSet for CD (via MCS) and Management exist
+				g.Expect(k8sClient.Get(ctx, serviceSetKey, &serviceSet)).ToNot(HaveOccurred())
+				g.Expect(k8sClient.Get(ctx, mgmtServiceSetKey, &mgmtServiceSet)).ToNot(HaveOccurred())
 			}).Should(Succeed())
 		})
 	})

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -310,6 +310,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 
 			serviceSet := &kcmv1.ServiceSet{}
 			deleteIfNotFound(ctx, serviceSetKey, serviceSet)
+			deleteIfNotFound(ctx, mgmtServiceSetKey, serviceSet)
 		})
 
 		It("should successfully reconcile the resource", func() {
@@ -326,7 +327,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 				g.Expect(k8sClient.Get(ctx, serviceSetKey, &serviceSet)).NotTo(HaveOccurred())
 			}).Should(Succeed())
 
-			By("updating MutliClusterService to remove cluster selector")
+			By("updating MultiClusterService to remove cluster selector")
 			Eventually(func(g Gomega) {
 				// Update the MCS
 				g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).NotTo(HaveOccurred())
@@ -361,7 +362,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			}).Should(Succeed())
 
-			By("updating MutliClusterService to re-add cluster selector")
+			By("updating MultiClusterService to re-add cluster selector")
 			Eventually(func(g Gomega) {
 				// Update the MCS
 				g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).NotTo(HaveOccurred())


### PR DESCRIPTION
# Description

* If the MCS's `.spec.clusterSelector` is empty then ALL ClusterDeployments are fetched from the kube server.
* So change it to not fetch the list of ClusterDeployments if the MCS selector is empty.
* Fixes https://github.com/k0rdent/kcm/issues/2610.

# Verification

Created the following 2 ClusterDeployments:
```sh
➜  ~ kkcm get clusterdeployment
NAME         READY   SERVICES   TEMPLATE                   MESSAGES          AGE   LABELS
wali-dev-0   True    0/0        aws-standalone-cp-1-0-26   Object is ready   38h   k0rdent.mirantis.com/component=kcm,owner=dev-team
wali-dev-1   True    0/0        aws-standalone-cp-1-0-26   Object is ready   55m   k0rdent.mirantis.com/component=kcm,owner=dev-team
```
Then created the following MCS with nginx service and empty selector:
```yaml
apiVersion: k0rdent.mirantis.com/v1beta1
kind: MultiClusterService
metadata:
  name: mcs0
spec:
  serviceSpec:
    provider:
      name: ksm-projectsveltos
      selfManagement: true
      config:
        continueOnError: true
        priority: 100
    services:
      - template: ingress-nginx-4-13-0
        name: nginx
        namespace: nginx
```
✅ Verified that only the ServiceSet for self-managing the management cluster was created (cuz `selfManagement: true`) and no ServiceSets were created for the ClusterDeployments as expected:
```sh
➜  ~ kkcm get serviceset
NAME                  CLUSTER      MULTICLUSTERSERVER   PROVIDER             SELF-MANAGEMENT   AGE
management-6ec16280                mcs0                 ksm-projectsveltos   true              96s
wali-dev-0            wali-dev-0                        ksm-projectsveltos                     38h
wali-dev-1            wali-dev-1                        ksm-projectsveltos                     52m
```
Now added the following selector the the MCS:
```yaml
. . .
spec:
  clusterSelector:
    matchLabels:
      owner: dev-team
. . .
```
✅ Verified that a ServiceSet for each of the ClusterDeployment was created:
```sh
➜  ~ kkcm get serviceset  
NAME                  CLUSTER      MULTICLUSTERSERVER   PROVIDER             SELF-MANAGEMENT   AGE
management-6ec16280                mcs0                 ksm-projectsveltos   true              4m57s
wali-dev-0            wali-dev-0                        ksm-projectsveltos                     38h
wali-dev-0-6ec16280   wali-dev-0   mcs0                 ksm-projectsveltos                     2m22s
wali-dev-1            wali-dev-1                        ksm-projectsveltos                     56m
wali-dev-1-6ec16280   wali-dev-1   mcs0                 ksm-projectsveltos                     2m22s
```
✅ And the ClusterDeployments now show `1/1` service deployed:
```sh
➜  ~ kkcm get clusterdeployments.k0rdent.mirantis.com --show-labels
NAME         READY   SERVICES   TEMPLATE                   MESSAGES          AGE   LABELS
wali-dev-0   True    1/1        aws-standalone-cp-1-0-26   Object is ready   38h   k0rdent.mirantis.com/component=kcm,owner=dev-team
wali-dev-1   True    1/1        aws-standalone-cp-1-0-26   Object is ready   57m   k0rdent.mirantis.com/component=kcm,owner=dev-team
```