### PR TITLE
fix: ensure that the drift detection manager is deployed on install

### DIFF
--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -200,6 +200,7 @@ func (r *ManagementReconciler) update(ctx context.Context, management *kcmv1.Man
 	driftRequeue, driftErr := r.ensureDriftDetectionManager(ctx, management)
 	if driftErr != nil {
 		l.Error(driftErr, "failed to ensure drift-detection-manager is deployed")
+		requeue = true
 	}
 	if driftRequeue {
 		requeue = true
@@ -506,11 +507,23 @@ func (r *ManagementReconciler) ensureDriftDetectionManager(ctx context.Context, 
 		restartAnnotation   = "k0rdent.mirantis.com/drift-detection-ensure-restart"
 	)
 
-	driftDeploy := &appsv1.Deployment{}
-	if err := r.Client.Get(ctx, client.ObjectKey{Name: driftDetectionName, Namespace: sveltosNS}, driftDeploy); err == nil {
-		return false, nil // already present, nothing to do
-	} else if !apierrors.IsNotFound(err) {
-		return false, fmt.Errorf("checking for %s: %w", driftDetectionName, err)
+	// we'll list deployments in projectsveltos namespace
+	deployList := &appsv1.DeploymentList{}
+	if err := r.Client.List(ctx, deployList, client.InNamespace(sveltosNS)); err != nil {
+		return false, fmt.Errorf("listing deployments in %s: %w", sveltosNS, err)
+	}
+
+	// we'll iterate over the deployments list and check for addon-controller and drift-detection-manager
+	// if the drift-detection-manager is present, we'll exit. This mean that all required components are
+	// already deployed.
+	var addonDeploy *appsv1.Deployment
+	for i := range deployList.Items {
+		switch deployList.Items[i].Name {
+		case driftDetectionName:
+			return false, nil // already present, nothing to do
+		case addonControllerName:
+			addonDeploy = &deployList.Items[i]
+		}
 	}
 
 	mgmtCluster := &libsveltosv1beta1.SveltosCluster{}
@@ -521,12 +534,8 @@ func (r *ManagementReconciler) ensureDriftDetectionManager(ctx context.Context, 
 		return false, fmt.Errorf("checking for mgmt/mgmt SveltosCluster: %w", err)
 	}
 
-	addonDeploy := &appsv1.Deployment{}
-	if err := r.Client.Get(ctx, client.ObjectKey{Name: addonControllerName, Namespace: sveltosNS}, addonDeploy); err != nil {
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("getting %s: %w", addonControllerName, err)
+	if addonDeploy == nil {
+		return true, nil // addon-controller not yet present; requeue
 	}
 
 	if annotations := addonDeploy.Spec.Template.Annotations; annotations != nil && annotations[restartAnnotation] != "" {

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -28,6 +28,7 @@ import (
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -195,6 +196,14 @@ func (r *ManagementReconciler) update(ctx context.Context, management *kcmv1.Man
 		management.Status.Release = management.Spec.Release
 	}
 	management.Status.ObservedGeneration = management.Generation
+
+	driftRequeue, driftErr := r.ensureDriftDetectionManager(ctx, management)
+	if driftErr != nil {
+		l.Error(driftErr, "failed to ensure drift-detection-manager is deployed")
+	}
+	if driftRequeue {
+		requeue = true
+	}
 
 	if r.RegistryCredentialsSecretName != "" && r.GlobalRegistry != "" {
 		if err := r.createCldRegistryCredSecret(ctx); err != nil {
@@ -479,6 +488,62 @@ self.status.availableReplicas == self.status.readyReplicas`,
 	l.Info("Successfully created StateManagementProvider object")
 	r.eventf(mgmt, "StateManagementProviderCreated", "Created %s StateManagementProvider object", stateManagementProvider.GetName())
 	return nil
+}
+
+// ensureDriftDetectionManager ensures the drift-detection-manager Deployment is present in the
+// projectsveltos namespace.
+func (r *ManagementReconciler) ensureDriftDetectionManager(ctx context.Context, management *kcmv1.Management) (requeue bool, _ error) {
+	if !management.Status.Components[kcmv1.ProviderSveltosName].Success {
+		return false, nil
+	}
+
+	l := ctrl.LoggerFrom(ctx)
+
+	const (
+		sveltosNS           = "projectsveltos"
+		addonControllerName = "addon-controller"
+		driftDetectionName  = "drift-detection-manager"
+		restartAnnotation   = "k0rdent.mirantis.com/drift-detection-ensure-restart"
+	)
+
+	driftDeploy := &appsv1.Deployment{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: driftDetectionName, Namespace: sveltosNS}, driftDeploy); err == nil {
+		return false, nil // already present, nothing to do
+	} else if !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("checking for %s: %w", driftDetectionName, err)
+	}
+
+	mgmtCluster := &libsveltosv1beta1.SveltosCluster{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: "mgmt", Namespace: "mgmt"}, mgmtCluster); err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return true, nil // SveltosCluster not yet created; requeue
+		}
+		return false, fmt.Errorf("checking for mgmt/mgmt SveltosCluster: %w", err)
+	}
+
+	addonDeploy := &appsv1.Deployment{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: addonControllerName, Namespace: sveltosNS}, addonDeploy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("getting %s: %w", addonControllerName, err)
+	}
+
+	if annotations := addonDeploy.Spec.Template.Annotations; annotations != nil && annotations[restartAnnotation] != "" {
+		return true, nil // restart already triggered; wait for drift-detection-manager to appear
+	}
+
+	l.Info("Triggering addon-controller restart so upgradeDriftDetection goroutine runs with mgmt/mgmt present")
+	patch := client.MergeFrom(addonDeploy.DeepCopy())
+	if addonDeploy.Spec.Template.Annotations == nil {
+		addonDeploy.Spec.Template.Annotations = make(map[string]string)
+	}
+	addonDeploy.Spec.Template.Annotations[restartAnnotation] = time.Now().UTC().Format(time.RFC3339)
+	if err := r.Client.Patch(ctx, addonDeploy, patch); err != nil {
+		return false, fmt.Errorf("patching %s to trigger restart: %w", addonControllerName, err)
+	}
+
+	return true, nil
 }
 
 func (r *ManagementReconciler) delete(ctx context.Context, management *kcmv1.Management) (ctrl.Result, error) {

--- a/internal/controller/management_controller_test.go
+++ b/internal/controller/management_controller_test.go
@@ -24,6 +24,8 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -490,4 +492,132 @@ var _ = Describe("Management Controller", func() {
 			}).WithTimeout(timeout).WithPolling(interval).Should(BeTrue())
 		})
 	})
+
+	Context("ensureDriftDetectionManager", func() {
+		const (
+			sveltosNS            = "projectsveltos"
+			mgmtClusterName      = "mgmt"
+			mgmtClusterNamespace = "mgmt"
+			addonControllerName  = "addon-controller"
+			driftDetectionName   = "drift-detection-manager"
+			restartAnnotation    = "k0rdent.mirantis.com/drift-detection-ensure-restart"
+		)
+
+		var mgmt *kcmv1.Management
+
+		BeforeEach(func() {
+			By("ensuring the projectsveltos and mgmt namespaces exist")
+			for _, ns := range []string{sveltosNS, mgmtClusterNamespace} {
+				Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: ns},
+				}))).To(Succeed())
+			}
+
+			mgmt = &kcmv1.Management{
+				Status: kcmv1.ManagementStatus{
+					ComponentsCommonStatus: kcmv1.ComponentsCommonStatus{
+						Components: map[string]kcmv1.ComponentStatus{
+							kcmv1.ProviderSveltosName: {Success: true},
+						},
+					},
+				},
+			}
+		})
+
+		AfterEach(func() {
+			By("cleaning up test deployments and SveltosCluster")
+			for _, name := range []string{driftDetectionName, addonControllerName} {
+				_ = k8sClient.Delete(ctx, &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: sveltosNS},
+				})
+			}
+			_ = k8sClient.Delete(ctx, &libsveltosv1beta1.SveltosCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "mgmt", Namespace: mgmtClusterNamespace},
+			})
+		})
+
+		It("skips when drift-detection-manager already exists", func() {
+			driftDetector := newSveltosDeployment(driftDetectionName, sveltosNS)
+			Expect(k8sClient.Create(ctx, driftDetector)).To(Succeed())
+
+			addonController := newSveltosDeployment(addonControllerName, sveltosNS)
+			Expect(k8sClient.Create(ctx, addonController)).To(Succeed())
+
+			r := &ManagementReconciler{Client: k8sClient}
+			requeue, err := r.ensureDriftDetectionManager(ctx, mgmt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requeue).To(BeFalse())
+
+			got := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(addonController), got)).To(Succeed())
+			Expect(got.Spec.Template.Annotations).NotTo(HaveKey(restartAnnotation))
+		})
+
+		It("requeues without patching when mgmt/mgmt SveltosCluster is missing", func() {
+			addonController := newSveltosDeployment(addonControllerName, sveltosNS)
+			Expect(k8sClient.Create(ctx, addonController)).To(Succeed())
+
+			r := &ManagementReconciler{Client: k8sClient}
+			requeue, err := r.ensureDriftDetectionManager(ctx, mgmt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requeue).To(BeTrue())
+
+			got := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(addonController), got)).To(Succeed())
+			Expect(got.Spec.Template.Annotations).NotTo(HaveKey(restartAnnotation))
+		})
+
+		It("patches addon-controller with restart annotation when SveltosCluster exists", func() {
+			addonController := newSveltosDeployment(addonControllerName, sveltosNS)
+			Expect(k8sClient.Create(ctx, addonController)).To(Succeed())
+
+			Expect(k8sClient.Create(ctx, &libsveltosv1beta1.SveltosCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: mgmtClusterName, Namespace: mgmtClusterNamespace},
+			})).To(Succeed())
+
+			r := &ManagementReconciler{Client: k8sClient}
+			requeue, err := r.ensureDriftDetectionManager(ctx, mgmt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requeue).To(BeTrue())
+
+			got := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(addonController), got)).To(Succeed())
+			Expect(got.Spec.Template.Annotations).To(HaveKey(restartAnnotation))
+			firstTS := got.Spec.Template.Annotations[restartAnnotation]
+			Expect(firstTS).NotTo(BeEmpty())
+
+			By("a subsequent call should short-circuit on the existing annotation and keep it intact")
+			requeue, err = r.ensureDriftDetectionManager(ctx, mgmt)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requeue).To(BeTrue())
+
+			again := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(addonController), again)).To(Succeed())
+			Expect(again.Spec.Template.Annotations[restartAnnotation]).To(Equal(firstTS))
+		})
+	})
 })
+
+func newSveltosDeployment(name, namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "podinfo"},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/management_controller_test.go
+++ b/internal/controller/management_controller_test.go
@@ -537,10 +537,10 @@ var _ = Describe("Management Controller", func() {
 		})
 
 		It("skips when drift-detection-manager already exists", func() {
-			driftDetector := newSveltosDeployment(driftDetectionName, sveltosNS)
+			driftDetector := newSveltosDeployment(driftDetectionName)
 			Expect(k8sClient.Create(ctx, driftDetector)).To(Succeed())
 
-			addonController := newSveltosDeployment(addonControllerName, sveltosNS)
+			addonController := newSveltosDeployment(addonControllerName)
 			Expect(k8sClient.Create(ctx, addonController)).To(Succeed())
 
 			r := &ManagementReconciler{Client: k8sClient}
@@ -554,7 +554,7 @@ var _ = Describe("Management Controller", func() {
 		})
 
 		It("requeues without patching when mgmt/mgmt SveltosCluster is missing", func() {
-			addonController := newSveltosDeployment(addonControllerName, sveltosNS)
+			addonController := newSveltosDeployment(addonControllerName)
 			Expect(k8sClient.Create(ctx, addonController)).To(Succeed())
 
 			r := &ManagementReconciler{Client: k8sClient}
@@ -568,7 +568,7 @@ var _ = Describe("Management Controller", func() {
 		})
 
 		It("patches addon-controller with restart annotation when SveltosCluster exists", func() {
-			addonController := newSveltosDeployment(addonControllerName, sveltosNS)
+			addonController := newSveltosDeployment(addonControllerName)
 			Expect(k8sClient.Create(ctx, addonController)).To(Succeed())
 
 			Expect(k8sClient.Create(ctx, &libsveltosv1beta1.SveltosCluster{
@@ -598,11 +598,12 @@ var _ = Describe("Management Controller", func() {
 	})
 })
 
-func newSveltosDeployment(name, namespace string) *appsv1.Deployment {
+func newSveltosDeployment(name string) *appsv1.Deployment {
+	const sveltosNS = "projectsveltos"
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: sveltosNS,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where the drift detection manager is deployed after an upgrade OR after a fresh install when the addon controller (sveltos) is restarted. As a temporary measure, this PR ensures it's installed for all cases. Once issue https://github.com/projectsveltos/addon-controller/issues/1742 is resolved this PR can be reverted.
