### PR TITLE
fix: number of total and deployed services

### DIFF
--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -1266,9 +1266,14 @@ func (r *ClusterDeploymentReconciler) setServicesCondition(ctx context.Context, 
 		// one reports success and the other reports failure. Therefore, we take into account
 		// both the ServiceStates so we don't erroneously report failure when the service has
 		// successfully been deployed on the cluster by the MultiClusterService.
+		//
+		// Each service is counted at most once towards readyServices regardless of how many
+		// ServiceSets report it as deployed - otherwise the readyServices count can exceed
+		// totalServices (e.g. 9/5) when the same service is owned by multiple ServiceSets.
 		for _, svcState := range svcStates {
 			if svcState.State == kcmv1.ServiceStateDeployed {
 				readyServices++
+				break
 			}
 		}
 	}

--- a/internal/controller/clusterdeployment_controller_test.go
+++ b/internal/controller/clusterdeployment_controller_test.go
@@ -1278,6 +1278,95 @@ var _ = Describe("ClusterDeployment Controller", Ordered, func() {
 			},
 		}),
 	)
+
+	// Regression test: setServicesCondition used to increment readyServices for
+	// every ServiceState found, instead of at most once per (namespace, name).
+	// When the same Service is owned by both a CD-owned ServiceSet and an
+	// MCS-owned ServiceSet - which is legitimate and explicitly handled by the
+	// surrounding logic - both reporting Deployed would push readyServices
+	// above totalServices (the user-reported "9/5" symptom).
+	//
+	// We seed two ServiceSets pointing at the same cluster, each carrying the
+	// same Service entry in Deployed state, then drive setServicesCondition
+	// directly and assert the message is "1/1".
+	It("ServicesInReadyState must not double-count services duplicated across ServiceSets", func() {
+		const clusterName = "test-cd-dedup"
+		serviceSetCommon := func(suffix, mcs string) *kcmv1.ServiceSet {
+			return &kcmv1.ServiceSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName + "-" + suffix,
+					Namespace: namespace.Name,
+				},
+				Spec: kcmv1.ServiceSetSpec{
+					Cluster:             clusterName,
+					MultiClusterService: mcs,
+				},
+			}
+		}
+		deployedState := []kcmv1.ServiceState{
+			{
+				Type:                    "Helm",
+				LastStateTransitionTime: &metav1.Time{Time: time.Now()},
+				Namespace:               "ns-shared",
+				Name:                    "svc-shared",
+				Template:                "tmpl-shared",
+				State:                   kcmv1.ServiceStateDeployed,
+			},
+		}
+
+		By("creating a CD-owned ServiceSet reporting svc-shared as Deployed", func() {
+			ssCD := serviceSetCommon("cd", "")
+			Expect(k8sClient.Create(ctx, ssCD)).To(Succeed())
+			DeferCleanup(func() error { return crclient.IgnoreNotFound(k8sClient.Delete(ctx, ssCD)) })
+			ssCD.Status.Services = deployedState
+			Expect(k8sClient.Status().Update(ctx, ssCD)).To(Succeed())
+		})
+
+		By("creating an MCS-owned ServiceSet reporting the same svc-shared as Deployed", func() {
+			ssMCS := serviceSetCommon("mcs", "owning-mcs")
+			Expect(k8sClient.Create(ctx, ssMCS)).To(Succeed())
+			DeferCleanup(func() error { return crclient.IgnoreNotFound(k8sClient.Delete(ctx, ssMCS)) })
+			ssMCS.Status.Services = deployedState
+			Expect(k8sClient.Status().Update(ctx, ssMCS)).To(Succeed())
+		})
+
+		By("waiting for the cached client to observe both ServiceSets via the cluster index", func() {
+			Eventually(func(g Gomega) {
+				list := &kcmv1.ServiceSetList{}
+				g.Expect(mgrClient.List(ctx, list, crclient.MatchingFields{kcmv1.ServiceSetClusterIndexKey: clusterName})).To(Succeed())
+				g.Expect(list.Items).To(HaveLen(2))
+				for _, ss := range list.Items {
+					g.Expect(ss.Status.Services).To(HaveLen(1))
+					g.Expect(ss.Status.Services[0].State).To(Equal(kcmv1.ServiceStateDeployed))
+				}
+			}).Should(Succeed())
+		})
+
+		By("running setServicesCondition and asserting ready does not exceed total", func() {
+			cd := &kcmv1.ClusterDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: namespace.Name,
+				},
+				Spec: kcmv1.ClusterDeploymentSpec{
+					ServiceSpec: kcmv1.ServiceSpec{
+						Services: []kcmv1.Service{
+							{Namespace: "ns-shared", Name: "svc-shared", Template: "tmpl-shared"},
+						},
+					},
+				},
+			}
+			r := &ClusterDeploymentReconciler{MgmtClient: mgrClient}
+			Expect(r.setServicesCondition(ctx, cd)).To(Succeed())
+
+			Expect(cd.Status.Conditions).To(ContainElement(SatisfyAll(
+				HaveField("Type", kcmv1.ServicesInReadyStateCondition),
+				HaveField("Status", metav1.ConditionTrue),
+				HaveField("Reason", kcmv1.SucceededReason),
+				HaveField("Message", "1/1"),
+			)))
+		})
+	})
 })
 
 // deleteClusterDeployment triggers deletion and waits for DeletionTimestamp to appear.

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -169,11 +169,19 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 
 	var errs error
