### PR TITLE
fix(ksm): serviceset processing causing continuous reconcile

### DIFF
--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -413,7 +413,7 @@ func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient clie
 	defer func(initialStatus metav1.ConditionStatus) {
 		// we'll emit event only if the status changed from the initial value and it's now true.
 		conditionStatusChangedToTrue := initialStatus != status && status == metav1.ConditionTrue
-		if updateCondition(serviceSet, profileCondition, status, reason, message, r.timeFunc()) && conditionStatusChangedToTrue {
+		if conditionStatusChangedToTrue && updateCondition(serviceSet, profileCondition, status, reason, message, r.timeFunc()) {
 			l.Info("Successfully ensured ProjectSveltos Profile")
 			record.Eventf(serviceSet, nil, kcmv1.ServiceSetEnsureProfileSuccessEvent, kcmv1.ServiceSetEnsureProfileEventAction,
 				"Successfully ensured ProjectSveltos Profile for ServiceSet %s", serviceSet.Name)
@@ -681,7 +681,7 @@ func (r *ServiceSetReconciler) collectServiceStatuses(ctx context.Context, rgnCl
 	defer func(initialStatus metav1.ConditionStatus) {
 		// we'll emit event only if the status changed from the initial value and it's now true.
 		conditionStatusChangedToTrue := initialStatus != status && status == metav1.ConditionTrue
-		if updateCondition(serviceSet, statusesCollectedCondition, status, reason, message, r.timeFunc()) && conditionStatusChangedToTrue {
+		if conditionStatusChangedToTrue && updateCondition(serviceSet, statusesCollectedCondition, status, reason, message, r.timeFunc()) {
 			l.Info("Successfully collected services statuses")
 			record.Eventf(serviceSet, nil, kcmv1.ServiceSetCollectServiceStatusesSuccessEvent, kcmv1.ServiceSetCollectServiceStatusesEventAction,
 				"Successfully collected service statuses for ServiceSet %s", serviceSet.Name)

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -404,19 +404,22 @@ func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient clie
 	l := ctrl.LoggerFrom(ctx)
 	l.Info("Ensuring ProjectSveltos Profile")
 	profileCondition := findCondition(serviceSet, kcmv1.ServiceSetProfileCondition)
+	initialConditionStatus := profileCondition.Status
 
 	status := metav1.ConditionFalse
 	reason := kcmv1.ServiceSetProfileNotReadyReason
 	message := kcmv1.ServiceSetProfileNotReadyMessage
 
-	defer func() {
-		if updateCondition(serviceSet, profileCondition, status, reason, message, r.timeFunc()) && status == metav1.ConditionTrue {
+	defer func(initialStatus metav1.ConditionStatus) {
+		// we'll emit event only if the status changed from the initial value and it's now true.
+		conditionStatusChangedToTrue := initialStatus != status && status == metav1.ConditionTrue
+		if updateCondition(serviceSet, profileCondition, status, reason, message, r.timeFunc()) && conditionStatusChangedToTrue {
 			l.Info("Successfully ensured ProjectSveltos Profile")
 			record.Eventf(serviceSet, nil, kcmv1.ServiceSetEnsureProfileSuccessEvent, kcmv1.ServiceSetEnsureProfileEventAction,
 				"Successfully ensured ProjectSveltos Profile for ServiceSet %s", serviceSet.Name)
 		}
 		l.V(1).Info("Finished ensuring ProjectSveltos Profile", "duration", time.Since(start))
-	}()
+	}(initialConditionStatus)
 
 	spec, err := r.profileSpec(ctx, rgnClient, serviceSet)
 	if errors.Is(err, errBuildProfileFromConfigFailed) {
@@ -669,19 +672,22 @@ func (r *ServiceSetReconciler) collectServiceStatuses(ctx context.Context, rgnCl
 	l := ctrl.LoggerFrom(ctx)
 	l.Info("Collecting Service statuses")
 	statusesCollectedCondition := findCondition(serviceSet, kcmv1.ServiceSetStatusesCollectedCondition)
+	initialConditionStatus := statusesCollectedCondition.Status
 
 	status := metav1.ConditionFalse
 	reason := kcmv1.ServiceSetStatusesNotCollectedReason
 	message := kcmv1.ServiceSetStatusesNotCollectedMessage
 
-	defer func() {
-		if updateCondition(serviceSet, statusesCollectedCondition, status, reason, message, r.timeFunc()) && status == metav1.ConditionTrue {
+	defer func(initialStatus metav1.ConditionStatus) {
+		// we'll emit event only if the status changed from the initial value and it's now true.
+		conditionStatusChangedToTrue := initialStatus != status && status == metav1.ConditionTrue
+		if updateCondition(serviceSet, statusesCollectedCondition, status, reason, message, r.timeFunc()) && conditionStatusChangedToTrue {
 			l.Info("Successfully collected services statuses")
 			record.Eventf(serviceSet, nil, kcmv1.ServiceSetCollectServiceStatusesSuccessEvent, kcmv1.ServiceSetCollectServiceStatusesEventAction,
 				"Successfully collected service statuses for ServiceSet %s", serviceSet.Name)
 		}
 		l.V(1).Info("Finished services status collection", "duration", time.Since(start))
-	}()
+	}(initialConditionStatus)
 
 	if serviceSet.Spec.Provider.SelfManagement {
 		clusterProfile := new(addoncontrollerv1beta1.ClusterProfile)
@@ -1460,8 +1466,13 @@ func labelsMatchSelector(serviceSetLabels map[string]string, selector *metav1.La
 // If no condition is found, a new condition of given type is created.
 func findCondition(serviceSet *kcmv1.ServiceSet, conditionType string) metav1.Condition {
 	condition := apimeta.FindStatusCondition(serviceSet.Status.Conditions, conditionType)
+	// if the condition is not found, create a new one with given type and status "False"
 	if condition == nil {
-		condition = &metav1.Condition{Type: conditionType, ObservedGeneration: serviceSet.Generation}
+		condition = &metav1.Condition{
+			Type:               conditionType,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: serviceSet.Generation,
+		}
 	}
 	return *condition
 }

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -43,6 +43,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 		const (
 			serviceTemplate1Name    = "test-service-1-v0-1-0"
 			serviceTemplate2Name    = "test-service-2-v0-1-0"
+			serviceTemplate3Name    = "test-service-3-v0-1-0"
 			helmRepoName            = "test-helmrepo"
 			helmChartName           = "test-helmchart"
 			helmChartReleaseName    = "test-helmchart-release"
@@ -67,6 +68,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 		helmRepo := &sourcev1.HelmRepository{}
 		serviceTemplate := &kcmv1.ServiceTemplate{}
 		serviceTemplate2 := &kcmv1.ServiceTemplate{}
+		serviceTemplate3 := &kcmv1.ServiceTemplate{}
 		multiClusterService := &kcmv1.MultiClusterService{}
 		clusterDeployment := kcmv1.ClusterDeployment{}
 		serviceSet := kcmv1.ServiceSet{}
@@ -76,6 +78,7 @@ var _ = Describe("MultiClusterService Controller", func() {
 		helmChartRef := types.NamespacedName{Namespace: testSystemNamespace, Name: helmChartName}
 		serviceTemplate1Ref := types.NamespacedName{Namespace: testSystemNamespace, Name: serviceTemplate1Name}
 		serviceTemplate2Ref := types.NamespacedName{Namespace: testSystemNamespace, Name: serviceTemplate2Name}
+		serviceTemplate3Ref := types.NamespacedName{Namespace: testSystemNamespace, Name: serviceTemplate3Name}
 		multiClusterServiceRef := types.NamespacedName{Name: multiClusterServiceName}
 		serviceSetKey := types.NamespacedName{}
 		mgmtServiceSetKey := types.NamespacedName{}
@@ -195,6 +198,40 @@ var _ = Describe("MultiClusterService Controller", func() {
 				Expect(k8sClient.Status().Update(ctx, serviceTemplate2)).To(Succeed())
 			}
 
+			By("creating ServiceTemplate3 with Resources+LocalSourceRef (ConfigMap) and no version")
+			err = k8sClient.Get(ctx, serviceTemplate3Ref, serviceTemplate3)
+			if err != nil && apierrors.IsNotFound(err) {
+				serviceTemplate3 = &kcmv1.ServiceTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      serviceTemplate3Name,
+						Namespace: testSystemNamespace,
+						Labels:    map[string]string{kcmv1.GenericComponentNameLabel: kcmv1.GenericComponentLabelValueKCM},
+					},
+					Spec: kcmv1.ServiceTemplateSpec{
+						// Resources-only template with a ConfigMap-backed local source
+						// and NO Spec.Version — exercises the "no values, no versions"
+						// path where fillService*Versions falls back to the
+						// template name as the effective version.
+						Resources: &kcmv1.SourceSpec{
+							DeploymentType: "Local",
+							LocalSourceRef: &kcmv1.LocalSourceRef{
+								Kind: "ConfigMap",
+								Name: "manifests",
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, serviceTemplate3)).To(Succeed())
+				serviceTemplate3.Status = kcmv1.ServiceTemplateStatus{
+					TemplateStatusCommon: kcmv1.TemplateStatusCommon{
+						TemplateValidationStatus: kcmv1.TemplateValidationStatus{
+							Valid: true,
+						},
+					},
+				}
+				Expect(k8sClient.Status().Update(ctx, serviceTemplate3)).To(Succeed())
+			}
+
 			By("creating ClusterDeployment resource", func() {
 				clusterDeployment = kcmv1.ClusterDeployment{
 					ObjectMeta: metav1.ObjectMeta{
@@ -295,12 +332,30 @@ var _ = Describe("MultiClusterService Controller", func() {
 			}
 
 			By("cleaning up")
-			multiClusterServiceResource := &kcmv1.MultiClusterService{}
-			deleteIfNotFound(ctx, multiClusterServiceRef, multiClusterServiceResource)
+
+			// The MCS is created with kcmv1.MultiClusterServiceFinalizer preset so the
+			// reconciler can act in a single pass. At teardown the finalizer keeps the
+			// object stuck Terminating, which would cause subsequent tests to reuse a
+			// stale MCS (BeforeEach's NotFound guard skips re-creation). Clear the
+			// finalizer and wait for real deletion so each test starts fresh.
+			mcsToDelete := &kcmv1.MultiClusterService{}
+			if err := k8sClient.Get(ctx, multiClusterServiceRef, mcsToDelete); err == nil {
+				if len(mcsToDelete.Finalizers) > 0 {
+					mcsToDelete.Finalizers = nil
+					Expect(k8sClient.Update(ctx, mcsToDelete)).To(Succeed())
+				}
+				Expect(k8sClient.Delete(ctx, mcsToDelete)).To(Succeed())
+				Eventually(func() bool {
+					return apierrors.IsNotFound(k8sClient.Get(ctx, multiClusterServiceRef, &kcmv1.MultiClusterService{}))
+				}).Should(BeTrue())
+			} else if !apierrors.IsNotFound(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
 
 			serviceTemplateResource := &kcmv1.ServiceTemplate{}
 			deleteIfNotFound(ctx, serviceTemplate1Ref, serviceTemplateResource)
 			deleteIfNotFound(ctx, serviceTemplate2Ref, serviceTemplateResource)
+			deleteIfNotFound(ctx, serviceTemplate3Ref, serviceTemplateResource)
 
 			helmChartResource := &sourcev1.HelmChart{}
 			deleteIfNotFound(ctx, helmChartRef, helmChartResource)
@@ -382,5 +437,121 @@ var _ = Describe("MultiClusterService Controller", func() {
 				g.Expect(k8sClient.Get(ctx, mgmtServiceSetKey, &mgmtServiceSet)).ToNot(HaveOccurred())
 			}).Should(Succeed())
 		})
+
+		// Regression test for continuous ServiceSet generation bumps caused by
+		// in-place mutation of stored spec during every reconcile.
+		// Each entry updates the MCS services, drains transient reconciles caused
+		// by that spec change, captures ServiceSet.Generation, then reconciles
+		// repeatedly and asserts Generation never increases. A growing Generation
+		// would signal that the controller is still producing a spec diff against
+		// its own stored state.
+		DescribeTable("should keep ServiceSet generation stable across reconciles",
+			func(services []kcmv1.Service) {
+				multiClusterServiceReconciler := &MultiClusterServiceReconciler{
+					Client:          mgrClient,
+					timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+					SystemNamespace: testSystemNamespace,
+				}
+
+				By("updating MultiClusterService services to the entry's spec")
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					multiClusterService.Spec.ServiceSpec.Services = services
+					g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+				}).Should(Succeed())
+
+				By("draining reconciles until the ServiceSet spec reflects the update")
+				// Each reconcile is wrapped in Eventually so that transient
+				// conflict errors on MCS status updates (caused by mgrClient
+				// cache lag after our spec Update above) get retried until the
+				// cache catches up and the reconcile becomes a no-op.
+				Eventually(func(g Gomega) {
+					_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					g.Expect(err).NotTo(HaveOccurred())
+					fresh := &kcmv1.ServiceSet{}
+					g.Expect(k8sClient.Get(ctx, serviceSetKey, fresh)).To(Succeed())
+					g.Expect(fresh.Spec.Services).To(HaveLen(len(services)))
+				}).Should(Succeed())
+
+				// A couple more reconciles so the controller has converged on a
+				// stable spec before we sample Generation.
+				for range 2 {
+					Eventually(func(g Gomega) {
+						_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+						g.Expect(err).NotTo(HaveOccurred())
+					}).Should(Succeed())
+				}
+
+				fresh := &kcmv1.ServiceSet{}
+				Expect(k8sClient.Get(ctx, serviceSetKey, fresh)).To(Succeed())
+				initialGeneration := fresh.Generation
+				Expect(initialGeneration).To(BeNumerically(">", 0))
+
+				By("asserting ServiceSet generation is stable across repeated reconciles")
+				Consistently(func(g Gomega) {
+					_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					g.Expect(err).NotTo(HaveOccurred())
+					refreshed := &kcmv1.ServiceSet{}
+					g.Expect(k8sClient.Get(ctx, serviceSetKey, refreshed)).To(Succeed())
+					g.Expect(refreshed.Generation).To(Equal(initialGeneration),
+						"ServiceSet generation bumped from %d to %d — controller is producing a spec diff against its own stored state",
+						initialGeneration, refreshed.Generation)
+				}, 3*time.Second, 100*time.Millisecond).Should(Succeed())
+			},
+			Entry("service with inline Values",
+				[]kcmv1.Service{
+					{
+						Template:  serviceTemplate1Name,
+						Name:      helmChartReleaseName,
+						Namespace: "ns1",
+						Values:    "foo: bar",
+					},
+				},
+			),
+			Entry("service with ValuesFrom only",
+				[]kcmv1.Service{
+					{
+						Template:  serviceTemplate2Name,
+						Name:      helmChartReleaseName,
+						Namespace: "ns2",
+						ValuesFrom: []kcmv1.ValuesFrom{
+							{Kind: "ConfigMap", Name: "helm-values"},
+						},
+					},
+				},
+			),
+			Entry("service with no values, template with LocalSourceRef and no version",
+				[]kcmv1.Service{
+					{
+						Template:  serviceTemplate3Name,
+						Name:      helmChartReleaseName,
+						Namespace: "ns3",
+					},
+				},
+			),
+			Entry("mixed: inline Values, ValuesFrom, and LocalSourceRef-backed template",
+				[]kcmv1.Service{
+					{
+						Template:  serviceTemplate1Name,
+						Name:      helmChartReleaseName,
+						Namespace: "ns1",
+						Values:    "foo: bar",
+					},
+					{
+						Template:  serviceTemplate2Name,
+						Name:      helmChartReleaseName,
+						Namespace: "ns2",
+						ValuesFrom: []kcmv1.ValuesFrom{
+							{Kind: "ConfigMap", Name: "helm-values"},
+						},
+					},
+					{
+						Template:  serviceTemplate3Name,
+						Name:      helmChartReleaseName,
+						Namespace: "ns3",
+					},
+				},
+			),
+		)
 	})
 })

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -94,10 +94,11 @@ func fillServiceVersions(ctx context.Context, c client.Client, namespace string,
 			if version == "" && template.Spec.Helm != nil && template.Spec.Helm.ChartSpec != nil {
 				version = template.Spec.Helm.ChartSpec.Version
 			}
-			svc.Version = version
 
-			if svc.Version == "" {
+			if version == "" {
 				svc.Version = svc.Template
+			} else {
+				svc.Version = version
 			}
 		}
 	}
@@ -106,7 +107,7 @@ func fillServiceVersions(ctx context.Context, c client.Client, namespace string,
 
 func fillServiceWithValueVersions(ctx context.Context, c client.Client, namespace string, services []*kcmv1.ServiceWithValues) error {
 	for _, svc := range services {
-		if svc.Values == "" && svc.Template != "" {
+		if (svc.Version == nil || *svc.Version == "") && svc.Template != "" {
 			template := kcmv1.ServiceTemplate{}
 			if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: svc.Template}, &template); err != nil {
 				return fmt.Errorf("failed to fetch Template %s/%s: %w", namespace, svc.Template, err)
@@ -116,9 +117,11 @@ func fillServiceWithValueVersions(ctx context.Context, c client.Client, namespac
 			if version == "" && template.Spec.Helm != nil && template.Spec.Helm.ChartSpec != nil {
 				version = template.Spec.Helm.ChartSpec.Version
 			}
-			svc.Version = &version
-			if svc.Version == nil {
-				svc.Version = &svc.Template
+
+			if version == "" {
+				svc.Version = new(svc.Template)
+			} else {
+				svc.Version = new(version)
 			}
 		}
 	}
@@ -376,7 +379,7 @@ func makeService(s kcmv1.Service, version, template string) kcmv1.ServiceWithVal
 		// This will lead to persistent discrepancy between service definitions and
 		// lead to continuous serviceSet updates.
 		Namespace:   effectiveNamespace(s.Namespace),
-		Version:     &version,
+		Version:     new(version),
 		Template:    template,
 		Values:      s.Values,
 		ValuesFrom:  s.ValuesFrom,

--- a/internal/serviceset/util_test.go
+++ b/internal/serviceset/util_test.go
@@ -1214,6 +1214,140 @@ func Test_BuildServicesList(t *testing.T) {
 	}
 }
 
+// Test_GetServiceSetWithOperation_NoSpuriousUpdates verifies that calling
+// GetServiceSetWithOperation multiple times without any changes in the
+// desired services produces OperationNone after the initial Create.
+// This is a regression test for a bug where fillServiceWithValueVersions
+// checked `svc.Values == ""` instead of the version field, causing
+// version resolution to overwrite stored versions on every reconcile
+// and resulting in an infinite update loop (continuously increasing
+// .metadata.generation).
+func Test_GetServiceSetWithOperation_NoSpuriousUpdates(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(kcmv1.AddToScheme(scheme))
+
+	const (
+		systemNamespace = "test-system"
+		cdNamespace     = "test-ns"
+		cdName          = "test-cd"
+		providerName    = "custom-provider"
+		svcName         = "propagation-svc"
+		svcNamespace    = "default"
+		templateName    = "propagation-template"
+	)
+
+	selectorLabel := map[string]string{"test-selector": "true"}
+
+	// ServiceTemplate with Resources (not Helm) and NO Version.
+	// This is exactly the scenario that triggers the bug:
+	// fillServiceWithValueVersions would fall back to Template name
+	// as version, but the guard condition checked Values instead of
+	// Version, causing the fallback to fire on every reconcile.
+	serviceTemplate := &kcmv1.ServiceTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      templateName,
+			Namespace: cdNamespace,
+		},
+		Spec: kcmv1.ServiceTemplateSpec{
+			// No Helm, no Version — resource-type template
+			Resources: &kcmv1.SourceSpec{
+				LocalSourceRef: &kcmv1.LocalSourceRef{
+					Kind: "ConfigMap",
+					Name: "test-configmap",
+				},
+				DeploymentType: "Remote",
+			},
+		},
+		Status: kcmv1.ServiceTemplateStatus{
+			TemplateStatusCommon: kcmv1.TemplateStatusCommon{
+				TemplateValidationStatus: kcmv1.TemplateValidationStatus{
+					Valid: true,
+				},
+			},
+			SourceStatus: &kcmv1.SourceStatus{
+				Kind:      "ConfigMap",
+				Name:      "test-configmap",
+				Namespace: cdNamespace,
+			},
+		},
+	}
+
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cdName,
+			Namespace: cdNamespace,
+		},
+		Spec: kcmv1.ClusterDeploymentSpec{
+			Template:   "sample-template",
+			Credential: "sample-credential",
+			ServiceSpec: kcmv1.ServiceSpec{
+				Provider: kcmv1.StateManagementProviderConfig{
+					Name: providerName,
+				},
+				Services: []kcmv1.Service{
+					{
+						Name:      svcName,
+						Namespace: svcNamespace,
+						Template:  templateName,
+						// No Version set — version resolution must fill it
+					},
+				},
+			},
+		},
+	}
+
+	provider := &kcmv1.StateManagementProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: providerName,
+		},
+		Spec: kcmv1.StateManagementProviderSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: selectorLabel,
+			},
+			Adapter: kcmv1.ResourceReference{
+				APIVersion: "v1",
+				Kind:       "Deployment",
+				Name:       "adapter",
+				Namespace:  "adapter-ns",
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(serviceTemplate, cd, provider).
+		WithStatusSubresource(&kcmv1.ServiceSet{}).
+		WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetClusterIndexKey, kcmv1.ExtractServiceSetCluster).
+		WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetMultiClusterServiceIndexKey, kcmv1.ExtractServiceSetMultiClusterService).
+		Build()
+
+	opReq := OperationRequisites{
+		ObjectKey:       client.ObjectKey{Namespace: cdNamespace, Name: cdName},
+		CD:              cd,
+		SystemNamespace: systemNamespace,
+	}
+
+	// First call: ServiceSet does not exist → must return Create.
+	serviceSet, op, err := GetServiceSetWithOperation(t.Context(), cl, opReq)
+	require.NoError(t, err)
+	require.Equal(t, kcmv1.ServiceSetOperationCreate, op, "first call should return Create")
+
+	// Persist the ServiceSet (simulates what the controller does).
+	proc := NewProcessor(cl)
+	require.NoError(t, proc.CreateOrUpdateServiceSet(t.Context(), op, serviceSet))
+
+	// Subsequent calls: ServiceSet exists and nothing changed → must return None.
+	for i := range 5 {
+		_, op, err = GetServiceSetWithOperation(t.Context(), cl, opReq)
+		require.NoError(t, err)
+		require.Equal(t, kcmv1.ServiceSetOperationNone, op,
+			"iteration %d: expected OperationNone (no spurious update), got %s", i, op)
+	}
+}
+
 func Test_FilterServiceDependencies_Order(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes continuous service set reconciliation and event emitting. This was caused by the wrong guard `svc.Values == ""` in the auxiliary function called during the service set processing.
This wrong guard lead to continuous reconciliation of the serviceSets which contained services without inlined values (for example those used for local resources propagation). Such services were considered to be updated, and consequently the GetServiceSetWithOperation function returned operation "Update" which caused the update call to kube API.

**Which issue(s) this PR fixes**:

Fixes k0rdent/k0rdent-enterprise#311
