### PR TITLE
sec(templates): add quote string values in templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,8 +227,12 @@ package-chart-%: lint-chart-%
 	$(HELM) package --destination $(CHARTS_PACKAGE_DIR) $(TEMPLATES_SUBDIR)/$*
 
 .PHONY: lint-charts
-lint-charts: helm ## Run Helm dependency update and lint for charts.
+lint-charts: helm lint-quoted-values ## Run quote checks plus Helm dependency update and lint for charts.
 	@$(MAKE) $(patsubst %,lint-%-tmpl,$(TEMPLATE_FOLDERS))
+
+.PHONY: lint-quoted-values
+lint-quoted-values: yq ## Ensure string .Values YAML interpolations are quoted in template charts.
+	@YQ=$(YQ) $(SHELL) hack/lint-quoted-values.bash
 
 lint-%-tmpl:
 	@$(MAKE) TEMPLATES_SUBDIR=$(TEMPLATES_DIR)/$* $(patsubst %,lint-chart-%,$(shell ls $(TEMPLATES_DIR)/$*))

--- a/config/dev/adopted-clusterdeployment.yaml
+++ b/config/dev/adopted-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: adopted-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: adopted-cluster-1-0-1
+  template: adopted-cluster-1-0-2
   credential: adopted-cluster-cred
   config:
     clusterLabels: {}

--- a/config/dev/aks-clusterdeployment.yaml
+++ b/config/dev/aks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-aks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-aks-1-0-5
+  template: azure-aks-1-0-6
   credential: azure-aks-credential
   propagateCredentials: false
   config:

--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-26
+  template: aws-standalone-cp-1-0-27
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-26
+  template: azure-standalone-cp-1-0-27
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/docker-clusterdeployment.yaml
+++ b/config/dev/docker-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: docker-hosted-cp-1-0-6
+  template: docker-hosted-cp-1-0-7
   credential: docker-stub-credential
   config:
     clusterLabels: {}

--- a/config/dev/eks-clusterdeployment.yaml
+++ b/config/dev/eks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-eks-1-0-6
+  template: aws-eks-1-0-7
   credential: "aws-cluster-identity-cred"
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-24
+  template: gcp-standalone-cp-1-0-25
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/gke-clusterdeployment.yaml
+++ b/config/dev/gke-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-gke-1-0-10
+  template: gcp-gke-1-0-11
   credential: gcp-credential
   propagateCredentials: false
   config:

--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-6
+  template: kubevirt-standalone-cp-1-0-7
   credential: kubevirt-cred
   propagateCredentials: false
   config:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-28
+  template: openstack-standalone-cp-1-0-29
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-24
+  template: remote-cluster-1-0-25
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-24
+  template: vsphere-standalone-cp-1-0-25
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/hack/lint-quoted-values.bash
+++ b/hack/lint-quoted-values.bash
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Copyright 2026
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+: "${YQ:?YQ must be set to the yq binary path}"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "rg is required but was not found in PATH" >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ ! -d templates ]]; then
+  echo "templates directory not found."
+  exit 0
+fi
+
+declare -a violations=()
+
+while IFS=: read -r file line text; do
+  expr="${text#*:}"
+  key_prefix="${text%%:*}"
+
+  # Skip non-YAML-key template lines like '{{- end }}:{{ ... }}'.
+  if [[ "$key_prefix" == *"{{"* ]] || [[ "$key_prefix" == *"}}"* ]]; then
+    continue
+  fi
+
+  # Already-quoted values are safe in YAML scalar positions.
+  if [[ "$expr" == *"| quote"* ]] || [[ "$expr" == *"| squote"* ]] || [[ "$expr" == *" quote .Values"* ]]; then
+    continue
+  fi
+
+  # Skip template control lines and structured YAML render helpers.
+  if [[ "$expr" =~ \{\{[[:space:]]*[-]?[[:space:]]*(if|else|end|range|with)[[:space:]] ]]; then
+    continue
+  fi
+  if [[ "$expr" == *"toYaml"* ]] || [[ "$expr" == *"fromYaml"* ]] || [[ "$expr" == *"nindent"* ]] || [[ "$expr" == *"indent"* ]]; then
+    continue
+  fi
+
+  raw_path="$(printf '%s' "$expr" | grep -oE '\$?\.Values(\.[A-Za-z0-9_]+)+' | head -n1 | sed -E 's/^\$?\.Values\.//')"
+  if [[ -z "$raw_path" ]]; then
+    continue
+  fi
+
+  chart_dir="${file%%/templates/*}"
+  values_file="${chart_dir}/values.yaml"
+  if [[ ! -f "$values_file" ]]; then
+    continue
+  fi
+
+  is_string="$($YQ eval ".${raw_path} | (type == \"!!str\")" "$values_file" 2>/dev/null || true)"
+  has_string_default="false"
+  if [[ "$expr" =~ \|[[:space:]]*default[[:space:]]*\" ]]; then
+    has_string_default="true"
+  fi
+
+  if [[ "$is_string" == "true" || "$has_string_default" == "true" ]]; then
+    violations+=("${file}:${line}:${text}")
+  fi
+done < <(rg -n --glob 'templates/**/templates/*.yaml' ':\s*\{\{[^}]*\.Values\.[^}]*\}\}\s*$' templates)
+
+if ((${#violations[@]} > 0)); then
+  echo "Found unquoted string .Values interpolations in YAML value positions:"
+  printf '%s\n' "${violations[@]}"
+  exit 1
+fi
+
+echo "Quoted .Values check passed."

--- a/templates/cluster/adopted-cluster/Chart.yaml
+++ b/templates/cluster/adopted-cluster/Chart.yaml
@@ -6,6 +6,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 annotations:
   cluster.x-k8s.io/provider: infrastructure-internal

--- a/templates/cluster/adopted-cluster/templates/sveltoscluster.yaml
+++ b/templates/cluster/adopted-cluster/templates/sveltoscluster.yaml
@@ -12,4 +12,4 @@ metadata:
   {{- end }}
 spec:
   consecutiveFailureThreshold: {{ .Values.consecutiveFailureThreshold }}
-  kubeconfigName: {{ .Values.clusterIdentity.name }}
+  kubeconfigName: {{ .Values.clusterIdentity.name  | quote }}

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-eks/templates/awsmachinetemplate-worker.yaml
+++ b/templates/cluster/aws-eks/templates/awsmachinetemplate-worker.yaml
@@ -7,13 +7,13 @@ spec:
     spec:
       {{- if not (quote .Values.worker.amiID | empty) }}
       ami:
-        id: {{ .Values.worker.amiID }}
+        id: {{ .Values.worker.amiID  | quote }}
       {{- end }}
-      imageLookupFormat: {{ .Values.worker.imageLookup.format }}
-      imageLookupOrg: {{ .Values.worker.imageLookup.org }}
-      imageLookupBaseOS: {{ .Values.worker.imageLookup.baseOS }}
-      instanceType: {{ .Values.worker.instanceType }}
-      iamInstanceProfile: {{ .Values.worker.iamInstanceProfile }}
+      imageLookupFormat: {{ .Values.worker.imageLookup.format  | quote }}
+      imageLookupOrg: {{ .Values.worker.imageLookup.org  | quote }}
+      imageLookupBaseOS: {{ .Values.worker.imageLookup.baseOS  | quote }}
+      instanceType: {{ .Values.worker.instanceType  | quote }}
+      iamInstanceProfile: {{ .Values.worker.iamInstanceProfile  | quote }}
       publicIP: {{ .Values.publicIP }}
       rootVolume:
         size: {{ .Values.worker.rootVolumeSize }}

--- a/templates/cluster/aws-eks/templates/awsmanagedcontrolplane.yaml
+++ b/templates/cluster/aws-eks/templates/awsmanagedcontrolplane.yaml
@@ -3,12 +3,12 @@ kind: AWSManagedControlPlane
 metadata:
   name: {{ include "awsmanagedcontrolplane.name" . }}
 spec:
-  eksClusterName: {{ .Values.eksClusterName }}
-  region: {{ .Values.region }}
+  eksClusterName: {{ .Values.eksClusterName  | quote }}
+  region: {{ .Values.region  | quote }}
   {{- if not (quote .Values.sshKeyName | empty) }}
   sshKeyName: {{ .Values.sshKeyName | quote }}
   {{- end }}
-  version: {{ .Values.kubernetes.version }}
+  version: {{ .Values.kubernetes.version  | quote }}
   associateOIDCProvider: {{ .Values.associateOIDCProvider }}
   {{- with .Values.oidcIdentityProviderConfig }}
   oidcIdentityProviderConfig: {{- toYaml . | nindent 4 }}
@@ -21,8 +21,8 @@ spec:
   kubeProxy:
     disable: {{ .Values.kubeProxy.disable }}
   identityRef:
-    kind: {{ .Values.clusterIdentity.kind }}
-    name: {{ .Values.clusterIdentity.name }}
+    kind: {{ .Values.clusterIdentity.kind  | quote }}
+    name: {{ .Values.clusterIdentity.name  | quote }}
   {{- with .Values.addons }}
   addons: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/templates/cluster/aws-eks/templates/machinedeployment.yaml
+++ b/templates/cluster/aws-eks/templates/machinedeployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
     spec:
-      version: {{ .Values.kubernetes.version }}
+      version: {{ .Values.kubernetes.version  | quote }}
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.29
+version: 1.0.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/awscluster.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/awscluster.yaml
@@ -8,13 +8,13 @@ metadata:
   finalizers:
   - k0rdent.mirantis.com/cleanup
 spec:
-  region: {{ .Values.region }}
+  region: {{ .Values.region  | quote }}
   identityRef:
-    kind: {{ .Values.clusterIdentity.kind }}
-    name: {{ .Values.clusterIdentity.name }}
+    kind: {{ .Values.clusterIdentity.kind  | quote }}
+    name: {{ .Values.clusterIdentity.name  | quote }}
   network:
     vpc:
-      id: {{ .Values.vpcID }}
+      id: {{ .Values.vpcID  | quote }}
     {{- with .Values.subnets }}
     subnets:
       {{- toYaml . | nindent 6 }}

--- a/templates/cluster/aws-hosted-cp/templates/awsmachinetemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/awsmachinetemplate.yaml
@@ -7,14 +7,14 @@ spec:
     spec:
       {{- if not (quote .Values.amiID | empty) }}
       ami:
-        id: {{ .Values.amiID }}
+        id: {{ .Values.amiID  | quote }}
       {{- end }}
-      imageLookupFormat: {{ .Values.imageLookup.format }}
+      imageLookupFormat: {{ .Values.imageLookup.format  | quote }}
       imageLookupOrg: "{{ .Values.imageLookup.org }}"
-      imageLookupBaseOS: {{ .Values.imageLookup.baseOS }}
-      instanceType: {{ .Values.instanceType }}
+      imageLookupBaseOS: {{ .Values.imageLookup.baseOS  | quote }}
+      instanceType: {{ .Values.instanceType  | quote }}
       # Instance Profile created by `clusterawsadm bootstrap iam create-cloudformation-stack`
-      iamInstanceProfile: {{ .Values.iamInstanceProfile }}
+      iamInstanceProfile: {{ .Values.iamInstanceProfile  | quote }}
       cloudInit:
         # Makes CAPA use k0s bootstrap cloud-init directly and not via SSM
         # Simplifies the VPC setup as we do not need custom SSM endpoints etc.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   replicas: 3
   # dirty hack
-  version: {{ .Values.k0s.version | replace "+" "-" }}
+  version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
   {{- with .Values.k0smotron.service }}
   service:
     {{- toYaml . | nindent 4 }}
@@ -32,22 +32,22 @@ spec:
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.auth.configSecret.key }}
+          - key: {{ .Values.auth.configSecret.key  | quote }}
             path: {{ include "authentication-config.file" . }}
-        secretName: {{ .Values.auth.configSecret.name }}
+        secretName: {{ .Values.auth.configSecret.name  | quote }}
     {{- end }}
     {{- if .Values.dataSource.caSecret.name }}
     - path: /var/lib/k0s/kine-ca
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.dataSource.caSecret.key }}
+          - key: {{ .Values.dataSource.caSecret.key  | quote }}
             path: ca.crt
-        secretName: {{ .Values.dataSource.caSecret.name }}
+        secretName: {{ .Values.dataSource.caSecret.name  | quote }}
     {{- end }}
   {{- end }}
   {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
+  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
   {{- end }}
   manifests:
     - name: manifests
@@ -139,7 +139,7 @@ data:
         cloudConfig:
           enabled: true
           global:
-            KubernetesClusterID: {{ required ".Values.managementClusterName is required on AWS hosted deployment" .Values.managementClusterName }}
+            KubernetesClusterID: {{ required ".Values.managementClusterName is required on AWS hosted deployment" .Values.managementClusterName  | quote }}
         # Removing the default `node-role.kubernetes.io/control-plane` node selector
         # TODO: it does not work
         nodeSelector:

--- a/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -35,7 +35,7 @@ spec:
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"

--- a/templates/cluster/aws-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/machinedeployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
     spec:
-      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version "" }}
+      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version ""  | quote }}
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/awscluster.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/awscluster.yaml
@@ -7,10 +7,10 @@ metadata:
   finalizers:
     - k0rdent.mirantis.com/cleanup
 spec:
-  region: {{ .Values.region }}
+  region: {{ .Values.region  | quote }}
   identityRef:
-    kind: {{ .Values.clusterIdentity.kind }}
-    name: {{ .Values.clusterIdentity.name }}
+    kind: {{ .Values.clusterIdentity.kind  | quote }}
+    name: {{ .Values.clusterIdentity.name  | quote }}
   controlPlaneLoadBalancer:
     healthCheckProtocol: TCP
   network:

--- a/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-controlplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-controlplane.yaml
@@ -7,14 +7,14 @@ spec:
     spec:
       {{- if not (quote .Values.controlPlane.amiID | empty) }}
       ami:
-        id: {{ .Values.controlPlane.amiID }}
+        id: {{ .Values.controlPlane.amiID  | quote }}
       {{- end }}
-      imageLookupFormat: {{ .Values.controlPlane.imageLookup.format }}
+      imageLookupFormat: {{ .Values.controlPlane.imageLookup.format  | quote }}
       imageLookupOrg: "{{ .Values.controlPlane.imageLookup.org }}"
-      imageLookupBaseOS: {{ .Values.controlPlane.imageLookup.baseOS }}
-      instanceType: {{ .Values.controlPlane.instanceType }}
+      imageLookupBaseOS: {{ .Values.controlPlane.imageLookup.baseOS  | quote }}
+      instanceType: {{ .Values.controlPlane.instanceType  | quote }}
       # Instance Profile created by `clusterawsadm bootstrap iam create-cloudformation-stack`
-      iamInstanceProfile: {{ .Values.controlPlane.iamInstanceProfile }}
+      iamInstanceProfile: {{ .Values.controlPlane.iamInstanceProfile  | quote }}
       cloudInit:
         # Makes CAPA use k0s bootstrap cloud-init directly and not via SSM
         # Simplifies the VPC setup as we do not need custom SSM endpoints etc.

--- a/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-worker.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-worker.yaml
@@ -7,14 +7,14 @@ spec:
     spec:
       {{- if not (quote .Values.worker.amiID | empty) }}
       ami:
-        id: {{ .Values.worker.amiID }}
+        id: {{ .Values.worker.amiID  | quote }}
       {{- end }}
-      imageLookupFormat: {{ .Values.worker.imageLookup.format }}
+      imageLookupFormat: {{ .Values.worker.imageLookup.format  | quote }}
       imageLookupOrg: "{{ .Values.worker.imageLookup.org }}"
-      imageLookupBaseOS: {{ .Values.worker.imageLookup.baseOS }}
-      instanceType: {{ .Values.worker.instanceType }}
+      imageLookupBaseOS: {{ .Values.worker.imageLookup.baseOS  | quote }}
+      instanceType: {{ .Values.worker.instanceType  | quote }}
       # Instance Profile created by `clusterawsadm bootstrap iam create-cloudformation-stack`
-      iamInstanceProfile: {{ .Values.worker.iamInstanceProfile }}
+      iamInstanceProfile: {{ .Values.worker.iamInstanceProfile  | quote }}
       cloudInit:
         # Makes CAPA use k0s bootstrap cloud-init directly and not via SSM
         # Simplifies the VPC setup as we do not need custom SSM endpoints etc.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "k0scontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version }}
+  version: {{ .Values.k0s.version  | quote }}
   k0sConfigSpec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
@@ -31,8 +31,8 @@ spec:
     {{- else if .Values.auth.configSecret.name }}
     - contentFrom:
         secretRef:
-          name: {{ .Values.auth.configSecret.name }}
-          key: {{ default "config" .Values.auth.configSecret.key }}
+          name: {{ .Values.auth.configSecret.name  | quote }}
+          key: {{ default "config" .Values.auth.configSecret.key  | quote }}
       permissions: "0644"
       path: {{ include "authentication-config.fullpath" . }}
     {{- end }}

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -35,7 +35,7 @@ spec:
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"

--- a/templates/cluster/aws-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/machinedeployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
     spec:
-      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version "" }}
+      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version ""  | quote }}
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:

--- a/templates/cluster/azure-aks/Chart.yaml
+++ b/templates/cluster/azure-aks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure
   cluster.x-k8s.io/infrastructure-azure: v1beta1

--- a/templates/cluster/azure-aks/templates/azureasomanagedcluster.yaml
+++ b/templates/cluster/azure-aks/templates/azureasomanagedcluster.yaml
@@ -8,7 +8,7 @@ spec:
       kind: ResourceGroup
       metadata:
         annotations:
-          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name }}
+          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name  | quote }}
           meta.helm.sh/release-name: {{ .Release.Name }}
           meta.helm.sh/release-namespace: {{ .Release.Namespace }}
         labels:
@@ -16,4 +16,4 @@ spec:
           helm.toolkit.fluxcd.io/namespace: {{ .Release.Namespace }}
         name: {{ include "cluster.name" . }}
       spec:
-        location: {{ .Values.location }}
+        location: {{ .Values.location  | quote }}

--- a/templates/cluster/azure-aks/templates/azureasomanagedcontrolplane.yaml
+++ b/templates/cluster/azure-aks/templates/azureasomanagedcontrolplane.yaml
@@ -8,7 +8,7 @@ spec:
       kind: ManagedCluster
       metadata:
         annotations:
-          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name }}
+          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name  | quote }}
           meta.helm.sh/release-name: {{ .Release.Name }}
           meta.helm.sh/release-namespace: {{ .Release.Namespace }}
         labels:
@@ -22,7 +22,7 @@ spec:
           {{- if .Values.apiServerAccessProfile.enablePrivateCluster }}
           enablePrivateCluster: {{ .Values.apiServerAccessProfile.enablePrivateCluster }}
           enablePrivateClusterPublicFQDN: {{ .Values.apiServerAccessProfile.enablePrivateClusterPublicFQDN }}
-          privateDNSZone: {{ .Values.apiServerAccessProfile.privateDNSZone }}
+          privateDNSZone: {{ .Values.apiServerAccessProfile.privateDNSZone  | quote }}
           {{- end }}
         {{- with .Values.autoUpgradeProfile }}
         autoUpgradeProfile:
@@ -35,11 +35,11 @@ spec:
         dnsPrefix: {{ include "cluster.name" . }}
         identity:
           type: SystemAssigned
-        location: {{ .Values.location }}
+        location: {{ .Values.location  | quote }}
         networkProfile:
-          dnsServiceIP: {{ .Values.dnsServiceIP }}
-          networkPlugin: {{ .Values.kubernetes.networkPlugin }}
-          networkPolicy: {{ .Values.kubernetes.networkPolicy }}
+          dnsServiceIP: {{ .Values.dnsServiceIP  | quote }}
+          networkPlugin: {{ .Values.kubernetes.networkPlugin  | quote }}
+          networkPolicy: {{ .Values.kubernetes.networkPolicy  | quote }}
         oidcIssuerProfile:
           enabled: {{ .Values.oidcIssuerProfile.enabled }}
         owner:
@@ -48,8 +48,8 @@ spec:
           {{- if .Values.securityProfile.azureKeyVaultKms.enabled }}
           azureKeyVaultKms:
             enabled: {{ .Values.securityProfile.azureKeyVaultKms.enabled }}
-            keyId: {{ .Values.securityProfile.azureKeyVaultKms.keyId }}
-            keyVaultNetworkAccess: {{ .Values.securityProfile.azureKeyVaultKms.keyVaultNetworkAccess }}
+            keyId: {{ .Values.securityProfile.azureKeyVaultKms.keyId  | quote }}
+            keyVaultNetworkAccess: {{ .Values.securityProfile.azureKeyVaultKms.keyVaultNetworkAccess  | quote }}
             {{- with .Values.securityProfile.azureKeyVaultKms.keyVaultResourceReference }}
             keyVaultResourceReference:
               {{- toYaml . | nindent 14 }}