+	// totalMatchingClusters tracks how many clusters we expect ServiceSets to be deployed to.
+	// Sourcing the total from the matching ClusterDeployments (plus selfManagement) - rather
+	// than from the existing ServiceSets - ensures that clusters whose ServiceSet failed to be
+	// created (e.g. due to unsatisfied MCS dependencies or a transient error) are still
+	// counted in the denominator of the ClusterInReadyState condition.
+	totalMatchingClusters := 0
+
 	// if selfManagement flag is set, then we'll need to create serviceSet which does not refer
 	// any clusterDeployment, but also has selfManagement flag set to true.
 	if mcs.Spec.ServiceSpec.Provider.SelfManagement {
 		l.V(1).Info("Ensuring ServiceSet for the management cluster")
 		errs = r.createOrUpdateServiceSet(ctx, mcs, nil)
+		totalMatchingClusters++
 	}
 
 	clusters := new(kcmv1.ClusterDeploymentList)
@@ -188,6 +196,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 		if !cluster.DeletionTimestamp.IsZero() {
 			continue
 		}
+		totalMatchingClusters++
 		errs = errors.Join(errs, r.createOrUpdateServiceSet(ctx, mcs, &cluster))
 	}
 
@@ -197,7 +206,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 	l.V(1).Info("ServiceSets matching MCS found", "MCS", mcs.Name, "count", len(serviceSetList.Items))
 
-	setClustersCondition(ctx, mcs, serviceSetList.Items)
+	setClustersCondition(ctx, mcs, totalMatchingClusters, serviceSetList.Items)
 	if errs != nil {
 		return ctrl.Result{}, errs
 	}
@@ -216,11 +225,18 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 
 // setClustersCondition updates MultiClusterService's condition which shows number of clusters where services were
 // successfully deployed out of total number of matching clusters.
