### PR TITLE
fix: sequential upgrades pick dead-end branches

### DIFF
--- a/api/v1beta1/templatechain_common.go
+++ b/api/v1beta1/templatechain_common.go
@@ -131,13 +131,8 @@ func (s *TemplateChainSpec) findAllUpgradePaths(templateName string) ([][]Availa
 
 		// Iterate through available upgrades and find subsequent available upgrades
 		for _, upgrade := range template.AvailableUpgrades {
-			if !slices.ContainsFunc(path, func(upgrade AvailableUpgrade) bool {
-				for _, u := range path {
-					if u.Name == upgrade.Name && u.Version == upgrade.Version {
-						return true
-					}
-				}
-				return false
+			if !slices.ContainsFunc(path, func(u AvailableUpgrade) bool {
+				return u.Name == upgrade.Name && u.Version == upgrade.Version
 			}) {
 				upgradePath := make([]AvailableUpgrade, len(path)+1)
 				copy(upgradePath, path)

--- a/api/v1beta1/templatechain_common_test.go
+++ b/api/v1beta1/templatechain_common_test.go
@@ -113,10 +113,10 @@ func TestTemplateChainSpec_TemplateUpgradePath(t *testing.T) {
 					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}},
 				},
 				{
-					Versions: []AvailableUpgrade{{Name: "foo-0-3-0", Version: "0.3.0"}},
+					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}, {Name: "foo-0-3-0", Version: "0.3.0"}},
 				},
 				{
-					Versions: []AvailableUpgrade{{Name: "foo-0-4-0", Version: "0.4.0"}},
+					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}, {Name: "foo-0-3-0", Version: "0.3.0"}, {Name: "foo-0-4-0", Version: "0.4.0"}},
 				},
 			},
 		},
@@ -159,10 +159,13 @@ func TestTemplateChainSpec_TemplateUpgradePath(t *testing.T) {
 					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}},
 				},
 				{
-					Versions: []AvailableUpgrade{{Name: "foo-0-3-0", Version: "0.3.0"}},
+					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}, {Name: "foo-0-3-0", Version: "0.3.0"}},
 				},
 				{
-					Versions: []AvailableUpgrade{{Name: "foo-0-4-0", Version: "0.4.0"}},
+					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}, {Name: "foo-0-3-0", Version: "0.3.0"}, {Name: "foo-0-4-0", Version: "0.4.0"}},
+				},
+				{
+					Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "0.2.0"}, {Name: "foo-0-3-0", Version: "0.3.0"}, {Name: "foo-0-4-0", Version: "0.4.0"}, {Name: "foo-1-0-0", Version: "1.0.0"}},
 				},
 			},
 		},
@@ -205,7 +208,7 @@ func TestTemplateChainSpec_TemplateUpgradePath(t *testing.T) {
 			templateName: "foo-0-1-0",
 			expectedUpgradePath: []UpgradePath{
 				{Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "foo-0-2-0"}}},
