### PR TITLE
fix(am): filter namespace watch reconciles

### DIFF
--- a/api/v1beta1/indexers.go
+++ b/api/v1beta1/indexers.go
@@ -17,6 +17,8 @@ package v1beta1
 import (
 	"context"
 	"errors"
+	"maps"
+	"slices"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,6 +27,7 @@ import (
 func SetupIndexers(ctx context.Context, mgr ctrl.Manager) error {
 	var merr error
 	for _, f := range []func(context.Context, ctrl.Manager) error{
+		setupAccessManagementIndexer,
 		setupClusterDeploymentIndexer,
 		setupClusterDeploymentServicesIndexer,
 		setupClusterDeploymentServiceTemplateChainIndexer,
@@ -49,6 +52,106 @@ func SetupIndexers(ctx context.Context, mgr ctrl.Manager) error {
 	}
 
 	return merr
+}
+
+// access management
+
+const (
+	// AccessManagementTargetNamespaceListIndexKey indexes explicit namespace list targets from [AccessManagement] access rules.
+	AccessManagementTargetNamespaceListIndexKey = ".spec.accessRules[].targetNamespaces.list"
+	// AccessManagementUsesSelectorIndexKey indexes [AccessManagement] objects that use non-empty selectors in access rules.
+	AccessManagementUsesSelectorIndexKey = "k0rdent.access-management.selector"
+	// AccessManagementTargetsAllNamespacesIndexKey indexes [AccessManagement] objects with rules targeting all namespaces.
+	AccessManagementTargetsAllNamespacesIndexKey = "k0rdent.access-management.all-namespaces"
+)
+
+func setupAccessManagementIndexer(ctx context.Context, mgr ctrl.Manager) error {
+	var merr error
+	merr = errors.Join(merr,
+		mgr.GetFieldIndexer().IndexField(ctx, &AccessManagement{},
+			AccessManagementTargetNamespaceListIndexKey,
+			ExtractAccessManagementTargetNamespaceLists),
+		mgr.GetFieldIndexer().IndexField(ctx, &AccessManagement{},
+			AccessManagementUsesSelectorIndexKey,
+			ExtractAccessManagementUsesSelector),
+		mgr.GetFieldIndexer().IndexField(ctx, &AccessManagement{},
+			AccessManagementTargetsAllNamespacesIndexKey,
+			ExtractAccessManagementTargetsAllNamespaces),
+	)
+
+	return merr
+}
+
+// ExtractAccessManagementTargetNamespaceLists returns explicit namespace list targets from [AccessManagement] access rules.
+func ExtractAccessManagementTargetNamespaceLists(o client.Object) []string {
+	am, ok := o.(*AccessManagement)
+	if !ok {
+		return nil
+	}
+
+	targetNamespaces := make(map[string]struct{})
+	for _, rule := range am.Spec.AccessRules {
+		for _, namespace := range rule.TargetNamespaces.List {
+			targetNamespaces[namespace] = struct{}{}
+		}
+	}
+
+	if len(targetNamespaces) == 0 {
+		return nil
+	}
+
+	namespaces := slices.Collect(maps.Keys(targetNamespaces))
+	slices.Sort(namespaces)
+
+	return namespaces
+}
+
+// ExtractAccessManagementUsesSelector returns [AccessManagement] objects using non-empty selectors in access rules.
+func ExtractAccessManagementUsesSelector(o client.Object) []string {
+	am, ok := o.(*AccessManagement)
+	if !ok {
+		return nil
+	}
+
+	for _, rule := range am.Spec.AccessRules {
+		if targetNamespacesHasNonEmptySelector(rule.TargetNamespaces) {
+			return []string{"true"}
+		}
+	}
+
+	return nil
+}
+
+// ExtractAccessManagementTargetsAllNamespaces returns [AccessManagement] objects with at least one all-namespaces rule.
+func ExtractAccessManagementTargetsAllNamespaces(o client.Object) []string {
+	am, ok := o.(*AccessManagement)
+	if !ok {
+		return nil
+	}
+
+	for _, rule := range am.Spec.AccessRules {
+		if targetNamespacesSelectAllNamespaces(rule.TargetNamespaces) {
+			return []string{"true"}
+		}
+	}
+
+	return nil
+}
+
+func targetNamespacesHasNonEmptySelector(targetNamespaces TargetNamespaces) bool {
+	if targetNamespaces.StringSelector != "" {
+		return true
+	}
+
+	if targetNamespaces.Selector == nil {
+		return false
+	}
+
+	return len(targetNamespaces.Selector.MatchLabels) > 0 || len(targetNamespaces.Selector.MatchExpressions) > 0
+}
+
+func targetNamespacesSelectAllNamespaces(targetNamespaces TargetNamespaces) bool {
+	return len(targetNamespaces.List) == 0 && !targetNamespacesHasNonEmptySelector(targetNamespaces)
 }
 
 // cluster deployment

--- a/api/v1beta1/indexers_test.go
+++ b/api/v1beta1/indexers_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestExtractAccessManagementTargetNamespaceLists(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		object   client.Object
+		expected []string
+	}{
+		{
+			name:     "returns nil for unsupported object",
+			object:   &Credential{},
+			expected: nil,
+		},
+		{
+			name: "deduplicates and sorts namespaces",
+			object: &AccessManagement{
+				Spec: AccessManagementSpec{
+					AccessRules: []AccessRule{
+						{TargetNamespaces: TargetNamespaces{List: []string{"ns-b", "ns-a"}}},
+						{TargetNamespaces: TargetNamespaces{List: []string{"ns-b", "ns-c"}}},
+					},
+				},
+			},
+			expected: []string{"ns-a", "ns-b", "ns-c"},
+		},
+		{
+			name: "returns nil when no list-based targets",
+			object: &AccessManagement{
+				Spec: AccessManagementSpec{
+					AccessRules: []AccessRule{
+						{TargetNamespaces: TargetNamespaces{StringSelector: "env=prod"}},
+					},
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			namespaces := ExtractAccessManagementTargetNamespaceLists(tt.object)
+			require.Equal(t, tt.expected, namespaces)
+		})
+	}
+}
+
+func TestExtractAccessManagementUsesSelector(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		object   client.Object
+		expected []string
+	}{
+		{
+			name: "returns true marker for string selector",
+			object: &AccessManagement{
+				Spec: AccessManagementSpec{
+					AccessRules: []AccessRule{{TargetNamespaces: TargetNamespaces{StringSelector: "env=prod"}}},
+				},
+			},
+			expected: []string{"true"},
+		},
+		{
+			name: "returns true marker for structured selector",
+			object: &AccessManagement{
+				Spec: AccessManagementSpec{
+					AccessRules: []AccessRule{{TargetNamespaces: TargetNamespaces{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"env": "prod"}}}}},
+				},
+			},
+			expected: []string{"true"},
+		},
+		{
+			name: "returns nil for list-only rules",
+			object: &AccessManagement{
+				Spec: AccessManagementSpec{
+					AccessRules: []AccessRule{{TargetNamespaces: TargetNamespaces{List: []string{"ns-a"}}}},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "returns nil for empty structured selector",
+			object: &AccessManagement{
+				Spec: AccessManagementSpec{
+					AccessRules: []AccessRule{{TargetNamespaces: TargetNamespaces{Selector: &metav1.LabelSelector{}}}},
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := ExtractAccessManagementUsesSelector(tt.object)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractAccessManagementTargetsAllNamespaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		object   client.Object
+		expected []string
+	}{
+		{
+			name: "returns true marker for empty target namespaces",
+			object: &AccessManagement{
+				Spec: AccessManagementSpec{AccessRules: []AccessRule{{TargetNamespaces: TargetNamespaces{}}}},
+			},
+			expected: []string{"true"},
+		},
+		{
+			name: "returns true marker for empty structured selector",
+			object: &AccessManagement{
+				Spec: AccessManagementSpec{
+					AccessRules: []AccessRule{{TargetNamespaces: TargetNamespaces{Selector: &metav1.LabelSelector{}}}},
+				},
+			},
+			expected: []string{"true"},
+		},
+		{
+			name: "returns nil for explicit namespace list",
+			object: &AccessManagement{
+				Spec: AccessManagementSpec{
+					AccessRules: []AccessRule{{TargetNamespaces: TargetNamespaces{List: []string{"ns-a"}}}},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "returns nil for non-empty selector",
+			object: &AccessManagement{
+				Spec: AccessManagementSpec{
+					AccessRules: []AccessRule{{TargetNamespaces: TargetNamespaces{StringSelector: "env=prod"}}},
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := ExtractAccessManagementTargetsAllNamespaces(tt.object)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/controller/accessmanagement_controller.go
+++ b/internal/controller/accessmanagement_controller.go
@@ -18,15 +18,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	"github.com/K0rdent/kcm/internal/record"
@@ -139,7 +145,7 @@ func (r *AccessManagementReconciler) reconcileObj(ctx context.Context, accessMgm
 
 	var errs error
 	for _, rule := range accessMgmt.Spec.AccessRules {
-		namespaces, err := getTargetNamespaces(ctx, r.Client, rule.TargetNamespaces)
+		namespaces, err := r.getTargetNamespaces(ctx, rule.TargetNamespaces)
 		if err != nil {
 			return fmt.Errorf("failed to collect target namespaces: %w", err)
 		}
@@ -466,34 +472,26 @@ func (r *AccessManagementReconciler) getDataSources(ctx context.Context) (map[st
 	return systemDataSources, managedDataSources, nil
 }
 
-func getTargetNamespaces(ctx context.Context, cl client.Client, targetNamespaces kcmv1.TargetNamespaces) ([]string, error) {
+func (r *AccessManagementReconciler) getTargetNamespaces(ctx context.Context, targetNamespaces kcmv1.TargetNamespaces) ([]string, error) {
 	if len(targetNamespaces.List) > 0 {
 		return targetNamespaces.List, nil
 	}
-	var selector labels.Selector
-	var err error
-	if targetNamespaces.StringSelector != "" {
-		selector, err = labels.Parse(targetNamespaces.StringSelector)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		selector, err = metav1.LabelSelectorAsSelector(targetNamespaces.Selector)
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct selector from the namespaces selector %s: %w", targetNamespaces.Selector, err)
-		}
+
+	selector, selectorNonEmpty, err := r.targetNamespacesSelector(targetNamespaces)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct selector from target namespaces: %w", err)
 	}
 
 	var (
 		namespaces = new(corev1.NamespaceList)
 		listOpts   = new(client.ListOptions)
 	)
-	if !selector.Empty() {
+	if selectorNonEmpty {
 		listOpts.LabelSelector = selector
 	}
 
-	if err := cl.List(ctx, namespaces, listOpts); err != nil {
-		return nil, err
+	if err := r.List(ctx, namespaces, listOpts); err != nil {
+		return nil, fmt.Errorf("failed to list namespaces: %w", err)
 	}
 
 	result := make([]string, len(namespaces.Items))
@@ -662,6 +660,282 @@ func (r *AccessManagementReconciler) updateStatus(ctx context.Context, accessMgm
 	return nil
 }
 
+func (r *AccessManagementReconciler) mapNamespaceToRequests(ctx context.Context, obj client.Object) []ctrl.Request {
+	namespace, ok := obj.(*corev1.Namespace)
+	if !ok || namespace == nil {
+		return nil
+	}
+
+	l := ctrl.LoggerFrom(ctx).WithName("am-map-create")
+
+	fallback := func() []ctrl.Request {
+		return r.collectAccessManagementRequests(ctx, namespace.Name, func(am *kcmv1.AccessManagement) (bool, error) {
+			return r.accessManagementTargetsNamespace(am, namespace)
+		})
+	}
+
+	listTargetedAccessManagements, err := r.listAccessManagementByField(ctx, kcmv1.AccessManagementTargetNamespaceListIndexKey, namespace.Name)
+	if err != nil {
+		l.Error(err,
+			"failed to list AccessManagement resources by namespace list index, falling back to full scan",
+			"namespace", namespace.Name,
+		)
+		return fallback()
+	}
+
+	allNamespaceAccessManagements, err := r.listAccessManagementByField(ctx, kcmv1.AccessManagementTargetsAllNamespacesIndexKey, "true")
+	if err != nil {
+		l.Error(err,
+			"failed to list AccessManagement resources by all-namespaces index, falling back to full scan",
+			"namespace", namespace.Name,
+		)
+		return fallback()
+	}
+
+	selectorAccessManagements, err := r.listAccessManagementByField(ctx, kcmv1.AccessManagementUsesSelectorIndexKey, "true")
+	if err != nil {
+		l.Error(err,
+			"failed to list AccessManagement resources by selector index, falling back to full scan",
+			"namespace", namespace.Name,
+		)
+		return fallback()
+	}
+
+	candidateCount := len(listTargetedAccessManagements) + len(allNamespaceAccessManagements) + len(selectorAccessManagements)
+	requests := make([]ctrl.Request, 0, candidateCount)
+	enqueued := make(map[string]struct{}, candidateCount)
+	enqueueRequest := func(am *kcmv1.AccessManagement) {
+		if _, ok := enqueued[am.Name]; ok {
+			return
+		}
+
+		enqueued[am.Name] = struct{}{}
+		requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(am)})
+	}
+
+	for i := range listTargetedAccessManagements {
+		enqueueRequest(&listTargetedAccessManagements[i])
+	}
+
+	for i := range allNamespaceAccessManagements {
+		enqueueRequest(&allNamespaceAccessManagements[i])
+	}
+
+	for i := range selectorAccessManagements {
+		am := &selectorAccessManagements[i]
+		shouldEnqueue, selectorErr := r.accessManagementTargetsNamespace(am, namespace)
+		if selectorErr != nil {
+			l.Error(selectorErr,
+				"failed to evaluate AccessManagement namespace selector",
+				"accessManagement", am.Name,
+				"namespace", namespace.Name,
+			)
+			// skip enqueue on invalid selector to avoid fan-out on namespace churn
+			continue
+		}
+
+		if shouldEnqueue {
+			enqueueRequest(am)
+		}
+	}
+
+	return requests
+}
+
+func (r *AccessManagementReconciler) mapNamespaceLabelUpdateToRequests(ctx context.Context, oldObj, newObj client.Object) []ctrl.Request {
+	oldNamespace, okOld := oldObj.(*corev1.Namespace)
+	newNamespace, okNew := newObj.(*corev1.Namespace)
+	if !okOld || !okNew || oldNamespace == nil || newNamespace == nil {
+		return nil
+	}
+
+	l := ctrl.LoggerFrom(ctx).WithName("am-map-update")
+
+	selectorAccessManagements, err := r.listAccessManagementByField(ctx, kcmv1.AccessManagementUsesSelectorIndexKey, "true")
+	if err != nil {
+		l.Error(err,
+			"failed to list AccessManagement resources by selector index, falling back to full scan",
+			"namespace", newNamespace.Name,
+		)
+
+		return r.collectAccessManagementRequests(ctx, newNamespace.Name, func(am *kcmv1.AccessManagement) (bool, error) {
+			return r.accessManagementAffectedByNamespaceLabelUpdate(am, oldNamespace, newNamespace)
+		})
+	}
+
+	requests := make([]ctrl.Request, 0, len(selectorAccessManagements))
+	for i := range selectorAccessManagements {
+		am := &selectorAccessManagements[i]
+		affected, selectorErr := r.accessManagementAffectedByNamespaceLabelUpdate(am, oldNamespace, newNamespace)
+		if selectorErr != nil {
+			l.Error(selectorErr,
+				"failed to evaluate AccessManagement namespace selector",
+				"accessManagement", am.Name,
+				"namespace", newNamespace.Name,
+			)
+			// skip enqueue on invalid selector to avoid fan-out on namespace churn
+			continue
+		}
+
+		if affected {
+			requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(am)})
+		}
+	}
+
+	return requests
+}
+
+func (r *AccessManagementReconciler) listAccessManagementByField(ctx context.Context, indexKey, value string) ([]kcmv1.AccessManagement, error) {
+	accessManagements := new(kcmv1.AccessManagementList)
+	if err := r.List(ctx, accessManagements, client.MatchingFields{indexKey: value}); err != nil {
+		return nil, fmt.Errorf("failed to list AccessManagement resources by field %q=%q: %w", indexKey, value, err)
+	}
+
+	return accessManagements.Items, nil
+}
+
+func (r *AccessManagementReconciler) collectAccessManagementRequests(ctx context.Context, namespaceName string, shouldEnqueueFn func(*kcmv1.AccessManagement) (bool, error)) []ctrl.Request {
+	l := ctrl.LoggerFrom(ctx)
+
+	accessManagements := new(kcmv1.AccessManagementList)
+	if err := r.List(ctx, accessManagements); err != nil {
+		l.Error(err,
+			"failed to list AccessManagement resources for Namespace event",
+			"namespace", namespaceName,
+		)
+		return nil
+	}
+
+	requests := make([]ctrl.Request, 0, len(accessManagements.Items))
+	for i := range accessManagements.Items {
+		am := &accessManagements.Items[i]
+		shouldEnqueue, err := shouldEnqueueFn(am)
+		if err != nil {
+			l.Error(err,
+				"failed to evaluate AccessManagement namespace selector",
+				"accessManagement", am.Name,
+				"namespace", namespaceName,
+			)
+			// skip enqueue on invalid selector to avoid fan-out on namespace churn
+			continue
+		}
+
+		if shouldEnqueue {
+			requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(am)})
+		}
+	}
+
+	return requests
+}
+
+func (*AccessManagementReconciler) targetNamespacesSelector(targetNamespaces kcmv1.TargetNamespaces) (labels.Selector, bool, error) {
+	if targetNamespaces.StringSelector != "" {
+		selector, err := labels.Parse(targetNamespaces.StringSelector)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to parse string selector %q: %w", targetNamespaces.StringSelector, err)
+		}
+
+		return selector, !selector.Empty(), nil
+	}
+
+	if targetNamespaces.Selector == nil {
+		return nil, false, nil
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(targetNamespaces.Selector)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to convert selector: %w", err)
+	}
+
+	return selector, !selector.Empty(), nil
+}
+
+func (r *AccessManagementReconciler) ruleTargetsNamespace(rule kcmv1.AccessRule, namespace *corev1.Namespace) (bool, error) {
+	if len(rule.TargetNamespaces.List) > 0 {
+		return slices.Contains(rule.TargetNamespaces.List, namespace.Name), nil
+	}
+
+	selector, selectorNonEmpty, err := r.targetNamespacesSelector(rule.TargetNamespaces)
+	if err != nil {
+		return false, fmt.Errorf("failed to get target namespaces selector: %w", err)
+	}
+
+	if !selectorNonEmpty {
+		// empty selector means all namespaces
+		return true, nil
+	}
+
+	return selector.Matches(labels.Set(namespace.GetLabels())), nil
+}
+
+func (r *AccessManagementReconciler) accessManagementTargetsNamespace(accessMgmt *kcmv1.AccessManagement, namespace *corev1.Namespace) (bool, error) {
+	for _, rule := range accessMgmt.Spec.AccessRules {
+		matches, err := r.ruleTargetsNamespace(rule, namespace)
+		if err != nil {
+			return false, err
+		}
+
+		if matches {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (r *AccessManagementReconciler) ruleAffectedByNamespaceLabelUpdate(rule kcmv1.AccessRule, oldNamespace, newNamespace *corev1.Namespace) (bool, error) {
+	if len(rule.TargetNamespaces.List) > 0 {
+		return false, nil
+	}
+
+	selector, selectorNonEmpty, err := r.targetNamespacesSelector(rule.TargetNamespaces)
+	if err != nil {
+		return false, fmt.Errorf("failed to get target namespaces selector: %w", err)
+	}
+
+	if !selectorNonEmpty {
+		// empty selector means all namespaces; labels do not change membership
+		return false, nil
+	}
+
+	oldMatches := selector.Matches(labels.Set(oldNamespace.GetLabels()))
+	newMatches := selector.Matches(labels.Set(newNamespace.GetLabels()))
+
+	return oldMatches != newMatches, nil
+}
+
+func (r *AccessManagementReconciler) accessManagementAffectedByNamespaceLabelUpdate(accessMgmt *kcmv1.AccessManagement, oldNamespace, newNamespace *corev1.Namespace) (bool, error) {
+	for _, rule := range accessMgmt.Spec.AccessRules {
+		affected, err := r.ruleAffectedByNamespaceLabelUpdate(rule, oldNamespace, newNamespace)
+		if err != nil {
+			return false, err
+		}
+
+		if affected {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (*AccessManagementReconciler) getEventPredicates() predicate.TypedFuncs[client.Object] {
+	return predicate.TypedFuncs[client.Object]{
+		CreateFunc: func(event.TypedCreateEvent[client.Object]) bool { return true },
+		// no need for delete events, they can produce transient failures while namespaces terminate
+		DeleteFunc:  func(event.TypedDeleteEvent[client.Object]) bool { return false },
+		GenericFunc: func(event.TypedGenericEvent[client.Object]) bool { return false },
+		UpdateFunc: func(tue event.TypedUpdateEvent[client.Object]) bool {
+			if tue.ObjectOld == nil || tue.ObjectNew == nil {
+				return false
+			}
+
+			// reconcile on labels change because namespace selectors are label-based
+			return !maps.Equal(tue.ObjectOld.GetLabels(), tue.ObjectNew.GetLabels())
+		},
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *AccessManagementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
@@ -669,6 +943,22 @@ func (r *AccessManagementReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			RateLimiter: ratelimitutil.DefaultFastSlow(),
 		}).
 		For(&kcmv1.AccessManagement{}).
+		Watches(
+			&corev1.Namespace{},
+			handler.TypedFuncs[client.Object, ctrl.Request]{
+				CreateFunc: func(ctx context.Context, tce event.TypedCreateEvent[client.Object], q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+					for _, req := range r.mapNamespaceToRequests(ctx, tce.Object) {
+						q.Add(req)
+					}
+				},
+				UpdateFunc: func(ctx context.Context, tue event.TypedUpdateEvent[client.Object], q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+					for _, req := range r.mapNamespaceLabelUpdateToRequests(ctx, tue.ObjectOld, tue.ObjectNew) {
+						q.Add(req)
+					}
+				},
+			},
+			builder.WithPredicates(r.getEventPredicates()),
+		).
 		Complete(r)
 }
 

--- a/internal/controller/accessmanagement_controller_test.go
+++ b/internal/controller/accessmanagement_controller_test.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,7 +24,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
@@ -32,6 +35,7 @@ import (
 	"github.com/K0rdent/kcm/test/objects/credential"
 	"github.com/K0rdent/kcm/test/objects/datasource"
 	tc "github.com/K0rdent/kcm/test/objects/templatechain"
+	testscheme "github.com/K0rdent/kcm/test/scheme"
 )
 
 var _ = Describe("Template Management Controller", func() {
@@ -217,7 +221,7 @@ var _ = Describe("Template Management Controller", func() {
 			}
 
 			By("creating custom resources for the Kind ClusterTemplateChain, ServiceTemplateChain, Credentials, ClusterAuthentications, DataSources")
-			for _, obj := range []crclient.Object{
+			for _, obj := range []client.Object{
 				ctChain, ctChainToDelete, ctChainUnmanaged,
 				stChain, stChainToDelete, stChainUnmanaged,
 				cred, credToDelete, credUnmanaged,
@@ -236,35 +240,35 @@ var _ = Describe("Template Management Controller", func() {
 				for _, ns := range []*corev1.Namespace{systemNamespace, namespace1, namespace2, namespace3} {
 					chain.Namespace = ns.Name
 					err := k8sClient.Delete(ctx, chain)
-					Expect(crclient.IgnoreNotFound(err)).To(Succeed())
+					Expect(client.IgnoreNotFound(err)).To(Succeed())
 				}
 			}
 			for _, chain := range []*kcmv1.ServiceTemplateChain{stChain, stChainToDelete, stChainUnmanaged} {
 				for _, ns := range []*corev1.Namespace{systemNamespace, namespace1, namespace2, namespace3} {
 					chain.Namespace = ns.Name
 					err := k8sClient.Delete(ctx, chain)
-					Expect(crclient.IgnoreNotFound(err)).To(Succeed())
+					Expect(client.IgnoreNotFound(err)).To(Succeed())
 				}
 			}
 			for _, c := range []*kcmv1.Credential{cred, credToDelete, credUnmanaged} {
 				for _, ns := range []*corev1.Namespace{systemNamespace, namespace1, namespace2, namespace3} {
 					c.Namespace = ns.Name
 					err := k8sClient.Delete(ctx, c)
-					Expect(crclient.IgnoreNotFound(err)).To(Succeed())
+					Expect(client.IgnoreNotFound(err)).To(Succeed())
 				}
 			}
 			for _, clAuth := range []*kcmv1.ClusterAuthentication{clAuth, clAuthToDelete, clAuthUnmanaged} {
 				for _, ns := range []*corev1.Namespace{systemNamespace, namespace1, namespace2, namespace3} {
 					clAuth.Namespace = ns.Name
 					err := k8sClient.Delete(ctx, clAuth)
-					Expect(crclient.IgnoreNotFound(err)).To(Succeed())
+					Expect(client.IgnoreNotFound(err)).To(Succeed())
 				}
 			}
 
 			for _, ds := range []*kcmv1.DataSource{dsObj, dsToDelete, dsUnmanaged} {
 				for _, ns := range []*corev1.Namespace{systemNamespace, namespace1, namespace2, namespace3} {
 					ds.Namespace = ns.Name
-					Expect(crclient.IgnoreNotFound(k8sClient.Delete(ctx, ds))).To(Succeed())
+					Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, ds))).To(Succeed())
 				}
 			}
 
@@ -357,3 +361,203 @@ var _ = Describe("Template Management Controller", func() {
 		})
 	})
 })
+
+func TestMapNamespaceToRequests(t *testing.T) {
+	t.Parallel()
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "project-a",
+			Labels: map[string]string{"env": "prod", "tier": "frontend"},
+		},
+	}
+
+	accessManagements := []client.Object{
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "selector-string"},
+			Spec: kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{
+				TargetNamespaces: kcmv1.TargetNamespaces{StringSelector: "env=prod"},
+			}}},
+		},
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "selector-structured"},
+			Spec: kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{
+				TargetNamespaces: kcmv1.TargetNamespaces{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"tier": "frontend"}}},
+			}}},
+		},
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "list-target"},
+			Spec: kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{
+				TargetNamespaces: kcmv1.TargetNamespaces{List: []string{"project-a"}},
+			}}},
+		},
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "all-targets"},
+			Spec:       kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{}}},
+		},
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "selector-no-match"},
+			Spec: kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{
+				TargetNamespaces: kcmv1.TargetNamespaces{StringSelector: "env=dev"},
+			}}},
+		},
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "selector-invalid"},
+			Spec: kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{
+				TargetNamespaces: kcmv1.TargetNamespaces{StringSelector: "env in (prod"},
+			}}},
+		},
+	}
+
+	reconciler := newAccessManagementReconcilerWithIndexes(t, accessManagements...)
+
+	expected := map[types.NamespacedName]bool{
+		{Name: "selector-string"}:     true,
+		{Name: "selector-structured"}: true,
+		{Name: "list-target"}:         true,
+		{Name: "all-targets"}:         true,
+	}
+
+	requests := reconciler.mapNamespaceToRequests(t.Context(), namespace)
+	if len(requests) != len(expected) {
+		t.Fatalf("expected %d requests, got %d", len(expected), len(requests))
+	}
+
+	for _, req := range requests {
+		if !expected[req.NamespacedName] {
+			t.Fatalf("unexpected request queued: %s", req.String())
+		}
+		delete(expected, req.NamespacedName)
+	}
+	if len(expected) > 0 {
+		t.Fatalf("missing queued requests: %v", expected)
+	}
+}
+
+func Test_mapNamespaceLabelUpdateToRequests(t *testing.T) {
+	t.Parallel()
+
+	oldNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "project-a",
+			Labels: map[string]string{"env": "dev", "team": "core", "component": "api"},
+		},
+	}
+	newNamespace := oldNamespace.DeepCopy()
+	newNamespace.Labels["env"] = "prod"
+	newNamespace.Labels["team"] = "platform"
+	newNamespace.Labels["noise"] = "changed"
+
+	accessManagements := []client.Object{
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "selector-enter"},
+			Spec: kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{
+				TargetNamespaces: kcmv1.TargetNamespaces{StringSelector: "env=prod"},
+			}}},
+		},
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "selector-leave"},
+			Spec: kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{
+				TargetNamespaces: kcmv1.TargetNamespaces{StringSelector: "team=core"},
+			}}},
+		},
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "selector-stable"},
+			Spec: kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{
+				TargetNamespaces: kcmv1.TargetNamespaces{StringSelector: "component=api"},
+			}}},
+		},
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "selector-still-out"},
+			Spec: kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{
+				TargetNamespaces: kcmv1.TargetNamespaces{StringSelector: "zone=eu"},
+			}}},
+		},
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "list-target"},
+			Spec: kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{
+				TargetNamespaces: kcmv1.TargetNamespaces{List: []string{"project-a"}},
+			}}},
+		},
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "all-targets"},
+			Spec:       kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{}}},
+		},
+		&kcmv1.AccessManagement{
+			ObjectMeta: metav1.ObjectMeta{Name: "selector-invalid"},
+			Spec: kcmv1.AccessManagementSpec{AccessRules: []kcmv1.AccessRule{{
+				TargetNamespaces: kcmv1.TargetNamespaces{StringSelector: "env in (prod"},
+			}}},
+		},
+	}
+
+	reconciler := newAccessManagementReconcilerWithIndexes(t, accessManagements...)
+
+	expected := map[types.NamespacedName]bool{
+		{Name: "selector-enter"}: true,
+		{Name: "selector-leave"}: true,
+	}
+
+	requests := reconciler.mapNamespaceLabelUpdateToRequests(t.Context(), oldNamespace, newNamespace)
+	if len(requests) != len(expected) {
+		t.Fatalf("expected %d requests, got %d", len(expected), len(requests))
+	}
+
+	for _, req := range requests {
+		if !expected[req.NamespacedName] {
+			t.Fatalf("unexpected request queued: %s", req.String())
+		}
+		delete(expected, req.NamespacedName)
+	}
+
+	if len(expected) > 0 {
+		t.Fatalf("missing queued requests: %v", expected)
+	}
+}
+
+func Test_getEventPredicates(t *testing.T) {
+	t.Parallel()
+
+	predicates := (&AccessManagementReconciler{}).getEventPredicates()
+
+	if !predicates.Create(event.TypedCreateEvent[client.Object]{Object: &corev1.Namespace{}}) {
+		t.Fatal("expected create event to trigger reconcile")
+	}
+
+	if predicates.Delete(event.TypedDeleteEvent[client.Object]{Object: &corev1.Namespace{}}) {
+		t.Fatal("expected delete event to not trigger reconcile")
+	}
+
+	if predicates.Generic(event.TypedGenericEvent[client.Object]{Object: &corev1.Namespace{}}) {
+		t.Fatal("expected generic event to not trigger reconcile")
+	}
+
+	oldNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns", Labels: map[string]string{"env": "dev"}}}
+	newNamespace := oldNamespace.DeepCopy()
+	if predicates.Update(event.TypedUpdateEvent[client.Object]{ObjectOld: oldNamespace, ObjectNew: newNamespace}) {
+		t.Fatal("expected update event with unchanged labels to not trigger reconcile")
+	}
+
+	newNamespace.Labels["env"] = "prod"
+	if !predicates.Update(event.TypedUpdateEvent[client.Object]{ObjectOld: oldNamespace, ObjectNew: newNamespace}) {
+		t.Fatal("expected update event with changed labels to trigger reconcile")
+	}
+
+	if predicates.Update(event.TypedUpdateEvent[client.Object]{}) {
+		t.Fatal("expected update event with missing objects to not trigger reconcile")
+	}
+}
+
+func newAccessManagementReconcilerWithIndexes(t *testing.T, objs ...client.Object) *AccessManagementReconciler {
+	t.Helper()
+
+	return &AccessManagementReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(testscheme.Scheme).
+			WithIndex(&kcmv1.AccessManagement{}, kcmv1.AccessManagementTargetNamespaceListIndexKey, kcmv1.ExtractAccessManagementTargetNamespaceLists).
+			WithIndex(&kcmv1.AccessManagement{}, kcmv1.AccessManagementUsesSelectorIndexKey, kcmv1.ExtractAccessManagementUsesSelector).
+			WithIndex(&kcmv1.AccessManagement{}, kcmv1.AccessManagementTargetsAllNamespacesIndexKey, kcmv1.ExtractAccessManagementTargetsAllNamespaces).
+			WithObjects(objs...).
+			Build(),
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enqueue only AccessManagement objects that target the created Namespace.

On Namespace label updates, enqueue only when selector membership changes.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #2687