-func setClustersCondition(ctx context.Context, mcs *kcmv1.MultiClusterService, serviceSets []kcmv1.ServiceSet) {
+//
+// totalClusters is the number of clusters the MCS is expected to target (matching
+// ClusterDeployments that are not being deleted, plus one for selfManagement when
+// enabled). It must be sourced from the matching ClusterDeployments rather than from
+// the ServiceSets list, otherwise clusters whose ServiceSet was not created yet
+// (e.g. due to unsatisfied dependencies or transient errors) would be silently
+// dropped from the denominator and the condition would misrepresent reality.
+func setClustersCondition(ctx context.Context, mcs *kcmv1.MultiClusterService, totalClusters int, serviceSets []kcmv1.ServiceSet) {
 	l := ctrl.LoggerFrom(ctx)
 	l.V(1).Info("Reconciling MultiClusterService conditions")
 
-	var totalDeployments, readyDeployments int
+	var readyDeployments int
 
 	c := metav1.Condition{
 		Type:   kcmv1.ClusterInReadyStateCondition,
@@ -229,27 +245,25 @@ func setClustersCondition(ctx context.Context, mcs *kcmv1.MultiClusterService, s
 	}
 
 	for _, serviceSet := range serviceSets {
-		// We won't count serviceSets being deleted neither in total deployments count
-		// nor in successful deployments count. If the serviceSet is being deleted, this
-		// means that either corresponding cluster is being deleted or corresponding cluster
-		// has labels which don't match selector anymore. Hence all services defined in
-		// the service set will be removed from cluster and there is no reason to count
-		// them anyhow.
+		// We won't count serviceSets being deleted in the ready deployments count.
+		// If the serviceSet is being deleted, this means that either corresponding
+		// cluster is being deleted or corresponding cluster has labels which don't
+		// match selector anymore. Hence all services defined in the service set
+		// will be removed from cluster and there is no reason to count them anyhow.
 		if !serviceSet.DeletionTimestamp.IsZero() {
 			continue
 		}
-		totalDeployments++
 		if serviceSet.Status.Deployed {
 			readyDeployments++
 		}
 	}
 
-	if readyDeployments < totalDeployments {
+	if readyDeployments < totalClusters {
 		c.Status = metav1.ConditionFalse
 		c.Reason = kcmv1.FailedReason
 	}
 
-	c.Message = fmt.Sprintf("%d/%d", readyDeployments, totalDeployments)
+	c.Message = fmt.Sprintf("%d/%d", readyDeployments, totalClusters)
 	apimeta.SetStatusCondition(&mcs.Status.Conditions, c)
 }
 

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -438,6 +438,103 @@ var _ = Describe("MultiClusterService Controller", func() {
 			}).Should(Succeed())
 		})
 
+		// Regression test: the ClusterInReadyState denominator must be sourced from
+		// the matching ClusterDeployments (plus selfManagement), not from the list of
+		// existing ServiceSets. Previously, when ServiceSet creation was blocked for a
+		// matching cluster (e.g. an unmet DependsOn dependency or a transient error),
+		// that cluster silently vanished from the total and the status reported "0/0"
+		// while a matching cluster existed.
+		//
+		// We block ServiceSet creation by adding a DependsOn referencing a sibling MCS
+		// that has no ServiceSet for the matching CD. okToReconcileServiceSet errors,
+		// createOrUpdateServiceSet skips, and the matching CD must still show up in
+		// the denominator.
+		It("should reflect matching ClusterDeployments in ClusterInReadyState even when ServiceSet creation is blocked", func() {
+			const siblingMCSName = "test-multiclusterservice-dependency"
+
+			By("creating a sibling MCS that the test MCS will DependsOn", func() {
+				sibling := &kcmv1.MultiClusterService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   siblingMCSName,
+						Labels: map[string]string{kcmv1.GenericComponentNameLabel: kcmv1.GenericComponentLabelValueKCM},
+					},
+					Spec: kcmv1.MultiClusterServiceSpec{
+						ClusterSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"test": "true"},
+						},
+						ServiceSpec: kcmv1.ServiceSpec{
+							Provider: kcmv1.StateManagementProviderConfig{
+								Name: kubeutil.DefaultStateManagementProvider,
+							},
+							Services: []kcmv1.Service{
+								{Template: serviceTemplate1Name, Name: "sibling-rel", Namespace: "ns-sibling"},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, sibling)).To(Succeed())
+				DeferCleanup(func() {
+					got := &kcmv1.MultiClusterService{}
+					if err := k8sClient.Get(ctx, client.ObjectKey{Name: siblingMCSName}, got); err == nil {
+						Expect(k8sClient.Delete(ctx, got)).To(Succeed())
+					}
+				})
+
+				// The reconciler reads via mgrClient (cached), so wait for the
+				// cache to observe the sibling before exercising the dependency
+				// path. okToReconcileServiceSet must be able to Get the sibling
+				// MCS object for the dependency check to engage.
+				Eventually(func(g Gomega) {
+					g.Expect(mgrClient.Get(ctx, client.ObjectKey{Name: siblingMCSName}, &kcmv1.MultiClusterService{})).To(Succeed())
+				}).Should(Succeed())
+			})
+
+			By("adding DependsOn to the test MCS so okToReconcileServiceSet blocks creation", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					multiClusterService.Spec.DependsOn = []string{siblingMCSName}
+					g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+				}).Should(Succeed())
+
+				// Wait for mgrClient cache to observe the DependsOn update;
+				// otherwise the first Reconcile would see the old spec, find
+				// no dependencies to check, and create the ServiceSet.
+				Eventually(func(g Gomega) {
+					fresh := &kcmv1.MultiClusterService{}
+					g.Expect(mgrClient.Get(ctx, multiClusterServiceRef, fresh)).To(Succeed())
+					g.Expect(fresh.Spec.DependsOn).To(ContainElement(siblingMCSName))
+				}).Should(Succeed())
+			})
+
+			reconciler := &MultiClusterServiceReconciler{
+				Client:          mgrClient,
+				timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+				SystemNamespace: testSystemNamespace,
+			}
+
+			By("reconciling and asserting the denominator counts the matching CD even with no ServiceSet", func() {
+				Eventually(func(g Gomega) {
+					_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+
+					// ServiceSet for the matching CD must not exist - creation was
+					// blocked because the sibling's ServiceSet for this CD is missing.
+					err := k8sClient.Get(ctx, serviceSetKey, &kcmv1.ServiceSet{})
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+						"ServiceSet should not be created when DependsOn is unsatisfied")
+
+					// The matching CD must still appear in the denominator: "0/1",
+					// not "0/0" as the previous (buggy) implementation would report.
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					g.Expect(multiClusterService.Status.Conditions).To(ContainElement(SatisfyAll(
+						HaveField("Type", kcmv1.ClusterInReadyStateCondition),
+						HaveField("Status", metav1.ConditionFalse),
+						HaveField("Reason", kcmv1.FailedReason),
+						HaveField("Message", "0/1"),
+					)))
+				}).Should(Succeed())
+			})
+		})
+
 		// Regression test for continuous ServiceSet generation bumps caused by
 		// in-place mutation of stored spec during every reconcile.
 		// Each entry updates the MCS services, drains transient reconciles caused


