### PR TITLE
fix(templates): incorrect default values

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-27
+  template: aws-standalone-cp-1-0-28
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-27
+  template: azure-standalone-cp-1-0-28
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/eks-clusterdeployment.yaml
+++ b/config/dev/eks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-eks-1-0-8
+  template: aws-eks-1-0-9
   credential: "aws-cluster-identity-cred"
   config:
     clusterLabels: {}

--- a/config/dev/gke-clusterdeployment.yaml
+++ b/config/dev/gke-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-gke-1-0-11
+  template: gcp-gke-1-0-12
   credential: gcp-credential
   propagateCredentials: false
   config:

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-eks/templates/awsmachinetemplate-worker.yaml
+++ b/templates/cluster/aws-eks/templates/awsmachinetemplate-worker.yaml
@@ -6,20 +6,24 @@ spec:
   template:
     spec:
       {{- $ami := default dict .Values.worker.ami }}
+      {{- $workerAmiID := $ami.id | default "" | trim }}
+      {{- $legacyAmiID := .Values.worker.amiID | default "" | trim }}
       ami:
-        {{- if $ami.id }}
-        id: {{ $ami.id | quote }}
-        {{- else if .Values.worker.amiID }}
-        id: {{ .Values.worker.amiID  | quote }}
+        {{- if $workerAmiID }}
+        id: {{ $workerAmiID | quote }}
+        {{- else if $legacyAmiID }}
+        id: {{ $legacyAmiID | quote }}
         {{- else }}
         eksLookupType: {{ default "AmazonLinux2023" $ami.eksLookupType | quote }}
         {{- end }}
       {{- with .Values.worker.cloudInit }}
       cloudInit: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (not $workerAmiID) (not $legacyAmiID) }}
       imageLookupFormat: {{ .Values.worker.imageLookup.format  | quote }}
       imageLookupOrg: {{ .Values.worker.imageLookup.org  | quote }}
       imageLookupBaseOS: {{ .Values.worker.imageLookup.baseOS  | quote }}
+      {{- end }}
       instanceType: {{ .Values.worker.instanceType  | quote }}
       iamInstanceProfile: {{ .Values.worker.iamInstanceProfile  | quote }}
       publicIP: {{ .Values.publicIP }}
@@ -29,6 +33,7 @@ spec:
       nonRootVolumes: {{- toYaml . | nindent 8 }}
       {{- end }}
       uncompressedUserData: {{ .Values.worker.uncompressedUserData }}
-      {{- if not (quote .Values.sshKeyName | empty) }}
-      sshKeyName: {{ .Values.sshKeyName | quote }}
+      {{- $sshKeyName := .Values.sshKeyName }}
+      {{- if ne $sshKeyName nil }}
+      sshKeyName: {{ $sshKeyName | quote }}
       {{- end }}

--- a/templates/cluster/aws-eks/templates/awsmanagedcontrolplane.yaml
+++ b/templates/cluster/aws-eks/templates/awsmanagedcontrolplane.yaml
@@ -5,8 +5,9 @@ metadata:
 spec:
   eksClusterName: {{ .Values.eksClusterName  | quote }}
   region: {{ .Values.region  | quote }}
-  {{- if not (quote .Values.sshKeyName | empty) }}
-  sshKeyName: {{ .Values.sshKeyName | quote }}
+  {{- $sshKeyName := .Values.sshKeyName }}
+  {{- if ne $sshKeyName nil }}
+  sshKeyName: {{ $sshKeyName | quote }}
   {{- end }}
   version: {{ .Values.kubernetes.version  | quote }}
   associateOIDCProvider: {{ .Values.associateOIDCProvider }}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.30
+version: 1.0.31
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/awscluster.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/awscluster.yaml
@@ -19,8 +19,9 @@ spec:
     subnets:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-  {{- if not (quote .Values.sshKeyName | empty) }}
-  sshKeyName: {{ .Values.sshKeyName | quote }}
+  {{- $sshKeyName := .Values.sshKeyName }}
+  {{- if ne $sshKeyName nil }}
+  sshKeyName: {{ $sshKeyName | quote }}
   {{- end }}
   {{- with .Values.bastion }}
   bastion:

--- a/templates/cluster/aws-hosted-cp/templates/awsmachinetemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/awsmachinetemplate.yaml
@@ -5,13 +5,15 @@ metadata:
 spec:
   template:
     spec:
-      {{- if not (quote .Values.amiID | empty) }}
+      {{- $amiID := .Values.amiID | default "" | trim }}
+      {{- if $amiID }}
       ami:
