### PR TITLE
refactor: normalize requeue/error controller paths

### DIFF
--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -307,6 +307,10 @@ func (r *ManagementReconciler) startDependentControllers(ctx context.Context, ma
 	}
 
 	l := ctrl.LoggerFrom(ctx).WithValues("provider_name", kcmv1.ProviderSveltosName)
+
+	// WARN: FIXME: (ksm) if sveltos is an optional provider,
+	// absence of it means we will not have both the CLD and MCS controllers at all
+
 	if !management.Status.Components[kcmv1.ProviderSveltosName].Success {
 		msg := "Waiting for provider to be ready to setup controllers dependent on it"
 		r.eventf(management, "WaitingForSveltosReadiness", msg)
@@ -571,16 +575,30 @@ func (r *ManagementReconciler) delete(ctx context.Context, management *kcmv1.Man
 	r.eventf(management, "RemovingManagement", "Removing KCM management components")
 
 	requeue, err := r.removeHelmReleases(ctx, kcmv1.CoreKCMName, listOpts)
-	if err != nil || requeue {
-		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, err
+	if err != nil {
+		l.Error(err, "deleting helm releases")
+		return ctrl.Result{}, err
 	}
+	if requeue {
+		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
+	}
+
 	requeue, err = r.removeHelmCharts(ctx, listOpts)
-	if err != nil || requeue {
-		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, err
+	if err != nil {
+		l.Error(err, "deleting helm charts")
+		return ctrl.Result{}, err
 	}
+	if requeue {
+		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
+	}
+
 	requeue, err = r.removeHelmRepositories(ctx, listOpts)
-	if err != nil || requeue {
-		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, err
+	if err != nil {
+		l.Error(err, "deleting helm repositories")
+		return ctrl.Result{}, err
+	}
+	if requeue {
+		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
 	}
 
 	r.eventf(management, "RemovedManagement", "All KCM management components were removed")
@@ -601,41 +619,66 @@ func (r *ManagementReconciler) removeHelmReleases(ctx context.Context, kcmReleas
 	if err != nil && !apierrors.IsNotFound(err) {
 		return false, err
 	}
+
 	if err == nil && !kcmRelease.Spec.Suspend {
 		kcmRelease.Spec.Suspend = true
 		if err := r.Client.Update(ctx, kcmRelease); err != nil {
 			return false, err
 		}
 	}
+
 	l.Info("Ensuring all HelmReleases owned by KCM are removed")
+
 	gvk := helmcontrollerv2.GroupVersion.WithKind(helmcontrollerv2.HelmReleaseKind)
-	if err := kubeutil.EnsureDeleteAllOf(ctx, r.Client, gvk, opts); err != nil {
-		l.Error(err, "Not all HelmReleases owned by KCM are removed")
-		return true, err
+
+	requeue, err = kubeutil.EnsureDeleteAllOf(ctx, r.Client, gvk, opts)
+	if err != nil {
+		return false, fmt.Errorf("failed to delete all helm releases: %w", err)
 	}
-	return false, nil
+
+	if requeue {
+		l.Info("Waiting for HelmReleases owned by KCM to be removed")
+	}
+
+	return requeue, nil
 }
 
 func (r *ManagementReconciler) removeHelmCharts(ctx context.Context, opts *client.ListOptions) (requeue bool, err error) {
 	l := ctrl.LoggerFrom(ctx)
+
 	l.Info("Ensuring all HelmCharts owned by KCM are removed")
+
 	gvk := sourcev1.GroupVersion.WithKind(sourcev1.HelmChartKind)
-	if err := kubeutil.EnsureDeleteAllOf(ctx, r.Client, gvk, opts); err != nil {
-		l.Error(err, "Not all HelmCharts owned by KCM are removed")
-		return true, err
+
+	requeue, err = kubeutil.EnsureDeleteAllOf(ctx, r.Client, gvk, opts)
+	if err != nil {
+		return false, fmt.Errorf("failed to delete all helm charts: %w", err)
 	}
-	return false, nil
+
+	if requeue {
+		l.Info("Waiting for HelmCharts owned by KCM to be removed")
+	}
+
+	return requeue, nil
 }
 
 func (r *ManagementReconciler) removeHelmRepositories(ctx context.Context, opts *client.ListOptions) (requeue bool, err error) {
 	l := ctrl.LoggerFrom(ctx)
+
 	l.Info("Ensuring all HelmRepositories owned by KCM are removed")
+
 	gvk := sourcev1.GroupVersion.WithKind(sourcev1.HelmRepositoryKind)
-	if err := kubeutil.EnsureDeleteAllOf(ctx, r.Client, gvk, opts); err != nil {
-		l.Error(err, "Not all HelmRepositories owned by KCM are removed")
-		return true, err
+
+	requeue, err = kubeutil.EnsureDeleteAllOf(ctx, r.Client, gvk, opts)
+	if err != nil {
+		return false, fmt.Errorf("failed to delete all helm repositories: %w", err)
 	}
-	return false, nil
+
+	if requeue {
+		l.Info("Waiting for HelmRepositories owned by KCM to be removed")
+	}
+
+	return requeue, nil
 }
 
 func (r *ManagementReconciler) ensureUpgradeBackup(ctx context.Context, mgmt *kcmv1.Management) (requeue bool, _ error) {

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -113,11 +113,12 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
 	}
 
-	if updated, err := labelsutil.AddKCMComponentLabel(ctx, r.Client, mcs); updated || err != nil {
-		if err != nil {
-			l.Error(err, "adding component label")
-		}
-		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, err // generation has not changed, need explicit requeue
+	if updated, err := labelsutil.AddKCMComponentLabel(ctx, r.Client, mcs); err != nil {
+		l.Error(err, "adding component label")
+		return ctrl.Result{}, err
+	} else if updated {
+		// generation has not changed, so an explicit requeue is needed.
+		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
 	}
 
 	l.Info("Validating service templates")

--- a/internal/controller/region/controller.go
+++ b/internal/controller/region/controller.go
@@ -119,11 +119,11 @@ func (r *Reconciler) update(ctx context.Context, rgnlClient client.Client, restC
 		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
 	}
 
-	if updated, err := labelsutil.AddKCMComponentLabel(ctx, r.MgmtClient, region); updated || err != nil {
-		if err != nil {
-			l.Error(err, "adding component label")
-		}
-		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, err
+	if updated, err := labelsutil.AddKCMComponentLabel(ctx, r.MgmtClient, region); err != nil {
+		l.Error(err, "adding component label")
+		return ctrl.Result{}, err
+	} else if updated {
+		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
 	}
 
 	defer func() {

--- a/internal/controller/template_controller.go
+++ b/internal/controller/template_controller.go
@@ -189,7 +189,12 @@ func (r *TemplateReconciler) ReconcileTemplate(ctx context.Context, template tem
 			return ctrl.Result{}, fmt.Errorf("failed to check if Secrets %v exists: %w", helmRepositorySecrets, err)
 		}
 		if !exists {
-			return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, r.updateStatus(ctx, template, fmt.Sprintf("Some of the predeclared Secrets (%v) are missing (%v) in the %s namespace", helmRepositorySecrets, missingSecrets, r.SystemNamespace))
+			if err := r.updateStatus(ctx, template, fmt.Sprintf("Some of the predeclared Secrets (%v) are missing (%v) in the %s namespace", helmRepositorySecrets, missingSecrets, r.SystemNamespace)); err != nil {
+				l.Error(err, "updating status")
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
 		}
 	}
 

--- a/internal/util/kube/kube.go
+++ b/internal/util/kube/kube.go
@@ -22,6 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,23 +34,33 @@ const (
 	DefaultStateManagementProviderSelectorValue = "kcm-controller-manager"
 )
 
-func EnsureDeleteAllOf(ctx context.Context, cl client.Client, gvk schema.GroupVersionKind, opts *client.ListOptions) error {
+func EnsureDeleteAllOf(ctx context.Context, cl client.Client, gvk schema.GroupVersionKind, opts *client.ListOptions) (requeue bool, err error) {
+	l := ctrl.LoggerFrom(ctx).V(1).WithName("ensure-delete")
+
 	itemsList := &metav1.PartialObjectMetadataList{}
 	itemsList.SetGroupVersionKind(gvk)
 	if err := cl.List(ctx, itemsList, opts); err != nil {
-		return err
+		return false, fmt.Errorf("failed to list %s: %w", gvk.String(), err)
 	}
+
 	var errs error
 	for _, item := range itemsList.Items {
+		requeue = true
 		if item.DeletionTimestamp.IsZero() {
 			if err := cl.Delete(ctx, &item); client.IgnoreNotFound(err) != nil {
-				errs = errors.Join(errs, err)
+				errs = errors.Join(errs, fmt.Errorf("failed to delete %s %s/%s: %w", gvk.String(), item.Namespace, item.Name, err))
 				continue
 			}
 		}
-		errs = errors.Join(errs, fmt.Errorf("waiting for %s %s/%s removal", gvk.Kind, item.Namespace, item.Name))
+
+		l.Info("waiting for object removal", "gvk", gvk.String(), "object namespace", item.Namespace, "object name", item.Name)
 	}
-	return errs
+
+	if errs != nil {
+		return false, errs
+	}
+
+	return requeue, nil
 }
 
 func CurrentNamespace() string {

--- a/internal/util/kube/kube_test.go
+++ b/internal/util/kube/kube_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestEnsureDeleteAllOf(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	const ns = metav1.NamespaceDefault
+	gvk := corev1.SchemeGroupVersion.WithKind("ConfigMap")
+
+	tests := []struct {
+		name            string
+		seedObjects     []client.Object
+		listErr         error
+		deleteErr       error
+		wantRequeue     bool
+		wantErrContains string
+		assertBaseState func(t *testing.T, base client.Client)
+	}{
+		{
+			name: "returns requeue when objects are present",
+			seedObjects: []client.Object{
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: ns}},
+			},
+			wantRequeue: true,
+			assertBaseState: func(t *testing.T, base client.Client) {
+				t.Helper()
+				got := &corev1.ConfigMap{}
+				err := base.Get(t.Context(), client.ObjectKey{Namespace: ns, Name: "test-cm"}, got)
+				require.True(t, apierrors.IsNotFound(err))
+			},
+		},
+		{
+			name:        "returns no requeue when no objects are present",
+			wantRequeue: false,
+		},
+		{
+			name:            "returns hard error when list fails",
+			listErr:         errors.New("list failed"),
+			wantRequeue:     false,
+			wantErrContains: "failed to list",
+		},
+		{
+			name: "returns hard error when delete fails",
+			seedObjects: []client.Object{
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: ns}},
+			},
+			deleteErr:       errors.New("delete failed"),
+			wantRequeue:     false,
+			wantErrContains: "failed to delete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.seedObjects...).Build()
+
+			var cl client.Client = base
+			if tt.listErr != nil || tt.deleteErr != nil {
+				cl = &ensureDeleteAllOfErrClient{
+					Client:    base,
+					listErr:   tt.listErr,
+					deleteErr: tt.deleteErr,
+				}
+			}
+
+			requeue, err := EnsureDeleteAllOf(t.Context(), cl, gvk, &client.ListOptions{Namespace: ns})
+
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErrContains)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tt.wantRequeue, requeue)
+
+			if tt.assertBaseState != nil {
+				tt.assertBaseState(t, base)
+			}
+		})
+	}
+}
+
+type ensureDeleteAllOfErrClient struct {
+	client.Client
+	listErr   error
+	deleteErr error
+}
+
+func (e *ensureDeleteAllOfErrClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if _, ok := list.(*metav1.PartialObjectMetadataList); ok && e.listErr != nil {
+		return e.listErr
+	}
+
+	return e.Client.List(ctx, list, opts...)
+}
+
+func (e *ensureDeleteAllOfErrClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if e.deleteErr != nil {
+		return e.deleteErr
+	}
+
+	return e.Client.Delete(ctx, obj, opts...)
+}

--- a/internal/util/validation/cd.go
+++ b/internal/util/validation/cd.go
@@ -58,6 +58,10 @@ func ClusterDeployCredential(ctx context.Context, cl client.Client, systemNamesp
 		return fmt.Errorf("the Credential %s is not Ready", credKey)
 	}
 
+	if cred.Spec.IdentityRef == nil {
+		return fmt.Errorf("the Credential %s does not have identityRef", credKey)
+	}
+
 	return isCredIdentitySupportsClusterTemplate(ctx, cl, systemNamespace, cred, clusterTemplate)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Separate hard errors from requeue decisions across updated reconcilers and helper utilities

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #2698