### PR TITLE
fix: respect dependsOn on upgrades

### DIFF
--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -233,6 +233,13 @@ func ServicesUpgradePaths(
 // NOTE: Every service referenced in a DependsOn field must also appear in
 // the desired services list; referencing an absent service is an error.
 //
+// NOTE: desiredServices is expected to have its Versions already resolved by
+// the caller (e.g. via ResolveServiceVersions) so the version-aware gate can
+// compare against the resolved form that previous reconciles persisted in
+// ServiceSet.Spec. Passing unresolved services is tolerated — comparison
+// falls back to Template — but mixing resolved Spec versions with unresolved
+// desired versions will lock dependents.
+//
 // NOTE: This function works under the assumption that there will
 // always be just 1 ServiceSet for every unique combination of CD & MCS.
 //
@@ -328,7 +335,16 @@ func FilterServiceDependencies(
 
 	// Build version maps from the existing ServiceSet(s) so we can compare each
 	// service's currently-promised spec step against what the cluster actually
-	// runs and against the user's final desired version.
+	// runs and against the user's final desired version. Spec and status entries
+	// are normalised the same way so the comparison is symmetric: prefer Version,
+	// fall back to Template when Version is nil/empty.
+	//
+	// NOTE: When more than one ServiceSet matches (cd-only call with multiple
+	// MCS targeting the same cluster, or analogous), values overwrite on key
+	// collision. Current reconciler wiring guarantees at most one relevant
+	// ServiceSet per call (the MCS reconciler scopes by both cluster and MCS;
+	// the CD reconciler operates on the CD's own spec/ServiceSet only), so the
+	// overwrite is not observable in practice. Revisit if that wiring changes.
 	specVersion := make(map[client.ObjectKey]string)
 	statusVersion := make(map[client.ObjectKey]string)
 	statusState := make(map[client.ObjectKey]string)
@@ -344,24 +360,25 @@ func FilterServiceDependencies(
 			specVersion[ServiceKey(svc.Namespace, svc.Name)] = v
 		}
 		for _, svc := range sset.Status.Services {
-			k := ServiceKey(svc.Namespace, svc.Name)
+			v := ""
 			if svc.Version != nil {
-				statusVersion[k] = *svc.Version
+				v = *svc.Version
 			}
+			if v == "" {
+				v = svc.Template
+			}
+			k := ServiceKey(svc.Namespace, svc.Name)
+			statusVersion[k] = v
 			statusState[k] = svc.State
 		}
 	}
 
-	// Resolve versions on a copy of desiredServices so the gate below compares
-	// against the same resolved form that previous reconciles persisted in
-	// ServiceSet.Spec. Working on a copy avoids mutating the caller's slice.
-	resolvedDesired := make([]kcmv1.Service, len(desiredServices))
-	copy(resolvedDesired, desiredServices)
-	if err := ResolveServiceVersions(ctx, c, namespace, resolvedDesired); err != nil {
-		return nil, fmt.Errorf("failed to resolve desired service versions: %w", err)
-	}
-	desiredVersion := make(map[client.ObjectKey]string, len(resolvedDesired))
-	for _, svc := range resolvedDesired {
+	// desiredServices is expected to have Versions resolved by the caller
+	// (see ResolveServicesToApply). For each service, prefer Version; fall back
+	// to Template — same normalisation used above for spec/status — so the
+	// gate comparisons are like-for-like.
+	desiredVersion := make(map[client.ObjectKey]string, len(desiredServices))
+	for _, svc := range desiredServices {
 		v := svc.Version
 		if v == "" {
 			v = svc.Template
@@ -669,13 +686,20 @@ func ResolveServicesToApply(
 ) ([]kcmv1.ServiceWithValues, error) {
 	templateNamespace := serviceSet.Namespace
 
-	filteredServices, err := FilterServiceDependencies(ctx, c, systemNamespace, mcs, cd, desiredServices)
-	if err != nil {
-		return nil, fmt.Errorf("failed to filter service dependencies: %w", err)
+	// Resolve desiredServices' Versions once up front, on a copy to avoid
+	// mutating the caller's MCS/CD CR. FilterServiceDependencies and the
+	// downstream version-aware logic both consume the resolved slice, so the
+	// previous double-resolve (once inside FilterServiceDependencies, once on
+	// the returned filteredServices) is avoided.
+	resolvedDesired := make([]kcmv1.Service, len(desiredServices))
+	copy(resolvedDesired, desiredServices)
+	if err := ResolveServiceVersions(ctx, c, templateNamespace, resolvedDesired); err != nil {
+		return nil, fmt.Errorf("failed to resolve versions for desired services: %w", err)
 	}
 
-	if err := ResolveServiceVersions(ctx, c, templateNamespace, filteredServices); err != nil {
-		return nil, fmt.Errorf("failed to resolve versions for filtered services: %w", err)
+	filteredServices, err := FilterServiceDependencies(ctx, c, systemNamespace, mcs, cd, resolvedDesired)
+	if err != nil {
+		return nil, fmt.Errorf("failed to filter service dependencies: %w", err)
 	}
 
 	storedServices := serviceSet.Spec.Services
@@ -684,7 +708,7 @@ func ResolveServicesToApply(
 	}
 
 	upgradePaths, err := ServicesUpgradePaths(
-		ctx, c, ServicesWithDesiredChains(desiredServices, storedServices), templateNamespace)
+		ctx, c, ServicesWithDesiredChains(resolvedDesired, storedServices), templateNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine upgrade paths: %w", err)
 	}

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -216,12 +216,19 @@ func ServicesUpgradePaths(
 // cd & mcs from cd's namespace or from system namespace if cd is nil.
 //
 // A service is eligible (its count reaches zero) only when every service it
-// directly or transitively depends on has a Deployed status in the fetched
-// ServiceSets. Services in a non-Deployed state (Failed, Provisioning, etc.)
-// are NOT treated as deployed, even if their dependents are already in the
-// ServiceSet spec. This guarantees that a failing dependency keeps its
-// dependents locked at their stored version (via BuildServicesList) rather
-// than allowing them to be upgraded or mutated.
+// directly or transitively depends on is fully synced — all of:
+//   - status is Deployed,
+//   - Status.Version == Spec.Version (no in-flight upgrade),
+//   - Spec.Version == user's desired version (no advancement queued).
+//
+// Services in a non-Deployed state (Failed, Provisioning, etc.) are NOT treated
+// as deployed, even if their dependents are already in the ServiceSet spec.
+// This guarantees that a failing dependency keeps its dependents locked at
+// their stored version (via BuildServicesList) rather than allowing them to be
+// upgraded or mutated. The version checks extend the same protection to upgrade
+// scenarios: while a dependency is mid-upgrade or about to be advanced, its
+// dependents stay locked at their stored versions, ensuring upgrades propagate
+// down the dependency chain in the declared order rather than all at once.
 //
 // NOTE: Every service referenced in a DependsOn field must also appear in
 // the desired services list; referencing an absent service is an error.
@@ -319,24 +326,69 @@ func FilterServiceDependencies(
 		return nil, fmt.Errorf("failed to list ServiceSets: %w", err)
 	}
 
-	// Map of services (with their states) from the status of fetched ServiceSets.
-	servicesFromStatus := make(map[client.ObjectKey]string)
+	// Build version maps from the existing ServiceSet(s) so we can compare each
+	// service's currently-promised spec step against what the cluster actually
+	// runs and against the user's final desired version.
+	specVersion := make(map[client.ObjectKey]string)
+	statusVersion := make(map[client.ObjectKey]string)
+	statusState := make(map[client.ObjectKey]string)
 	for _, sset := range serviceSets.Items {
+		for _, svc := range sset.Spec.Services {
+			v := ""
+			if svc.Version != nil {
+				v = *svc.Version
+			}
+			if v == "" {
+				v = svc.Template
+			}
+			specVersion[ServiceKey(svc.Namespace, svc.Name)] = v
+		}
 		for _, svc := range sset.Status.Services {
-			servicesFromStatus[ServiceKey(svc.Namespace, svc.Name)] = svc.State
+			k := ServiceKey(svc.Namespace, svc.Name)
+			if svc.Version != nil {
+				statusVersion[k] = *svc.Version
+			}
+			statusState[k] = svc.State
 		}
 	}
 
-	// Find out which services have been successfully deployed.
-	// Only an explicit Deployed status counts; non-Deployed services (Failed,
-	// Provisioning, etc.) are not treated as deployed even if their dependents
-	// are already present in the ServiceSet spec. This preserves the invariant
-	// that a failing dependency keeps its dependents locked at their stored
-	// version (via BuildServicesList) rather than upgrading or mutating them.
-	for svc, state := range servicesFromStatus {
-		if state == kcmv1.ServiceStateDeployed {
-			deployedServices[ServiceKey(svc.Namespace, svc.Name)] = struct{}{}
+	// Resolve versions on a copy of desiredServices so the gate below compares
+	// against the same resolved form that previous reconciles persisted in
+	// ServiceSet.Spec. Working on a copy avoids mutating the caller's slice.
+	resolvedDesired := make([]kcmv1.Service, len(desiredServices))
+	copy(resolvedDesired, desiredServices)
+	if err := ResolveServiceVersions(ctx, c, namespace, resolvedDesired); err != nil {
+		return nil, fmt.Errorf("failed to resolve desired service versions: %w", err)
+	}
+	desiredVersion := make(map[client.ObjectKey]string, len(resolvedDesired))
+	for _, svc := range resolvedDesired {
+		v := svc.Version
+		if v == "" {
+			v = svc.Template
 		}
+		desiredVersion[ServiceKey(svc.Namespace, svc.Name)] = v
+	}
+
+	// A service counts as "deployed" for the purpose of unlocking its dependents
+	// only when all three hold:
+	//   1. its status is Deployed (the current step actually runs on the cluster),
+	//   2. Status.Version == Spec.Version (no in-flight upgrade), and
+	//   3. Spec.Version == user's desired version (no advancement queued for this
+	//      reconcile).
+	// This restores correct dependency ordering on upgrades: a service whose user
+	// just bumped the desired version stops satisfying its dependents until the
+	// new version is both written into Spec and observed in Status.
+	for k := range serviceIdx {
+		if statusState[k] != kcmv1.ServiceStateDeployed {
+			continue
+		}
+		if statusVersion[k] != specVersion[k] {
+			continue
+		}
+		if specVersion[k] != desiredVersion[k] {
+			continue
+		}
+		deployedServices[k] = struct{}{}
 	}
 
 	// For each of the successfully deployed services,

--- a/internal/serviceset/util_test.go
+++ b/internal/serviceset/util_test.go
@@ -32,6 +32,8 @@ import (
 	kubeutil "github.com/K0rdent/kcm/internal/util/kube"
 )
 
+const testSystemNamespace = "test-system-ns"
+
 func Test_ServicesToDeploy(t *testing.T) {
 	t.Parallel()
 
@@ -398,8 +400,6 @@ func Test_ServicesToDeploy(t *testing.T) {
 }
 
 func Test_FilterServiceDependencies(t *testing.T) {
-	systemNamespace := "test-system-ns"
-
 	cd := &kcmv1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cd",
@@ -820,7 +820,7 @@ func Test_FilterServiceDependencies(t *testing.T) {
 				WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetMultiClusterServiceIndexKey, kcmv1.ExtractServiceSetMultiClusterService).
 				Build()
 
-			filtered, err := FilterServiceDependencies(t.Context(), client, systemNamespace, nil, cd, testServices2Services(t, tc.desiredServices))
+			filtered, err := FilterServiceDependencies(t.Context(), client, testSystemNamespace, nil, cd, testServices2Services(t, tc.desiredServices))
 			if tc.wantErr {
 				require.Error(t, err)
 				return
@@ -836,8 +836,6 @@ func Test_FilterServiceDependencies_Operation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(kcmv1.AddToScheme(scheme))
-
-	systemNamespace := "test-system-ns"
 
 	cd := &kcmv1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -933,7 +931,7 @@ func Test_FilterServiceDependencies_Operation(t *testing.T) {
 					WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetClusterIndexKey, kcmv1.ExtractServiceSetCluster).
 					Build()
 
-				filtered, err = FilterServiceDependencies(t.Context(), client, systemNamespace, nil, cd, testServices2Services(t, tc.desiredServices))
+				filtered, err = FilterServiceDependencies(t.Context(), client, testSystemNamespace, nil, cd, testServices2Services(t, tc.desiredServices))
 				require.NoError(t, err)
 				// For each iteration of desiredServices being filtered wrt dependencies,
 				// we expect the returned filtered services to match the expected services.
@@ -1230,13 +1228,12 @@ func Test_GetServiceSetWithOperation_NoSpuriousUpdates(t *testing.T) {
 	utilruntime.Must(kcmv1.AddToScheme(scheme))
 
 	const (
-		systemNamespace = "test-system"
-		cdNamespace     = "test-ns"
-		cdName          = "test-cd"
-		providerName    = "custom-provider"
-		svcName         = "propagation-svc"
-		svcNamespace    = "default"
-		templateName    = "propagation-template"
+		cdNamespace  = "test-ns"
+		cdName       = "test-cd"
+		providerName = "custom-provider"
+		svcName      = "propagation-svc"
+		svcNamespace = "default"
+		templateName = "propagation-template"
 	)
 
 	selectorLabel := map[string]string{"test-selector": "true"}
@@ -1327,7 +1324,7 @@ func Test_GetServiceSetWithOperation_NoSpuriousUpdates(t *testing.T) {
 	opReq := OperationRequisites{
 		ObjectKey:       client.ObjectKey{Namespace: cdNamespace, Name: cdName},
 		CD:              cd,
-		SystemNamespace: systemNamespace,
+		SystemNamespace: testSystemNamespace,
 	}
 
 	// First call: ServiceSet does not exist → must return Create.
@@ -1388,5 +1385,271 @@ func Test_FilterServiceDependencies_Order(t *testing.T) {
 			require.Equal(t, prev, got, "output order must be stable across calls")
 		}
 		prev = got
+	}
+}
+
+// Test_FilterServiceDependencies_VersionGate covers the version-aware dependency
+// gate: a dependency satisfies its dependents only when (state == Deployed) AND
+// (Status.Version == Spec.Version) AND (Spec.Version == user's desired version).
+// Each case isolates one of those conditions.
+func Test_FilterServiceDependencies_VersionGate(t *testing.T) {
+	t.Parallel()
+
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cd", Namespace: "test-cd-ns"},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(kcmv1.AddToScheme(scheme))
+
+	makeServiceSet := func(spec []kcmv1.ServiceWithValues, status []kcmv1.ServiceState) *kcmv1.ServiceSet {
+		return &kcmv1.ServiceSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: cd.Namespace, Name: cd.Name},
+			Spec:       kcmv1.ServiceSetSpec{Cluster: cd.Name, Services: spec},
+			Status:     kcmv1.ServiceSetStatus{Services: status},
+		}
+	}
+
+	a := func(version string) kcmv1.Service {
+		return kcmv1.Service{Namespace: "ns", Name: "a", Template: "tpl-a", Version: version}
+	}
+	b := func(version string) kcmv1.Service {
+		return kcmv1.Service{
+			Namespace: "ns", Name: "b", Template: "tpl-b", Version: version,
+			DependsOn: []kcmv1.ServiceDependsOn{{Namespace: "ns", Name: "a"}},
+		}
+	}
+	specOf := func(name, version string) kcmv1.ServiceWithValues {
+		return kcmv1.ServiceWithValues{Namespace: "ns", Name: name, Template: "tpl-" + name, Version: new(version)}
+	}
+	statusOf := func(name, state, version string) kcmv1.ServiceState {
+		return kcmv1.ServiceState{Namespace: "ns", Name: name, State: state, Version: new(version)}
+	}
+
+	for _, tc := range []struct {
+		name            string
+		desiredServices []kcmv1.Service
+		objects         []client.Object
+		expected        []string
+	}{
+		{
+			name:            "fully synced dep unlocks dependent",
+			desiredServices: []kcmv1.Service{a("v1"), b("v1")},
+			objects: []client.Object{makeServiceSet(
+				[]kcmv1.ServiceWithValues{specOf("a", "v1")},
+				[]kcmv1.ServiceState{statusOf("a", kcmv1.ServiceStateDeployed, "v1")},
+			)},
+			expected: []string{"a", "b"},
+		},
+		{
+			name:            "in-flight dep (status != spec) locks dependent",
+			desiredServices: []kcmv1.Service{a("v2"), b("v1")},
+			objects: []client.Object{makeServiceSet(
+				[]kcmv1.ServiceWithValues{specOf("a", "v2")},
+				[]kcmv1.ServiceState{statusOf("a", kcmv1.ServiceStateProvisioning, "v1")},
+			)},
+			expected: []string{"a"},
+		},
+		{
+			name:            "spec lags desired locks dependent (KOF upgrade bug)",
+			desiredServices: []kcmv1.Service{a("v2"), b("v2")},
+			objects: []client.Object{makeServiceSet(
+				[]kcmv1.ServiceWithValues{specOf("a", "v1"), specOf("b", "v1")},
+				[]kcmv1.ServiceState{
+					statusOf("a", kcmv1.ServiceStateDeployed, "v1"),
+					statusOf("b", kcmv1.ServiceStateDeployed, "v1"),
+				},
+			)},
+			expected: []string{"a"},
+		},
+		{
+			name:            "dep at user-desired version unlocks dependent on upgrade",
+			desiredServices: []kcmv1.Service{a("v2"), b("v2")},
+			objects: []client.Object{makeServiceSet(
+				[]kcmv1.ServiceWithValues{specOf("a", "v2"), specOf("b", "v1")},
+				[]kcmv1.ServiceState{
+					statusOf("a", kcmv1.ServiceStateDeployed, "v2"),
+					statusOf("b", kcmv1.ServiceStateDeployed, "v1"),
+				},
+			)},
+			expected: []string{"a", "b"},
+		},
+		{
+			name:            "failed dep locks dependent (regression with versions present)",
+			desiredServices: []kcmv1.Service{a("v1"), b("v1")},
+			objects: []client.Object{makeServiceSet(
+				[]kcmv1.ServiceWithValues{specOf("a", "v1")},
+				[]kcmv1.ServiceState{statusOf("a", kcmv1.ServiceStateFailed, "v1")},
+			)},
+			expected: []string{"a"},
+		},
+		{
+			name:            "first install — no ServiceSet exists, only no-dep services pass",
+			desiredServices: []kcmv1.Service{a("v1"), b("v1")},
+			objects:         nil,
+			expected:        []string{"a"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tc.objects...).
+				WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetClusterIndexKey, kcmv1.ExtractServiceSetCluster).
+				WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetMultiClusterServiceIndexKey, kcmv1.ExtractServiceSetMultiClusterService).
+				Build()
+
+			filtered, err := FilterServiceDependencies(t.Context(), cl, testSystemNamespace, nil, cd, tc.desiredServices)
+			require.NoError(t, err)
+
+			names := make([]string, len(filtered))
+			for i, svc := range filtered {
+				names[i] = svc.Name
+			}
+			require.ElementsMatch(t, tc.expected, names)
+		})
+	}
+}
+
+// Test_FilterServiceDependencies_UpgradeOrdering walks the KOF-shaped dependency
+// chain (cm → ops → storage → collectors) through a full v1→v2 bump and verifies
+// that exactly one new service unlocks per "upstream finished" step. This is a
+// direct regression test for the issue where an upgrade let all four services
+// land in the ServiceSet spec simultaneously.
+func Test_FilterServiceDependencies_UpgradeOrdering(t *testing.T) {
+	t.Parallel()
+
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cd", Namespace: "test-cd-ns"},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(kcmv1.AddToScheme(scheme))
+
+	desired := []kcmv1.Service{
+		{Namespace: "kof", Name: "cm", Template: "cm", Version: "v2"},
+		{
+			Namespace: "kof", Name: "ops", Template: "ops", Version: "v2",
+			DependsOn: []kcmv1.ServiceDependsOn{{Namespace: "kof", Name: "cm"}},
+		},
+		{
+			Namespace: "kof", Name: "storage", Template: "storage", Version: "v2",
+			DependsOn: []kcmv1.ServiceDependsOn{{Namespace: "kof", Name: "ops"}},
+		},
+		{
+			Namespace: "kof", Name: "collectors", Template: "collectors", Version: "v2",
+			DependsOn: []kcmv1.ServiceDependsOn{{Namespace: "kof", Name: "storage"}},
+		},
+	}
+	services := []string{"cm", "ops", "storage", "collectors"}
+
+	allDeployed := func() map[string]string {
+		m := make(map[string]string, len(services))
+		for _, s := range services {
+			m[s] = kcmv1.ServiceStateDeployed
+		}
+		return m
+	}
+	versionsAt := func(advanced map[string]struct{}, advancedVersion, fallback string) map[string]string {
+		m := make(map[string]string, len(services))
+		for _, s := range services {
+			if _, ok := advanced[s]; ok {
+				m[s] = advancedVersion
+			} else {
+				m[s] = fallback
+			}
+		}
+		return m
+	}
+	advancedSet := func(names ...string) map[string]struct{} {
+		m := make(map[string]struct{}, len(names))
+		for _, n := range names {
+			m[n] = struct{}{}
+		}
+		return m
+	}
+
+	for _, tc := range []struct {
+		name           string
+		specVersions   map[string]string
+		statusVersions map[string]string
+		statusStates   map[string]string
+		expected       []string
+	}{
+		{
+			name:           "all v1, user just bumped to v2 — only chain head eligible",
+			specVersions:   versionsAt(advancedSet(), "v2", "v1"),
+			statusVersions: versionsAt(advancedSet(), "v2", "v1"),
+			statusStates:   allDeployed(),
+			expected:       []string{"cm"},
+		},
+		{
+			name:           "cm spec advanced, status lagging — dependents still locked",
+			specVersions:   versionsAt(advancedSet("cm"), "v2", "v1"),
+			statusVersions: versionsAt(advancedSet(), "v2", "v1"),
+			statusStates: func() map[string]string {
+				m := allDeployed()
+				m["cm"] = kcmv1.ServiceStateProvisioning
+				return m
+			}(),
+			expected: []string{"cm"},
+		},
+		{
+			name:           "cm finished v2 — ops unlocked, storage and collectors still locked",
+			specVersions:   versionsAt(advancedSet("cm"), "v2", "v1"),
+			statusVersions: versionsAt(advancedSet("cm"), "v2", "v1"),
+			statusStates:   allDeployed(),
+			expected:       []string{"cm", "ops"},
+		},
+		{
+			name:           "ops finished v2 — storage unlocked, collectors still locked",
+			specVersions:   versionsAt(advancedSet("cm", "ops"), "v2", "v1"),
+			statusVersions: versionsAt(advancedSet("cm", "ops"), "v2", "v1"),
+			statusStates:   allDeployed(),
+			expected:       []string{"cm", "ops", "storage"},
+		},
+		{
+			name:           "storage finished v2 — collectors unlocked, all eligible",
+			specVersions:   versionsAt(advancedSet("cm", "ops", "storage"), "v2", "v1"),
+			statusVersions: versionsAt(advancedSet("cm", "ops", "storage"), "v2", "v1"),
+			statusStates:   allDeployed(),
+			expected:       []string{"cm", "ops", "storage", "collectors"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sset := &kcmv1.ServiceSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: cd.Namespace, Name: cd.Name},
+				Spec:       kcmv1.ServiceSetSpec{Cluster: cd.Name},
+			}
+			for _, name := range services {
+				specVer := tc.specVersions[name]
+				statusVer := tc.statusVersions[name]
+				sset.Spec.Services = append(sset.Spec.Services, kcmv1.ServiceWithValues{
+					Namespace: "kof", Name: name, Template: name, Version: &specVer,
+				})
+				sset.Status.Services = append(sset.Status.Services, kcmv1.ServiceState{
+					Namespace: "kof", Name: name, State: tc.statusStates[name], Version: &statusVer,
+				})
+			}
+
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(sset).
+				WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetClusterIndexKey, kcmv1.ExtractServiceSetCluster).
+				WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetMultiClusterServiceIndexKey, kcmv1.ExtractServiceSetMultiClusterService).
+				Build()
+
+			filtered, err := FilterServiceDependencies(t.Context(), cl, testSystemNamespace, nil, cd, desired)
+			require.NoError(t, err)
+
+			names := make([]string, len(filtered))
+			for i, svc := range filtered {
+				names[i] = svc.Name
+			}
+			require.ElementsMatch(t, tc.expected, names)
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In a MultiClusterService (MCS) chain where each service declared dependsOn against the previous one — e.g. KOF's cert-manager → kof-operators → kof-storage → kof-collectors — the declared dependency order was honored only during the initial install. Once all services were running, upgrading them produced an out-of-order rollout: all charts on the child cluster were bumped to the new version essentially at once, with no respect for the dependency chain. In the reported case the observed order was roughly alphabetical (cert-manager → kof-collectors → kof-operators → kof-storage) instead of the declared chain.

The dependency gate that controls which services may be promoted into the runtime ServiceSet only checked whether each upstream service was in a Deployed state. It did not consider which version was deployed. On a fresh install this worked, because each upstream had to first reach Deployed before its dependents became eligible. On an upgrade, however, every service was already Deployed (at the previous version), so the gate immediately let every service through in a single reconcile, and the controller wrote the new versions for all of them at once. The downstream state-management adapter then applied them in its own order, breaking the chain.

The dependency gate was tightened from a single state check into a three-part check: a service satisfies its dependents only when (1) it is in the Deployed state, (2) what's actually running on the cluster matches what the controller currently promised it would run, and (3) what the controller currently promised matches the user's desired version. Whenever any of those drift — because the user just bumped a version, an upstream is mid-upgrade, or an upstream is failing — dependents stay locked at their stored versions until the upstream is fully caught up. This restores one-step-per-reconcile promotion along the declared chain on upgrades, while preserving the existing first-install behavior and the existing protection against mutating dependents whose upstream is in a failed state.

**Which issue(s) this PR fixes**:

Fixes #2588 
