### PR TITLE
chore(templates): bump chart versions and align values overrides

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-29
+  template: aws-standalone-cp-1-0-30
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-30
+  template: azure-standalone-cp-1-0-31
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-27
+  template: gcp-standalone-cp-1-0-28
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-32
+  template: openstack-standalone-cp-1-0-33
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-27
+  template: vsphere-standalone-cp-1-0-28
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.32
+version: 1.0.33
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -136,7 +136,7 @@ data:
       {{- else }}
       chartName: aws-cloud-controller-manager/aws-cloud-controller-manager
       {{- end }}
-      version: 0.0.9
+      version: 0.0.11
       releaseName: aws-cloud-controller-manager
       namespace: kube-system
       values: |
@@ -144,7 +144,7 @@ data:
           {{- if $global.registry }}
           repository: {{ $global.registry }}/provider-aws/cloud-controller-manager
           {{- end }}
-          tag: v1.30.3
+          tag: v1.34.0
         args:
           - --v=2
           - --cloud-provider=aws
@@ -186,7 +186,7 @@ data:
       {{- else }}
       chartName: aws-ebs-csi-driver/aws-ebs-csi-driver
       {{- end }}
-      version: 2.33.0
+      version: 2.58.0
       releaseName: aws-ebs-csi-driver
       namespace: kube-system
       values: |
@@ -196,22 +196,22 @@ data:
         sidecars:
           provisioner:
             image:
-              repository: {{ $global.registry }}/kubernetes-csi/external-provisioner
+              repository: {{ $global.registry }}/csi-components/csi-provisioner
           attacher:
             image:
-              repository: {{ $global.registry }}/kubernetes-csi/external-attacher
+              repository: {{ $global.registry }}/csi-components/csi-attacher
           snapshotter:
             image:
-              repository: {{ $global.registry }}/external-snapshotter/csi-snapshotter
+              repository: {{ $global.registry }}/csi-components/csi-snapshotter
           livenessProbe:
             image:
-              repository: {{ $global.registry }}/kubernetes-csi/livenessprobe
+              repository: {{ $global.registry }}/csi-components/livenessprobe
           resizer:
             image:
-              repository: {{ $global.registry }}/kubernetes-csi/external-resizer
+              repository: {{ $global.registry }}/csi-components/csi-resizer
           nodeDriverRegistrar:
             image:
-              repository: {{ $global.registry }}/kubernetes-csi/node-driver-registrar
+              repository: {{ $global.registry }}/csi-components/csi-node-driver-registrar
           volumemodifier:
             image:
               repository: {{ $global.registry }}/ebs-csi-driver/volume-modifier-for-k8s

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.29
+version: 1.0.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -97,7 +97,7 @@ spec:
           {{- else }}
           chartName: aws-cloud-controller-manager/aws-cloud-controller-manager
           {{- end }}
-          version: 0.0.9
+          version: 0.0.11
           releaseName: aws-cloud-controller-manager
           namespace: kube-system
           values: |
@@ -107,7 +107,7 @@ spec:
               {{- if $global.registry }}
               repository: {{ $global.registry }}/provider-aws/cloud-controller-manager
               {{- end }}
-              tag: v1.30.3
+              tag: v1.34.0
             args:
               - --v=2
               - --cloud-provider=aws
@@ -138,7 +138,7 @@ spec:
           {{- else }}
           chartName: aws-ebs-csi-driver/aws-ebs-csi-driver
           {{- end }}
-          version: 2.33.0
+          version: 2.58.0
           releaseName: aws-ebs-csi-driver
           namespace: kube-system
           values: |
@@ -148,22 +148,22 @@ spec:
             sidecars:
               provisioner:
                 image:
-                  repository: {{ $global.registry }}/kubernetes-csi/external-provisioner
+                  repository: {{ $global.registry }}/csi-components/csi-provisioner
               attacher:
                 image:
-                  repository: {{ $global.registry }}/kubernetes-csi/external-attacher
+                  repository: {{ $global.registry }}/csi-components/csi-attacher
               snapshotter:
                 image:
-                  repository: {{ $global.registry }}/external-snapshotter/csi-snapshotter
+                  repository: {{ $global.registry }}/csi-components/csi-snapshotter
               livenessProbe:
                 image:
