### PR TITLE
feat(template): Allow to disable ingress deployment

### DIFF
--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -13,7 +13,7 @@ spec:
   {{- end }}
   {{- if $ingressEnabled }}
   ingress:
-    deploy: true
+    deploy: {{ .Values.ingress.deploy }}
     className: {{ .Values.ingress.className  | quote }}
     {{- with .Values.ingress.annotations }}
     annotations:

--- a/templates/cluster/openstack-hosted-cp/values.schema.json
+++ b/templates/cluster/openstack-hosted-cp/values.schema.json
@@ -316,6 +316,10 @@
           "description": "Ingress class name (must support SSL passthrough, e.g., haproxy, nginx, traefik)",
           "type": "string"
         },
+        "deploy": {
+          "description": "Automatically deploy ingress",
+          "type": "boolean"
+        },
         "enabled": {
           "description": "Enable ingress for control plane access (requires k0s v1.34.1+k0s.0 or later)",
           "type": "boolean"

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -15,6 +15,7 @@ clusterAnnotations: {} # @schema description: Annotations to apply to the cluste
 
 ingress: # @schema description: Ingress configuration for control plane access via management or regional cluster load balancer; type: object
   enabled: false # @schema description: Enable ingress for control plane access (requires k0s v1.34.1+k0s.0 or later); type: boolean
+  deploy: true # @schema description: Automatically deploy ingress; type: boolean
   className: "haproxy" # @schema description: Ingress class name (must support SSL passthrough, e.g., haproxy, nginx, traefik); type: string
   apiHost: "" # @schema description: Hostname for Kubernetes API (e.g., kube-api.example.com). Required when ingress is enabled; type: string
   konnectivityHost: "" # @schema description: Hostname for konnectivity server (e.g., konnectivity.example.com). Required when ingress is enabled; type: string

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-27.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-27.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-26
+  name: openstack-hosted-cp-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-hosted-cp
-      version: 1.0.26
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:

With the addition of the ingress for openstack hosted cp template the deploy property is always set to true. In case you want to deploy the ingress yourself or use a TLSRoute with a Gateway you should be able to disable the deployment of the ingress.

This change exposes ingress.deploy in the values.yaml, so that you can set it to false if you have to.
