### PR TITLE
fix(cld): infra-internal readiness via Sveltos dep

### DIFF
--- a/api/v1beta1/providerinterface_types.go
+++ b/api/v1beta1/providerinterface_types.go
@@ -24,6 +24,9 @@ const (
 
 	// InfrastructureProviderPrefix is the prefix used for infrastructure provider names
 	InfrastructureProviderPrefix = "infrastructure-"
+
+	// InternalInfrastructureProvider is the full provider name for internal infrastructure.
+	InternalInfrastructureProvider = InfrastructureProviderPrefix + "internal"
 )
 
 // GroupVersionKind unambiguously identifies a kind. It doesn't anonymously include GroupVersion

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -1668,7 +1668,7 @@ func getRegionalClient(ctx context.Context, cl client.Client, serviceSet *kcmv1.
 		return nil, fmt.Errorf("failed to get %s Credential: %w", credKey, err)
 	}
 
-	rgnClient, err := kubeutil.GetRegionalClientByRegionName(ctx, cl, systemNamespace, cred.Spec.Region, schemeutil.GetRegionalSchemeWithSveltos)
+	rgnClient, err := kubeutil.GetRegionalClientByRegionName(ctx, cl, systemNamespace, cred.Spec.Region, schemeutil.GetRegionalScheme)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get regional client: %w", err)
 	}

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package controller implements Kubernetes reconcilers for KCM resources.
 package controller
 
 import (
@@ -27,6 +28,7 @@ import (
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	fluxconditions "github.com/fluxcd/pkg/runtime/conditions"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"golang.org/x/sync/errgroup"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -370,7 +372,8 @@ func (r *ClusterDeploymentReconciler) updateCluster(
 	l := ctrl.LoggerFrom(ctx)
 
 	cd := scope.cd
-	r.initClusterConditions(cd)
+	observeCAPI, observeSveltos := r.getRuntimeReadinessTargets(clusterTpl)
+	r.initClusterConditions(cd, observeCAPI, observeSveltos)
 
 	if !clusterTpl.Status.Valid {
 		return r.setInvalidTemplateCondition(ctx, clusterTpl, cd)
@@ -480,12 +483,8 @@ func (r *ClusterDeploymentReconciler) updateCluster(
 		}
 	}
 
-	requeue, err := r.aggregateCapiConditions(ctx, scope)
+	requeue, err := r.aggregateRuntimeConditions(ctx, scope, observeCAPI, observeSveltos)
 	if err != nil {
-		if requeue {
-			return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, err
-		}
-
 		return ctrl.Result{}, err
 	}
 
@@ -1056,7 +1055,7 @@ func (r *ClusterDeploymentReconciler) validateConfig(ctx context.Context, cd *kc
 	return nil
 }
 
-func (*ClusterDeploymentReconciler) initClusterConditions(cd *kcmv1.ClusterDeployment) (changed bool) {
+func (*ClusterDeploymentReconciler) initClusterConditions(cd *kcmv1.ClusterDeployment, observeCAPI, observeSveltos bool) (changed bool) {
 	// NOTE: do not put here the PredeclaredSecretsExistCondition since it won't be set if no secrets have been set
 	for _, typ := range [5]string{
 		kcmv1.CredentialReadyCondition,
@@ -1084,7 +1083,197 @@ func (*ClusterDeploymentReconciler) initClusterConditions(cd *kcmv1.ClusterDeplo
 			changed = true
 		}
 	}
+
+	setRuntimeCondition := func(observe bool, condType, waitingMessage string) {
+		if observe {
+			if apimeta.FindStatusCondition(cd.Status.Conditions, condType) == nil {
+				if apimeta.SetStatusCondition(&cd.Status.Conditions, metav1.Condition{
+					Type:               condType,
+					Status:             metav1.ConditionUnknown,
+					Reason:             kcmv1.ProgressingReason,
+					Message:            waitingMessage,
+					ObservedGeneration: cd.Generation,
+				}) {
+					changed = true
+				}
+			}
+
+			return
+		}
+
+		if apimeta.RemoveStatusCondition(&cd.Status.Conditions, condType) {
+			changed = true
+		}
+	}
+
+	setRuntimeCondition(observeCAPI, kcmv1.CAPIClusterSummaryCondition, "Waiting for CAPI cluster status")
+	setRuntimeCondition(observeSveltos, kcmv1.SveltosClusterReadyCondition, "Waiting for SveltosCluster status")
+
 	return changed
+}
+
+func (*ClusterDeploymentReconciler) getRuntimeReadinessTargets(clusterTpl *kcmv1.ClusterTemplate) (observeCAPI, observeSveltos bool) {
+	if clusterTpl == nil {
+		return true, false
+	}
+
+	var hasInfrastructureProvider bool
+	for _, provider := range clusterTpl.Status.Providers {
+		if !strings.HasPrefix(provider, kcmv1.InfrastructureProviderPrefix) {
+			continue
+		}
+
+		hasInfrastructureProvider = true
+		if provider == kcmv1.InternalInfrastructureProvider {
+			observeSveltos = true
+			if observeCAPI {
+				break
+			}
+			continue
+		}
+
+		observeCAPI = true
+		if observeSveltos {
+			break
+		}
+	}
+
+	// keep the existing CAPI-based behavior when providers are not discovered yet
+	if !hasInfrastructureProvider {
+		observeCAPI = true
+	}
+
+	return observeCAPI, observeSveltos
+}
+
+func (r *ClusterDeploymentReconciler) aggregateRuntimeConditions(ctx context.Context, scope *clusterScope, observeCAPI, observeSveltos bool) (requeue bool, err error) { //nolint:revive // these are control flags, we cannot avoid them
+	if observeCAPI {
+		capiRequeue, capiErr := r.aggregateCapiConditions(ctx, scope)
+		if capiErr != nil {
+			err = errors.Join(err, capiErr)
+		} else {
+			requeue = requeue || capiRequeue
+		}
+	}
+
+	if observeSveltos {
+		sveltosRequeue, sveltosErr := r.aggregateSveltosConditions(ctx, scope)
+		if sveltosErr != nil {
+			err = errors.Join(err, sveltosErr)
+		} else {
+			requeue = requeue || sveltosRequeue
+		}
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return requeue, nil
+}
+
+func (*ClusterDeploymentReconciler) aggregateSveltosConditions(ctx context.Context, scope *clusterScope) (requeue bool, _ error) {
+	cd := scope.cd
+	conditions := cd.GetConditions()
+
+	sveltosCluster := &libsveltosv1beta1.SveltosCluster{}
+	clusterKey := client.ObjectKeyFromObject(cd)
+
+	if err := scope.rgnClient.Get(ctx, clusterKey, sveltosCluster); err != nil {
+		if !apierrors.IsNotFound(err) {
+			cond := metav1.Condition{
+				Type:               kcmv1.SveltosClusterReadyCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             kcmv1.FailedReason,
+				ObservedGeneration: cd.Generation,
+				Message:            err.Error(),
+			}
+
+			apimeta.SetStatusCondition(conditions, cond)
+
+			return false, fmt.Errorf("failed to get SveltosCluster %s: %w", clusterKey, err)
+		}
+
+		cond := metav1.Condition{
+			Type:               kcmv1.SveltosClusterReadyCondition,
+			Status:             metav1.ConditionUnknown,
+			Reason:             kcmv1.ProgressingReason,
+			ObservedGeneration: cd.Generation,
+			Message:            fmt.Sprintf("Waiting for SveltosCluster %s", clusterKey),
+		}
+
+		apimeta.SetStatusCondition(conditions, cond)
+
+		return true, nil
+	}
+
+	cond := metav1.Condition{
+		Type:               kcmv1.SveltosClusterReadyCondition,
+		ObservedGeneration: cd.Generation,
+	}
+
+	if sveltosCluster.Status.Ready {
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = kcmv1.SucceededReason
+		cond.Message = "SveltosCluster is ready"
+
+		apimeta.SetStatusCondition(conditions, cond)
+
+		return false, nil
+	}
+
+	if sveltosCluster.Status.ConnectionStatus == libsveltosv1beta1.ConnectionDown {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = kcmv1.FailedReason
+		cond.Message = "SveltosCluster connection is down"
+		if sveltosCluster.Status.FailureMessage != nil && *sveltosCluster.Status.FailureMessage != "" {
+			cond.Message = *sveltosCluster.Status.FailureMessage
+		}
+
+		apimeta.SetStatusCondition(conditions, cond)
+
+		return true, nil
+	}
+
+	if sveltosCluster.Status.FailureMessage != nil && *sveltosCluster.Status.FailureMessage != "" {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = kcmv1.FailedReason
+		cond.Message = *sveltosCluster.Status.FailureMessage
+
+		apimeta.SetStatusCondition(conditions, cond)
+
+		return true, nil
+	}
+
+	cond.Status = metav1.ConditionUnknown
+	cond.Reason = kcmv1.ProgressingReason
+	cond.Message = "SveltosCluster is not ready yet"
+
+	apimeta.SetStatusCondition(conditions, cond)
+
+	return true, nil
+}
+
+func (*ClusterDeploymentReconciler) sveltosReadinessStatusChanged(oldStatus, newStatus libsveltosv1beta1.SveltosClusterStatus) bool {
+	if oldStatus.Ready != newStatus.Ready {
+		return true
+	}
+
+	if oldStatus.ConnectionStatus != newStatus.ConnectionStatus {
+		return true
+	}
+
+	oldFailureMessage := ""
+	if oldStatus.FailureMessage != nil {
+		oldFailureMessage = *oldStatus.FailureMessage
+	}
+
+	newFailureMessage := ""
+	if newStatus.FailureMessage != nil {
+		newFailureMessage = *newStatus.FailureMessage
+	}
+
+	return oldFailureMessage != newFailureMessage
 }
 
 func (r *ClusterDeploymentReconciler) aggregateCapiConditions(ctx context.Context, scope *clusterScope) (requeue bool, _ error) {
@@ -1138,7 +1327,8 @@ func (r *ClusterDeploymentReconciler) aggregateCapiConditions(ctx context.Contex
 			Message:            err.Error(),
 		}
 		apimeta.SetStatusCondition(conditions, *capiCondition)
-		return true, fmt.Errorf("failed to get condition summary from Cluster %s: %w", client.ObjectKeyFromObject(cluster), err)
+
+		return false, err // already wrapped
 	}
 
 	if apimeta.SetStatusCondition(conditions, *capiCondition) {
@@ -1314,7 +1504,8 @@ func handleClusterDeploymentFailedConditions(cond metav1.Condition) (errMsg, war
 		kcmv1.TemplateReadyCondition,
 		kcmv1.DataSourceReadyCondition,
 		kcmv1.ClusterDataSourceReadyCondition,
-		kcmv1.ClusterAuthenticationReadyCondition:
+		kcmv1.ClusterAuthenticationReadyCondition,
+		kcmv1.SveltosClusterReadyCondition:
 
 		errMsg = cond.Message
 
@@ -2030,7 +2221,7 @@ func (*ClusterDeploymentReconciler) warnf(cd *kcmv1.ClusterDeployment, reason, m
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error { //nolint:maintidx // watcher wiring is intentionally centralized
 	r.MgmtClient = mgr.GetClient()
 	r.helmActor = helm.NewActor(mgr.GetConfig(), r.MgmtClient.RESTMapper())
 
@@ -2183,6 +2374,49 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					_, okn := tue.ObjectNew.GetAnnotations()[kcmv1.RegionPauseAnnotation]
 					_, oko := tue.ObjectOld.GetAnnotations()[kcmv1.RegionPauseAnnotation]
 					return !okn && oko // new without; old with
+				},
+			}),
+		).
+		Watches(&libsveltosv1beta1.SveltosCluster{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
+				clusterDeploymentRef := client.ObjectKeyFromObject(o)
+				clusterDeployment := kcmv1.ClusterDeployment{}
+				if err := r.MgmtClient.Get(ctx, clusterDeploymentRef, &clusterDeployment); err != nil {
+					if apierrors.IsNotFound(err) {
+						return nil
+					}
+					if !kubeutil.IsRetriableAPIError(err) {
+						ctrl.LoggerFrom(ctx).Error(err,
+							"failed to get ClusterDeployment for SveltosCluster event; skipping enqueue",
+							"clusterDeployment", clusterDeploymentRef,
+						)
+						return nil
+					}
+
+					ctrl.LoggerFrom(ctx).Error(err,
+						"failed to get ClusterDeployment for SveltosCluster event; enqueuing reconcile anyway",
+						"clusterDeployment", clusterDeploymentRef,
+					)
+				}
+
+				return []ctrl.Request{{NamespacedName: clusterDeploymentRef}}
+			}),
+			builder.WithPredicates(predicate.Funcs{
+				GenericFunc: func(event.TypedGenericEvent[client.Object]) bool { return false },
+				CreateFunc:  func(event.TypedCreateEvent[client.Object]) bool { return true },
+				DeleteFunc:  func(event.TypedDeleteEvent[client.Object]) bool { return true },
+				UpdateFunc: func(tue event.TypedUpdateEvent[client.Object]) bool {
+					oldSC, ok := tue.ObjectOld.(*libsveltosv1beta1.SveltosCluster)
+					if !ok {
+						return false
+					}
+
+					newSC, ok := tue.ObjectNew.(*libsveltosv1beta1.SveltosCluster)
+					if !ok {
+						return false
+					}
+
+					return r.sveltosReadinessStatusChanged(oldSC.Status, newSC.Status)
 				},
 			}),
 		).

--- a/internal/controller/clusterdeployment_controller_test.go
+++ b/internal/controller/clusterdeployment_controller_test.go
@@ -780,6 +780,32 @@ func Test_updateClusterDeploymentConditions(t *testing.T) {
 			},
 		},
 		{
+			name: "Sveltos Cluster is not ready; should reflect Failed reason in Ready condition.",
+			currentConditions: []metav1.Condition{
+				{
+					Type:               kcmv1.SveltosClusterReadyCondition,
+					Status:             metav1.ConditionFalse,
+					Reason:             kcmv1.FailedReason,
+					LastTransitionTime: metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+					Message:            "failed to connect to adopted cluster",
+				},
+				{
+					Type:               kcmv1.ReadyCondition,
+					Status:             metav1.ConditionUnknown,
+					Reason:             kcmv1.ProgressingReason,
+					Message:            "Some old Ready condition message",
+					ObservedGeneration: 1,
+				},
+			},
+			expectedReadyCondition: metav1.Condition{
+				Type:               kcmv1.ReadyCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             kcmv1.FailedReason,
+				Message:            "failed to connect to adopted cluster",
+				ObservedGeneration: generation,
+			},
+		},
+		{
 			name: "Cluster is ready, should reflect Succeeded reason in Ready condition.",
 			currentConditions: []metav1.Condition{
 				{
@@ -855,6 +881,65 @@ func checkReadyCondition(t *testing.T, conditions []metav1.Condition, expectedRe
 		}
 	}
 	t.Errorf("Ready condition not found")
+}
+
+func Test_getRuntimeReadinessTargets(t *testing.T) {
+	tests := []struct {
+		name           string
+		providers      []string
+		observeCAPI    bool
+		observeSveltos bool
+	}{
+		{
+			name:           "defaults to CAPI when providers are empty",
+			providers:      nil,
+			observeCAPI:    true,
+			observeSveltos: false,
+		},
+		{
+			name:           "uses CAPI for non-internal infra providers",
+			providers:      []string{"infrastructure-aws", "bootstrap-k0smotron"},
+			observeCAPI:    true,
+			observeSveltos: false,
+		},
+		{
+			name:           "uses Sveltos for internal provider",
+			providers:      []string{kcmv1.InternalInfrastructureProvider},
+			observeCAPI:    false,
+			observeSveltos: true,
+		},
+		{
+			name:           "uses both when internal and external infra providers are present",
+			providers:      []string{kcmv1.InternalInfrastructureProvider, "infrastructure-openstack"},
+			observeCAPI:    true,
+			observeSveltos: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterTpl := &kcmv1.ClusterTemplate{}
+			clusterTpl.Status.Providers = tt.providers
+
+			observeCAPI, observeSveltos := (&ClusterDeploymentReconciler{}).getRuntimeReadinessTargets(clusterTpl)
+			if observeCAPI != tt.observeCAPI {
+				t.Fatalf("observeCAPI mismatch: got=%v want=%v", observeCAPI, tt.observeCAPI)
+			}
+			if observeSveltos != tt.observeSveltos {
+				t.Fatalf("observeSveltos mismatch: got=%v want=%v", observeSveltos, tt.observeSveltos)
+			}
+		})
+	}
+
+	t.Run("nil cluster template, must have CAPI without Sveltos", func(t *testing.T) {
+		observeCAPI, observeSveltos := (&ClusterDeploymentReconciler{}).getRuntimeReadinessTargets(nil)
+		if !observeCAPI {
+			t.Fatal("observeCAPI mismatch: got=false want=true")
+		}
+		if observeSveltos {
+			t.Fatal("observeSveltos mismatch: got=true want=false")
+		}
+	})
 }
 
 func Test_detectHelmChartNameChange(t *testing.T) {

--- a/internal/util/kube/kube.go
+++ b/internal/util/kube/kube.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,4 +92,13 @@ func AddOwnerReference(dependent, owner client.Object) (changed bool) {
 	)
 	dependent.SetOwnerReferences(ownerRefs)
 	return true
+}
+
+// IsRetriableAPIError reports whether a Kubernetes API error is transient.
+func IsRetriableAPIError(err error) bool {
+	return apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err)
 }

--- a/internal/util/scheme/scheme.go
+++ b/internal/util/scheme/scheme.go
@@ -64,22 +64,13 @@ func getManagementScheme() (*runtime.Scheme, error) {
 }
 
 func GetRegionalScheme() (*runtime.Scheme, error) {
-	return buildRegionalScheme(nil)
+	return buildRegionalScheme()
 }
 
-func GetRegionalSchemeWithSveltos() (*runtime.Scheme, error) {
-	extra := []func(*runtime.Scheme) error{
-		addoncontrollerv1beta1.AddToScheme,
-		libsveltosv1beta1.AddToScheme,
-	}
-	return buildRegionalScheme(extra)
-}
-
-func buildRegionalScheme(extra []func(*runtime.Scheme) error) (*runtime.Scheme, error) {
+func buildRegionalScheme() (*runtime.Scheme, error) {
 	s := runtime.NewScheme()
-	schemes := append(getRegionalAPI(), extra...)
 
-	for _, f := range schemes {
+	for _, f := range getRegionalAPI() {
 		if err := f(s); err != nil {
 			return nil, fmt.Errorf("failed to add to scheme: %w", err)
 		}
@@ -110,5 +101,7 @@ func getRegionalAPI() []func(*runtime.Scheme) error {
 		ipamv1.AddToScheme,
 		inclusteripamv1alpha2.AddToScheme,
 		infobloxv1alpha1.AddToScheme,
+		addoncontrollerv1beta1.AddToScheme,
+		libsveltosv1beta1.AddToScheme,
 	}
 }

--- a/internal/util/validation/cd.go
+++ b/internal/util/validation/cd.go
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package validation contains validation helpers for KCM API resources.
 package validation
 
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
@@ -58,7 +62,62 @@ func ClusterDeployCredential(ctx context.Context, cl client.Client, systemNamesp
 		return fmt.Errorf("the Credential %s is not Ready", credKey)
 	}
 
-	return isCredIdentitySupportsClusterTemplate(ctx, cl, systemNamespace, cred, clusterTemplate)
+	if cred.Spec.IdentityRef == nil {
+		return fmt.Errorf("the Credential %s does not have identityRef", credKey)
+	}
+
+	if err := isCredIdentitySupportsClusterTemplate(ctx, cl, systemNamespace, cred, clusterTemplate); err != nil {
+		return fmt.Errorf("checking credential identity reference supports cluster template: %w", err)
+	}
+
+	if slices.Contains(clusterTemplate.Status.Providers, kcmv1.InternalInfrastructureProvider) {
+		if err := validateInternalCredentialKubeconfig(ctx, cl, cred); err != nil {
+			return fmt.Errorf("validating internal credential kubeconfig: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func validateInternalCredentialKubeconfig(ctx context.Context, cl client.Client, cred *kcmv1.Credential) error {
+	secretNamespace := cred.Spec.IdentityRef.Namespace
+	if secretNamespace == "" {
+		secretNamespace = cred.Namespace
+	}
+
+	secretKey := client.ObjectKey{Namespace: secretNamespace, Name: cred.Spec.IdentityRef.Name}
+	secret := new(corev1.Secret)
+	if err := cl.Get(ctx, secretKey, secret); err != nil {
+		return fmt.Errorf("failed to get Secret %s referred in the Credential %s: %w", secretKey, client.ObjectKeyFromObject(cred), err)
+	}
+
+	secretDataKeys := slices.Collect(maps.Keys(secret.Data))
+	slices.Sort(secretDataKeys)
+
+	var (
+		firstErr    error
+		firstErrKey string
+	)
+
+	for _, key := range secretDataKeys {
+		if len(secret.Data[key]) == 0 {
+			continue
+		}
+
+		if _, err := clientcmd.RESTConfigFromKubeConfig(secret.Data[key]); err == nil {
+			return nil
+		} else if firstErr == nil {
+			// keep scanning: any later key may still contain a kubeconfig that can build a REST client
+			firstErr = err
+			firstErrKey = key
+		}
+	}
+
+	if firstErr != nil {
+		return fmt.Errorf("invalid kubeconfig in Secret %s key %q: %w", secretKey, firstErrKey, firstErr)
+	}
+
+	return fmt.Errorf("secret %s referred in the Credential %s does not contain kubeconfig data", secretKey, client.ObjectKeyFromObject(cred))
 }
 
 func getProviderClusterIdentityKinds(ctx context.Context, rgnClient client.Client, parent ClusterParent, infraProviderName string) []string {
@@ -102,7 +161,7 @@ func isCredIdentitySupportsClusterTemplate(ctx context.Context, mgmtClient clien
 			continue
 		}
 
-		if providerName == kcmv1.InfrastructureProviderPrefix+"internal" {
+		if providerName == kcmv1.InternalInfrastructureProvider {
 			if idtyKind != secretKind {
 				return errMsg(providerName)
 			}

--- a/internal/webhook/clusterdeployment_webhook_test.go
+++ b/internal/webhook/clusterdeployment_webhook_test.go
@@ -42,6 +42,7 @@ import (
 const (
 	testSvcTemplate1Name = "test-servicetemplate-1"
 	testSystemNamespace  = "test-system-namespace"
+	internalProviderName = kcmv1.InternalInfrastructureProvider
 )
 
 var (
@@ -409,6 +410,119 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 			err: fmt.Sprintf("the ClusterDeployment is invalid: the Credential %s/%s is not Ready", metav1.NamespaceDefault, testCredentialName),
 		},
 		{
+			name: "should fail if credential identityRef is missing",
+			ClusterDeployment: clusterdeployment.NewClusterDeployment(
+				clusterdeployment.WithClusterTemplate(testTemplateName),
+				clusterdeployment.WithCredential(testCredentialName),
+			),
+			existingObjects: []runtime.Object{
+				management.NewManagement(
+					management.WithAvailableProviders(kcmv1.Providers{internalProviderName}),
+				),
+				credential.NewCredential(
+					credential.WithName(testCredentialName),
+					credential.WithReady(true),
+				),
+				template.NewClusterTemplate(
+					template.WithName(testTemplateName),
+					template.WithProvidersStatus(
+						internalProviderName,
+					),
+					template.WithValidationStatus(kcmv1.TemplateValidationStatus{Valid: true}),
+				),
+			},
+			err: fmt.Sprintf("the ClusterDeployment is invalid: the Credential %s/%s does not have identityRef", metav1.NamespaceDefault, testCredentialName),
+		},
+		{
+			name: "should fail for internal provider if kubeconfig in Secret is invalid",
+			ClusterDeployment: clusterdeployment.NewClusterDeployment(
+				clusterdeployment.WithClusterTemplate(testTemplateName),
+				clusterdeployment.WithCredential(testCredentialName),
+			),
+			existingObjects: []runtime.Object{
+				management.NewManagement(
+					management.WithAvailableProviders(kcmv1.Providers{internalProviderName}),
+				),
+				credential.NewCredential(
+					credential.WithName(testCredentialName),
+					credential.WithReady(true),
+					credential.WithIdentityRef(
+						&corev1.ObjectReference{
+							Kind:      "Secret",
+							Name:      testSecretName,
+							Namespace: metav1.NamespaceDefault,
+						}),
+				),
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSecretName,
+						Namespace: metav1.NamespaceDefault,
+					},
+					Data: map[string][]byte{"value": []byte("hello")},
+				},
+				template.NewClusterTemplate(
+					template.WithName(testTemplateName),
+					template.WithProvidersStatus(
+						internalProviderName,
+					),
+					template.WithValidationStatus(kcmv1.TemplateValidationStatus{Valid: true}),
+				),
+			},
+			err: "the ClusterDeployment is invalid: validating internal credential kubeconfig: invalid kubeconfig in Secret default/test-secret key \"value\"",
+		},
+		{
+			name: "should succeed for internal provider if Secret contains valid kubeconfig",
+			ClusterDeployment: clusterdeployment.NewClusterDeployment(
+				clusterdeployment.WithClusterTemplate(testTemplateName),
+				clusterdeployment.WithCredential(testCredentialName),
+			),
+			existingObjects: []runtime.Object{
+				management.NewManagement(
+					management.WithAvailableProviders(kcmv1.Providers{internalProviderName}),
+				),
+				credential.NewCredential(
+					credential.WithName(testCredentialName),
+					credential.WithReady(true),
+					credential.WithIdentityRef(
+						&corev1.ObjectReference{
+							Kind:      "Secret",
+							Name:      testSecretName,
+							Namespace: metav1.NamespaceDefault,
+						}),
+				),
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSecretName,
+						Namespace: metav1.NamespaceDefault,
+					},
+					Data: map[string][]byte{"value": []byte(`apiVersion: v1
+kind: Config
+clusters:
+- name: test-cluster
+  cluster:
+    server: https://127.0.0.1:6443
+users:
+- name: test-user
+  user:
+    token: test-token
+contexts:
+- name: test-context
+  context:
+    cluster: test-cluster
+    user: test-user
+current-context: test-context
+`)},
+				},
+				template.NewClusterTemplate(
+					template.WithName(testTemplateName),
+					template.WithProvidersStatus(
+						internalProviderName,
+					),
+					template.WithValidationStatus(kcmv1.TemplateValidationStatus{Valid: true}),
+				),
+			},
+		},
+		{
 			name: "should fail if credential and template providers doesn't match",
 			ClusterDeployment: clusterdeployment.NewClusterDeployment(
 				clusterdeployment.WithClusterTemplate(testTemplateName),
@@ -447,7 +561,7 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 				),
 				providerInterface,
 			},
-			err: fmt.Sprintf("the ClusterDeployment is invalid: provider %s does not support ClusterIdentity Kind %s from the Credential %s/%s", "infrastructure-aws", "SomeOtherDummyClusterStaticIdentity", metav1.NamespaceDefault, testCredentialName),
+			err: fmt.Sprintf("the ClusterDeployment is invalid: checking credential identity reference supports cluster template: provider %s does not support ClusterIdentity Kind %s from the Credential %s/%s", "infrastructure-aws", "SomeOtherDummyClusterStaticIdentity", metav1.NamespaceDefault, testCredentialName),
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adopted-cluster readiness is now tied to Sveltos runtime conditions when applicable.

Validates invalid kubeconfig before trying to proceed further with credentials.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2196 
