### PR TITLE
test(ksm): sequential upgrades tests

### DIFF
--- a/api/v1beta1/templatechain_common.go
+++ b/api/v1beta1/templatechain_common.go
@@ -131,13 +131,8 @@ func (s *TemplateChainSpec) findAllUpgradePaths(templateName string) ([][]Availa
 
 		// Iterate through available upgrades and find subsequent available upgrades
 		for _, upgrade := range template.AvailableUpgrades {
-			if !slices.ContainsFunc(path, func(upgrade AvailableUpgrade) bool {
-				for _, u := range path {
-					if u.Name == upgrade.Name && u.Version == upgrade.Version {
-						return true
-					}
-				}
-				return false
+			if !slices.ContainsFunc(path, func(existing AvailableUpgrade) bool {
+				return existing.Name == upgrade.Name && existing.Version == upgrade.Version
 			}) {
 				upgradePath := make([]AvailableUpgrade, len(path)+1)
 				copy(upgradePath, path)

--- a/api/v1beta1/templatechain_common_test.go
+++ b/api/v1beta1/templatechain_common_test.go
@@ -113,10 +113,10 @@ func TestTemplateChainSpec_TemplateUpgradePath(t *testing.T) {
 					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}},
 				},
 				{
-					Versions: []AvailableUpgrade{{Name: "foo-0-3-0", Version: "0.3.0"}},
+					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}, {Name: "foo-0-3-0", Version: "0.3.0"}},
 				},
 				{
-					Versions: []AvailableUpgrade{{Name: "foo-0-4-0", Version: "0.4.0"}},
+					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}, {Name: "foo-0-3-0", Version: "0.3.0"}, {Name: "foo-0-4-0", Version: "0.4.0"}},
 				},
 			},
 		},
@@ -159,10 +159,13 @@ func TestTemplateChainSpec_TemplateUpgradePath(t *testing.T) {
 					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}},
 				},
 				{
-					Versions: []AvailableUpgrade{{Name: "foo-0-3-0", Version: "0.3.0"}},
+					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}, {Name: "foo-0-3-0", Version: "0.3.0"}},
 				},
 				{
-					Versions: []AvailableUpgrade{{Name: "foo-0-4-0", Version: "0.4.0"}},
+					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}, {Name: "foo-0-3-0", Version: "0.3.0"}, {Name: "foo-0-4-0", Version: "0.4.0"}},
+				},
+				{
+					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}, {Name: "foo-0-3-0", Version: "0.3.0"}, {Name: "foo-0-4-0", Version: "0.4.0"}, {Name: "foo-1-0-0", Version: "1.0.0"}},
 				},
 			},
 		},
@@ -205,7 +208,7 @@ func TestTemplateChainSpec_TemplateUpgradePath(t *testing.T) {
 			templateName: "foo-0-1-0",
 			expectedUpgradePath: []UpgradePath{
 				{Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "foo-0-2-0"}}},
-				{Versions: []AvailableUpgrade{{Name: "foo-0-3-0", Version: "foo-0-3-0"}}},
+				{Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "foo-0-2-0"}, {Name: "foo-0-3-0", Version: "foo-0-3-0"}}},
 			},
 		},
 		"upgrade-path-4": {
@@ -245,6 +248,9 @@ func TestTemplateChainSpec_TemplateUpgradePath(t *testing.T) {
 			expectedUpgradePath: []UpgradePath{
 				{
 					Versions: []AvailableUpgrade{{Name: "foo-0-4-0", Version: "0.4.0"}},
+				},
+				{
+					Versions: []AvailableUpgrade{{Name: "foo-0-4-0", Version: "0.4.0"}, {Name: "foo-1-0-0", Version: "1.0.0"}},
 				},
 			},
 		},

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -344,7 +344,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 				Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 			}
 