@@ -68,18 +68,18 @@ spec:
           workloadIdentity:
             enabled: {{ .Values.securityProfile.workloadIdentity.enabled }}
         serviceMeshProfile:
-          mode: {{ .Values.serviceMeshProfile.mode }}
+          mode: {{ .Values.serviceMeshProfile.mode  | quote }}
           {{- if eq .Values.serviceMeshProfile.mode "Istio" }}
           istio:
             certificateAuthority:
-              certChainObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.certChainObjectName }}
-              certObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.certObjectName }}
-              keyObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.keyObjectName }}
+              certChainObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.certChainObjectName  | quote }}
+              certObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.certObjectName  | quote }}
+              keyObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.keyObjectName  | quote }}
               {{- with .Values.serviceMeshProfile.istio.certificateAuthority.keyVaultReference }}
               keyVaultReference:
                 {{- toYaml . | nindent 16 }}
               {{- end }}
-              rootCertObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.rootCertObjectName }}
+              rootCertObjectName: {{ .Values.serviceMeshProfile.istio.certificateAuthority.rootCertObjectName  | quote }}
             {{- with .Values.serviceMeshProfile.istio.components }}
             components:
               {{- toYaml . | nindent 14 }}
@@ -95,4 +95,4 @@ spec:
         sku:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-  version: {{ .Values.kubernetes.version }}
+  version: {{ .Values.kubernetes.version  | quote }}

--- a/templates/cluster/azure-aks/templates/azureasomanagedmachinepool-controlplane.yaml
+++ b/templates/cluster/azure-aks/templates/azureasomanagedmachinepool-controlplane.yaml
@@ -8,7 +8,7 @@ spec:
       kind: ManagedClustersAgentPool
       metadata:
         annotations:
-          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name }}
+          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name  | quote }}
           meta.helm.sh/release-name: {{ .Release.Name }}
           meta.helm.sh/release-namespace: {{ .Release.Namespace }}
         labels:
@@ -36,5 +36,5 @@ spec:
         osDiskSizeGB: {{ .Values.machinePools.system.osDiskSizeGB }}
         owner:
           name: {{ include "cluster.name" . }}
-        type: {{ .Values.machinePools.system.type }}
-        vmSize: {{ .Values.machinePools.system.vmSize }}
+        type: {{ .Values.machinePools.system.type  | quote }}
+        vmSize: {{ .Values.machinePools.system.vmSize  | quote }}

--- a/templates/cluster/azure-aks/templates/azureasomanagedmachinepool-worker.yaml
+++ b/templates/cluster/azure-aks/templates/azureasomanagedmachinepool-worker.yaml
@@ -9,7 +9,7 @@ spec:
       kind: ManagedClustersAgentPool
       metadata:
         annotations:
-          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name }}
+          serviceoperator.azure.com/credential-from: {{ .Values.clusterIdentity.name  | quote }}
           meta.helm.sh/release-name: {{ .Release.Name }}
           meta.helm.sh/release-namespace: {{ .Release.Namespace }}
         labels:
@@ -37,5 +37,5 @@ spec:
         osDiskSizeGB: {{ .Values.machinePools.user.osDiskSizeGB }}
         owner:
           name: {{ include "cluster.name" . }}
-        type: {{ .Values.machinePools.user.type }}
-        vmSize: {{ .Values.machinePools.user.vmSize }}
+        type: {{ .Values.machinePools.user.type  | quote }}
+        vmSize: {{ .Values.machinePools.user.vmSize  | quote }}

--- a/templates/cluster/azure-aks/templates/machinepool-controlplane.yaml
+++ b/templates/cluster/azure-aks/templates/machinepool-controlplane.yaml
@@ -14,4 +14,4 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureASOManagedMachinePool
         name: {{ include "machinepool.system.name" . }}
-      version: {{ .Values.kubernetes.version }}
+      version: {{ .Values.kubernetes.version  | quote }}

--- a/templates/cluster/azure-aks/templates/machinepool-worker.yaml
+++ b/templates/cluster/azure-aks/templates/machinepool-worker.yaml
@@ -14,4 +14,4 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureASOManagedMachinePool
         name: {{ include "machinepool.user.name" . }}
-      version: {{ .Values.kubernetes.version }}
+      version: {{ .Values.kubernetes.version  | quote }}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.31
+version: 1.0.32
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/azurecluster.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/azurecluster.yaml
@@ -13,21 +13,21 @@ spec:
   {{- end }}
   networkSpec:
     vnet:
-      resourceGroup: {{ .Values.resourceGroup }}
-      name: {{ .Values.network.vnetName }}
+      resourceGroup: {{ .Values.resourceGroup  | quote }}
+      name: {{ .Values.network.vnetName  | quote }}
     subnets:
-      - name: {{ .Values.network.nodeSubnetName }}
+      - name: {{ .Values.network.nodeSubnetName  | quote }}
         role: node
         routeTable:
-          name: {{ .Values.network.routeTableName }}
+          name: {{ .Values.network.routeTableName  | quote }}
         securityGroup:
-          name: {{ .Values.network.securityGroupName }}
-  location: {{ .Values.location }}
+          name: {{ .Values.network.securityGroupName  | quote }}
+  location: {{ .Values.location  | quote }}
   {{- if .Values.bastion.enabled }}
   {{- with .Values.bastion.bastionSpec }}
   bastionSpec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
-  subscriptionID: {{ required ".Values.subscriptionID is required to create a cluster" .Values.subscriptionID }}
-  resourceGroup: {{ .Values.resourceGroup }}
+  subscriptionID: {{ required ".Values.subscriptionID is required to create a cluster" .Values.subscriptionID  | quote }}
+  resourceGroup: {{ .Values.resourceGroup  | quote }}

--- a/templates/cluster/azure-hosted-cp/templates/azuremachinetemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/azuremachinetemplate.yaml
@@ -9,9 +9,9 @@ spec:
         diskSizeGB: {{ .Values.rootVolumeSize }}
         osType: Linux
       {{- if not ( .Values.sshPublicKey | empty) }}
-      sshPublicKey: {{ .Values.sshPublicKey }}
+      sshPublicKey: {{ .Values.sshPublicKey  | quote }}
       {{- end }}
-      vmSize: {{ required ".Values.vmSize is required" .Values.vmSize }}
+      vmSize: {{ required ".Values.vmSize is required" .Values.vmSize  | quote }}
       {{- if not (quote .Values.image | empty) }}
       {{- with .Values.image }}
       image:

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version | replace "+" "-" }}
+  version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
   {{- with .Values.k0smotron.service }}
   service:
     {{- toYaml . | nindent 4 }}
@@ -31,22 +31,22 @@ spec:
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.auth.configSecret.key }}
+          - key: {{ .Values.auth.configSecret.key  | quote }}
             path: {{ include "authentication-config.file" . }}
-        secretName: {{ .Values.auth.configSecret.name }}
+        secretName: {{ .Values.auth.configSecret.name  | quote }}
     {{- end }}
     {{- if .Values.dataSource.caSecret.name }}
     - path: /var/lib/k0s/kine-ca
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.dataSource.caSecret.key }}
+          - key: {{ .Values.dataSource.caSecret.key  | quote }}
             path: ca.crt
-        secretName: {{ .Values.dataSource.caSecret.name }}
+        secretName: {{ .Values.dataSource.caSecret.name  | quote }}
     {{- end }}
   {{- end }}
   {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
+  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
   {{- end }}
   manifests:
     - name: manifests

--- a/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -35,7 +35,7 @@ spec:
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"

--- a/templates/cluster/azure-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/machinedeployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
     spec:
-      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version "" }}
+      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version ""  | quote }}
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/azurecluster.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/azurecluster.yaml
@@ -9,11 +9,11 @@ spec:
   identityRef:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  location: {{ .Values.location }}
+  location: {{ .Values.location  | quote }}
   {{- if .Values.bastion.enabled }}
   {{- with .Values.bastion.bastionSpec }}
   bastionSpec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
-  subscriptionID: {{ required ".Values.subscriptionID is required to create a cluster" .Values.subscriptionID }}
+  subscriptionID: {{ required ".Values.subscriptionID is required to create a cluster" .Values.subscriptionID  | quote }}

--- a/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-controlplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-controlplane.yaml
@@ -9,9 +9,9 @@ spec:
         diskSizeGB: {{ .Values.controlPlane.rootVolumeSize }}
         osType: Linux
       {{- if not (quote .Values.controlPlane.sshPublicKey | empty) }}
-      sshPublicKey: {{ .Values.controlPlane.sshPublicKey }}
+      sshPublicKey: {{ .Values.controlPlane.sshPublicKey  | quote }}
       {{- end }}
-      vmSize: {{ required ".Values.controlPlane.vmSize is required" .Values.controlPlane.vmSize }}
+      vmSize: {{ required ".Values.controlPlane.vmSize is required" .Values.controlPlane.vmSize  | quote }}
       {{- if not (quote .Values.controlPlane.image | empty) }}
       {{- with .Values.controlPlane.image }}
       image:

--- a/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-worker.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-worker.yaml
@@ -9,9 +9,9 @@ spec:
         diskSizeGB: {{ .Values.worker.rootVolumeSize }}
         osType: Linux
       {{- if not (quote .Values.worker.sshPublicKey | empty) }}
-      sshPublicKey: {{ .Values.worker.sshPublicKey }}
+      sshPublicKey: {{ .Values.worker.sshPublicKey  | quote }}
       {{- end }}
-      vmSize: {{ required ".Values.worker.vmSize is required" .Values.worker.vmSize }}
+      vmSize: {{ required ".Values.worker.vmSize is required" .Values.worker.vmSize  | quote }}
       {{- if not (quote .Values.worker.image | empty) }}
       {{- with .Values.worker.image }}
       image:

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "k0scontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version }}
+  version: {{ .Values.k0s.version  | quote }}
   k0sConfigSpec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
@@ -25,8 +25,8 @@ spec:
       {{- if .Values.auth.configSecret.name }}
       - contentFrom:
           secretRef:
-            name: {{ .Values.auth.configSecret.name }}
-            key: {{ default "config" .Values.auth.configSecret.key }}
+            name: {{ .Values.auth.configSecret.name  | quote }}
+            key: {{ default "config" .Values.auth.configSecret.key  | quote }}
         permissions: "0644"
         path: {{ include "authentication-config.fullpath" . }}
       {{- end }}

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -35,7 +35,7 @@ spec:
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"

--- a/templates/cluster/azure-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/machinedeployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
     spec:
-      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version "" }}
+      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version ""  | quote }}
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/docker-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/docker-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -3,7 +3,7 @@ kind: K0smotronControlPlane
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
 spec:
-  version: {{ .Values.k0s.version | replace "+" "-" }}
+  version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
   persistence:
     type: emptyDir
   {{- with .Values.k0smotron.service }}

--- a/templates/cluster/docker-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/docker-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   template:
     spec:
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       {{- with .Values.k0s.workerArgs }}
       args: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/cluster/docker-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/docker-hosted-cp/templates/machinedeployment.yaml
@@ -19,7 +19,7 @@ spec:
           kind: K0sWorkerConfigTemplate
           name: {{ include "k0sworkerconfigtemplate.name" . }}
       clusterName: {{ include "cluster.name" . }}
-      version: {{ (split "+" .Values.k0s.version)._0 }}
+      version: {{ (split "+" .Values.k0s.version)._0  | quote }}
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: DockerMachineTemplate

--- a/templates/cluster/gcp-gke/Chart.yaml
+++ b/templates/cluster/gcp-gke/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-gke/templates/gcpmanagedcluster.yaml
+++ b/templates/cluster/gcp-gke/templates/gcpmanagedcluster.yaml
@@ -11,14 +11,14 @@ metadata:
   finalizers:
     - k0rdent.mirantis.com/cleanup
 spec:
-  project: {{ required ".Values.project is required" .Values.project }}
-  region: {{ required ".Values.region is required" .Values.region }}
+  project: {{ required ".Values.project is required" .Values.project  | quote }}
+  region: {{ required ".Values.region is required" .Values.region  | quote }}
   network:
-    name: {{ .Values.network.name }}
+    name: {{ .Values.network.name  | quote }}
     mtu: {{ .Values.network.mtu }}
   {{- if .Values.additionalLabels }}
   additionalLabels: {{- toYaml .Values.additionalLabels | nindent 4 }}
   {{- end }}
   credentialsRef:
-    name: {{ .Values.clusterIdentity.name }}
+    name: {{ .Values.clusterIdentity.name  | quote }}
     namespace: {{ .Values.clusterIdentity.namespace }}

--- a/templates/cluster/gcp-gke/templates/gcpmanagedcontrolplane.yaml
+++ b/templates/cluster/gcp-gke/templates/gcpmanagedcontrolplane.yaml
@@ -9,12 +9,12 @@ metadata:
     # deletion to get stuck due to the missing cluster.
     helm.sh/resource-policy: keep
 spec:
-  version: {{ .Values.version | default .Values.controlPlaneVersion }}
-  gkeClusterName: {{ .Values.gkeClusterName }}
-  project: {{ .Values.project }}
-  location: {{ .Values.location | default .Values.region }}
+  version: {{ .Values.version | default .Values.controlPlaneVersion  | quote }}
+  gkeClusterName: {{ .Values.gkeClusterName  | quote }}
+  project: {{ .Values.project  | quote }}
+  location: {{ .Values.location | default .Values.region  | quote }}
   enableAutopilot: {{ .Values.enableAutopilot }}
-  releaseChannel: {{ .Values.releaseChannel }}
+  releaseChannel: {{ .Values.releaseChannel  | quote }}
   {{- if .Values.masterAuthorizedNetworksConfig }}
   master_authorized_networks_config: {{ .Values.masterAuthorizedNetworksConfig }}
   {{- end }}

--- a/templates/cluster/gcp-gke/templates/gcpmanagedmachinepool.yaml
+++ b/templates/cluster/gcp-gke/templates/gcpmanagedmachinepool.yaml
@@ -4,8 +4,8 @@ kind: GCPManagedMachinePool
 metadata:
   name: {{ include "machinepool.name" . }}
 spec:
-  nodePoolName: {{ .Values.machines.nodePoolName }}
-  machineType: {{ .Values.machines.machineType }}
+  nodePoolName: {{ .Values.machines.nodePoolName  | quote }}
+  machineType: {{ .Values.machines.machineType  | quote }}
   diskSizeGB: {{ .Values.machines.diskSizeGB }}
   {{- with .Values.machines }}
   localSsdCount: {{ .localSsdCount }}

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.28
+version: 1.0.29
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/gcpcluster.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/gcpcluster.yaml
@@ -5,14 +5,14 @@ metadata:
   finalizers:
     - k0rdent.mirantis.com/cleanup
 spec:
-  project: {{ .Values.project }}
-  region: {{ .Values.region }}
+  project: {{ .Values.project  | quote }}
+  region: {{ .Values.region  | quote }}
   network:
-    name: {{ .Values.network.name }}
+    name: {{ .Values.network.name  | quote }}
     mtu: {{ .Values.network.mtu }}
   {{- if .Values.additionalLabels }}
   additionalLabels: {{- toYaml .Values.additionalLabels | nindent 4 }}
   {{- end }}
   credentialsRef:
-    name: {{ .Values.clusterIdentity.name }}
+    name: {{ .Values.clusterIdentity.name  | quote }}
     namespace: {{ .Values.clusterIdentity.namespace }}

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version | replace "+" "-" }}
+  version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
   {{- with .Values.k0smotron.service }}
   service:
     {{- toYaml . | nindent 4 }}
@@ -31,22 +31,22 @@ spec:
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.auth.configSecret.key }}
+          - key: {{ .Values.auth.configSecret.key  | quote }}
             path: {{ include "authentication-config.file" . }}
-        secretName: {{ .Values.auth.configSecret.name }}
+        secretName: {{ .Values.auth.configSecret.name  | quote }}
     {{- end }}
     {{- if .Values.dataSource.caSecret.name }}
     - path: /var/lib/k0s/kine-ca
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.dataSource.caSecret.key }}
+          - key: {{ .Values.dataSource.caSecret.key  | quote }}
             path: ca.crt
-        secretName: {{ .Values.dataSource.caSecret.name }}
+        secretName: {{ .Values.dataSource.caSecret.name  | quote }}
     {{- end }}
   {{- end }}
   {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
+  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
   {{- end }}
   manifests:
     - name: manifests

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -35,7 +35,7 @@ spec:
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"

--- a/templates/cluster/gcp-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/machinedeployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
     spec:
-      version: {{ (split "+" .Values.k0s.version)._0 }}
+      version: {{ (split "+" .Values.k0s.version)._0  | quote }}
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/gcpcluster.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/gcpcluster.yaml
@@ -5,14 +5,14 @@ metadata:
   finalizers:
     - k0rdent.mirantis.com/cleanup
 spec:
-  project: {{ .Values.project }}
-  region: {{ .Values.region }}
+  project: {{ .Values.project  | quote }}
+  region: {{ .Values.region  | quote }}
   network:
-    name: {{ .Values.network.name }}
+    name: {{ .Values.network.name  | quote }}
     mtu: {{ .Values.network.mtu }}
   {{- if .Values.additionalLabels }}
   additionalLabels: {{- toYaml .Values.additionalLabels | nindent 4 }}
   {{- end }}
   credentialsRef:
-    name: {{ .Values.clusterIdentity.name }}
+    name: {{ .Values.clusterIdentity.name  | quote }}
     namespace: {{ .Values.clusterIdentity.namespace }}

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "k0scontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version }}
+  version: {{ .Values.k0s.version  | quote }}
   k0sConfigSpec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
@@ -25,8 +25,8 @@ spec:
       {{- if .Values.auth.configSecret.name }}
       - contentFrom:
           secretRef:
-            name: {{ .Values.auth.configSecret.name }}
-            key: {{ default "config" .Values.auth.configSecret.key }}
+            name: {{ .Values.auth.configSecret.name  | quote }}
+            key: {{ default "config" .Values.auth.configSecret.key  | quote }}
         permissions: "0644"
         path: {{ include "authentication-config.fullpath" . }}
       {{- end }}

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -35,7 +35,7 @@ spec:
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"

--- a/templates/cluster/gcp-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/machinedeployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
     spec:
-      version: {{ (split "+" .Values.k0s.version)._0 }}
+      version: {{ (split "+" .Values.k0s.version)._0  | quote }}
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version | replace "+" "-" }}
+  version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
   {{- with .Values.k0smotron.service }}
   service:
     {{- toYaml . | nindent 4 }}
@@ -31,22 +31,22 @@ spec:
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.auth.configSecret.key }}
+          - key: {{ .Values.auth.configSecret.key  | quote }}
             path: {{ include "authentication-config.file" . }}
-        secretName: {{ .Values.auth.configSecret.name }}
+        secretName: {{ .Values.auth.configSecret.name  | quote }}
     {{- end }}
     {{- if .Values.dataSource.caSecret.name }}
     - path: /var/lib/k0s/kine-ca
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.dataSource.caSecret.key }}
+          - key: {{ .Values.dataSource.caSecret.key  | quote }}
             path: ca.crt
