### PR TITLE
refactor(gen): provider templates with appVersion

### DIFF
--- a/hack/templates.sh
+++ b/hack/templates.sh
@@ -27,20 +27,48 @@ rm -f "$TEMPLATES_OUTPUT_DIR"/*.yaml
 
 for type in "$TEMPLATES_DIR"/*; do
   [ -d "$type" ] || continue
-  kind="$(echo "${type#*/}Template" | awk '{$1=toupper(substr($1,0,1))substr($1,2)}1')"
+  type_name=$(basename "$type")
+  kind="$(printf '%sTemplate\n' "$type_name" | awk '{$1=toupper(substr($1,1,1))substr($1,2)}1')"
   for chart in "$type"/*; do
     if [ -d "$chart" ]; then
-      name=$(grep '^name:' "$chart"/Chart.yaml | awk '{print $2}')
+      chart_file="$chart/Chart.yaml"
+      [ -f "$chart_file" ] || continue
+
+      name=$(grep '^name:' "$chart_file" | awk '{print $2}')
+      if [ -z "$name" ]; then
+        echo "Missing .name in $chart_file" >&2
+        exit 1
+      fi
+
       if [ "$name" = "$KCM_TEMPLATES_CHART_NAME" ]; then continue; fi
-      version=$(grep '^version:' "$chart"/Chart.yaml | awk '{print $2}')
-      template_name=$name-$(echo "$version" | sed 's/^v//; s/\./-/g')
+
+      version=$(grep '^version:' "$chart_file" | awk '{print $2}')
+      if [ -z "$version" ]; then
+        echo "Missing .version in $chart_file" >&2
+        exit 1
+      fi
+      template_version=$version
+
+      if [ "$kind" = "ProviderTemplate" ]; then
+        raw_app_version=$(grep '^appVersion:' "$chart_file" | awk '{print $2}' | tr -d '"')
+        # Preserve prerelease/build qualifiers to avoid collisions between versions like
+        # v1.1.0-rc.1 and v1.1.0 while still producing DNS-safe dashed names.
+        app_version=$(echo "$raw_app_version" |
+          sed -E 's/^[vV]//; s/[^0-9A-Za-z.+-]/-/g; s/[.+]/-/g; s/[^0-9A-Za-z-]/-/g; s/^-+//; s/-+$//; s/-+/-/g' |
+          tr '[:upper:]' '[:lower:]')
+        if [ -z "$app_version" ] || ! echo "$app_version" | grep -Eq '[0-9]'; then
+          echo "Invalid appVersion in $chart/Chart.yaml: $raw_app_version" >&2
+          exit 1
+        fi
+        template_version=$app_version
+      fi
+
+      template_name=$name-$(echo "$template_version" | sed 's/\./-/g')
       if [ "$kind" = "ProviderTemplate" ]; then file_name=$name; else file_name=$template_name; fi
 
       cat <<EOF >"$TEMPLATES_OUTPUT_DIR"/"$file_name".yaml
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: $kind
-EOF
-      cat <<EOF >>"$TEMPLATES_OUTPUT_DIR"/"$file_name".yaml
 metadata:
   name: $template_name
   annotations:

--- a/templates/provider/kcm-regional/Chart.yaml
+++ b/templates/provider/kcm-regional/Chart.yaml
@@ -14,6 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.8.0
+appVersion: "v1.8.0"
 dependencies:
   - name: cert-manager
     version: 1.20.2

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -11,27 +11,27 @@ spec:
   regional:
     template: kcm-regional-1-8-0
   capi:
-    template: cluster-api-1-1-8
+    template: cluster-api-1-12-5
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
-      template: cluster-api-provider-k0sproject-k0smotron-1-0-22
+      template: cluster-api-provider-k0sproject-k0smotron-1-10-3
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-1-0-22
+      template: cluster-api-provider-azure-1-23-0
     - name: cluster-api-provider-vsphere
-      template: cluster-api-provider-vsphere-1-0-15
+      template: cluster-api-provider-vsphere-1-15-1
     - name: cluster-api-provider-aws
-      template: cluster-api-provider-aws-1-0-19
+      template: cluster-api-provider-aws-2-11-0
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-1-0-22
+      template: cluster-api-provider-openstack-0-13-0-mirantis-0
     - name: cluster-api-provider-docker
-      template: cluster-api-provider-docker-1-0-15
+      template: cluster-api-provider-docker-1-12-5
     - name: cluster-api-provider-gcp
-      template: cluster-api-provider-gcp-1-0-16
+      template: cluster-api-provider-gcp-1-11-1
     - name: cluster-api-provider-ipam
-      template: cluster-api-provider-ipam-1-0-10
+      template: cluster-api-provider-ipam-1-1-0-rc-1
     - name: cluster-api-provider-infoblox
-      template: cluster-api-provider-infoblox-1-0-9
+      template: cluster-api-provider-infoblox-0-1-0
     - name: cluster-api-provider-kubevirt
-      template: cluster-api-provider-kubevirt-1-0-5
+      template: cluster-api-provider-kubevirt-0-11-0
     - name: projectsveltos
       template: projectsveltos-1-8-0

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-aws-1-0-19
+  name: cluster-api-provider-aws-2-11-0
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-1-0-22
+  name: cluster-api-provider-azure-1-23-0
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-docker-1-0-15
+  name: cluster-api-provider-docker-1-12-5
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-gcp-1-0-16
+  name: cluster-api-provider-gcp-1-11-1
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-infoblox.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-infoblox.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-infoblox-1-0-9
+  name: cluster-api-provider-infoblox-0-1-0
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-ipam.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-ipam.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-ipam-1-0-10
+  name: cluster-api-provider-ipam-1-1-0-rc-1
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-k0sproject-k0smotron-1-0-22
+  name: cluster-api-provider-k0sproject-k0smotron-1-10-3
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-kubevirt-1-0-5
+  name: cluster-api-provider-kubevirt-0-11-0
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-1-0-22
+  name: cluster-api-provider-openstack-0-13-0-mirantis-0
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-vsphere-1-0-15
+  name: cluster-api-provider-vsphere-1-15-1
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/templates/cluster-api.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api.yaml
@@ -1,7 +1,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-1-1-8
+  name: cluster-api-1-12-5
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -14,6 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.8.0
+appVersion: "v1.8.0"
 dependencies:
   - name: flux2
     version: 2.17.2


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the logic in the `ProviderTemplate` files generation to contain not the meaningless chart version, but rather make an effort in parsing the `appVersion` and project it in the name.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