-			By("creating ServiceTemplates for v1, v2 and v3")
+			By("creating ServiceTemplates for v1, v2 and v3 with valid status")
 			for _, tmpl := range []struct {
 				name    string
 				version string
@@ -366,6 +366,12 @@ var _ = Describe("MultiClusterService Controller", func() {
 					},
 				}
 				Expect(k8sClient.Create(ctx, st)).To(Succeed())
+				st.Status = kcmv1.ServiceTemplateStatus{
+					TemplateStatusCommon: kcmv1.TemplateStatusCommon{
+						TemplateValidationStatus: kcmv1.TemplateValidationStatus{Valid: true},
+					},
+				}
+				Expect(k8sClient.Status().Update(ctx, st)).To(Succeed())
 				DeferCleanup(k8sClient.Delete, st)
 			}
 
@@ -398,6 +404,8 @@ var _ = Describe("MultiClusterService Controller", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, chain)).To(Succeed())
+			chain.Status = kcmv1.TemplateChainStatus{Valid: true}
+			Expect(k8sClient.Status().Update(ctx, chain)).To(Succeed())
 			DeferCleanup(k8sClient.Delete, chain)
 
 			By("creating ClusterDeployment")
@@ -483,12 +491,15 @@ var _ = Describe("MultiClusterService Controller", func() {
 
 			By("marking v1 as Deployed in the ServiceSet status")
 			Expect(k8sClient.Get(ctx, seqServiceSetKey, seqSS)).To(Succeed())
+			now := metav1.Now()
 			seqSS.Status.Services = []kcmv1.ServiceState{
 				{
-					Name:      seqServiceName,
-					Namespace: seqServiceNS,
-					State:     kcmv1.ServiceStateDeployed,
-					Version:   new("1"),
+					Type:                    kcmv1.ServiceTypeHelm,
+					LastStateTransitionTime: &now,
+					Name:                    seqServiceName,
+					Namespace:               seqServiceNS,
+					State:                   kcmv1.ServiceStateDeployed,
+					Version:                 new("1"),
 				},
 			}
 			Expect(k8sClient.Status().Update(ctx, seqSS)).To(Succeed())
@@ -499,6 +510,20 @@ var _ = Describe("MultiClusterService Controller", func() {
 			updatedMCS.Spec.ServiceSpec.Services[0].Template = seqTemplate3
 			updatedMCS.Spec.ServiceSpec.Services[0].Version = "3"
 			Expect(k8sClient.Update(ctx, updatedMCS)).To(Succeed())
+
+			By("waiting for mgrClient cache to reflect ServiceSet spec, status, and MCS update before cycle 2")
+			Eventually(func(g Gomega) {
+				ss := &kcmv1.ServiceSet{}
+				g.Expect(mgrClient.Get(ctx, seqServiceSetKey, ss)).To(Succeed())
+				g.Expect(ss.Spec.Services).To(HaveLen(1))
+				g.Expect(ss.Spec.Services[0].Template).To(Equal(seqTemplate1))
+				g.Expect(ss.Status.Services).To(HaveLen(1))
+				g.Expect(ss.Status.Services[0].State).To(Equal(kcmv1.ServiceStateDeployed))
+
+				mcs := &kcmv1.MultiClusterService{}
+				g.Expect(mgrClient.Get(ctx, seqMCSRef, mcs)).To(Succeed())
+				g.Expect(mcs.Spec.ServiceSpec.Services[0].Template).To(Equal(seqTemplate3))
+			}).Should(Succeed())
 
 			By("cycle 2: reconcile must enforce sequential step — ServiceSet moves to v2, not v3")
 			Eventually(func(g Gomega) {
@@ -513,15 +538,30 @@ var _ = Describe("MultiClusterService Controller", func() {
 
 			By("marking v2 as Deployed in the ServiceSet status")
 			Expect(k8sClient.Get(ctx, seqServiceSetKey, seqSS)).To(Succeed())
+			now = metav1.Now()
 			seqSS.Status.Services = []kcmv1.ServiceState{
 				{
-					Name:      seqServiceName,
-					Namespace: seqServiceNS,
-					State:     kcmv1.ServiceStateDeployed,
-					Version:   new("2"),
+					Type:                    kcmv1.ServiceTypeHelm,
+					LastStateTransitionTime: &now,
+					Name:                    seqServiceName,
+					Namespace:               seqServiceNS,
+					State:                   kcmv1.ServiceStateDeployed,
+					Version:                 new("2"),
 				},
 			}
 			Expect(k8sClient.Status().Update(ctx, seqSS)).To(Succeed())
+
+			By("waiting for mgrClient cache to reflect v2 deployed status before cycle 3")
+			Eventually(func(g Gomega) {
+				ss := &kcmv1.ServiceSet{}
+				g.Expect(mgrClient.Get(ctx, seqServiceSetKey, ss)).To(Succeed())
+				g.Expect(ss.Spec.Services).To(HaveLen(1))
+				g.Expect(ss.Spec.Services[0].Template).To(Equal(seqTemplate2))
+				g.Expect(ss.Status.Services).To(HaveLen(1))
+				g.Expect(ss.Status.Services[0].State).To(Equal(kcmv1.ServiceStateDeployed))
+				g.Expect(ss.Status.Services[0].Version).NotTo(BeNil())
+				g.Expect(*ss.Status.Services[0].Version).To(Equal("2"))
+			}).Should(Succeed())
 
 			By("cycle 3: reconcile advances service to the final target v3")
 			Eventually(func(g Gomega) {

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -319,4 +319,220 @@ var _ = Describe("MultiClusterService Controller", func() {
 			}).Should(Succeed())
 		})
 	})
+
+	Context("When reconciling sequential service upgrades", func() {
+		const (
+			seqMCSName     = "test-seq-upgrade-mcs"
+			seqTemplate1   = "test-seq-svc-a-v1"
+			seqTemplate2   = "test-seq-svc-a-v2"
+			seqTemplate3   = "test-seq-svc-a-v3"
+			seqChainName   = "test-seq-svc-a-chain"
+			seqServiceName = "seq-service-a"
+			seqServiceNS   = "seq-ns"
+			seqCDLabel     = "seq-upgrade-test"
+		)
+
+		var seqServiceSetKey types.NamespacedName
+		seqMCSRef := types.NamespacedName{Name: seqMCSName}
+
+		BeforeEach(func() {
+			By("ensuring test namespace exists")
+			ns := &corev1.Namespace{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: testSystemNamespace}, ns)
+			if apierrors.IsNotFound(err) {
+				ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testSystemNamespace}}
+				Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+			}
+
+			By("creating ServiceTemplates for v1, v2 and v3")
+			for _, tmpl := range []struct {
+				name    string
+				version string
+			}{
+				{seqTemplate1, "1"},
+				{seqTemplate2, "2"},
+				{seqTemplate3, "3"},
+			} {
+				st := &kcmv1.ServiceTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: tmpl.name, Namespace: testSystemNamespace},
+					Spec: kcmv1.ServiceTemplateSpec{
+						Version: tmpl.version,
+						Helm: &kcmv1.HelmSpec{
+							ChartSpec: &sourcev1.HelmChartSpec{
+								Chart:   tmpl.name,
+								Version: tmpl.version,
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, st)).To(Succeed())
+				DeferCleanup(k8sClient.Delete, st)
+			}
+
+			By("creating ServiceTemplateChain for v1->v2->v3")
+			// KCMManagedLabelKey bypasses the webhook's template-existence check,
+			// avoiding a potential cache-sync race between template creation and
+			// chain admission validation.
+			chain := &kcmv1.ServiceTemplateChain{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      seqChainName,
+					Namespace: testSystemNamespace,
+					Labels:    map[string]string{kcmv1.KCMManagedLabelKey: kcmv1.KCMManagedLabelValue},
+				},
+				Spec: kcmv1.TemplateChainSpec{
+					SupportedTemplates: []kcmv1.SupportedTemplate{
+						{
+							Name: seqTemplate1,
+							AvailableUpgrades: []kcmv1.AvailableUpgrade{
+								{Name: seqTemplate2, Version: "2"},
+							},
+						},
+						{
+							Name: seqTemplate2,
+							AvailableUpgrades: []kcmv1.AvailableUpgrade{
+								{Name: seqTemplate3, Version: "3"},
+							},
+						},
+						{Name: seqTemplate3},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, chain)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, chain)
+
+			By("creating ClusterDeployment")
+			seqCD := kcmv1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "seq-cd-",
+					Namespace:    testSystemNamespace,
+					Labels:       map[string]string{seqCDLabel: "true"},
+				},
+				Spec: kcmv1.ClusterDeploymentSpec{
+					Template:   "sample-template",
+					Credential: "sample-credential",
+					Config:     &apiextv1.JSON{Raw: []byte(`{"foo":"bar"}`)},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &seqCD)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, &seqCD)
+
+			mcsNameHash := sha256.Sum256([]byte(seqMCSName))
+			seqServiceSetKey = types.NamespacedName{
+				Namespace: seqCD.Namespace,
+				Name:      fmt.Sprintf("%s-%x", seqCD.Name, mcsNameHash[:4]),
+			}
+			DeferCleanup(func() {
+				ss := &kcmv1.ServiceSet{}
+				if err := k8sClient.Get(ctx, seqServiceSetKey, ss); err == nil {
+					_ = k8sClient.Delete(ctx, ss)
+				}
+			})
+
+			By("creating MultiClusterService")
+			seqMCS := &kcmv1.MultiClusterService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: seqMCSName,
+					Finalizers: []string{
+						// Added manually to avoid an extra reconcile cycle just
+						// for finalizer registration before the actual assertions.
+						kcmv1.MultiClusterServiceFinalizer,
+					},
+				},
+				Spec: kcmv1.MultiClusterServiceSpec{
+					ClusterSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{seqCDLabel: "true"},
+					},
+					ServiceSpec: kcmv1.ServiceSpec{
+						Provider: kcmv1.StateManagementProviderConfig{
+							Name: kubeutil.DefaultStateManagementProvider,
+						},
+						Services: []kcmv1.Service{
+							{
+								Name:          seqServiceName,
+								Namespace:     seqServiceNS,
+								Template:      seqTemplate1,
+								Version:       "1",
+								TemplateChain: seqChainName,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, seqMCS)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, seqMCS)
+		})
+
+		It("should advance service through v1->v2->v3 one step at a time", func() {
+			reconciler := &MultiClusterServiceReconciler{
+				Client:          mgrClient,
+				timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+				SystemNamespace: testSystemNamespace,
+			}
+			seqSS := &kcmv1.ServiceSet{}
+
+			By("cycle 1: initial reconcile deploys service at v1")
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: seqMCSRef})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(k8sClient.Get(ctx, seqServiceSetKey, seqSS)).To(Succeed())
+				g.Expect(seqSS.Spec.Services).To(HaveLen(1))
+				g.Expect(seqSS.Spec.Services[0].Template).To(Equal(seqTemplate1))
+				g.Expect(seqSS.Spec.Services[0].Version).NotTo(BeNil())
+				g.Expect(*seqSS.Spec.Services[0].Version).To(Equal("1"))
+			}).Should(Succeed())
+
+			By("marking v1 as Deployed in the ServiceSet status")
+			Expect(k8sClient.Get(ctx, seqServiceSetKey, seqSS)).To(Succeed())
+			seqSS.Status.Services = []kcmv1.ServiceState{
+				{
+					Name:      seqServiceName,
+					Namespace: seqServiceNS,
+					State:     kcmv1.ServiceStateDeployed,
+					Version:   new("1"),
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, seqSS)).To(Succeed())
+
+			By("updating MultiClusterService target to v3 — skipping v2 to exercise sequential enforcement")
+			updatedMCS := &kcmv1.MultiClusterService{}
+			Expect(k8sClient.Get(ctx, seqMCSRef, updatedMCS)).To(Succeed())
+			updatedMCS.Spec.ServiceSpec.Services[0].Template = seqTemplate3
+			updatedMCS.Spec.ServiceSpec.Services[0].Version = "3"
+			Expect(k8sClient.Update(ctx, updatedMCS)).To(Succeed())
+
+			By("cycle 2: reconcile must enforce sequential step — ServiceSet moves to v2, not v3")
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: seqMCSRef})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(k8sClient.Get(ctx, seqServiceSetKey, seqSS)).To(Succeed())
+				g.Expect(seqSS.Spec.Services).To(HaveLen(1))
+				g.Expect(seqSS.Spec.Services[0].Template).To(Equal(seqTemplate2))
+				g.Expect(seqSS.Spec.Services[0].Version).NotTo(BeNil())
+				g.Expect(*seqSS.Spec.Services[0].Version).To(Equal("2"))
+			}).Should(Succeed())
+
+			By("marking v2 as Deployed in the ServiceSet status")
+			Expect(k8sClient.Get(ctx, seqServiceSetKey, seqSS)).To(Succeed())
+			seqSS.Status.Services = []kcmv1.ServiceState{
+				{
+					Name:      seqServiceName,
+					Namespace: seqServiceNS,
+					State:     kcmv1.ServiceStateDeployed,
+					Version:   new("2"),
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, seqSS)).To(Succeed())
+
+			By("cycle 3: reconcile advances service to the final target v3")
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: seqMCSRef})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(k8sClient.Get(ctx, seqServiceSetKey, seqSS)).To(Succeed())
+				g.Expect(seqSS.Spec.Services).To(HaveLen(1))
+				g.Expect(seqSS.Spec.Services[0].Template).To(Equal(seqTemplate3))
+				g.Expect(seqSS.Spec.Services[0].Version).NotTo(BeNil())
+				g.Expect(*seqSS.Spec.Services[0].Version).To(Equal("3"))
+			}).Should(Succeed())
+		})
+	})
 })