-        secretName: {{ .Values.dataSource.caSecret.name }}
+        secretName: {{ .Values.dataSource.caSecret.name  | quote }}
     {{- end }}
   {{- end }}
   {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
+  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
   {{- end }}
   controllerPlaneFlags:
     - --debug=true

--- a/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -35,7 +35,7 @@ spec:
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
       - --kubelet-extra-args="--fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}

--- a/templates/cluster/kubevirt-hosted-cp/templates/kubevirtcluster.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/kubevirtcluster.yaml
@@ -7,7 +7,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
     spec:
-      type: {{ .Values.cluster.controlPlaneServiceTemplate.spec.type }}
+      type: {{ .Values.cluster.controlPlaneServiceTemplate.spec.type  | quote }}
   {{- if .Values.clusterIdentity }}
   infraClusterSecretRef: {{- toYaml .Values.clusterIdentity | nindent 4 }}
   {{- end }}

--- a/templates/cluster/kubevirt-hosted-cp/templates/kubevirtmachinetemplate.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/kubevirtmachinetemplate.yaml
@@ -6,13 +6,13 @@ spec:
   template:
     spec:
       virtualMachineBootstrapCheck:
-        checkStrategy: {{ .Values.worker.bootstrapCheckStrategy }}
+        checkStrategy: {{ .Values.worker.bootstrapCheckStrategy  | quote }}
       virtualMachineTemplate:
         metadata:
           namespace: {{ .Release.Namespace | trunc 63 }}
           annotations: {{- toYaml .Values.worker.annotations | nindent 12 }}
         spec:
-          runStrategy: {{ .Values.worker.runStrategy }}
+          runStrategy: {{ .Values.worker.runStrategy  | quote }}
           template:
             metadata:
               annotations: {{- toYaml .Values.worker.annotations | nindent 16 }}
@@ -22,7 +22,7 @@ spec:
               domain:
                 cpu:
                   cores: {{ .Values.worker.cpus }}
-                  model: {{ .Values.worker.cpu.model }}
+                  model: {{ .Values.worker.cpu.model  | quote }}
                   numa: {{- toYaml .Values.worker.cpu.numa | nindent 20 }}
                 ioThreadsPolicy: {{ .Values.worker.ioThreadsPolicy }}
                 devices:
@@ -30,7 +30,7 @@ spec:
                   disks: {{- include "devices.disks" .Values.worker | nindent 20 }}
                   networkInterfaceMultiqueue: {{ .Values.worker.networkInterfaceMultiqueue }}
                 memory:
-                  guest: {{ .Values.worker.memory }}
+                  guest: {{ .Values.worker.memory  | quote }}
               evictionStrategy: External
               networks: {{- toYaml .Values.worker.networks | nindent 16 }}
               volumes:

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "k0scontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version }}
+  version: {{ .Values.k0s.version  | quote }}
   k0sConfigSpec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
@@ -26,8 +26,8 @@ spec:
       {{- if .Values.auth.configSecret.name }}
       - contentFrom:
           secretRef:
-            name: {{ .Values.auth.configSecret.name }}
-            key: {{ default "config" .Values.auth.configSecret.key }}
+            name: {{ .Values.auth.configSecret.name  | quote }}
+            key: {{ default "config" .Values.auth.configSecret.key  | quote }}
         permissions: "0644"
         path: {{ include "authentication-config.fullpath" . }}
       {{- end }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -35,7 +35,7 @@ spec:
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
       - --kubelet-extra-args="--fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/kubevirtcluster.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/kubevirtcluster.yaml
@@ -7,7 +7,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
     spec:
-      type: {{ .Values.cluster.controlPlaneServiceTemplate.spec.type }}
+      type: {{ .Values.cluster.controlPlaneServiceTemplate.spec.type  | quote }}
   {{- if .Values.clusterIdentity }}
   infraClusterSecretRef: {{- toYaml .Values.clusterIdentity | nindent 4 }}
   {{- end }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
@@ -6,13 +6,13 @@ spec:
   template:
     spec:
       virtualMachineBootstrapCheck:
-        checkStrategy: {{ .Values.controlPlane.bootstrapCheckStrategy }}
+        checkStrategy: {{ .Values.controlPlane.bootstrapCheckStrategy  | quote }}
       virtualMachineTemplate:
         metadata:
           namespace: {{ .Release.Namespace | trunc 63 }}
           annotations: {{- toYaml .Values.controlPlane.annotations | nindent 12 }}
         spec:
-          runStrategy: {{ .Values.controlPlane.runStrategy }}
+          runStrategy: {{ .Values.controlPlane.runStrategy  | quote }}
           template:
             metadata:
               annotations: {{- toYaml .Values.controlPlane.annotations | nindent 16 }}
@@ -22,7 +22,7 @@ spec:
               domain:
                 cpu:
                   cores: {{ .Values.controlPlane.cpus }}
-                  model: {{ .Values.controlPlane.cpu.model }}
+                  model: {{ .Values.controlPlane.cpu.model  | quote }}
                   numa: {{- toYaml .Values.controlPlane.cpu.numa | nindent 20 }}
                 ioThreadsPolicy: {{ .Values.controlPlane.ioThreadsPolicy }}
                 devices:
@@ -30,7 +30,7 @@ spec:
                   disks: {{- include "devices.disks" .Values.controlPlane | nindent 20 }}
                   networkInterfaceMultiqueue: {{ .Values.controlPlane.networkInterfaceMultiqueue }}
                 memory:
-                  guest: {{ .Values.controlPlane.memory }}
+                  guest: {{ .Values.controlPlane.memory  | quote }}
               evictionStrategy: External
               networks: {{- toYaml .Values.controlPlane.networks | nindent 16 }}
               volumes:

--- a/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
@@ -6,13 +6,13 @@ spec:
   template:
     spec:
       virtualMachineBootstrapCheck:
-        checkStrategy: {{ .Values.worker.bootstrapCheckStrategy }}
+        checkStrategy: {{ .Values.worker.bootstrapCheckStrategy  | quote }}
       virtualMachineTemplate:
         metadata:
           namespace: {{ .Release.Namespace | trunc 63 }}
           annotations: {{- toYaml .Values.worker.annotations | nindent 12 }}
         spec:
-          runStrategy: {{ .Values.worker.runStrategy }}
+          runStrategy: {{ .Values.worker.runStrategy  | quote }}
           template:
             metadata:
               annotations: {{- toYaml .Values.worker.annotations | nindent 16 }}
@@ -22,7 +22,7 @@ spec:
               domain:
                 cpu:
                   cores: {{ .Values.worker.cpus }}
-                  model: {{ .Values.worker.cpu.model }}
+                  model: {{ .Values.worker.cpu.model  | quote }}
                   numa: {{- toYaml .Values.worker.cpu.numa | nindent 20 }}
                 ioThreadsPolicy: {{ .Values.worker.ioThreadsPolicy }}
                 devices:
@@ -30,7 +30,7 @@ spec:
                   disks: {{- include "devices.disks" .Values.worker | nindent 20 }}
                   networkInterfaceMultiqueue: {{ .Values.worker.networkInterfaceMultiqueue }}
                 memory:
-                  guest: {{ .Values.worker.memory }}
+                  guest: {{ .Values.worker.memory  | quote }}
               evictionStrategy: External
               networks: {{- toYaml .Values.worker.networks | nindent 16 }}
               volumes:

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version | replace "+" "-" }}
+  version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
   {{- with .Values.k0smotron.service }}
   service:
     {{- toYaml . | nindent 4 }}
@@ -14,14 +14,14 @@ spec:
   {{- if $ingressEnabled }}
   ingress:
     deploy: true
-    className: {{ .Values.ingress.className }}
+    className: {{ .Values.ingress.className  | quote }}
     {{- with .Values.ingress.annotations }}
     annotations:
       {{- toYaml . | nindent 6 }}
     {{- end }}
     port: {{ .Values.ingress.port }}
-    apiHost: {{ .Values.ingress.apiHost }}
-    konnectivityHost: {{ .Values.ingress.konnectivityHost }}
+    apiHost: {{ .Values.ingress.apiHost  | quote }}
+    konnectivityHost: {{ .Values.ingress.konnectivityHost  | quote }}
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
@@ -44,22 +44,22 @@ spec:
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.auth.configSecret.key }}
+          - key: {{ .Values.auth.configSecret.key  | quote }}
             path: {{ include "authentication-config.file" . }}
-        secretName: {{ .Values.auth.configSecret.name }}
+        secretName: {{ .Values.auth.configSecret.name  | quote }}
     {{- end }}
     {{- if .Values.dataSource.caSecret.name }}
     - path: /var/lib/k0s/kine-ca
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.dataSource.caSecret.key }}
+          - key: {{ .Values.dataSource.caSecret.key  | quote }}
             path: ca.crt
-        secretName: {{ .Values.dataSource.caSecret.name }}
+        secretName: {{ .Values.dataSource.caSecret.name  | quote }}
     {{- end }}
   {{- end }}
   {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
+  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
   {{- end }}
   manifests:
     - name: manifests
@@ -162,7 +162,7 @@ data:
             value: {{ .Values.ccmRegional | quote }}
           {{- if $ingressEnabled }}
           - name: KUBERNETES_SERVICE_HOST
-            value: {{ .Values.ingress.apiHost }}
+            value: {{ .Values.ingress.apiHost  | quote }}
           - name: KUBERNETES_SERVICE_PORT
             value: {{ .Values.ingress.port | quote }}
           {{- end }}
@@ -176,7 +176,7 @@ data:
           {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
           - name: cloud-ca-cert
             secret:
-              secretName: {{ .Values.identityRef.caCert.secretName }}
+              secretName: {{ .Values.identityRef.caCert.secretName  | quote }}
           {{- end }}
         extraVolumeMounts:
           - name: flexvolume-dir
@@ -187,7 +187,7 @@ data:
             readOnly: true
           {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
           - name: cloud-ca-cert
-            mountPath: {{ .Values.identityRef.caCert.path }}
+            mountPath: {{ .Values.identityRef.caCert.path  | quote }}
           {{- end }}
   2-chart-openstack-cinder-csi.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
@@ -265,11 +265,11 @@ data:
             volumes:
             - name: cloud-ca-cert
               secret:
-                secretName: {{ .Values.identityRef.caCert.secretName }}
+                secretName: {{ .Values.identityRef.caCert.secretName  | quote }}
             volumeMounts:
             - name: cloud-config
               mountPath: /etc/kubernetes
               readOnly: true
             - name: cloud-ca-cert
-              mountPath: {{ .Values.identityRef.caCert.path }}
+              mountPath: {{ .Values.identityRef.caCert.path  | quote }}
            {{- end }}

--- a/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -35,7 +35,7 @@ spec:
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"

--- a/templates/cluster/openstack-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/machinedeployment.yaml
@@ -13,7 +13,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
     spec:
-      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version "" }}
+      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version ""  | quote }}
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:

--- a/templates/cluster/openstack-hosted-cp/templates/openstackcluster.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/openstackcluster.yaml
@@ -16,9 +16,9 @@ spec:
     {{- toYaml .Values.externalNetwork | nindent 4 }}
   {{- end }}
   identityRef:
-    name: {{ .Values.clusterIdentity.name }}
-    cloudName: {{ .Values.identityRef.cloudName | default "openstack" }}
-    region: {{ .Values.identityRef.region | default "RegionOne" }}
+    name: {{ .Values.clusterIdentity.name  | quote }}
+    cloudName: {{ .Values.identityRef.cloudName | default "openstack"  | quote }}
+    region: {{ .Values.identityRef.region | default "RegionOne"  | quote }}
   managedSecurityGroups: {{- toYaml .Values.managedSecurityGroups | nindent 4 }}
   {{- if .Values.network }}
   network:

--- a/templates/cluster/openstack-hosted-cp/templates/openstackmachinetemplate.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/openstackmachinetemplate.yaml
@@ -5,14 +5,14 @@ metadata:
 spec:
   template:
     spec:
-      flavor: {{ .Values.flavor }}
+      flavor: {{ .Values.flavor  | quote }}
       identityRef:
-        name: {{ .Values.clusterIdentity.name }}
-        region: {{ .Values.identityRef.region }}
-        cloudName: {{ .Values.identityRef.cloudName}}
+        name: {{ .Values.clusterIdentity.name  | quote }}
+        region: {{ .Values.identityRef.region  | quote }}
+        cloudName: {{ .Values.identityRef.cloudName | quote }}
       image:
         filter:
-          name: {{ .Values.image.filter.name }}
+          name: {{ .Values.image.filter.name  | quote }}
           {{- if .Values.image.filter.tags }}
           tags:
             {{- range $tag := .Values.image.filter.tags }}

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.28
+version: 1.0.29
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "k0scontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version }}
+  version: {{ .Values.k0s.version  | quote }}
   k0sConfigSpec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
@@ -25,8 +25,8 @@ spec:
       {{- if .Values.auth.configSecret.name }}
       - contentFrom:
           secretRef:
-            name: {{ .Values.auth.configSecret.name }}
-            key: {{ default "config" .Values.auth.configSecret.key }}
+            name: {{ .Values.auth.configSecret.name  | quote }}
+            key: {{ default "config" .Values.auth.configSecret.key  | quote }}
         permissions: "0644"
         path: {{ include "authentication-config.fullpath" . }}
       {{- end }}
@@ -108,7 +108,7 @@ spec:
                 {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
                 - name: cloud-ca-cert
                   secret:
-                    secretName: {{ .Values.identityRef.caCert.secretName }}
+                    secretName: {{ .Values.identityRef.caCert.secretName  | quote }}
                 {{- end }}
               extraVolumeMounts:
                 - name: flexvolume-dir
@@ -119,7 +119,7 @@ spec:
                   readOnly: true
                 {{- if and .Values.identityRef.caCert .Values.identityRef.caCert.secretName }}
                 - name: cloud-ca-cert
-                  mountPath: {{ .Values.identityRef.caCert.path }}
+                  mountPath: {{ .Values.identityRef.caCert.path  | quote }}
                 {{- end }}
       - path: /var/lib/k0s/manifests/kcm/2-chart-openstack-cinder-csi.yaml
         permissions: "0644"
@@ -194,13 +194,13 @@ spec:
                   volumes:
                   - name: cloud-ca-cert
                     secret:
-                      secretName: {{ .Values.identityRef.caCert.secretName }}
+                      secretName: {{ .Values.identityRef.caCert.secretName  | quote }}
                   volumeMounts:
                   - name: cloud-config
                     mountPath: /etc/kubernetes
                     readOnly: true
                   - name: cloud-ca-cert
-                    mountPath: {{ .Values.identityRef.caCert.path }}
+                    mountPath: {{ .Values.identityRef.caCert.path  | quote }}
                  {{- end }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
     preStartCommands:

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -35,7 +35,7 @@ spec:
       preStartCommands:
       - "sudo update-ca-certificates"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"

--- a/templates/cluster/openstack-standalone-cp/templates/openstackcluster.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackcluster.yaml
@@ -19,9 +19,9 @@ spec:
     {{- toYaml .Values.externalNetwork | nindent 4 }}
   {{- end }}
   identityRef:
-    name: {{ .Values.clusterIdentity.name }}
-    cloudName: {{ .Values.identityRef.cloudName | default "openstack" }}
-    region: {{ .Values.identityRef.region | default "RegionOne" }}
+    name: {{ .Values.clusterIdentity.name  | quote }}
+    cloudName: {{ .Values.identityRef.cloudName | default "openstack"  | quote }}
+    region: {{ .Values.identityRef.region | default "RegionOne"  | quote }}
   managedSecurityGroups: {{- toYaml .Values.managedSecurityGroups | nindent 4 }}
   {{- if .Values.managedSubnets }}
   managedSubnets:

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-controlplane.yaml
@@ -5,14 +5,14 @@ metadata:
 spec:
   template:
     spec:
-      flavor: {{ .Values.controlPlane.flavor }}
+      flavor: {{ .Values.controlPlane.flavor  | quote }}
       identityRef:
-        name: {{ .Values.clusterIdentity.name }}
-        region: {{ .Values.identityRef.region }}
-        cloudName: {{ .Values.identityRef.cloudName}}
+        name: {{ .Values.clusterIdentity.name  | quote }}
+        region: {{ .Values.identityRef.region  | quote }}
+        cloudName: {{ .Values.identityRef.cloudName | quote }}
       image:
         filter:
-          name: {{ .Values.controlPlane.image.filter.name }}
+          name: {{ .Values.controlPlane.image.filter.name  | quote }}
           {{- if .Values.controlPlane.image.filter.tags }}
           tags:
             {{- range $tag := .Values.controlPlane.image.filter.tags }}

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
@@ -5,14 +5,14 @@ metadata:
 spec:
   template:
     spec:
-      flavor: {{ .Values.worker.flavor }}
+      flavor: {{ .Values.worker.flavor  | quote }}
       identityRef:
-        name: {{ .Values.clusterIdentity.name }}
-        region: {{ .Values.identityRef.region }}
-        cloudName: {{ .Values.identityRef.cloudName}}
+        name: {{ .Values.clusterIdentity.name  | quote }}
+        region: {{ .Values.identityRef.region  | quote }}
+        cloudName: {{ .Values.identityRef.cloudName | quote }}
       image:
         filter:
-          name: {{ .Values.worker.image.filter.name }}
+          name: {{ .Values.worker.image.filter.name  | quote }}
           {{- if .Values.worker.image.filter.tags }}
           tags:
             {{- range $tag := .Values.worker.image.filter.tags }}

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version | replace "+" "-" }}
+  version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
   {{- with .Values.k0smotron.controllerPlaneFlags }}
   controllerPlaneFlags:
     {{- toYaml . | nindent 4 }}
@@ -35,22 +35,22 @@ spec:
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.auth.configSecret.key }}
+          - key: {{ .Values.auth.configSecret.key  | quote }}
             path: {{ include "authentication-config.file" . }}
-        secretName: {{ .Values.auth.configSecret.name }}
+        secretName: {{ .Values.auth.configSecret.name  | quote }}
     {{- end }}
     {{- if .Values.dataSource.caSecret.name }}
     - path: /var/lib/k0s/kine-ca
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.dataSource.caSecret.key }}
+          - key: {{ .Values.dataSource.caSecret.key  | quote }}
             path: ca.crt
-        secretName: {{ .Values.dataSource.caSecret.name }}
+        secretName: {{ .Values.dataSource.caSecret.name  | quote }}
     {{- end }}
   {{- end }}
   {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
+  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
   {{- end }}
   k0sConfig:
     apiVersion: k0s.k0sproject.io/v1beta1

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -28,7 +28,7 @@ metadata:
     # to prevent premature K0sWorkerConfig deletion
     helm.sh/resource-policy: keep
 spec:
-  version: {{ $.Values.k0s.version }}
+  version: {{ $.Values.k0s.version  | quote }}
   {{- if $global.k0sURL }}
   downloadURL: "{{ $global.k0sURL }}/k0s-{{ $.Values.k0s.version }}-{{ $.Values.k0s.arch }}"
   {{- end }}
@@ -84,6 +84,6 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   sshKeyRef:
-    name: {{ $.Values.clusterIdentity.name }}
+    name: {{ $.Values.clusterIdentity.name  | quote }}
 ---
 {{- end }}

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.27
+version: 1.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version | replace "+" "-" }}
+  version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
   {{- with .Values.k0smotron.service }}
   service:
     {{- toYaml . | nindent 4 }}
@@ -31,22 +31,22 @@ spec:
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.auth.configSecret.key }}
+          - key: {{ .Values.auth.configSecret.key  | quote }}
             path: {{ include "authentication-config.file" . }}
-        secretName: {{ .Values.auth.configSecret.name }}
+        secretName: {{ .Values.auth.configSecret.name  | quote }}
     {{- end }}
     {{- if .Values.dataSource.caSecret.name }}
     - path: /var/lib/k0s/kine-ca
       secret:
         defaultMode: 420
         items:
-          - key: {{ .Values.dataSource.caSecret.key }}
+          - key: {{ .Values.dataSource.caSecret.key  | quote }}
             path: ca.crt
-        secretName: {{ .Values.dataSource.caSecret.name }}
+        secretName: {{ .Values.dataSource.caSecret.name  | quote }}
     {{- end }}
   {{- end }}
   {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName }}
+  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
   {{- end }}
   manifests:
     - name: manifests

--- a/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
         - --kubelet-extra-args="--fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}

--- a/templates/cluster/vsphere-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/machinedeployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
     spec:
-      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version "" }}
+      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version ""  | quote }}
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:

--- a/templates/cluster/vsphere-hosted-cp/templates/vspherecluster.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/vspherecluster.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   identityRef:
     kind: VSphereClusterIdentity
-    name: {{ .Values.clusterIdentity.name }}
+    name: {{ .Values.clusterIdentity.name  | quote }}
   controlPlaneEndpoint:
-    host: {{ .Values.controlPlaneEndpointIP }}
+    host: {{ .Values.controlPlaneEndpointIP  | quote }}
     port: 6443
-  server: {{ .Values.vsphere.server }}
-  thumbprint: {{ .Values.vsphere.thumbprint }}
+  server: {{ .Values.vsphere.server  | quote }}
+  thumbprint: {{ .Values.vsphere.thumbprint  | quote }}

--- a/templates/cluster/vsphere-hosted-cp/templates/vspheremachinetemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/vspheremachinetemplate.yaml
@@ -6,20 +6,20 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{ .Values.vsphere.datacenter }}
-      datastore: {{ .Values.vsphere.datastore }}
+      datacenter: {{ .Values.vsphere.datacenter  | quote }}
+      datastore: {{ .Values.vsphere.datastore  | quote }}
       diskGiB: {{ .Values.rootVolumeSize }}
-      folder: {{ .Values.vsphere.folder }}
+      folder: {{ .Values.vsphere.folder  | quote }}
       memoryMiB: {{ .Values.memory }}
       network:
         devices:
         - dhcp4: true