-                  repository: {{ $global.registry }}/kubernetes-csi/livenessprobe
+                  repository: {{ $global.registry }}/csi-components/livenessprobe
               resizer:
                 image:
-                  repository: {{ $global.registry }}/kubernetes-csi/external-resizer
+                  repository: {{ $global.registry }}/csi-components/csi-resizer
               nodeDriverRegistrar:
                 image:
-                  repository: {{ $global.registry }}/kubernetes-csi/node-driver-registrar
+                  repository: {{ $global.registry }}/csi-components/csi-node-driver-registrar
               volumemodifier:
                 image:
                   repository: {{ $global.registry }}/ebs-csi-driver/volume-modifier-for-k8s

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.35
+version: 1.0.36
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -135,7 +135,7 @@ data:
       {{- else }}
       chartName: cloud-provider-azure/cloud-provider-azure
       {{- end }}
-      version: 1.31.2
+      version: 1.34.6
       order: 1
       releaseName: cloud-provider-azure
       namespace: kube-system
@@ -147,11 +147,13 @@ data:
           {{- if $global.registry }}
           imageRepository: {{ $global.registry }}
           {{- end }}
-          imageTag: v1.32.4
+          imageTag: v1.34.3
         cloudNodeManager:
-          imageTag: v1.32.4
+          imageTag: v1.34.3
         {{- if $global.registry }}
           imageRepository: {{ $global.registry }}
+          healthProbeProxyImage: {{ $global.registry }}/kubernetes/azure-health-probe-proxy:v1.34.3
+          healthProbeProxyImageWindows: {{ $global.registry }}/kubernetes/azure-health-probe-proxy:v1.34.3
         {{- end }}
   2-chart-azuredisk-csi-driver.yaml: |
     apiVersion: helm.k0sproject.io/v1beta1
@@ -180,7 +182,7 @@ data:
       {{- else }}
       chartName: azuredisk-csi-driver/azuredisk-csi-driver
       {{- end }}
-      version: v1.30.3
+      version: 1.34.3
       order: 2
       releaseName: azuredisk-csi-driver
       namespace: kube-system

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.30
+version: 1.0.31
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -76,7 +76,7 @@ spec:
             {{- else }}
             chartName: cloud-provider-azure/cloud-provider-azure
             {{- end }}
-            version: 1.31.2
+            version: 1.34.6
             order: 1
             releaseName: cloud-provider-azure
             namespace: kube-system
@@ -88,11 +88,13 @@ spec:
                 {{- if $global.registry }}
                 imageRepository: {{ $global.registry }}
                 {{- end }}
-                imageTag: v1.32.4
+                imageTag: v1.34.3
               cloudNodeManager:
-                imageTag: v1.32.4
+                imageTag: v1.34.3
               {{- if $global.registry }}
                 imageRepository: {{ $global.registry }}
+                healthProbeProxyImage: {{ $global.registry }}/kubernetes/azure-health-probe-proxy:v1.34.3
+                healthProbeProxyImageWindows: {{ $global.registry }}/kubernetes/azure-health-probe-proxy:v1.34.3
               {{- end }}
       - path: /var/lib/k0s/manifests/kcm/2-chart-azuredisk-csi-driver.yaml
         permissions: "0644"
@@ -118,7 +120,7 @@ spec:
             {{- else }}
             chartName: azuredisk-csi-driver/azuredisk-csi-driver
             {{- end }}
-            version: v1.30.3
+            version: 1.34.3
             order: 2
             releaseName: azuredisk-csi-driver
             namespace: kube-system

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.31
+version: 1.0.32
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -135,7 +135,7 @@ data:
       {{- else }}
       chartName: gcp-cloud-controller-manager/gcp-cloud-controller-manager
       {{- end }}
-      version: 0.0.1
+      version: 0.0.2
       releaseName: gcp-cloud-controller-manager
       namespace: kube-system
       values: |
@@ -150,7 +150,7 @@ data:
           {{- if $global.registry }}
           repository: {{ $global.registry }}/k8s-staging-cloud-provider-gcp/cloud-controller-manager
           {{- end }}
-          tag: v32.2.3
+          tag: v36.0.0
         args:
           - --cloud-provider=gce
           - --leader-elect=true
