### PR TITLE
feat: support topology spread constraints in kcm chart

### DIFF
--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -125,6 +125,9 @@ spec:
       {{- with .Values.controller.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "kcm.fullname" . }}-controller-manager

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -169,6 +169,10 @@
           "description": "Tolerations to allow the pod to schedule on tainted nodes",
           "type": "array"
         },
+        "topologySpreadConstraints": {
+          "description": "Topology spread constraints for pod scheduling",
+          "type": "array"
+        },
         "validateClusterUpgradePath": {
           "description": "Specifies whether the ClusterDeployment upgrade path should be validated",
           "type": "boolean"

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -27,6 +27,7 @@ controller:
   nodeSelector: {} # @schema type: object; description: Node selector to constrain the pod to run on specific nodes
   affinity: {} # @schema type: object; description: Affinity rules for pod scheduling
   tolerations: [] # @schema type: array; description: Tolerations to allow the pod to schedule on tainted nodes
+  topologySpreadConstraints: [] # @schema type: array; description: Topology spread constraints for pod scheduling
   validateClusterUpgradePath: true # @schema type: boolean; description: Specifies whether the ClusterDeployment upgrade path should be validated
   enableSveltosCtrl: true # @schema type: boolean; description: Enables built-in ServiceSet controller to reconcile ProjectSveltos objects
   enableSveltosExpiredCtrl: false # @schema type: boolean; description: Enables SveltosCluster controller, updating stuck (expired) sveltos management cluster kubeconfig tokens


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for configuring `topologySpreadConstraints` for the KCM controller pod through the Helm chart.

Changes included:
- Adds `controller.topologySpreadConstraints` to `templates/provider/kcm/values.yaml` with an empty list default.
- Adds the value to `templates/provider/kcm/values.schema.json` so chart values validation accepts it.
- Renders `controller.topologySpreadConstraints` into the controller manager Deployment pod spec when configured.

This lets operators spread KCM controller replicas across zones, nodes, or other topology domains using native Kubernetes scheduling constraints.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:

N/A

**Testing**:

- `helm lint templates/provider/kcm`