-        id: {{ .Values.amiID  | quote }}
+        id: {{ $amiID | quote }}
+      {{- else }}
+      imageLookupFormat: {{ .Values.imageLookup.format | quote }}
+      imageLookupOrg: {{ .Values.imageLookup.org | quote }}
+      imageLookupBaseOS: {{ .Values.imageLookup.baseOS | quote }}
       {{- end }}
-      imageLookupFormat: {{ .Values.imageLookup.format  | quote }}
-      imageLookupOrg: "{{ .Values.imageLookup.org }}"
-      imageLookupBaseOS: {{ .Values.imageLookup.baseOS  | quote }}
       instanceType: {{ .Values.instanceType  | quote }}
       # Instance Profile created by `clusterawsadm bootstrap iam create-cloudformation-stack`
       iamInstanceProfile: {{ .Values.iamInstanceProfile  | quote }}
@@ -19,9 +21,11 @@ spec:
         # Makes CAPA use k0s bootstrap cloud-init directly and not via SSM
         # Simplifies the VPC setup as we do not need custom SSM endpoints etc.
         insecureSkipSecretsManager: true
-      {{- range $id := .Values.securityGroupIDs }}
+      {{- with .Values.securityGroupIDs }}
       additionalSecurityGroups:
+        {{- range $id := . }}
         - id: {{ $id }}
+        {{- end }}
       {{- end }}
       publicIP: {{ .Values.publicIP }}
       rootVolume:

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.27
+version: 1.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/awscluster.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/awscluster.yaml
@@ -19,8 +19,9 @@ spec:
         protocol: tcp
         fromPort: 9443
         toPort: 9443
-  {{- if not (quote .Values.sshKeyName | empty) }}
-  sshKeyName: {{ .Values.sshKeyName | quote }}
+  {{- $sshKeyName := .Values.sshKeyName }}
+  {{- if ne $sshKeyName nil }}
+  sshKeyName: {{ $sshKeyName | quote }}
   {{- end }}
   {{- with .Values.bastion }}
   bastion:

--- a/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-controlplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-controlplane.yaml
@@ -5,13 +5,15 @@ metadata:
 spec:
   template:
     spec:
-      {{- if not (quote .Values.controlPlane.amiID | empty) }}
+      {{- $amiID := .Values.controlPlane.amiID | default "" | trim }}
+      {{- if $amiID }}
       ami:
-        id: {{ .Values.controlPlane.amiID  | quote }}
+        id: {{ $amiID | quote }}
+      {{- else }}
+      imageLookupFormat: {{ .Values.controlPlane.imageLookup.format | quote }}
+      imageLookupOrg: {{ .Values.controlPlane.imageLookup.org | quote }}
+      imageLookupBaseOS: {{ .Values.controlPlane.imageLookup.baseOS | quote }}
       {{- end }}
-      imageLookupFormat: {{ .Values.controlPlane.imageLookup.format  | quote }}
-      imageLookupOrg: "{{ .Values.controlPlane.imageLookup.org }}"
-      imageLookupBaseOS: {{ .Values.controlPlane.imageLookup.baseOS  | quote }}
       instanceType: {{ .Values.controlPlane.instanceType  | quote }}
       # Instance Profile created by `clusterawsadm bootstrap iam create-cloudformation-stack`
       iamInstanceProfile: {{ .Values.controlPlane.iamInstanceProfile  | quote }}

--- a/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-worker.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-worker.yaml
@@ -5,13 +5,15 @@ metadata:
 spec:
   template:
     spec:
-      {{- if not (quote .Values.worker.amiID | empty) }}
+      {{- $amiID := .Values.worker.amiID | default "" | trim }}
+      {{- if $amiID }}
       ami:
-        id: {{ .Values.worker.amiID  | quote }}
+        id: {{ $amiID | quote }}
+      {{- else }}
+      imageLookupFormat: {{ .Values.worker.imageLookup.format | quote }}
+      imageLookupOrg: {{ .Values.worker.imageLookup.org | quote }}
+      imageLookupBaseOS: {{ .Values.worker.imageLookup.baseOS | quote }}
       {{- end }}
-      imageLookupFormat: {{ .Values.worker.imageLookup.format  | quote }}
-      imageLookupOrg: "{{ .Values.worker.imageLookup.org }}"
-      imageLookupBaseOS: {{ .Values.worker.imageLookup.baseOS  | quote }}
       instanceType: {{ .Values.worker.instanceType  | quote }}
       # Instance Profile created by `clusterawsadm bootstrap iam create-cloudformation-stack`
       iamInstanceProfile: {{ .Values.worker.iamInstanceProfile  | quote }}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.32
+version: 1.0.33
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/azuremachinetemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/azuremachinetemplate.yaml
@@ -8,11 +8,10 @@ spec:
       osDisk:
         diskSizeGB: {{ .Values.rootVolumeSize }}
         osType: Linux