### PR DESCRIPTION
**What this PR does / why we need it**:

The ClusterDeployment's ServicesInReadyState condition reports an X/Y ratio: ready services out of total. Users observed impossible values where X exceeded Y (for example 9/5), which is not a meaningful progress indicator. A single cluster can have multiple ServiceSets pointing at it — one created by the ClusterDeployment itself, plus any number created by MultiClusterServices that select that cluster. These ServiceSets each maintain their own Status.Services list, and the same (namespace, name) service can appear in more than one of those lists.
When computing the ratio, the controller built a map keyed by (namespace, name) to consolidate all observed states for each service. The denominator was correct: len(map) — the count of unique services. But the numerator walked every state entry across every ServiceSet without deduplicating, so each Deployed observation incremented the ready count. Whenever a service had Deployed entries in more than one ServiceSet, it was counted twice (or more) in the numerator while contributing only once to the denominator. The more ServiceSets tracked the same service, the further the numerator drifted above the denominator.
This isn't about the user defining the same service twice. From the user's perspective there's a single service; the duplication is purely internal — multiple ServiceSets independently tracking the same (namespace, name). Any time that happens with Deployed state in more than one of them, the buggy loop overcounted.

The fix is to count each unique service at most once in the numerator. Once any Deployed observation is found for a given (namespace, name), that service is considered ready and the loop moves on to the next unique service. Now both numerator and denominator are expressed in the same unit — unique services — and the invariant X ≤ Y is restored.

The MultiClusterService was reporting an artificially low cluster total because the denominator was derived from the list of existing ServiceSets rather than from the list of matching clusters. Whenever ServiceSet creation was blocked or had not yet succeeded for a matching cluster (for example, due to an unsatisfied inter-MCS dependency or a transient error), that cluster silently disappeared from the total, misrepresenting reconciliation progress.

The fix sources the total from the matching ClusterDeployments (plus the self-management cluster when applicable) and uses ServiceSets only to count how many are actually deployed.

**Which issue(s) this PR fixes**:

Fixes #2631 
