### PR TITLE
fix: too many files open error in kind cluster while testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,10 @@ kind-deploy: kind ## Create a kind cluster if it does not exist.
 			$(KIND) create cluster -n $(KIND_CLUSTER_NAME) --config "$(KIND_CONFIG_PATH)"; \
 		else \
 			$(KIND) create cluster -n $(KIND_CLUSTER_NAME); \
-		fi \
+		fi; \
+		$(CONTAINER_TOOL) exec $(KIND_CLUSTER_NAME)-control-plane bash -c "echo 'fs.inotify.max_user_watches=524288' >> /etc/sysctl.conf"; \
+    $(CONTAINER_TOOL) exec $(KIND_CLUSTER_NAME)-control-plane bash -c "echo 'fs.inotify.max_user_instances=512' >> /etc/sysctl.conf"; \
+    $(CONTAINER_TOOL) exec $(KIND_CLUSTER_NAME)-control-plane sysctl -p /etc/sysctl.conf; \
 	fi
 
 .PHONY: kind-undeploy

--- a/Makefile
+++ b/Makefile
@@ -366,9 +366,10 @@ kind-deploy: kind ## Create a kind cluster if it does not exist.
 		else \
 			$(KIND) create cluster -n $(KIND_CLUSTER_NAME); \
 		fi; \
-		$(CONTAINER_TOOL) exec $(KIND_CLUSTER_NAME)-control-plane bash -c "echo 'fs.inotify.max_user_watches=524288' >> /etc/sysctl.conf"; \
-    $(CONTAINER_TOOL) exec $(KIND_CLUSTER_NAME)-control-plane bash -c "echo 'fs.inotify.max_user_instances=512' >> /etc/sysctl.conf"; \
-    $(CONTAINER_TOOL) exec $(KIND_CLUSTER_NAME)-control-plane sysctl -p /etc/sysctl.conf; \
+		$(CONTAINER_TOOL) exec "$(KIND_CLUSTER_NAME)-control-plane" bash -ec \
+			"echo 'fs.inotify.max_user_watches=524288' >> /etc/sysctl.conf; \
+			 echo 'fs.inotify.max_user_instances=512' >> /etc/sysctl.conf; \
+			 sysctl -p /etc/sysctl.conf"; \
 	fi
 
 .PHONY: kind-undeploy


### PR DESCRIPTION
# Description

Sometimes when running `make test-e2e` locally, k0rdent doesn't install completely because it keeps waiting for one or more components to be deployed. In my case, it was CAPD:
```
  NotAllComponentsHealthy: Components not ready: [cluster-api-provider-docker]
```

Looking at the CAPD pod logs, I could see the following error:
```
  E0430 20:07:08.417077       1 main.go:324] "Problem running manager" err="too many open files" logger="setup"
```

Which turned out to be a [known issue in kind](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files). This PR applies that fix. 