@@ -185,7 +185,7 @@ data:
       {{- else }}
       chartName: gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver
       {{- end }}
-      version: 0.0.2
+      version: 0.0.3
       releaseName: gcp-compute-persistent-disk-csi-driver
       namespace: kube-system
       values: |
@@ -208,7 +208,7 @@ data:
             enabled: false
         defaultStorageClass:
           enabled: true
-          {{- if $global.registry }}
+        {{- if $global.registry }}
         controller:
           provisioner:
             image:
@@ -223,6 +223,9 @@ data:
             image:
               repository: {{ $global.registry }}/sig-storage/csi-snapshotter
           driver:
+            image:
+              repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+          tainter:
             image:
               repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
         {{- end }}

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.27
+version: 1.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -76,7 +76,7 @@ spec:
             {{- else }}
             chartName: gcp-cloud-controller-manager/gcp-cloud-controller-manager
             {{- end }}
-            version: 0.0.1
+            version: 0.0.2
             releaseName: gcp-cloud-controller-manager
             namespace: kube-system
             values: |
@@ -93,7 +93,7 @@ spec:
                 {{- if $global.registry }}
                 repository: {{ $global.registry }}/k8s-staging-cloud-provider-gcp/cloud-controller-manager
                 {{- end }}
-                tag: v32.2.3
+                tag: v36.0.0
               args:
                 - --cloud-provider=gce
                 - --leader-elect=true
@@ -125,7 +125,7 @@ spec:
             {{- else }}
             chartName: gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver
             {{- end }}
-            version: 0.0.2
+            version: 0.0.3
             releaseName: gcp-compute-persistent-disk-csi-driver
             namespace: kube-system
             values: |
@@ -163,6 +163,9 @@ spec:
                   image:
                     repository: {{ $global.registry }}/sig-storage/csi-snapshotter
                 driver:
+                  image:
+                    repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+                tainter:
                   image:
                     repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
               {{- end }}
@@ -223,7 +226,7 @@ spec:
                 {{- else }}
                 chartname: mirantis/gcp-cloud-controller-manager
                 {{- end }}
-                version: "0.0.1"
+                version: "0.0.2"
                 values: |
                   cloudConfig:
                     enabled: true
@@ -238,7 +241,7 @@ spec:
                     {{- if $global.registry }}
                     repository: {{ $global.registry }}/k8s-staging-cloud-provider-gcp/cloud-controller-manager
                     {{- end }}
-                    tag: v32.2.3
+                    tag: v36.0.0
                   args:
                     - --cloud-provider=gce
                     - --leader-elect=true
@@ -253,7 +256,7 @@ spec:
                 {{- else }}
                 chartname: mirantis/gcp-compute-persistent-disk-csi-driver
                 {{- end }}
-                version: "0.0.2"
+                version: "0.0.3"
                 values: |
                   cloudCredentials:
                     secretName: gcp-cloud-sa
@@ -289,6 +292,9 @@ spec:
                       image:
                         repository: {{ $global.registry }}/sig-storage/csi-snapshotter
                     driver:
+                      image:
+                        repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+                    tainter:
                       image:
                         repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
                   {{- end }}

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.28
+version: 1.0.29
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -148,7 +148,7 @@ data:
       {{- else }}
       chartName: openstack-cloud-controller-manager/openstack-cloud-controller-manager
       {{- end }}
-      version: 2.31.1
+      version: 2.35.0
       order: 1
       releaseName: openstack-cloud-controller-manager
       namespace: kube-system
@@ -231,7 +231,7 @@ data:
       {{- else }}
       chartName: openstack-cinder-csi/openstack-cinder-csi
       {{- end }}
-      version: 2.31.2
+      version: 2.35.0
       order: 2
       releaseName: openstack-cinder-csi
       namespace: kube-system

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.32
+version: 1.0.33
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -76,7 +76,7 @@ spec:
             {{- else }}
             chartName: openstack-cloud-controller-manager/openstack-cloud-controller-manager
             {{- end }}
-            version: 2.31.1
+            version: 2.35.0
             order: 1
             releaseName: openstack-cloud-controller-manager
             namespace: kube-system
@@ -153,7 +153,7 @@ spec:
             {{- else }}
             chartName: openstack-cinder-csi/openstack-cinder-csi
             {{- end }}
-            version: 2.31.2
+            version: 2.35.0
             order: 2
             releaseName: openstack-cinder-csi
             namespace: kube-system

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.30
+version: 1.0.31
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -135,7 +135,7 @@ data:
       {{- else }}
       chartName: vsphere-cpi/vsphere-cpi
       {{- end }}
-      version: 1.31.0
+      version: 1.36.0
       releaseName: vsphere-cpi
       namespace: kube-system
       order: 1
@@ -190,7 +190,7 @@ data:
       {{- else }}
       chartName: vsphere-csi-driver/vsphere-csi-driver
       {{- end }}
-      version: 0.0.3
+      version: 0.0.4
       releaseName: vsphere-csi-driver
       namespace: kube-system
       order: 2
@@ -208,12 +208,12 @@ data:
             {{- if $global.registry }}
             repo: {{ $global.registry }}/csi-vsphere/driver
             {{- end }}
-            tag: v3.1.2
+            tag: v3.7.0
           syncer:
             {{- if $global.registry }}
             repo: {{ $global.registry }}/csi-vsphere/syncer
             {{- end }}
-            tag: v3.1.2
+            tag: v3.7.0
           {{- if $global.registry }}
           nodeDriverRegistrar:
             repo: {{ $global.registry }}/sig-storage/csi-node-driver-registrar

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.27
+version: 1.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -81,7 +81,7 @@ spec:
             {{- else }}
             chartName: kube-vip/kube-vip
             {{- end }}
-            version: 0.6.1
+            version: 0.9.9
             releaseName: kube-vip
             namespace: kube-system
             order: 1
@@ -132,7 +132,7 @@ spec:
             {{- else }}
             chartName: vsphere-cpi/vsphere-cpi
             {{- end }}
-            version: 1.31.0
+            version: 1.36.0
             releaseName: vsphere-cpi
             namespace: kube-system
             order: 2
@@ -183,7 +183,7 @@ spec:
             {{- else }}
             chartName: vsphere-csi-driver/vsphere-csi-driver
             {{- end }}
-            version: 0.0.3
+            version: 0.0.4
             releaseName: vsphere-csi-driver
             namespace: kube-system
             order: 3
@@ -199,12 +199,12 @@ spec:
                   {{- if $global.registry }}
                   repo: {{ $global.registry }}/csi-vsphere/driver
                   {{- end }}
-                  tag: v3.1.2
+                  tag: v3.7.0
                 syncer:
                   {{- if $global.registry }}
                   repo: {{ $global.registry }}/csi-vsphere/syncer
                   {{- end }}
-                  tag: v3.1.2
+                  tag: v3.7.0
                 {{- if $global.registry }}
                 nodeDriverRegistrar:
                   repo: {{ $global.registry }}/sig-storage/csi-node-driver-registrar

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-33.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-33.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-32
+  name: aws-hosted-cp-1-0-33
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.32
+      chart: aws-hosted-cp
+      version: 1.0.33
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-30.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-30.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-27
+  name: aws-standalone-cp-1-0-30
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.27
+      chart: aws-standalone-cp
+      version: 1.0.30
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-36.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-36.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-35
+  name: azure-hosted-cp-1-0-36
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: azure-hosted-cp
-      version: 1.0.35
+      version: 1.0.36
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-31.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-31.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-30
+  name: azure-standalone-cp-1-0-31
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.30
+      chart: azure-standalone-cp
+      version: 1.0.31
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-32.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-32.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-27
+  name: gcp-hosted-cp-1-0-32
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.27
+      chart: gcp-hosted-cp
+      version: 1.0.32
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-28.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-28.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-31
+  name: gcp-standalone-cp-1-0-28
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.31
+      chart: gcp-standalone-cp
+      version: 1.0.28
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-29.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-29.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-32
+  name: openstack-hosted-cp-1-0-29
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.32
+      chart: openstack-hosted-cp
+      version: 1.0.29
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-33.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-33.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-28
+  name: openstack-standalone-cp-1-0-33
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.28
+      chart: openstack-standalone-cp
+      version: 1.0.33
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-31.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-31.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-29
+  name: vsphere-hosted-cp-1-0-31
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.29
+      chart: vsphere-hosted-cp
+      version: 1.0.31
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-28.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-28.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-30
+  name: vsphere-standalone-cp-1-0-28
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.30
+      chart: vsphere-standalone-cp
+      version: 1.0.28
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Closes #2523 

## Summary

- Bumped K0smotron control plane chart versions across provider templates to the latest upstream releases.
- Added kube-vip chart update for vSphere standalone control plane.

## Changes

- Updated chart versions in K0smotronControlPlane templates for AWS, Azure, GCP, OpenStack, and vSphere hosted clusters.
- Updated kube-vip chart version in the vSphere standalone control plane template.

| Template | Chart | Old<br>Version | Old<br>App Version | New<br>Version | New<br>App Version |
|---|---|---|---|---|---|
| [aws-hosted-cp](https://github.com/k0rdent/kcm/blob/main/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml#L101) | [aws-cloud-controller-manager](https://github.com/Mirantis/helm-charts/tree/main/mirantis/aws-cloud-controller-manager) | `0.0.9` | | `0.0.11` | `v1.34.0` |
| [aws-hosted-cp](https://github.com/k0rdent/kcm/blob/main/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml#L151) | [aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/v1.59.0/charts/aws-ebs-csi-driver) | `2.33.0` | `1.33.0` | `2.58.0` | `1.58.0` |
| [azure-hosted-cp](https://github.com/k0rdent/kcm/blob/main/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml#L100) | [cloud-provider-azure](https://github.com/Mirantis/helm-charts/tree/main/mirantis/cloud-provider-azure) | `1.31.2` | | `1.34.6` | `v1.34.3` |
| [azure-hosted-cp](https://github.com/k0rdent/kcm/blob/main/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml#L145) | [azuredisk-csi-driver](https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/v1.34.3/charts/v1.34.3/azuredisk-csi-driver) | `v1.30.3` | `v1.30.3` | `1.34.3` | `1.34.3` |
| [gcp-hosted-cp](https://github.com/k0rdent/kcm/blob/main/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml#L100) | [gcp-cloud-controller-manager](https://github.com/Mirantis/helm-charts/tree/main/mirantis/gcp-cloud-controller-manager) | `0.0.1` | | `0.0.2` | `v36.0.0` |
| [gcp-hosted-cp](https://github.com/k0rdent/kcm/blob/main/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml#L150) | [gcp-compute-persistent-disk-csi-driver](https://github.com/Mirantis/helm-charts/tree/main/mirantis/gcp-compute-persistent-disk-csi-driver) | `0.0.2` | | `0.0.3` | `v1.25.1` |
| [openstack-hosted-cp](https://github.com/k0rdent/kcm/blob/main/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml#L113) | [openstack-cloud-controller-manager](https://github.com/kubernetes/cloud-provider-openstack/blob/v1.35.0/charts/openstack-cloud-controller-manager) | `2.31.1` | `v1.31.1` | `2.35.0` | `v1.35.0` |
| [openstack-hosted-cp](https://github.com/k0rdent/kcm/blob/main/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml#L196) | [openstack-cinder-csi](https://github.com/kubernetes/cloud-provider-openstack/blob/v1.35.0/charts/cinder-csi-plugin) | `2.31.2` | `v1.31.1` | `2.35.0` | `v1.35.0` |
| [vsphere-hosted-cp](https://github.com/k0rdent/kcm/blob/main/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml#L100) | [vsphere-cpi](https://github.com/kubernetes/cloud-provider-vsphere/blob/v1.36.0/charts/vsphere-cpi) | `1.31.0` | `1.31.0` | `1.36.0` | `1.36.0` |
| [vsphere-hosted-cp](https://github.com/k0rdent/kcm/blob/main/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml#L155) | [vsphere-csi-driver](https://github.com/Mirantis/helm-charts/tree/main/mirantis/vsphere-csi-driver) | `0.0.3` | | `0.0.4` | `3.7.0` |
| [vsphere-standalone-cp](https://github.com/k0rdent/kcm/blob/main/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml#L58) | [kube-vip](https://github.com/kube-vip/helm-charts/blob/kube-vip-0.9.9/charts/kube-vip) | `0.6.1` | `v0.8.0` | `0.9.9` | `v1.0.4` |