-      {{- if not ( .Values.sshPublicKey | empty) }}
-      sshPublicKey: {{ .Values.sshPublicKey  | quote }}
+      {{- with .Values.sshPublicKey | default "" | trim }}
+      sshPublicKey: {{ . | quote }}
       {{- end }}
       vmSize: {{ required ".Values.vmSize is required" .Values.vmSize  | quote }}
-      {{- if not (quote .Values.image | empty) }}
       {{- with .Values.image }}
       image:
         {{- if .id }}
@@ -24,5 +23,4 @@ spec:
         marketplace:
           {{- toYaml .marketplace | nindent 10 }}
         {{- end }}
-      {{- end }}
       {{- end }}

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.27
+version: 1.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-controlplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-controlplane.yaml
@@ -8,11 +8,10 @@ spec:
       osDisk:
         diskSizeGB: {{ .Values.controlPlane.rootVolumeSize }}
         osType: Linux
-      {{- if not (quote .Values.controlPlane.sshPublicKey | empty) }}
-      sshPublicKey: {{ .Values.controlPlane.sshPublicKey  | quote }}
+      {{- with .Values.controlPlane.sshPublicKey | default "" | trim }}
+      sshPublicKey: {{ . | quote }}
       {{- end }}
       vmSize: {{ required ".Values.controlPlane.vmSize is required" .Values.controlPlane.vmSize  | quote }}
-      {{- if not (quote .Values.controlPlane.image | empty) }}
       {{- with .Values.controlPlane.image }}
       image:
         {{- if .id }}
@@ -24,5 +23,4 @@ spec:
         marketplace:
           {{- toYaml .marketplace | nindent 10 }}
         {{- end }}
-      {{- end }}
       {{- end }}

--- a/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-worker.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-worker.yaml
@@ -8,11 +8,10 @@ spec:
       osDisk:
         diskSizeGB: {{ .Values.worker.rootVolumeSize }}
         osType: Linux
-      {{- if not (quote .Values.worker.sshPublicKey | empty) }}
-      sshPublicKey: {{ .Values.worker.sshPublicKey  | quote }}
+      {{- with .Values.worker.sshPublicKey | default "" | trim }}
+      sshPublicKey: {{ . | quote }}
       {{- end }}
       vmSize: {{ required ".Values.worker.vmSize is required" .Values.worker.vmSize  | quote }}
-      {{- if not (quote .Values.worker.image | empty) }}
       {{- with .Values.worker.image }}
       image:
         {{- if .id }}
@@ -24,5 +23,4 @@ spec:
         marketplace:
           {{- toYaml .marketplace | nindent 10 }}
         {{- end }}
-      {{- end }}
       {{- end }}

--- a/templates/cluster/gcp-gke/Chart.yaml
+++ b/templates/cluster/gcp-gke/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-gke/templates/gcpmanagedcontrolplane.yaml
+++ b/templates/cluster/gcp-gke/templates/gcpmanagedcontrolplane.yaml
@@ -9,12 +9,15 @@ metadata:
     # deletion to get stuck due to the missing cluster.
     helm.sh/resource-policy: keep
 spec:
-  version: {{ .Values.version | default .Values.controlPlaneVersion  | quote }}
+  {{- $version := .Values.version | default .Values.controlPlaneVersion | default "" | trim }}
+  {{- with $version }}
+  version: {{ . | quote }}
+  {{- end }}
   gkeClusterName: {{ .Values.gkeClusterName  | quote }}
   project: {{ .Values.project  | quote }}
   location: {{ .Values.location | default .Values.region  | quote }}
   enableAutopilot: {{ .Values.enableAutopilot }}
   releaseChannel: {{ .Values.releaseChannel  | quote }}
