### PR TITLE
refactor: optimizations to CD reconcile process

### DIFF
--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -15,11 +15,13 @@
 package controller
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -32,6 +34,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -266,9 +269,10 @@ func (r *ClusterDeploymentReconciler) reconcileUpdate(ctx context.Context, scope
 		return ctrl.Result{}, err
 	}
 
+	oldCD := cd.DeepCopy()
 	clusterTpl := &kcmv1.ClusterTemplate{}
 	defer func() {
-		err = errors.Join(err, r.updateStatus(ctx, cd, clusterTpl))
+		err = errors.Join(err, r.updateStatus(ctx, oldCD, cd, clusterTpl))
 	}()
 
 	if scope.region != nil {
@@ -1190,32 +1194,27 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, cd *kc
 		return fmt.Errorf("failed to create or update ServiceSet for ClusterDeployment %s: %w", client.ObjectKeyFromObject(cd), err)
 	}
 
-	var (
-		serviceStatuses []kcmv1.ServiceState
-		upgradePaths    []kcmv1.ServiceUpgradePaths
-		errs            error
-	)
+	serviceSetList := new(kcmv1.ServiceSetList)
+	if err := r.MgmtClient.List(ctx, serviceSetList, client.InNamespace(cd.Namespace), client.MatchingFields{kcmv1.ServiceSetClusterIndexKey: cd.Name}); err != nil {
+		return fmt.Errorf("failed to list ServiceSets matching %s/%s ClusterDeployment: %w", cd.Namespace, cd.Name, err)
+	}
+	l.V(1).Info("ServiceSets matching ClusterDeployment found", "CD", cd.Namespace+"/"+cd.Name, "count", len(serviceSetList.Items))
 
-	// we'll update services' statuses and join errors
-	serviceStatuses, err = r.collectServicesStatuses(ctx, cd)
-	cd.Status.Services = serviceStatuses
-	errs = errors.Join(errs, err)
+	// we'll update services' statuses
+	cd.Status.Services = collectServicesStatuses(serviceSetList.Items)
 
-	// we'll update services' upgrade paths and join errors
-	upgradePaths, err = serviceset.ServicesUpgradePaths(ctx, r.MgmtClient, cd.Spec.ServiceSpec.Services, cd.Namespace)
+	// we'll update services' upgrade paths
+	upgradePaths, err := serviceset.ServicesUpgradePaths(ctx, r.MgmtClient, cd.Spec.ServiceSpec.Services, cd.Namespace)
 	cd.Status.ServicesUpgradePaths = upgradePaths
-	errs = errors.Join(errs, err)
-	return errs
+
+	// we'll update cd status to show no of deployed services
+	setServicesCondition(cd, serviceSetList.Items)
+	return err
 }
 
 // setServicesCondition updates ClusterDeployment's condition which shows number of successfully
 // deployed services out of total number of desired services.
-func (r *ClusterDeploymentReconciler) setServicesCondition(ctx context.Context, cd *kcmv1.ClusterDeployment) error {
-	serviceSetList := new(kcmv1.ServiceSetList)
-	if err := r.MgmtClient.List(ctx, serviceSetList, client.MatchingFields{kcmv1.ServiceSetClusterIndexKey: cd.Name}); err != nil {
-		return fmt.Errorf("failed to list ServiceSets for ClusterDeployment %s: %w", client.ObjectKeyFromObject(cd), err)
-	}
-
+func setServicesCondition(cd *kcmv1.ClusterDeployment, serviceSets []kcmv1.ServiceSet) {
 	var totalServices, readyServices int
 
 	c := metav1.Condition{
@@ -1229,7 +1228,7 @@ func (r *ClusterDeploymentReconciler) setServicesCondition(ctx context.Context, 
 		len(cd.Spec.ServiceSpec.Services),
 	)
 
-	for _, serviceSet := range serviceSetList.Items {
+	for _, serviceSet := range serviceSets {
 		// we'll skip serviceSets being deleted
 		if !serviceSet.DeletionTimestamp.IsZero() {
 			continue
@@ -1285,24 +1284,23 @@ func (r *ClusterDeploymentReconciler) setServicesCondition(ctx context.Context, 
 
 	c.Message = fmt.Sprintf("%d/%d", readyServices, totalServices)
 	apimeta.SetStatusCondition(&cd.Status.Conditions, c)
-	return nil
 }
 
 // updateStatus updates the status for the ClusterDeployment object.
-func (r *ClusterDeploymentReconciler) updateStatus(ctx context.Context, cd *kcmv1.ClusterDeployment, template *kcmv1.ClusterTemplate) error {
-	if err := r.setServicesCondition(ctx, cd); err != nil {
-		return fmt.Errorf("failed to set services condition: %w", err)
+func (r *ClusterDeploymentReconciler) updateStatus(ctx context.Context, oldObj, newObj *kcmv1.ClusterDeployment, template *kcmv1.ClusterTemplate) error {
+	if equality.Semantic.DeepEqual(oldObj.Status, newObj.Status) {
+		return nil
 	}
 
-	cd.Status.ObservedGeneration = cd.Generation
-	cd.Status.Conditions = conditionsutil.UpdateReadyCondition(cd.Status.Conditions, cd.Generation, handleClusterDeploymentFailedConditions)
+	newObj.Status.ObservedGeneration = newObj.Generation
+	newObj.Status.Conditions = conditionsutil.UpdateReadyCondition(newObj.Status.Conditions, newObj.Generation, handleClusterDeploymentFailedConditions)
 
-	if err := r.setAvailableUpgrades(ctx, cd, template); err != nil {
+	if err := r.setAvailableUpgrades(ctx, newObj, template); err != nil { // wahab: fetches clustertemplatechains
 		return errors.New("failed to set available upgrades")
 	}
 
-	if err := r.MgmtClient.Status().Update(ctx, cd); err != nil {
-		return fmt.Errorf("failed to update status for clusterDeployment %s/%s: %w", cd.Namespace, cd.Name, err)
+	if err := r.MgmtClient.Status().Update(ctx, newObj); err != nil {
+		return fmt.Errorf("failed to update status for clusterDeployment %s/%s: %w", newObj.Namespace, newObj.Name, err)
 	}
 
 	return nil
@@ -1358,6 +1356,7 @@ func (r *ClusterDeploymentReconciler) reconcileDelete(ctx context.Context, mgmt 
 	l := ctrl.LoggerFrom(ctx)
 
 	cd := scope.cd
+	oldCD := cd.DeepCopy()
 
 	scope.deletionState = &clusterDeletionState{
 		cloudResourcesDeleted:    !cd.Spec.CleanupOnDeletion,
@@ -1377,7 +1376,7 @@ func (r *ClusterDeploymentReconciler) reconcileDelete(ctx context.Context, mgmt 
 		// Skip status update if the finalizer has been removed since the object
 		// may already be deleted by the time this defer runs.
 		if controllerutil.ContainsFinalizer(cd, kcmv1.ClusterDeploymentFinalizer) {
-			err = errors.Join(err, r.updateStatus(ctx, cd, nil))
+			err = errors.Join(err, r.updateStatus(ctx, oldCD, cd, nil))
 		}
 	}()
 
@@ -1955,18 +1954,24 @@ func (r *ClusterDeploymentReconciler) handleCertificateSecrets(ctx context.Conte
 	return nil
 }
 
-func (r *ClusterDeploymentReconciler) collectServicesStatuses(ctx context.Context, cd *kcmv1.ClusterDeployment) ([]kcmv1.ServiceState, error) {
-	serviceSets := new(kcmv1.ServiceSetList)
-	if err := r.MgmtClient.List(ctx, serviceSets, client.InNamespace(cd.Namespace), client.MatchingFields{kcmv1.ServiceSetClusterIndexKey: cd.Name}); err != nil {
-		return nil, fmt.Errorf("failed to list ServiceSets: %w", err)
-	}
-	aggregatedServiceStatuses := make([]kcmv1.ServiceState, 0, len(serviceSets.Items))
+func collectServicesStatuses(serviceSets []kcmv1.ServiceSet) []kcmv1.ServiceState {
+	aggregatedServiceStatuses := make([]kcmv1.ServiceState, 0, len(serviceSets))
 
-	for _, serviceSet := range serviceSets.Items {
+	for _, serviceSet := range serviceSets {
 		aggregatedServiceStatuses = append(aggregatedServiceStatuses, serviceSet.Status.Services...)
 	}
 
-	return aggregatedServiceStatuses, nil
+	slices.SortFunc(aggregatedServiceStatuses, func(a, b kcmv1.ServiceState) int {
+		if n := cmp.Compare(a.Type, b.Type); n != 0 {
+			return n
+		}
+		if n := cmp.Compare(a.Namespace, b.Namespace); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	return aggregatedServiceStatuses
 }
 
 func configNeedsUpdate(config *apiextv1.JSON, providerData []kcmv1.ClusterIPAMProviderData) (bool, error) {

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -1201,20 +1201,20 @@ func (r *ClusterDeploymentReconciler) updateServices(ctx context.Context, cd *kc
 	l.V(1).Info("ServiceSets matching ClusterDeployment found", "CD", cd.Namespace+"/"+cd.Name, "count", len(serviceSetList.Items))
 
 	// we'll update services' statuses
-	cd.Status.Services = collectServicesStatuses(serviceSetList.Items)
+	cd.Status.Services = r.collectServicesStatuses(serviceSetList.Items)
 
 	// we'll update services' upgrade paths
 	upgradePaths, err := serviceset.ServicesUpgradePaths(ctx, r.MgmtClient, cd.Spec.ServiceSpec.Services, cd.Namespace)
 	cd.Status.ServicesUpgradePaths = upgradePaths
 
 	// we'll update cd status to show no of deployed services
-	setServicesCondition(cd, serviceSetList.Items)
+	r.setServicesCondition(cd, serviceSetList.Items)
 	return err
 }
 
 // setServicesCondition updates ClusterDeployment's condition which shows number of successfully
 // deployed services out of total number of desired services.
-func setServicesCondition(cd *kcmv1.ClusterDeployment, serviceSets []kcmv1.ServiceSet) {
+func (*ClusterDeploymentReconciler) setServicesCondition(cd *kcmv1.ClusterDeployment, serviceSets []kcmv1.ServiceSet) {
 	var totalServices, readyServices int
 
 	c := metav1.Condition{
@@ -1224,7 +1224,7 @@ func setServicesCondition(cd *kcmv1.ClusterDeployment, serviceSets []kcmv1.Servi
 	}
 
 	serviceStateMap := make(
-		map[client.ObjectKey][]*kcmv1.ServiceState,
+		map[client.ObjectKey][]kcmv1.ServiceState,
 		len(cd.Spec.ServiceSpec.Services),
 	)
 
@@ -1248,7 +1248,7 @@ func setServicesCondition(cd *kcmv1.ClusterDeployment, serviceSets []kcmv1.Servi
 			}
 
 			key := serviceset.ServiceKey(svc.Namespace, svc.Name)
-			serviceStateMap[key] = append(serviceStateMap[key], &svc)
+			serviceStateMap[key] = append(serviceStateMap[key], svc)
 		}
 	}
 
@@ -1288,15 +1288,15 @@ func setServicesCondition(cd *kcmv1.ClusterDeployment, serviceSets []kcmv1.Servi
 
 // updateStatus updates the status for the ClusterDeployment object.
 func (r *ClusterDeploymentReconciler) updateStatus(ctx context.Context, oldObj, newObj *kcmv1.ClusterDeployment, template *kcmv1.ClusterTemplate) error {
-	if equality.Semantic.DeepEqual(oldObj.Status, newObj.Status) {
-		return nil
-	}
-
 	newObj.Status.ObservedGeneration = newObj.Generation
 	newObj.Status.Conditions = conditionsutil.UpdateReadyCondition(newObj.Status.Conditions, newObj.Generation, handleClusterDeploymentFailedConditions)
 
-	if err := r.setAvailableUpgrades(ctx, newObj, template); err != nil { // wahab: fetches clustertemplatechains
+	if err := r.setAvailableUpgrades(ctx, newObj, template); err != nil {
 		return errors.New("failed to set available upgrades")
+	}
+
+	if equality.Semantic.DeepEqual(oldObj.Status, newObj.Status) {
+		return nil
 	}
 
 	if err := r.MgmtClient.Status().Update(ctx, newObj); err != nil {
@@ -1789,6 +1789,9 @@ func (r *ClusterDeploymentReconciler) setAvailableUpgrades(ctx context.Context, 
 		availableUpgrades = append(availableUpgrades, availableUpgrade.Name)
 	}
 
+	// Sorting here so that comparison between old and new status is accurate.
+	slices.Sort(availableUpgrades)
+
 	clusterDeployment.Status.AvailableUpgrades = availableUpgrades
 	return nil
 }
@@ -1954,14 +1957,14 @@ func (r *ClusterDeploymentReconciler) handleCertificateSecrets(ctx context.Conte
 	return nil
 }
 
-func collectServicesStatuses(serviceSets []kcmv1.ServiceSet) []kcmv1.ServiceState {
+func (*ClusterDeploymentReconciler) collectServicesStatuses(serviceSets []kcmv1.ServiceSet) []kcmv1.ServiceState {
 	aggregatedServiceStatuses := make([]kcmv1.ServiceState, 0, len(serviceSets))
 
 	for _, serviceSet := range serviceSets {
 		aggregatedServiceStatuses = append(aggregatedServiceStatuses, serviceSet.Status.Services...)
 	}
 
-	slices.SortFunc(aggregatedServiceStatuses, func(a, b kcmv1.ServiceState) int {
+	slices.SortStableFunc(aggregatedServiceStatuses, func(a, b kcmv1.ServiceState) int {
 		if n := cmp.Compare(a.Type, b.Type); n != 0 {
 			return n
 		}

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -1292,7 +1292,7 @@ func (r *ClusterDeploymentReconciler) updateStatus(ctx context.Context, oldObj, 
 	newObj.Status.Conditions = conditionsutil.UpdateReadyCondition(newObj.Status.Conditions, newObj.Generation, handleClusterDeploymentFailedConditions)
 
 	if err := r.setAvailableUpgrades(ctx, newObj, template); err != nil {
-		return errors.New("failed to set available upgrades")
+		return fmt.Errorf("failed to set available upgrades: %w", err)
 	}
 
 	if equality.Semantic.DeepEqual(oldObj.Status, newObj.Status) {

--- a/internal/controller/clusterdeployment_controller_test.go
+++ b/internal/controller/clusterdeployment_controller_test.go
@@ -1343,6 +1343,8 @@ var _ = Describe("ClusterDeployment Controller", Ordered, func() {
 		})
 
 		By("running setServicesCondition and asserting ready does not exceed total", func() {
+			ssCD := serviceSetCommon("cd", "")
+			ssCD.Status.Services = deployedState
 			cd := &kcmv1.ClusterDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      clusterName,
@@ -1356,8 +1358,9 @@ var _ = Describe("ClusterDeployment Controller", Ordered, func() {
 					},
 				},
 			}
+
 			r := &ClusterDeploymentReconciler{MgmtClient: mgrClient}
-			Expect(r.setServicesCondition(ctx, cd)).To(Succeed())
+			r.setServicesCondition(cd, []kcmv1.ServiceSet{*ssCD})
 
 			Expect(cd.Status.Conditions).To(ContainElement(SatisfyAll(
 				HaveField("Type", kcmv1.ServicesInReadyStateCondition),

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -206,7 +206,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 	l.V(1).Info("ServiceSets matching MCS found", "MCS", mcs.Name, "count", len(serviceSetList.Items))
 
-	setClustersCondition(ctx, mcs, totalMatchingClusters, serviceSetList.Items)
+	r.setClustersCondition(ctx, mcs, serviceSetList.Items)
 	if errs != nil {
 		return ctrl.Result{}, errs
 	}
@@ -232,7 +232,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 // the ServiceSets list, otherwise clusters whose ServiceSet was not created yet
 // (e.g. due to unsatisfied dependencies or transient errors) would be silently
 // dropped from the denominator and the condition would misrepresent reality.
-func setClustersCondition(ctx context.Context, mcs *kcmv1.MultiClusterService, totalClusters int, serviceSets []kcmv1.ServiceSet) {
+func (*MultiClusterServiceReconciler) setClustersCondition(ctx context.Context, mcs *kcmv1.MultiClusterService, totalClusters int, serviceSets []kcmv1.ServiceSet) {
 	l := ctrl.LoggerFrom(ctx)
 	l.V(1).Info("Reconciling MultiClusterService conditions")
 
@@ -334,7 +334,7 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 
 	// We need to sort the slice of matching clusters in order to avoid any
 	// unnecessary reconciles when the status is compared in the `updateStatus` func.
-	slices.SortFunc(resultingClusters, func(a, b kcmv1.MatchingCluster) int {
+	slices.SortStableFunc(resultingClusters, func(a, b kcmv1.MatchingCluster) int {
 		if n := cmp.Compare(a.Kind, b.Kind); n != 0 {
 			return n
 		}

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -206,7 +206,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 	l.V(1).Info("ServiceSets matching MCS found", "MCS", mcs.Name, "count", len(serviceSetList.Items))
 
-	r.setClustersCondition(ctx, mcs, serviceSetList.Items)
+	r.setClustersCondition(ctx, mcs, totalMatchingClusters, serviceSetList.Items)
 	if errs != nil {
 		return ctrl.Result{}, errs
 	}


### PR DESCRIPTION
# Description

This PR does the following changes to improve CD reconciliation process and potentially reduce reduce the frequency of `the object has been modified` errors.
1. Add comparison between the status of old and new CD object before updating the status in Kube API.
2. Remove `setServicesCondition` func from `updateStatus` func and place it in the `updateServices` func where other services related status are also set (and it helps with 3 below).
3. Both `collectServicesStatuses` func and `setServicesCondition` fetched list of ServiceSets which means we were doing 2 round-trips for the same data. So changed these functions to instead accept a list of ServiceSets as an argument reducing to 1 round-trip.
4. Sorted the final list of service statuses (`aggregatedServiceStatuses`) returned by the `collectServicesStatuses` func so that the comparison in 1 doesn't fail due due to sort order.