### PR TITLE
chore(template): add openstack tls verify example

### DIFF
--- a/config/dev/openstack-credentials.yaml
+++ b/config/dev/openstack-credentials.yaml
@@ -66,6 +66,7 @@ data:
     {{- $$network_id := $$cluster.status.externalNetwork.id -}}
     {{- $$network_name := $$cluster.status.externalNetwork.name -}}
 
+    {{- $$verify := index $$openstack "verify" -}}
     {{- $$ca_cert := index $$identity "data" "cacert" -}}
     ---
     apiVersion: v1
@@ -96,6 +97,10 @@ data:
         password="{{ index $$openstack "password" }}"
         {{- end }}
         region="{{ index $$openstack "region_name" }}"
+
+        {{- if or (eq $$verify false) (eq (lower (printf "%v" $$verify)) "false") }}
+        tls-insecure=true
+        {{- end }}
 
         {{- if $$ca_cert }}
         ca-file=/etc/cacert/ca.crt


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the example of how to use `verify` for `tls-verify` in our exemplar (dev) config.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #977 