-  {{- if .Values.masterAuthorizedNetworksConfig }}
-  master_authorized_networks_config: {{ .Values.masterAuthorizedNetworksConfig }}
+  {{- with .Values.masterAuthorizedNetworksConfig }}
+  master_authorized_networks_config: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/templates/cluster/gcp-gke/values.schema.json
+++ b/templates/cluster/gcp-gke/values.schema.json
@@ -70,8 +70,13 @@
       }
     },
     "controlPlaneVersion": {
-      "description": "Deprecated. Use the '.version' field instead. The control plane version of the GKE cluster. If not specified, the default version currently supported by GKE will be used",
-      "type": "string"
+      "description": "Deprecated. Use the '.version' field instead. Set to null or omit to let GKE select the default control plane version. If set, must be a non-empty version string",
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "\\S",
+      "minLength": 1
     },
     "enableAutopilot": {
       "description": "Indicates whether to enable autopilot for this GKE cluster",
@@ -247,8 +252,13 @@
       ]
     },
     "version": {
-      "description": "Version represents the version of the GKE control plane. If not specified, the default version currently supported by GKE will be used. See: https://cloud.google.com/kubernetes-engine/docs/release-notes",
-      "type": "string"
+      "description": "Version represents the version of the GKE control plane. Set to null or omit to let GKE select the default version. If set, must be a non-empty version string. See: https://cloud.google.com/kubernetes-engine/docs/release-notes",
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "\\S",
+      "minLength": 1
     },
     "workersNumber": {
       "description": "The number of the worker nodes. Should be divisible by the number of zones in machines.nodeLocations. If nodeLocations is not specified, must be divisible by the number of zones in this region (default: 3)",

--- a/templates/cluster/gcp-gke/values.yaml
+++ b/templates/cluster/gcp-gke/values.yaml
@@ -20,7 +20,7 @@ gkeClusterName: "" # @schema description: The name of the GKE cluster. If you do
 project: "" # @schema description: The name of the project to deploy the cluster to; type: string; required: true
 enableAutopilot: false # @schema description: Indicates whether to enable autopilot for this GKE cluster; type: boolean
 releaseChannel: "regular" # @schema description: The release channel of the GKE cluster; enum: rapid,regular,stable; type: string
-controlPlaneVersion: "" # @schema description: Deprecated. Use the '.version' field instead. The control plane version of the GKE cluster. If not specified, the default version currently supported by GKE will be used; type: string
+controlPlaneVersion: null # @schema description: Deprecated. Use the '.version' field instead. Set to null or omit to let GKE select the default control plane version. If set, must be a non-empty version string; type: [string, null]; minLength: 1; pattern: \S
 masterAuthorizedNetworksConfig: {} # @schema description: Represents configuration options for master authorized networks feature of the GKE cluster. This feature is disabled if this field is not specified; type: object
 region: "" # @schema description: The GCP Region the cluster lives in; type: string; required: true
 location: "" # @schema description: The location where the GKE cluster will be created. If unspecified, a region will be used, making the cluster regional. Otherwise, specifying a location will create a zonal cluster; type: string
@@ -52,4 +52,4 @@ machines: # @schema description: Managed machines' parameters; type: object
     autoUpgrade: true # @schema description: AutoUpgrade specifies whether node auto-upgrade is enabled for the node pool. If enabled, node auto-upgrade helps keep the nodes in your node pool up to date with the latest release version of Kubernetes; type: boolean
     autoRepair: false # @schema description: AutoRepair specifies whether the node auto-repair is enabled for the node pool. If enabled, the nodes in this node pool will be monitored and, if they fail health checks too many times, an automatic repair action will be triggered; type: boolean
 
-version: "" # @schema description: Version represents the version of the GKE control plane. If not specified, the default version currently supported by GKE will be used. See: https://cloud.google.com/kubernetes-engine/docs/release-notes; type: string
+version: null # @schema description: Version represents the version of the GKE control plane. Set to null or omit to let GKE select the default version. If set, must be a non-empty version string. See: https://cloud.google.com/kubernetes-engine/docs/release-notes; type: [string, null]; minLength: 1; pattern: \S

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: Release
 metadata:
-  name: kcm-1-8-0
+  name: kcm-1-9-0-rc0
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/templates/aws-eks-1-0-9.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-1-0-9.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-32
+  name: aws-eks-1-0-9
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.32
+      chart: aws-eks
+      version: 1.0.9
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-31.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-31.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-27
+  name: aws-hosted-cp-1-0-31
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.27
+      chart: aws-hosted-cp
+      version: 1.0.31
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-28.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-28.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-eks-1-0-8
+  name: aws-standalone-cp-1-0-28
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-eks
-      version: 1.0.8
+      chart: aws-standalone-cp
+      version: 1.0.28
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-33.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-33.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-27
+  name: azure-hosted-cp-1-0-33
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.27
+      chart: azure-hosted-cp
+      version: 1.0.33
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-28.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-28.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-gke-1-0-11
+  name: azure-standalone-cp-1-0-28
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-gke
-      version: 1.0.11
+      chart: azure-standalone-cp
+      version: 1.0.28
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-12.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-12.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-30
+  name: gcp-gke-1-0-12
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.30
+      chart: gcp-gke
+      version: 1.0.12
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes misleading defaults in AWS- and Azure-related templates, now omiting ssh-key in Azure and properly handle it in AWS; mutual exclusive image lookups and explicit AMI ID in AWS; duplicated keys in hosted AWS.

Fixes empty update request in GKE template by omiting the version completely.

Sets the Release name correctly.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