-          networkName: {{ .Values.network }}
+          networkName: {{ .Values.network  | quote }}
       numCPUs: {{ .Values.cpus }}
       os: Linux
       powerOffMode: hard
-      resourcePool: {{ .Values.vsphere.resourcePool }}
-      server: {{ .Values.vsphere.server }}
+      resourcePool: {{ .Values.vsphere.resourcePool  | quote }}
+      server: {{ .Values.vsphere.server  | quote }}
       storagePolicyName: ""
-      template: {{ .Values.vmTemplate }}
-      thumbprint: {{ .Values.vsphere.thumbprint }}
+      template: {{ .Values.vmTemplate  | quote }}
+      thumbprint: {{ .Values.vsphere.thumbprint  | quote }}

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "k0scontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
-  version: {{ .Values.k0s.version }}
+  version: {{ .Values.k0s.version  | quote }}
   k0sConfigSpec:
     {{- if $global.k0sURL }}
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
@@ -30,8 +30,8 @@ spec:
       {{- if .Values.auth.configSecret.name }}
       - contentFrom:
           secretRef:
-            name: {{ .Values.auth.configSecret.name }}
-            key: {{ default "config" .Values.auth.configSecret.key }}
+            name: {{ .Values.auth.configSecret.name  | quote }}
+            key: {{ default "config" .Values.auth.configSecret.key  | quote }}
         permissions: "0644"
         path: {{ include "authentication-config.fullpath" . }}
       {{- end }}
@@ -83,7 +83,7 @@ spec:
                 repository: {{ $global.registry }}/kube-vip/kube-vip
               {{- end }}
               config:
-                address: {{ .Values.controlPlaneEndpointIP }}
+                address: {{ .Values.controlPlaneEndpointIP  | quote }}
               env:
                 svc_enable: "true"
                 cp_enable: "true"

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -9,7 +9,7 @@ spec:
       {{- if $global.k0sURL }}
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
-      version: {{ .Values.k0s.version }}
+      version: {{ .Values.k0s.version  | quote }}
       args:
         - --kubelet-extra-args="--fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.workerArgs }}

--- a/templates/cluster/vsphere-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/machinedeployment.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
     spec:
-      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version "" }}
+      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version ""  | quote }}
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:

--- a/templates/cluster/vsphere-standalone-cp/templates/vspherecluster.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/vspherecluster.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   identityRef:
     kind: VSphereClusterIdentity
-    name: {{ .Values.clusterIdentity.name }}
+    name: {{ .Values.clusterIdentity.name  | quote }}
   controlPlaneEndpoint:
-    host: {{ .Values.controlPlaneEndpointIP }}
+    host: {{ .Values.controlPlaneEndpointIP  | quote }}
     port: 6443
-  server: {{ .Values.vsphere.server }}
-  thumbprint: {{ .Values.vsphere.thumbprint }}
+  server: {{ .Values.vsphere.server  | quote }}
+  thumbprint: {{ .Values.vsphere.thumbprint  | quote }}

--- a/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-controlplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-controlplane.yaml
@@ -6,15 +6,15 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{ .Values.vsphere.datacenter }}
-      datastore: {{ .Values.vsphere.datastore }}
+      datacenter: {{ .Values.vsphere.datacenter  | quote }}
+      datastore: {{ .Values.vsphere.datastore  | quote }}
       diskGiB: {{ .Values.controlPlane.rootVolumeSize }}
-      folder: {{ .Values.vsphere.folder }}
+      folder: {{ .Values.vsphere.folder  | quote }}
       memoryMiB: {{ .Values.controlPlane.memory }}
       network:
         devices:
         - dhcp4: {{ not .Values.ipamEnabled  }}
-          networkName: {{ .Values.controlPlane.network }}
+          networkName: {{ .Values.controlPlane.network  | quote }}
           {{- if .Values.ipamEnabled  }}
           addressesFromPools:
             - {{- toYaml .Values.ipPool.config | nindent 14 }}
@@ -25,8 +25,8 @@ spec:
       numCPUs: {{ .Values.controlPlane.cpus }}
       os: Linux
       powerOffMode: hard
-      resourcePool: {{ .Values.vsphere.resourcePool }}
-      server: {{ .Values.vsphere.server }}
+      resourcePool: {{ .Values.vsphere.resourcePool  | quote }}
+      server: {{ .Values.vsphere.server  | quote }}
       storagePolicyName: ""
-      template: {{ .Values.controlPlane.vmTemplate }}
-      thumbprint: {{ .Values.vsphere.thumbprint }}
+      template: {{ .Values.controlPlane.vmTemplate  | quote }}
+      thumbprint: {{ .Values.vsphere.thumbprint  | quote }}

--- a/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-worker.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-worker.yaml
@@ -6,15 +6,15 @@ spec:
   template:
     spec:
       cloneMode: linkedClone
-      datacenter: {{ .Values.vsphere.datacenter }}
-      datastore: {{ .Values.vsphere.datastore }}
+      datacenter: {{ .Values.vsphere.datacenter  | quote }}
+      datastore: {{ .Values.vsphere.datastore  | quote }}
       diskGiB: {{ .Values.worker.rootVolumeSize }}
-      folder: {{ .Values.vsphere.folder }}
+      folder: {{ .Values.vsphere.folder  | quote }}
       memoryMiB: {{ .Values.worker.memory }}
       network:
         devices:
         - dhcp4: {{ not .Values.ipamEnabled }}
-          networkName: {{ .Values.worker.network }}
+          networkName: {{ .Values.worker.network  | quote }}
           {{- if .Values.ipamEnabled  }}
           addressesFromPools:
             - {{- toYaml .Values.ipPool.config | nindent 14 }}
@@ -25,8 +25,8 @@ spec:
       numCPUs: {{ .Values.worker.cpus }}
       os: Linux
       powerOffMode: hard
-      resourcePool: {{ .Values.vsphere.resourcePool }}
-      server: {{ .Values.vsphere.server }}
+      resourcePool: {{ .Values.vsphere.resourcePool  | quote }}
+      server: {{ .Values.vsphere.server  | quote }}
       storagePolicyName: ""
-      template: {{ .Values.worker.vmTemplate }}
-      thumbprint: {{ .Values.vsphere.thumbprint }}
+      template: {{ .Values.worker.vmTemplate  | quote }}
+      thumbprint: {{ .Values.vsphere.thumbprint  | quote }}

--- a/templates/provider/cluster-api-provider-aws/Chart.yaml
+++ b/templates/provider/cluster-api-provider-aws/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.17
+version: 1.0.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-aws/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-aws/templates/provider.yaml
@@ -8,8 +8,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   manager: {{ include "spec.manager" . | nindent 4 }}
   {{- if $global.registry }}

--- a/templates/provider/cluster-api-provider-aws/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-aws/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.configSecret.name }}
-  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  name: {{ .Values.configSecret.name  | quote }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
 stringData:
 {{ toYaml .Values.config | indent 2 }}
 {{- end }}

--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.21
+version: 1.0.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-azure/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-azure/templates/provider.yaml
@@ -8,8 +8,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   manager: {{- toYaml .Values.manager | nindent 4 }}
   {{- if $global.registry }}

--- a/templates/provider/cluster-api-provider-azure/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-azure/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.configSecret.name }}
-  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  name: {{ .Values.configSecret.name  | quote }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
 stringData:
 {{ toYaml .Values.config | indent 2 }}
 {{- end }}

--- a/templates/provider/cluster-api-provider-docker/Chart.yaml
+++ b/templates/provider/cluster-api-provider-docker/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-docker/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-docker/templates/provider.yaml
@@ -8,8 +8,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   manager: {{- toYaml .Values.manager | nindent 4 }}
   {{- if $global.registry }}

--- a/templates/provider/cluster-api-provider-docker/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-docker/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.configSecret.name }}
-  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  name: {{ .Values.configSecret.name  | quote }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
 stringData:
 {{ toYaml .Values.config | indent 2 }}
 {{- end }}

--- a/templates/provider/cluster-api-provider-gcp/Chart.yaml
+++ b/templates/provider/cluster-api-provider-gcp/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.15
+version: 1.0.16
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-gcp/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-gcp/templates/provider.yaml
@@ -8,8 +8,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   manager: {{ include "spec.manager" . | nindent 4 }}
   {{- if $global.registry }}

--- a/templates/provider/cluster-api-provider-gcp/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-gcp/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.configSecret.name }}
-  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  name: {{ .Values.configSecret.name  | quote }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
 stringData:
 {{ toYaml .Values.config | indent 2 }}
 {{- end }}

--- a/templates/provider/cluster-api-provider-infoblox/Chart.yaml
+++ b/templates/provider/cluster-api-provider-infoblox/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-infoblox/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-infoblox/templates/provider.yaml
@@ -8,8 +8,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   {{- if $global.registry }}
   fetchConfig:

--- a/templates/provider/cluster-api-provider-infoblox/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-infoblox/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.configSecret.name }}
-  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  name: {{ .Values.configSecret.name  | quote }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
 stringData:
 {{ toYaml .Values.config | indent 2 }}
 {{- end }}

--- a/templates/provider/cluster-api-provider-ipam/Chart.yaml
+++ b/templates/provider/cluster-api-provider-ipam/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.9
+version: 1.0.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-ipam/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-ipam/templates/provider.yaml
@@ -8,8 +8,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   {{- if $global.registry }}
   fetchConfig:

--- a/templates/provider/cluster-api-provider-ipam/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-ipam/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.configSecret.name }}
-  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  name: {{ .Values.configSecret.name  | quote }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
 stringData:
 {{ toYaml .Values.config | indent 2 }}
 {{- end }}

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.21
+version: 1.0.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/providers.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/providers.yaml
@@ -8,8 +8,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   manager: {{- toYaml .Values.infrastructure.manager | nindent 4 }}
   {{- if $global.registry }}
@@ -31,8 +31,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   manager: {{- toYaml .Values.bootstrap.manager | nindent 4 }}
   {{- if $global.registry }}
@@ -54,8 +54,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   manager: {{- toYaml .Values.controlPlane.manager | nindent 4 }}
   {{- if $global.registry }}

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.configSecret.name }}
-  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  name: {{ .Values.configSecret.name  | quote }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
 stringData:
 {{ toYaml .Values.config | indent 2 }}
 {{- end }}

--- a/templates/provider/cluster-api-provider-kubevirt/Chart.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-kubevirt/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/templates/provider.yaml
@@ -8,8 +8,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   manager: {{- toYaml .Values.manager | nindent 4 }}
   {{- if $global.registry }}

--- a/templates/provider/cluster-api-provider-kubevirt/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.configSecret.name }}
-  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  name: {{ .Values.configSecret.name  | quote }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
 stringData:
 {{ toYaml .Values.config | indent 2 }}
 {{- end }}

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.21
+version: 1.0.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
@@ -8,8 +8,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   manager: {{- toYaml .Values.manager | nindent 4 }}
   {{- if $global.registry }}

--- a/templates/provider/cluster-api-provider-openstack/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.configSecret.name }}
-  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  name: {{ .Values.configSecret.name  | quote }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
 stringData:
 {{ toYaml .Values.config | indent 2 }}
 {{- end }}

--- a/templates/provider/cluster-api-provider-vsphere/Chart.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-vsphere/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/templates/provider.yaml
@@ -8,8 +8,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   manager: {{- toYaml .Values.manager | nindent 4 }}
   {{- if $global.registry }}

--- a/templates/provider/cluster-api-provider-vsphere/templates/secret.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.configSecret.name }}
-  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  name: {{ .Values.configSecret.name  | quote }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
 stringData:
 {{ toYaml .Values.config | indent 2 }}
 {{- end }}

--- a/templates/provider/cluster-api/Chart.yaml
+++ b/templates/provider/cluster-api/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.7
+version: 1.1.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api/templates/provider.yaml
+++ b/templates/provider/cluster-api/templates/provider.yaml
@@ -8,8 +8,8 @@ spec:
   version: {{ $version }}
   {{- if .Values.configSecret.name }}
   configSecret:
-    name: {{ .Values.configSecret.name }}
-    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+    name: {{ .Values.configSecret.name  | quote }}
+    namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
   {{- end }}
   manager: {{- toYaml .Values.manager | nindent 4 }}
   {{- if $global.registry }}

--- a/templates/provider/cluster-api/templates/secret.yaml
+++ b/templates/provider/cluster-api/templates/secret.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.configSecret.name }}
-  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63 }}
+  name: {{ .Values.configSecret.name  | quote }}
+  namespace: {{ .Values.configSecret.namespace | default .Release.Namespace | trunc 63  | quote }}
 stringData:
 {{ toYaml .Values.config | indent 2 }}
 {{- end }}

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -11,27 +11,27 @@ spec:
   regional:
     template: kcm-regional-1-8-0
   capi:
-    template: cluster-api-1-1-7
+    template: cluster-api-1-1-8
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
-      template: cluster-api-provider-k0sproject-k0smotron-1-0-21
+      template: cluster-api-provider-k0sproject-k0smotron-1-0-22
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-1-0-21
+      template: cluster-api-provider-azure-1-0-22
     - name: cluster-api-provider-vsphere
-      template: cluster-api-provider-vsphere-1-0-14
+      template: cluster-api-provider-vsphere-1-0-15
     - name: cluster-api-provider-aws
-      template: cluster-api-provider-aws-1-0-17
+      template: cluster-api-provider-aws-1-0-18
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-1-0-21
+      template: cluster-api-provider-openstack-1-0-22
     - name: cluster-api-provider-docker
-      template: cluster-api-provider-docker-1-0-14
+      template: cluster-api-provider-docker-1-0-15
     - name: cluster-api-provider-gcp
-      template: cluster-api-provider-gcp-1-0-15
+      template: cluster-api-provider-gcp-1-0-16
     - name: cluster-api-provider-ipam
-      template: cluster-api-provider-ipam-1-0-9
+      template: cluster-api-provider-ipam-1-0-10
     - name: cluster-api-provider-infoblox
-      template: cluster-api-provider-infoblox-1-0-8
+      template: cluster-api-provider-infoblox-1-0-9
     - name: cluster-api-provider-kubevirt
-      template: cluster-api-provider-kubevirt-1-0-4
+      template: cluster-api-provider-kubevirt-1-0-5
     - name: projectsveltos
       template: projectsveltos-1-8-0

--- a/templates/provider/kcm-templates/files/templates/adopted-cluster-1-0-2.yaml
+++ b/templates/provider/kcm-templates/files/templates/adopted-cluster-1-0-2.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-28
+  name: adopted-cluster-1-0-2
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.28
+      chart: adopted-cluster
+      version: 1.0.2
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-eks-1-0-7.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-1-0-7.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-24
+  name: aws-eks-1-0-7
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.24
+      chart: aws-eks
+      version: 1.0.7
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-30.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-30.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-26
+  name: aws-hosted-cp-1-0-30
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.26
+      chart: aws-hosted-cp
+      version: 1.0.30
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-27.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-27.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-24
+  name: aws-standalone-cp-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.24
+      chart: aws-standalone-cp
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-aks-1-0-6.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-aks-1-0-6.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-26
+  name: azure-aks-1-0-6
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.26
+      chart: azure-aks
+      version: 1.0.6
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-32.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-32.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: adopted-cluster-1-0-1
+  name: azure-hosted-cp-1-0-32
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: adopted-cluster
-      version: 1.0.1
+      chart: azure-hosted-cp
+      version: 1.0.32
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-27.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-27.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-24
+  name: azure-standalone-cp-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.24
+      chart: azure-standalone-cp
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-aws-1-0-17
+  name: cluster-api-provider-aws-1-0-18
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-aws
-      version: 1.0.17
+      version: 1.0.18
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-1-0-21
+  name: cluster-api-provider-azure-1-0-22
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-azure
-      version: 1.0.21
+      version: 1.0.22
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-docker-1-0-14
+  name: cluster-api-provider-docker-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-docker
-      version: 1.0.14
+      version: 1.0.15
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-gcp-1-0-15
+  name: cluster-api-provider-gcp-1-0-16
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-gcp
-      version: 1.0.15
+      version: 1.0.16
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-infoblox.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-infoblox.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-infoblox-1-0-8
+  name: cluster-api-provider-infoblox-1-0-9
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-infoblox
-      version: 1.0.8
+      version: 1.0.9
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-ipam.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-ipam.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-ipam-1-0-9
+  name: cluster-api-provider-ipam-1-0-10
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-ipam
-      version: 1.0.9
+      version: 1.0.10
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-k0sproject-k0smotron-1-0-21
+  name: cluster-api-provider-k0sproject-k0smotron-1-0-22
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-k0sproject-k0smotron
-      version: 1.0.21
+      version: 1.0.22
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-kubevirt-1-0-4
+  name: cluster-api-provider-kubevirt-1-0-5
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-kubevirt
-      version: 1.0.4
+      version: 1.0.5
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-1-0-21
+  name: cluster-api-provider-openstack-1-0-22
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 1.0.21
+      version: 1.0.22
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-vsphere-1-0-14
+  name: cluster-api-provider-vsphere-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-vsphere
-      version: 1.0.14
+      version: 1.0.15
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-1-1-7
+  name: cluster-api-1-1-8
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api
-      version: 1.1.7
+      version: 1.1.8
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-7.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-7.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-27
+  name: docker-hosted-cp-1-0-7
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.27
+      chart: docker-hosted-cp
+      version: 1.0.7
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-11.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-11.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-24
+  name: gcp-gke-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.24
+      chart: gcp-gke
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-29.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-29.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-6
+  name: gcp-hosted-cp-1-0-29
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-standalone-cp
-      version: 1.0.6
+      chart: gcp-hosted-cp
+      version: 1.0.29
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-25.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-25.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-29
+  name: gcp-standalone-cp-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.29
+      chart: gcp-standalone-cp
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-7.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-7.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-28
+  name: kubevirt-hosted-cp-1-0-7
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.28
+      chart: kubevirt-hosted-cp
+      version: 1.0.7
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-7.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-7.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-eks-1-0-6
+  name: kubevirt-standalone-cp-1-0-7
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-eks
-      version: 1.0.6
+      chart: kubevirt-standalone-cp
+      version: 1.0.7
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-25.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-25.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-aks-1-0-5
+  name: openstack-hosted-cp-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-aks
-      version: 1.0.5
+      chart: openstack-hosted-cp
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-29.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-29.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: docker-hosted-cp-1-0-6
+  name: openstack-standalone-cp-1-0-29
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: docker-hosted-cp
-      version: 1.0.6
+      chart: openstack-standalone-cp
+      version: 1.0.29
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-25.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-25.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-31
+  name: remote-cluster-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.31
+      chart: remote-cluster
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-28.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-28.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-gke-1-0-10
+  name: vsphere-hosted-cp-1-0-28
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-gke
-      version: 1.0.10
+      chart: vsphere-hosted-cp
+      version: 1.0.28
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-25.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-25.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-hosted-cp-1-0-6
+  name: vsphere-standalone-cp-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-hosted-cp
-      version: 1.0.6
+      chart: vsphere-standalone-cp
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
         {{- else }}
         {{- .Values.image.repository }}
         {{- end }}:{{ .Values.image.tag | default .Chart.AppVersion }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.image.pullPolicy  | quote }}
         {{- if .Values.admissionWebhook.enabled }}
         ports:
         - containerPort: {{ .Values.admissionWebhook.port }}
@@ -110,7 +110,7 @@ spec:
         securityContext: {{ toYaml .Values.containerSecurityContext | nindent 10 }}
         {{- if .Values.admissionWebhook.enabled }}
         volumeMounts:
-          - mountPath: {{ .Values.admissionWebhook.certDir }}
+          - mountPath: {{ .Values.admissionWebhook.certDir  | quote }}
             name: cert
             readOnly: true
         {{- end }}
@@ -129,7 +129,7 @@ spec:
       terminationGracePeriodSeconds: 10
       {{- if .Values.controller.imagePullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.controller.imagePullSecret }}
+        - name: {{ .Values.controller.imagePullSecret  | quote }}
       {{- else if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}

--- a/templates/provider/kcm/templates/metrics-service.yaml
+++ b/templates/provider/kcm/templates/metrics-service.yaml
@@ -6,7 +6,7 @@ metadata:
     control-plane: {{ include "kcm.fullname" . }}-controller-manager
   {{- include "kcm.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.metricsService.type }}
+  type: {{ .Values.metricsService.type  | quote }}
   selector:
     control-plane: {{ include "kcm.fullname" . }}-controller-manager
   {{- include "kcm.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `quote` string values in cluster- and provider-templates.

Adds a custom bash script to discover unquoted string-typed values.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #2641