### PR TITLE
chore(api): clarify schema cm namespace

### DIFF
--- a/api/v1beta1/templates_common.go
+++ b/api/v1beta1/templates_common.go
@@ -86,6 +86,9 @@ type TemplateStatusCommon struct {
 	// Description contains information about the template.
 	Description string `json:"description,omitempty"`
 	// SchemaConfigMapName specifies the name of the ConfigMap that contains the JSON Schema definition for Helm Chart validation.
+	//
+	// The ConfigMap's namespace is either in the system namespace for [ProviderTemplate]
+	// or is inherited from either a [ClusterTemplate] or a [ServiceTemplate].
 	SchemaConfigMapName string `json:"schemaConfigMapName,omitempty"`
 
 	TemplateValidationStatus `json:",inline"`

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clustertemplates.yaml
@@ -971,7 +971,11 @@ spec:
                     type: string
                   type: array
                 schemaConfigMapName:
-                  description: SchemaConfigMapName specifies the name of the ConfigMap that contains the JSON Schema definition for Helm Chart validation.
+                  description: |-
+                    SchemaConfigMapName specifies the name of the ConfigMap that contains the JSON Schema definition for Helm Chart validation.
+
+                    The ConfigMap's namespace is either in the system namespace for [ProviderTemplate]
+                    or is inherited from either a [ClusterTemplate] or a [ServiceTemplate].
                   type: string
                 valid:
                   description: Valid indicates whether the template passed validation or not.

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_providertemplates.yaml
@@ -963,7 +963,11 @@ spec:
                     type: string
                   type: array
                 schemaConfigMapName:
-                  description: SchemaConfigMapName specifies the name of the ConfigMap that contains the JSON Schema definition for Helm Chart validation.
+                  description: |-
+                    SchemaConfigMapName specifies the name of the ConfigMap that contains the JSON Schema definition for Helm Chart validation.
+
+                    The ConfigMap's namespace is either in the system namespace for [ProviderTemplate]
+                    or is inherited from either a [ClusterTemplate] or a [ServiceTemplate].
                   type: string
                 valid:
                   description: Valid indicates whether the template passed validation or not.

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicetemplates.yaml
@@ -2382,7 +2382,11 @@ spec:
                   format: int64
                   type: integer
                 schemaConfigMapName:
-                  description: SchemaConfigMapName specifies the name of the ConfigMap that contains the JSON Schema definition for Helm Chart validation.
+                  description: |-
+                    SchemaConfigMapName specifies the name of the ConfigMap that contains the JSON Schema definition for Helm Chart validation.
+
+                    The ConfigMap's namespace is either in the system namespace for [ProviderTemplate]
+                    or is inherited from either a [ClusterTemplate] or a [ServiceTemplate].
                   type: string
                 sourceStatus:
                   description: SourceStatus reflects the status of the source.


### PR DESCRIPTION
**What this PR does / why we need it**:
Clarifies the namespace of the ConfigMap that contains a Template's schema.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Relates to #2645 