-				{Versions: []AvailableUpgrade{{Name: "foo-0-3-0", Version: "foo-0-3-0"}}},
+				{Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "foo-0-2-0"}, {Name: "foo-0-3-0", Version: "foo-0-3-0"}}},
 			},
 		},
 		"upgrade-path-4": {
@@ -245,6 +248,9 @@ func TestTemplateChainSpec_TemplateUpgradePath(t *testing.T) {
 			expectedUpgradePath: []UpgradePath{
 				{
 					Versions: []AvailableUpgrade{{Name: "foo-0-4-0", Version: "0.4.0"}},
+				},
+				{
+					Versions: []AvailableUpgrade{{Name: "foo-0-4-0", Version: "0.4.0"}, {Name: "foo-1-0-0", Version: "1.0.0"}},
 				},
 			},
 		},

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -481,7 +481,6 @@ func appendIfNotPresent(
 // service that falls within [currentVersion, desiredVersion]. Returns a zero-value
 // AvailableUpgrade if no matching step is found in upgradePaths.
 func minimumUpgradeStep(upgradePaths []kcmv1.ServiceUpgradePaths, name, currentVersion, desiredVersion string) kcmv1.AvailableUpgrade {
-
 	current, err := semver.NewVersion(currentVersion)
 	if err != nil {
 		return kcmv1.AvailableUpgrade{}
@@ -525,7 +524,6 @@ func minimumUpgradeStep(upgradePaths []kcmv1.ServiceUpgradePaths, name, currentV
 		}
 
 		for _, upgrade := range path.AvailableUpgrades {
-
 			var hasMin bool
 			var maxInPath *semver.Version
 			var candidate kcmv1.AvailableUpgrade

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -478,9 +478,10 @@ func appendIfNotPresent(
 }
 
 // minimumUpgradeStep returns the smallest available upgrade version for the named
-// service that falls within [currentVersion, desiredVersion]. Returns a zero-value
-// AvailableUpgrade if no matching step is found in upgradePaths.
-func minimumUpgradeStep(upgradePaths []kcmv1.ServiceUpgradePaths, name, currentVersion, desiredVersion string) kcmv1.AvailableUpgrade {
+// service that falls within (currentVersion, desiredVersion]. Only upgrade paths
+// that actually contain the desired version are considered, avoiding dead-end branches.
+// Returns a zero-value AvailableUpgrade if no matching step is found in upgradePaths.
+func minimumUpgradeStep(upgradePaths []kcmv1.ServiceUpgradePaths, name, namespace, currentVersion, desiredVersion string) kcmv1.AvailableUpgrade {
 	current, err := semver.NewVersion(currentVersion)
 	if err != nil {
 		return kcmv1.AvailableUpgrade{}
@@ -490,64 +491,32 @@ func minimumUpgradeStep(upgradePaths []kcmv1.ServiceUpgradePaths, name, currentV
 		return kcmv1.AvailableUpgrade{}
 	}
 
-	var minNext *semver.Version
+	var best kcmv1.AvailableUpgrade
+	var bestNext *semver.Version
 
 	for _, path := range upgradePaths {
-		if path.Name != name {
+		if path.Name != name || effectiveNamespace(path.Namespace) != effectiveNamespace(namespace) {
 			continue
 		}
 		for _, upgrade := range path.AvailableUpgrades {
+			// Only consider upgrade paths that can actually reach the desired version.
+			if !slices.ContainsFunc(upgrade.Versions, func(u kcmv1.AvailableUpgrade) bool {
+				v, err := semver.NewVersion(u.Version)
+				return err == nil && v.Equal(desired)
+			}) {
+				continue
+			}
+
 			for _, u := range upgrade.Versions {
 				v, err := semver.NewVersion(u.Version)
 				if err != nil {
 					continue
 				}
 				if v.Compare(current) > 0 && v.Compare(desired) <= 0 {
-					if minNext == nil || v.Compare(minNext) < 0 {
-						minNext = v
+					if bestNext == nil || v.Compare(bestNext) < 0 {
+						best = u
+						bestNext = v
 					}
-				}
-			}
-		}
-	}
-
-	if minNext == nil {
-		return kcmv1.AvailableUpgrade{}
-	}
-
-	var best kcmv1.AvailableUpgrade
-	var bestMax *semver.Version
-
-	for _, path := range upgradePaths {
-		if path.Name != name {
-			continue
-		}
-
-		for _, upgrade := range path.AvailableUpgrades {
-			var hasMin bool
-			var maxInPath *semver.Version
-			var candidate kcmv1.AvailableUpgrade
-
-			for _, u := range upgrade.Versions {
-				v, err := semver.NewVersion(u.Version)
-				if err != nil {
-					continue
-				}
-
-				if maxInPath == nil || v.Compare(maxInPath) > 0 {
-					maxInPath = v
-				}
-
-				if v.Equal(minNext) {
-					hasMin = true
-					candidate = u
-				}
-			}
-
-			if hasMin {
-				if bestMax == nil || maxInPath.Compare(bestMax) > 0 {
-					best = candidate
-					bestMax = maxInPath
 				}
 			}
 		}
@@ -660,7 +629,7 @@ func ServicesToDeploy(
 
 		// find the minimum valid upgrade step towards the desired version
 		currentVersion := deployedVersions[key]
-		minimumUpgrade := minimumUpgradeStep(upgradePaths, s.Name, currentVersion, desiredVersion)
+		minimumUpgrade := minimumUpgradeStep(upgradePaths, s.Name, s.Namespace, currentVersion, desiredVersion)
 		if minimumUpgrade.Version == "" {
 			minimumUpgrade = kcmv1.AvailableUpgrade{
 				Name:    desiredTemplate,

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -481,6 +481,7 @@ func appendIfNotPresent(
 // service that falls within [currentVersion, desiredVersion]. Returns a zero-value
 // AvailableUpgrade if no matching step is found in upgradePaths.
 func minimumUpgradeStep(upgradePaths []kcmv1.ServiceUpgradePaths, name, currentVersion, desiredVersion string) kcmv1.AvailableUpgrade {
+
 	current, err := semver.NewVersion(currentVersion)
 	if err != nil {
 		return kcmv1.AvailableUpgrade{}
@@ -490,8 +491,7 @@ func minimumUpgradeStep(upgradePaths []kcmv1.ServiceUpgradePaths, name, currentV
 		return kcmv1.AvailableUpgrade{}
 	}
 
-	var result kcmv1.AvailableUpgrade
-	var resultSV *semver.Version
+	var minNext *semver.Version
 
 	for _, path := range upgradePaths {
 		if path.Name != name {
@@ -503,16 +503,59 @@ func minimumUpgradeStep(upgradePaths []kcmv1.ServiceUpgradePaths, name, currentV
 				if err != nil {
 					continue
 				}
-				if v.Compare(current) >= 0 && v.Compare(desired) <= 0 {
-					if resultSV == nil || v.Compare(resultSV) < 0 {
-						result = u
-						resultSV = v
+				if v.Compare(current) > 0 && v.Compare(desired) <= 0 {
+					if minNext == nil || v.Compare(minNext) < 0 {
+						minNext = v
 					}
 				}
 			}
 		}
 	}
-	return result
+
+	if minNext == nil {
+		return kcmv1.AvailableUpgrade{}
+	}
+
+	var best kcmv1.AvailableUpgrade
+	var bestMax *semver.Version
+
+	for _, path := range upgradePaths {
+		if path.Name != name {
+			continue
+		}
+
+		for _, upgrade := range path.AvailableUpgrades {
+
+			var hasMin bool
+			var maxInPath *semver.Version
+			var candidate kcmv1.AvailableUpgrade
+
+			for _, u := range upgrade.Versions {
+				v, err := semver.NewVersion(u.Version)
+				if err != nil {
+					continue
+				}
+
+				if maxInPath == nil || v.Compare(maxInPath) > 0 {
+					maxInPath = v
+				}
+
+				if v.Equal(minNext) {
+					hasMin = true
+					candidate = u
+				}
+			}
+
+			if hasMin {
+				if bestMax == nil || maxInPath.Compare(bestMax) > 0 {
+					best = candidate
+					bestMax = maxInPath
+				}
+			}
+		}
+	}
+
+	return best
 }
 
 // ServicesToDeploy computes the target ServiceWithValues for each service in

--- a/internal/serviceset/util_test.go
+++ b/internal/serviceset/util_test.go
@@ -35,75 +35,118 @@ import (
 const testSystemNamespace = "test-system-ns"
 
 func TestMinimumUpgradeStep(t *testing.T) {
-	tests := []struct {
-		name            string
-		current         string
-		desired         string
-		expectedVersion string
-	}{
-		{
-			name:            "sequential upgrade enforced (dead branch fix)",
-			current:         "4.11.3",
-			desired:         "4.12.3",
-			expectedVersion: "4.11.5",
-		},
-		{
-			name:            "direct upgrade when no intermediate exists",
-			current:         "4.11.5",
-			desired:         "4.12.3",
-			expectedVersion: "4.12.3",
-		},
-		{
-			name:            "no valid upgrade",
-			current:         "4.12.3",
-			desired:         "4.11.3",
-			expectedVersion: "",
-		},
-	}
+	t.Parallel()
 
-	upgradePaths := []kcmv1.ServiceUpgradePaths{
+	// Shared upgrade paths: ingress-nginx with a two-hop path 4.11.5 → 4.12.3
+	// and a single-hop path directly to each version.
+	ingressUpgradePaths := []kcmv1.ServiceUpgradePaths{
 		{
 			Name: "ingress-nginx",
 			AvailableUpgrades: []kcmv1.UpgradePath{
 				{
 					Versions: []kcmv1.AvailableUpgrade{
-						{Version: "4.11.5"},
+						{Name: "ingress-nginx-4-11-5", Version: "4.11.5"},
 					},
 				},
 				{
 					Versions: []kcmv1.AvailableUpgrade{
-						{Version: "4.12.3"},
+						{Name: "ingress-nginx-4-12-3", Version: "4.12.3"},
 					},
 				},
 				{
 					Versions: []kcmv1.AvailableUpgrade{
-						{Version: "4.11.5"},
-						{Version: "4.12.3"},
+						{Name: "ingress-nginx-4-11-5", Version: "4.11.5"},
+						{Name: "ingress-nginx-4-12-3", Version: "4.12.3"},
 					},
 				},
 			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := minimumUpgradeStep(
-				upgradePaths,
-				"ingress-nginx",
-				tt.current,
-				tt.desired,
-			)
+	tests := map[string]struct {
+		upgradePaths    []kcmv1.ServiceUpgradePaths
+		name            string
+		namespace       string
+		current         string
+		desired         string
+		expectedVersion string
+		expectedName    string
+	}{
+		"sequential upgrade enforced (dead branch fix)": {
+			upgradePaths:    ingressUpgradePaths,
+			name:            "ingress-nginx",
+			current:         "4.11.3",
+			desired:         "4.12.3",
+			expectedVersion: "4.11.5",
+			expectedName:    "ingress-nginx-4-11-5",
+		},
+		"direct upgrade when no intermediate exists": {
+			upgradePaths:    ingressUpgradePaths,
+			name:            "ingress-nginx",
+			current:         "4.11.5",
+			desired:         "4.12.3",
+			expectedVersion: "4.12.3",
+			expectedName:    "ingress-nginx-4-12-3",
+		},
+		"no valid upgrade": {
+			upgradePaths: ingressUpgradePaths,
+			name:         "ingress-nginx",
+			current:      "4.12.3",
+			desired:      "4.11.3",
+		},
+		// #2613: smallest candidate (2.0.0) is on a dead-end branch with no path
+		// to the desired version (3.0.0); the function must skip it and pick 3.0.0.
+		"dead-end branch avoided when no cross-branch path exists": {
+			upgradePaths: []kcmv1.ServiceUpgradePaths{
+				{
+					Name: "my-app",
+					AvailableUpgrades: []kcmv1.UpgradePath{
+						{
+							Versions: []kcmv1.AvailableUpgrade{
+								{Name: "my-app-2-0-0", Version: "2.0.0"},
+							},
+						},
+						{
+							Versions: []kcmv1.AvailableUpgrade{
+								{Name: "my-app-3-0-0", Version: "3.0.0"},
+							},
+						},
+					},
+				},
+			},
+			name:            "my-app",
+			current:         "1.0.0",
+			desired:         "3.0.0",
+			expectedVersion: "3.0.0",
+			expectedName:    "my-app-3-0-0",
+		},
+		"namespace mismatch returns no upgrade": {
+			upgradePaths: []kcmv1.ServiceUpgradePaths{
+				{
+					Name:      "my-app",
+					Namespace: "team-a",
+					AvailableUpgrades: []kcmv1.UpgradePath{
+						{
+							Versions: []kcmv1.AvailableUpgrade{
+								{Name: "my-app-2-0-0", Version: "2.0.0"},
+							},
+						},
+					},
+				},
+			},
+			name:      "my-app",
+			namespace: "team-b",
+			current:   "1.0.0",
+			desired:   "2.0.0",
+		},
+	}
 
-			if tt.expectedVersion == "" {
-				if result.Version != "" {
-					t.Fatalf("expected no upgrade, got %s", result.Version)
-				}
-				return
-			}
-
-			if result.Version != tt.expectedVersion {
-				t.Fatalf("expected %s, got %s", tt.expectedVersion, result.Version)
-			}
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			result := minimumUpgradeStep(tt.upgradePaths, tt.name, tt.namespace, tt.current, tt.desired)
+			require.Equal(t, tt.expectedVersion, result.Version)
+			require.Equal(t, tt.expectedName, result.Name)
 		})
 	}
 }

--- a/internal/serviceset/util_test.go
+++ b/internal/serviceset/util_test.go
@@ -34,6 +34,80 @@ import (
 
 const testSystemNamespace = "test-system-ns"
 
+func TestMinimumUpgradeStep(t *testing.T) {
+	tests := []struct {
+		name            string
+		current         string
+		desired         string
+		expectedVersion string
+	}{
+		{
+			name:            "sequential upgrade enforced (dead branch fix)",
+			current:         "4.11.3",
+			desired:         "4.12.3",
+			expectedVersion: "4.11.5",
+		},
+		{
+			name:            "direct upgrade when no intermediate exists",
+			current:         "4.11.5",
+			desired:         "4.12.3",
+			expectedVersion: "4.12.3",
+		},
+		{
+			name:            "no valid upgrade",
+			current:         "4.12.3",
+			desired:         "4.11.3",
+			expectedVersion: "",
+		},
+	}
+
+	upgradePaths := []kcmv1.ServiceUpgradePaths{
+		{
+			Name: "ingress-nginx",
+			AvailableUpgrades: []kcmv1.UpgradePath{
+				{
+					Versions: []kcmv1.AvailableUpgrade{
+						{Version: "4.11.5"},
+					},
+				},
+				{
+					Versions: []kcmv1.AvailableUpgrade{
+						{Version: "4.12.3"},
+					},
+				},
+				{
+					Versions: []kcmv1.AvailableUpgrade{
+						{Version: "4.11.5"},
+						{Version: "4.12.3"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := minimumUpgradeStep(
+				upgradePaths,
+				"ingress-nginx",
+				tt.current,
+				tt.desired,
+			)
+
+			if tt.expectedVersion == "" {
+				if result.Version != "" {
+					t.Fatalf("expected no upgrade, got %s", result.Version)
+				}
+				return
+			}
+
+			if result.Version != tt.expectedVersion {
+				t.Fatalf("expected %s, got %s", tt.expectedVersion, result.Version)
+			}
+		})
+	}
+}
+
 func Test_ServicesToDeploy(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -112,8 +112,39 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 			},
 		})
 
-		for i, v := range nginxVersions {
-			name := fmt.Sprintf("%s-%s", nginxChartName, strings.ReplaceAll(v, ".", "-"))
+		supportedTemplates = make([]kcmv1.SupportedTemplate, 0, len(nginxVersions))
+
+		for i := range nginxVersions {
+			name := fmt.Sprintf("%s-%s", nginxChartName, strings.ReplaceAll(nginxVersions[i], ".", "-"))
+
+			st := kcmv1.SupportedTemplate{
+				Name: name,
+			}
+
+			if i == len(nginxVersions)-1 {
+				supportedTemplates = append(supportedTemplates, st)
+				continue
+			}
+
+			nextName := fmt.Sprintf("%s-%s", nginxChartName, strings.ReplaceAll(nginxVersions[i+1], ".", "-"))
+			st.AvailableUpgrades = append(st.AvailableUpgrades, kcmv1.AvailableUpgrade{
+				Name:    nextName,
+				Version: nginxVersions[i+1],
+			})
+
+			if i == 0 && len(nginxVersions) > 2 {
+				skipName := fmt.Sprintf("%s-%s", nginxChartName, strings.ReplaceAll(nginxVersions[i+2], ".", "-"))
+				st.AvailableUpgrades = append(st.AvailableUpgrades, kcmv1.AvailableUpgrade{
+					Name:    skipName,
+					Version: nginxVersions[i+2],
+				})
+			}
+
+			supportedTemplates = append(supportedTemplates, st)
+		}
+
+		for _, v := range nginxVersions {
+			//name := fmt.Sprintf("%s-%s", nginxChartName, strings.ReplaceAll(v, ".", "-"))
 			serviceTemplateSpecs = append(serviceTemplateSpecs, kcmv1.ServiceTemplateSpec{
 				Helm: &kcmv1.HelmSpec{
 					ChartSpec: &sourcev1.HelmChartSpec{
@@ -125,20 +156,6 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 						Version: v,
 					},
 				},
-			})
-
-			var upgrades []kcmv1.AvailableUpgrade
-			for j := i + 1; j < len(nginxVersions); j++ {
-				nv := nginxVersions[j]
-				upgrades = append(upgrades, kcmv1.AvailableUpgrade{
-					Name:    fmt.Sprintf("%s-%s", nginxChartName, strings.ReplaceAll(nv, ".", "-")),
-					Version: nv,
-				})
-			}
-
-			supportedTemplates = append(supportedTemplates, kcmv1.SupportedTemplate{
-				Name:              name,
-				AvailableUpgrades: upgrades,
 			})
 		}
 

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -144,7 +144,6 @@ var _ = Describe("Functional e2e tests", Label("provider:cloud", "provider:docke
 		}
 
 		for _, v := range nginxVersions {
-			//name := fmt.Sprintf("%s-%s", nginxChartName, strings.ReplaceAll(v, ".", "-"))
 			serviceTemplateSpecs = append(serviceTemplateSpecs, kcmv1.ServiceTemplateSpec{
 				Helm: &kcmv1.HelmSpec{
 					ChartSpec: &sourcev1.HelmChartSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where a sequential upgrade will end up not picking the latest version to upgrade to in the case where there are multiple branches of upgrades.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2613