--- a/internal/serviceset/util_test.go
+++ b/internal/serviceset/util_test.go
@@ -317,6 +317,120 @@ func Test_ServicesToDeploy(t *testing.T) {
 			},
 		},
 		{
+			// Sequential upgrade: v1→v2→v3 chain (no direct v1→v3 allowed).
+			//
+			// Cycle 1: service A is deployed at v1. User changes desired to v3.
+			// UpgradePaths from template-a-1 lists both v2 (direct step) and the
+			// full path [v2, v3] reaching v3. desiredVersionInUpgradePaths finds
+			// "3" in the second path → upgradeAvailable=true.
+			// minimumUpgradeStep picks "2" as the minimum in [currentVersion="1",
+			// desiredVersion="3"], so the ServiceSet is updated to v2, not v3.
+			description: "sequential-upgrade-cycle1-v1-deployed-desired-v3-emits-v2",
+			upgradePaths: []kcmv1.ServiceUpgradePaths{
+				{
+					Name:      "service-a",
+					Namespace: metav1.NamespaceDefault,
+					Template:  "template-a-1",
+					AvailableUpgrades: []kcmv1.UpgradePath{
+						{Versions: []kcmv1.AvailableUpgrade{{Name: "template-a-2", Version: "2"}}},
+						{Versions: []kcmv1.AvailableUpgrade{{Name: "template-a-2", Version: "2"}, {Name: "template-a-3", Version: "3"}}},
+					},
+				},
+			},
+			desiredServices: []kcmv1.Service{
+				{Name: "service-a", Namespace: metav1.NamespaceDefault, Template: "template-a-3", Version: "3"},
+			},
+			deployedServices: &kcmv1.ServiceSet{
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{State: kcmv1.ServiceStateDeployed, Name: "service-a", Namespace: metav1.NamespaceDefault, Version: new("1")},
+					},
+				},
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "service-a", Namespace: metav1.NamespaceDefault, Template: "template-a-1", Version: new("1")},
+					},
+				},
+			},
+			expectedServices: []kcmv1.ServiceWithValues{
+				{Name: "service-a", Namespace: metav1.NamespaceDefault, Template: "template-a-2", Version: new("2")},
+			},
+		},
+		{
+			// Sequential upgrade: v1→v2→v3 chain.
+			//
+			// Cycle 2: spec was updated to v2 in cycle 1 but the cluster still
+			// reports v1 as deployed. The upgrade to v2 is in-flight.
+			// ServicesToDeploy must preserve the in-flight v2 unchanged.
+			description: "sequential-upgrade-cycle2-v2-in-flight-preserved",
+			upgradePaths: []kcmv1.ServiceUpgradePaths{
+				{
+					Name:      "service-a",
+					Namespace: metav1.NamespaceDefault,
+					Template:  "template-a-2",
+					AvailableUpgrades: []kcmv1.UpgradePath{
+						{Versions: []kcmv1.AvailableUpgrade{{Name: "template-a-3", Version: "3"}}},
+					},
+				},
+			},
+			desiredServices: []kcmv1.Service{
+				{Name: "service-a", Namespace: metav1.NamespaceDefault, Template: "template-a-3", Version: "3"},
+			},
+			deployedServices: &kcmv1.ServiceSet{
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						// cluster still at v1; v2 upgrade is in progress
+						{State: kcmv1.ServiceStateDeployed, Name: "service-a", Namespace: metav1.NamespaceDefault, Version: new("1")},
+					},
+				},
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						// spec already advanced to v2 by cycle 1
+						{Name: "service-a", Namespace: metav1.NamespaceDefault, Template: "template-a-2", Version: new("2")},
+					},
+				},
+			},
+			expectedServices: []kcmv1.ServiceWithValues{
+				{Name: "service-a", Namespace: metav1.NamespaceDefault, Template: "template-a-2", Version: new("2")},
+			},
+		},
+		{
+			// Sequential upgrade: v1→v2→v3 chain.
+			//
+			// Cycle 3: v2 is now reported as deployed. The next reconcile must
+			// advance the spec to v3 (the final desired version).
+			description: "sequential-upgrade-cycle3-v2-deployed-advance-to-v3",
+			upgradePaths: []kcmv1.ServiceUpgradePaths{
+				{
+					Name:      "service-a",
+					Namespace: metav1.NamespaceDefault,
+					Template:  "template-a-2",
+					AvailableUpgrades: []kcmv1.UpgradePath{
+						{Versions: []kcmv1.AvailableUpgrade{{Name: "template-a-3", Version: "3"}}},
+					},
+				},
+			},
+			desiredServices: []kcmv1.Service{
+				{Name: "service-a", Namespace: metav1.NamespaceDefault, Template: "template-a-3", Version: "3"},
+			},
+			deployedServices: &kcmv1.ServiceSet{
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						// v2 fully deployed
+						{State: kcmv1.ServiceStateDeployed, Name: "service-a", Namespace: metav1.NamespaceDefault, Version: new("2")},
+					},
+				},
+				Spec: kcmv1.ServiceSetSpec{
+					Services: []kcmv1.ServiceWithValues{
+						{Name: "service-a", Namespace: metav1.NamespaceDefault, Template: "template-a-2", Version: new("2")},
+					},
+				},
+			},
+			expectedServices: []kcmv1.ServiceWithValues{
+				{Name: "service-a", Namespace: metav1.NamespaceDefault, Template: "template-a-3", Version: new("3")},
+			},
+		},
+		{
 			description: "service-should-not-be-upgraded",
 			upgradePaths: []kcmv1.ServiceUpgradePaths{
 				{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds unit- and integration tests to ensure service set builder resolve the sequence of service deployment properly in case of sequential upgrades 

**Which issue(s) this PR fixes**:

