### PR TITLE
feat: allow to keep deployed services when changing MultiClusterService selector

### DIFF
--- a/api/v1beta1/multiclusterservice_types.go
+++ b/api/v1beta1/multiclusterservice_types.go
@@ -317,10 +317,22 @@ type ServiceSpec struct {
 type MultiClusterServiceSpec struct {
 	// ClusterSelector identifies target clusters to manage services on.
 	ClusterSelector metav1.LabelSelector `json:"clusterSelector,omitempty"`
+
 	// DependsOn is a list of other MultiClusterServices this one depends on.
 	DependsOn []string `json:"dependsOn,omitempty"`
+
 	// ServiceSpec is spec related to deployment of services.
 	ServiceSpec ServiceSpec `json:"serviceSpec,omitempty"`
+
+	// +kubebuilder:default:=false
+
+	// KeepServicesOnSelectorMismatch indicates whether ServiceSets owned by
+	// this MultiClusterService should be preserved on clusters whose labels
+	// no longer match ClusterSelector, including the case where
+	// ClusterSelector is cleared. When true, services already deployed on
+	// such clusters keep running, enabling per-cluster opt-in rollouts driven
+	// by selector changes.
+	KeepServicesOnSelectorMismatch bool `json:"keepServicesOnSelectorMismatch,omitempty"`
 }
 
 // ServiceStatus contains details for the state of services.
@@ -406,7 +418,7 @@ type UpgradePath struct {
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time elapsed since object creation",priority=0
 
 // MultiClusterService is the Schema for the multiclusterservices API
-type MultiClusterService struct {
+type MultiClusterService struct { //nolint:govet // false-positive
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -529,6 +529,10 @@ func (r *MultiClusterServiceReconciler) createOrUpdateServiceSet(
 }
 
 func (r *MultiClusterServiceReconciler) cleanupServiceSets(ctx context.Context, mcs *kcmv1.MultiClusterService) error {
+	if mcs.Spec.KeepServicesOnSelectorMismatch {
+		return nil
+	}
+
 	serviceSets := new(kcmv1.ServiceSetList)
 	// we'll list all ServiceSets which have .spec.multiClusterService defined and match
 	// current MultiClusterService object being reconciled

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -192,11 +192,13 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 
 	l.V(1).Info("Matching ClusterDeployments found", "count", len(clusters.Items))
+	matchingClusterKeys := make(map[client.ObjectKey]struct{}, len(clusters.Items))
 	for _, cluster := range clusters.Items {
 		if !cluster.DeletionTimestamp.IsZero() {
 			continue
 		}
 		totalMatchingClusters++
+		matchingClusterKeys[client.ObjectKeyFromObject(&cluster)] = struct{}{}
 		errs = errors.Join(errs, r.createOrUpdateServiceSet(ctx, mcs, &cluster))
 	}
 
@@ -206,7 +208,29 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 	l.V(1).Info("ServiceSets matching MCS found", "MCS", mcs.Name, "count", len(serviceSetList.Items))
 
-	r.setClustersCondition(ctx, mcs, totalMatchingClusters, serviceSetList.Items)
+	// Filter ServiceSets down to the ones whose target cluster currently matches
+	// the selector (or the self-management ServiceSet when SelfManagement is on).
+	// With KeepServicesOnSelectorMismatch=true the full serviceSetList includes
+	// ServiceSets we intentionally preserved on clusters that no longer match;
+	// those should not be counted in ClusterInReadyState (numerator) nor surfaced
+	// in `.status.matchingClusters`, both of which are defined as scoped to
+	// currently-matching clusters. The preserved ServiceSets still exist
+	// on cluster and continue running their services — they're just not
+	// reflected in MCS status until their cluster matches again.
+	currentlyMatchingServiceSets := make([]kcmv1.ServiceSet, 0, len(serviceSetList.Items))
+	for _, ss := range serviceSetList.Items {
+		if ss.Spec.Cluster == "" {
+			if mcs.Spec.ServiceSpec.Provider.SelfManagement {
+				currentlyMatchingServiceSets = append(currentlyMatchingServiceSets, ss)
+			}
+			continue
+		}
+		if _, ok := matchingClusterKeys[client.ObjectKey{Namespace: ss.Namespace, Name: ss.Spec.Cluster}]; ok {
+			currentlyMatchingServiceSets = append(currentlyMatchingServiceSets, ss)
+		}
+	}
+
+	r.setClustersCondition(ctx, mcs, totalMatchingClusters, currentlyMatchingServiceSets)
 	if errs != nil {
 		return ctrl.Result{}, errs
 	}
@@ -218,7 +242,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	upgradePaths, servicesErr = serviceset.ServicesUpgradePaths(ctx, r.Client, mcs.Spec.ServiceSpec.Services, r.SystemNamespace)
 	mcs.Status.ServicesUpgradePaths = upgradePaths
 
-	clustersErr := r.setMatchingClusters(ctx, mcs, serviceSetList.Items)
+	clustersErr := r.setMatchingClusters(ctx, mcs, currentlyMatchingServiceSets)
 
 	return result, errors.Join(servicesErr, clustersErr)
 }

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -637,6 +637,112 @@ var _ = Describe("MultiClusterService Controller", func() {
 			}, 2*time.Second, 100*time.Millisecond).Should(Succeed())
 		})
 
+		It("should update preserved ServiceSet in place when ClusterDeployment labels match again", func() {
+			multiClusterServiceReconciler := &MultiClusterServiceReconciler{
+				Client:          mgrClient,
+				timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+				SystemNamespace: testSystemNamespace,
+			}
+
+			By("reconciling MultiClusterService to create the initial ServiceSet")
+			Eventually(func(g Gomega) {
+				_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(k8sClient.Get(ctx, serviceSetKey, &serviceSet)).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			// Capture the UID so we can later prove the ServiceSet was updated
+			// in place rather than recreated. A changed UID would indicate that
+			// the controller deleted the kept ServiceSet on rematch and stamped
+			// out a fresh one — which would defeat the rollout flow this flag
+			// is designed to support.
+			initialUID := serviceSet.UID
+			Expect(initialUID).NotTo(BeEmpty())
+			initialServicesCount := len(multiClusterService.Spec.ServiceSpec.Services)
+
+			By("setting KeepServicesOnSelectorMismatch=true on the MultiClusterService")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+				multiClusterService.Spec.KeepServicesOnSelectorMismatch = true
+				g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+			}).Should(Succeed())
+
+			By("removing the matching label from the ClusterDeployment so the ServiceSet is preserved")
+			Eventually(func(g Gomega) {
+				fresh := &kcmv1.ClusterDeployment{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&clusterDeployment), fresh)).To(Succeed())
+				delete(fresh.Labels, "test")
+				g.Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
+			}).Should(Succeed())
+
+			By("waiting for the mgrClient cache to observe the label removal")
+			Eventually(func(g Gomega) {
+				observedCD := &kcmv1.ClusterDeployment{}
+				g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(&clusterDeployment), observedCD)).To(Succeed())
+				g.Expect(observedCD.Labels).NotTo(HaveKey("test"))
+			}).Should(Succeed())
+
+			By("reconciling to confirm the ServiceSet is preserved while the cluster is mismatched")
+			Eventually(func(g Gomega) {
+				_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+				g.Expect(err).NotTo(HaveOccurred())
+				fresh := &kcmv1.ServiceSet{}
+				g.Expect(k8sClient.Get(ctx, serviceSetKey, fresh)).To(Succeed())
+				g.Expect(fresh.UID).To(Equal(initialUID))
+			}).Should(Succeed())
+
+			By("updating the MultiClusterService Services list while the cluster is mismatched")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+				multiClusterService.Spec.ServiceSpec.Services = append(
+					multiClusterService.Spec.ServiceSpec.Services,
+					kcmv1.Service{
+						Template:  serviceTemplate3Name,
+						Name:      helmChartReleaseName,
+						Namespace: "ns3",
+					},
+				)
+				g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+			}).Should(Succeed())
+
+			By("re-adding the matching label to the ClusterDeployment so it matches the selector again")
+			Eventually(func(g Gomega) {
+				fresh := &kcmv1.ClusterDeployment{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&clusterDeployment), fresh)).To(Succeed())
+				if fresh.Labels == nil {
+					fresh.Labels = map[string]string{}
+				}
+				fresh.Labels["test"] = "true"
+				g.Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
+			}).Should(Succeed())
+
+			By("waiting for the mgrClient cache to observe the rematch and the new Services entry")
+			Eventually(func(g Gomega) {
+				observedCD := &kcmv1.ClusterDeployment{}
+				g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(&clusterDeployment), observedCD)).To(Succeed())
+				g.Expect(observedCD.Labels).To(HaveKeyWithValue("test", "true"))
+
+				observedMCS := &kcmv1.MultiClusterService{}
+				g.Expect(mgrClient.Get(ctx, multiClusterServiceRef, observedMCS)).To(Succeed())
+				g.Expect(observedMCS.Spec.ServiceSpec.Services).To(HaveLen(initialServicesCount + 1))
+			}).Should(Succeed())
+
+			By("reconciling and asserting the preserved ServiceSet is updated in place to reflect the new MCS spec")
+			Eventually(func(g Gomega) {
+				_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				fresh := &kcmv1.ServiceSet{}
+				g.Expect(k8sClient.Get(ctx, serviceSetKey, fresh)).To(Succeed())
+				g.Expect(fresh.UID).To(Equal(initialUID),
+					"ServiceSet UID changed — the controller recreated it on rematch instead of updating in place")
+				g.Expect(fresh.DeletionTimestamp.IsZero()).To(BeTrue(),
+					"ServiceSet was marked for deletion on rematch")
+				g.Expect(fresh.Spec.Services).To(HaveLen(initialServicesCount+1),
+					"ServiceSet spec did not converge to the updated MCS Services list after rematch")
+			}).Should(Succeed())
+		})
+
 		// Regression test for continuous ServiceSet generation bumps caused by
 		// in-place mutation of stored spec during every reconcile.
 		// Each entry updates the MCS services, drains transient reconciles caused

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -535,6 +535,108 @@ var _ = Describe("MultiClusterService Controller", func() {
 			})
 		})
 
+		It("should preserve ServiceSet when ClusterDeployment labels diverge from selector and KeepServicesOnSelectorMismatch is set", func() {
+			multiClusterServiceReconciler := &MultiClusterServiceReconciler{
+				Client:          mgrClient,
+				timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+				SystemNamespace: testSystemNamespace,
+			}
+
+			By("reconciling MultiClusterService to create the initial ServiceSet")
+			Eventually(func(g Gomega) {
+				_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(k8sClient.Get(ctx, serviceSetKey, &serviceSet)).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("setting KeepServicesOnSelectorMismatch=true on the MultiClusterService")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+				multiClusterService.Spec.KeepServicesOnSelectorMismatch = true
+				g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+			}).Should(Succeed())
+
+			By("removing the matching label from the ClusterDeployment so it diverges from the selector")
+			Eventually(func(g Gomega) {
+				fresh := &kcmv1.ClusterDeployment{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&clusterDeployment), fresh)).To(Succeed())
+				delete(fresh.Labels, "test")
+				g.Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
+			}).Should(Succeed())
+
+			// Block the assertion until the reconciler's cached client actually
+			// observes both changes. Without this gate, a spuriously passing
+			// test could result from the reconciler operating on a stale spec
+			// (flag still false, label still matches) and trivially leaving
+			// the ServiceSet alone.
+			By("waiting for the mgrClient cache to observe both spec changes")
+			Eventually(func(g Gomega) {
+				observedMCS := &kcmv1.MultiClusterService{}
+				g.Expect(mgrClient.Get(ctx, multiClusterServiceRef, observedMCS)).To(Succeed())
+				g.Expect(observedMCS.Spec.KeepServicesOnSelectorMismatch).To(BeTrue())
+
+				observedCD := &kcmv1.ClusterDeployment{}
+				g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(&clusterDeployment), observedCD)).To(Succeed())
+				g.Expect(observedCD.Labels).NotTo(HaveKey("test"))
+			}).Should(Succeed())
+
+			By("asserting the ServiceSet is preserved across repeated reconciles despite the label mismatch")
+			Consistently(func(g Gomega) {
+				_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				fresh := &kcmv1.ServiceSet{}
+				g.Expect(k8sClient.Get(ctx, serviceSetKey, fresh)).To(Succeed(),
+					"ServiceSet was deleted despite KeepServicesOnSelectorMismatch=true")
+				g.Expect(fresh.DeletionTimestamp.IsZero()).To(BeTrue(),
+					"ServiceSet was marked for deletion despite KeepServicesOnSelectorMismatch=true")
+			}, 2*time.Second, 100*time.Millisecond).Should(Succeed())
+		})
+
+		It("should preserve ServiceSet when ClusterSelector is cleared and KeepServicesOnSelectorMismatch is set", func() {
+			multiClusterServiceReconciler := &MultiClusterServiceReconciler{
+				Client:          mgrClient,
+				timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+				SystemNamespace: testSystemNamespace,
+			}
+
+			By("reconciling MultiClusterService to create the initial ServiceSet")
+			Eventually(func(g Gomega) {
+				_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(k8sClient.Get(ctx, serviceSetKey, &serviceSet)).NotTo(HaveOccurred())
+			}).Should(Succeed())
+
+			By("setting KeepServicesOnSelectorMismatch=true and clearing ClusterSelector in a single update")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+				multiClusterService.Spec.KeepServicesOnSelectorMismatch = true
+				multiClusterService.Spec.ClusterSelector = metav1.LabelSelector{}
+				g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+			}).Should(Succeed())
+
+			By("waiting for the mgrClient cache to observe the cleared selector and the flag")
+			Eventually(func(g Gomega) {
+				observedMCS := &kcmv1.MultiClusterService{}
+				g.Expect(mgrClient.Get(ctx, multiClusterServiceRef, observedMCS)).To(Succeed())
+				g.Expect(observedMCS.Spec.KeepServicesOnSelectorMismatch).To(BeTrue())
+				g.Expect(observedMCS.Spec.ClusterSelector.MatchLabels).To(BeEmpty())
+				g.Expect(observedMCS.Spec.ClusterSelector.MatchExpressions).To(BeEmpty())
+			}).Should(Succeed())
+
+			By("asserting the ServiceSet is preserved across repeated reconciles despite the empty selector")
+			Consistently(func(g Gomega) {
+				_, err := multiClusterServiceReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				fresh := &kcmv1.ServiceSet{}
+				g.Expect(k8sClient.Get(ctx, serviceSetKey, fresh)).To(Succeed(),
+					"ServiceSet was deleted despite KeepServicesOnSelectorMismatch=true")
+				g.Expect(fresh.DeletionTimestamp.IsZero()).To(BeTrue(),
+					"ServiceSet was marked for deletion despite KeepServicesOnSelectorMismatch=true")
+			}, 2*time.Second, 100*time.Millisecond).Should(Succeed())
+		})
+
 		// Regression test for continuous ServiceSet generation bumps caused by
 		// in-place mutation of stored spec during every reconcile.
 		// Each entry updates the MCS services, drains transient reconciles caused

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -108,6 +108,16 @@ spec:
                   items:
                     type: string
                   type: array
+                keepServicesOnSelectorMismatch:
+                  default: false
+                  description: |-
+                    KeepServicesOnSelectorMismatch indicates whether ServiceSets owned by
+                    this MultiClusterService should be preserved on clusters whose labels
+                    no longer match ClusterSelector, including the case where
+                    ClusterSelector is cleared. When true, services already deployed on
+                    such clusters keep running, enabling per-cluster opt-in rollouts driven
+                    by selector changes.
+                  type: boolean
                 serviceSpec:
                   description: ServiceSpec is spec related to deployment of services.
                   properties:


### PR DESCRIPTION
**What this PR does / why we need it**:

When a MultiClusterService (MCS) is used to roll out services across many clusters via clusterSelector, changing the selector (e.g., bumping a version label from kof-version: v1.0.0 to v2.0.0) causes the controller to delete the underlying ServiceSet objects on clusters that no longer match. That deletion cascades into uninstalling the deployed services from those clusters — there is no way to perform a gradual, per-cluster rollout without losing the existing deployment.

Introduced an opt-in boolean field KeepServicesOnSelectorMismatch on the MCS spec. When set to true, the controller preserves ServiceSets on clusters whose labels no longer match the selector — including the case where the selector is cleared entirely. This enables granular, opt-in upgrade flows: operators can relabel clusters one at a time to migrate them to a new MCS version, while clusters still carrying the old labels continue running their existing services untouched.

The field defaults to false, so the existing behavior is preserved for all current users.

**Which issue(s) this PR fixes**:

Fixes #2682 
