### PR TITLE
fix(templates): proper merge user and defaults vals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,7 @@ $(IMAGES_PACKAGE_DIR): | $(LOCALBIN)
 	mkdir -p $(IMAGES_PACKAGE_DIR)
 
 TEMPLATE_FOLDERS = $(patsubst $(TEMPLATES_DIR)/%,%,$(wildcard $(TEMPLATES_DIR)/*))
+TEST_CHARTS = $(sort $(patsubst %/tests/,%,$(dir $(wildcard $(TEMPLATES_DIR)/*/*/tests/*_test.yaml))))
 
 .PHONY: helm-package
 helm-package: $(CHARTS_PACKAGE_DIR) $(EXTENSION_CHARTS_PACKAGE_DIR) helm ## Package all template charts.
@@ -227,8 +228,22 @@ package-chart-%: lint-chart-%
 	$(HELM) package --destination $(CHARTS_PACKAGE_DIR) $(TEMPLATES_SUBDIR)/$*
 
 .PHONY: lint-charts
-lint-charts: helm lint-quoted-values ## Run quote checks plus Helm dependency update and lint for charts.
+lint-charts: helm lint-quoted-values test-charts ## Run quote checks plus Helm dependency update/lint and chart unit tests.
 	@$(MAKE) $(patsubst %,lint-%-tmpl,$(TEMPLATE_FOLDERS))
+
+.PHONY: test-charts
+test-charts: helm-plugin-unittest ## Run Helm unit tests for charts that define tests/*_test.yaml suites.
+	@if [ -z "$(TEST_CHARTS)" ]; then \
+		echo "No Helm unittest suites found."; \
+		exit 0; \
+	fi
+	@status=0; \
+	for chart in $(TEST_CHARTS); do \
+		echo "Running helm unittest in $$chart"; \
+		$(HELM) dependency update "$$chart" >/dev/null || status=$$?; \
+		$(HELM) unittest "$$chart" -f 'tests/*_test.yaml' -q || status=$$?; \
+	done; \
+	exit $$status
 
 .PHONY: lint-quoted-values
 lint-quoted-values: yq ## Ensure string .Values YAML interpolations are quoted in template charts.
@@ -674,7 +689,7 @@ SUPPORT_BUNDLE_CLI_VERSION ?= v0.117.0
 cli-install: controller-gen envtest golangci-lint helm kind yq cloud-nuke azure-nuke clusterawsadm clusterctl addlicense envsubst awscli ## Install all required CLI tools.
 
 .PHONY: helm-plugin-schema
-helm-plugin-schema: HELM_PLUGIN_URL ?= https://github.com/losisin/helm-values-schema-json.git
+helm-plugin-schema: HELM_SCHEMA_PLUGIN_URL ?= https://github.com/losisin/helm-values-schema-json.git
 helm-plugin-schema: HELM_SCHEMA_PLUGIN_VERSION ?= 2.3.1
 helm-plugin-schema: HELM_SCHEMA_PLUGIN_NAME ?= schema
 helm-plugin-schema: helm ## Install/update Helm schema plugin.
@@ -684,7 +699,21 @@ helm-plugin-schema: helm ## Install/update Helm schema plugin.
 	current="$$( $(HELM) plugin list 2>/dev/null | awk -v n="$$name" '$$1==n{print $$2}' )"; \
 	if [ "$$current" != "$$desired" ]; then \
 		$(HELM) plugin uninstall "$$name" >/dev/null 2>&1 || true; \
-		$(HELM) plugin install "$(HELM_PLUGIN_URL)" --version "$$desired" >/dev/null; \
+		$(HELM) plugin install "$(HELM_SCHEMA_PLUGIN_URL)" --version "$$desired" >/dev/null; \
+	fi
+
+.PHONY: helm-plugin-unittest
+helm-plugin-unittest: HELM_UNITTEST_PLUGIN_URL ?= https://github.com/helm-unittest/helm-unittest.git
+helm-plugin-unittest: HELM_UNITTEST_PLUGIN_VERSION ?= 1.1.0
+helm-plugin-unittest: HELM_UNITTEST_PLUGIN_NAME ?= unittest
+helm-plugin-unittest: helm ## Install/update Helm unittest plugin.
+	@set -e; \
+	name="$(HELM_UNITTEST_PLUGIN_NAME)"; \
+	desired="$(HELM_UNITTEST_PLUGIN_VERSION)"; \
+	current="$$( $(HELM) plugin list 2>/dev/null | awk -v n="$$name" '$$1==n{print $$2}' )"; \
+	if [ "$${current#v}" != "$$desired" ]; then \
+		$(HELM) plugin uninstall "$$name" >/dev/null 2>&1 || true; \
+		$(HELM) plugin install "$(HELM_UNITTEST_PLUGIN_URL)" --version "v$$desired" >/dev/null; \
 	fi
 
 .PHONY: controller-gen

--- a/templates/provider/cluster-api-provider-aws/Chart.yaml
+++ b/templates/provider/cluster-api-provider-aws/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.20
+version: 1.0.21
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-aws/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-aws/templates/_helpers.tpl
@@ -101,10 +101,152 @@ Build the default deployment settings
 {{- end }}
 
 {{/*
+Merge deployment settings while preserving default containers.
+Containers are merged by name with user values taking precedence.
+*/}}
+{{- define "infrastructureProvider.deployment.merge" -}}
+{{- $default := .default | default dict -}}
+{{- $user := .user | default dict -}}
+{{- $merged := merge (deepCopy $user) (deepCopy $default) -}}
+
+{{- $hasDefaultContainers := hasKey $default "containers" -}}
+{{- $hasUserContainers := hasKey $user "containers" -}}
+{{- if or $hasDefaultContainers $hasUserContainers -}}
+{{- $defaultContainers := get $default "containers" | default list -}}
+{{- $userContainers := get $user "containers" | default list -}}
+{{- if and (kindIs "slice" $defaultContainers) (kindIs "slice" $userContainers) -}}
+{{- $userContainersByName := dict -}}
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userContainersByName $name $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultNames := dict -}}
+{{- $mergedContainers := list -}}
+{{- range $defaultContainer := $defaultContainers -}}
+{{- $name := $defaultContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userContainersByName $name) -}}
+{{- $mergedContainer := merge (deepCopy (get $userContainersByName $name)) (deepCopy $defaultContainer) -}}
+{{- $hasDefaultEnv := hasKey $defaultContainer "env" -}}
+{{- $userContainer := get $userContainersByName $name -}}
+{{- $hasUserEnv := hasKey $userContainer "env" -}}
+{{- if or $hasDefaultEnv $hasUserEnv -}}
+{{- $defaultEnv := get $defaultContainer "env" | default list -}}
+{{- $userEnv := get $userContainer "env" | default list -}}
+{{- if and (kindIs "slice" $defaultEnv) (kindIs "slice" $userEnv) -}}
+{{- $userEnvByName := dict -}}
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $userEnvByName $envName $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultEnvNames := dict -}}
+{{- $mergedEnv := list -}}
+{{- range $item := $defaultEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $defaultEnvNames $envName true -}}
+{{- end -}}
+{{- if and (ne $envName "") (hasKey $userEnvByName $envName) -}}
+{{- $mergedEnv = append $mergedEnv (get $userEnvByName $envName) -}}
+{{- else -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if or (eq $envName "") (not (hasKey $defaultEnvNames $envName)) -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $mergedContainer "env" $mergedEnv -}}
+{{- end -}}
+{{- end -}}
+{{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+{{- else -}}
+{{- $mergedContainers = append $mergedContainers $defaultContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultNames $name)) -}}
+{{- $mergedContainers = append $mergedContainers $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultImagePullSecrets := hasKey $default "imagePullSecrets" -}}
+{{- $hasUserImagePullSecrets := hasKey $user "imagePullSecrets" -}}
+{{- if or $hasDefaultImagePullSecrets $hasUserImagePullSecrets -}}
+{{- $defaultImagePullSecrets := get $default "imagePullSecrets" | default list -}}
+{{- $userImagePullSecrets := get $user "imagePullSecrets" | default list -}}
+{{- if and (kindIs "slice" $defaultImagePullSecrets) (kindIs "slice" $userImagePullSecrets) -}}
+{{- $userImagePullSecretsByName := dict -}}
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userImagePullSecretsByName $name $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultImagePullSecretNames := dict -}}
+{{- $mergedImagePullSecrets := list -}}
+{{- range $secret := $defaultImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultImagePullSecretNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userImagePullSecretsByName $name) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets (get $userImagePullSecretsByName $name) -}}
+{{- else -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultImagePullSecretNames $name)) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "imagePullSecrets" $mergedImagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultTolerations := hasKey $default "tolerations" -}}
+{{- $hasUserTolerations := hasKey $user "tolerations" -}}
+{{- if or $hasDefaultTolerations $hasUserTolerations -}}
+{{- $defaultTolerations := get $default "tolerations" | default list -}}
+{{- $userTolerations := get $user "tolerations" | default list -}}
+{{- if and (kindIs "slice" $defaultTolerations) (kindIs "slice" $userTolerations) -}}
+{{- $_ := set $merged "tolerations" (concat $defaultTolerations $userTolerations) -}}
+{{- end -}}
+{{- end -}}
+
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
 Merge default deployment settings with user-provided overrides
 */}}
 {{- define "infrastructureProvider.deployment" -}}
-{{ toYaml (merge (.Values.deployment | default dict) (include "infrastructureProvider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "infrastructureProvider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.deployment | default dict -}}
+{{- include "infrastructureProvider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*

--- a/templates/provider/cluster-api-provider-aws/tests/deployment_merge_test.yaml
+++ b/templates/provider/cluster-api-provider-aws/tests/deployment_merge_test.yaml
@@ -1,0 +1,128 @@
+suite: AWS provider deployment merge
+templates:
+  - templates/provider.yaml
+
+tests:
+  - it: "omits deployment when no defaults and no deployment overrides are provided"
+    asserts:
+      - isKind:
+          of: InfrastructureProvider
+      - isNull:
+          path: spec.deployment
+
+  - it: "merges manager override with default manager container"
+    set:
+      global.registry: registry.example.com
+      deployment.containers:
+        - name: manager
+          env:
+            - name: SSH_KNOWN_HOSTS
+              value: ""
+    asserts:
+      - isKind:
+          of: InfrastructureProvider
+      - equal:
+          path: spec.deployment.containers[?(@.name=="manager")].name
+          value: manager
+      - matchRegex:
+          path: spec.deployment.containers[?(@.name=="manager")].imageUrl
+          pattern: '^registry\.example\.com/capi/cluster-api-aws-controller:.*$'
+      - contains:
+          path: spec.deployment.containers[?(@.name=="manager")].env
+          content:
+            name: SSH_KNOWN_HOSTS
+            value: ""
+
+  - it: "keeps default manager container and appends user sidecar"
+    set:
+      global.registry: registry.example.com
+      deployment.containers:
+        - name: sidecar
+          imageUrl: example.com/sidecar:v1
+    asserts:
+      - equal:
+          path: spec.deployment.containers[?(@.name=="manager")].name
+          value: manager
+      - matchRegex:
+          path: spec.deployment.containers[?(@.name=="manager")].imageUrl
+          pattern: '^registry\.example\.com/capi/cluster-api-aws-controller:.*$'
+      - equal:
+          path: spec.deployment.containers[?(@.name=="sidecar")].name
+          value: sidecar
+      - equal:
+          path: spec.deployment.containers[?(@.name=="sidecar")].imageUrl
+          value: example.com/sidecar:v1
+
+  - it: "preserves proxy env when user adds manager env"
+    set:
+      global.proxy.secretName: proxy-secret
+      deployment.containers:
+        - name: manager
+          env:
+            - name: SSH_KNOWN_HOSTS
+              value: ""
+    asserts:
+      - contains:
+          path: spec.deployment.containers[?(@.name=="manager")].env
+          content:
+            name: HTTP_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: proxy-secret
+                key: HTTP_PROXY
+                optional: true
+      - contains:
+          path: spec.deployment.containers[?(@.name=="manager")].env
+          content:
+            name: HTTPS_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: proxy-secret
+                key: HTTPS_PROXY
+                optional: true
+      - contains:
+          path: spec.deployment.containers[?(@.name=="manager")].env
+          content:
+            name: NO_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: proxy-secret
+                key: NO_PROXY
+                optional: true
+      - contains:
+          path: spec.deployment.containers[?(@.name=="manager")].env
+          content:
+            name: SSH_KNOWN_HOSTS
+            value: ""
+
+  - it: "preserves default imagePullSecrets and appends user secrets"
+    set:
+      global.imagePullSecrets:
+        - name: default-pull-secret
+      deployment.imagePullSecrets:
+        - name: user-pull-secret
+    asserts:
+      - contains:
+          path: spec.deployment.imagePullSecrets
+          content:
+            name: default-pull-secret
+      - contains:
+          path: spec.deployment.imagePullSecrets
+          content:
+            name: user-pull-secret
+
+  - it: "renders user deployment tolerations"
+    set:
+      deployment.tolerations:
+        - key: dedicated
+          operator: Equal
+          value: hmc-test
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.deployment.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: hmc-test
+            effect: NoSchedule

--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.23
+version: 1.0.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-azure/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-azure/templates/_helpers.tpl
@@ -81,10 +81,152 @@ Build the default deployment settings
 {{- end }}
 
 {{/*
+Merge deployment settings while preserving default containers.
+Containers are merged by name with user values taking precedence.
+*/}}
+{{- define "infrastructureProvider.deployment.merge" -}}
+{{- $default := .default | default dict -}}
+{{- $user := .user | default dict -}}
+{{- $merged := merge (deepCopy $user) (deepCopy $default) -}}
+
+{{- $hasDefaultContainers := hasKey $default "containers" -}}
+{{- $hasUserContainers := hasKey $user "containers" -}}
+{{- if or $hasDefaultContainers $hasUserContainers -}}
+{{- $defaultContainers := get $default "containers" | default list -}}
+{{- $userContainers := get $user "containers" | default list -}}
+{{- if and (kindIs "slice" $defaultContainers) (kindIs "slice" $userContainers) -}}
+{{- $userContainersByName := dict -}}
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userContainersByName $name $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultNames := dict -}}
+{{- $mergedContainers := list -}}
+{{- range $defaultContainer := $defaultContainers -}}
+{{- $name := $defaultContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userContainersByName $name) -}}
+{{- $mergedContainer := merge (deepCopy (get $userContainersByName $name)) (deepCopy $defaultContainer) -}}
+{{- $hasDefaultEnv := hasKey $defaultContainer "env" -}}
+{{- $userContainer := get $userContainersByName $name -}}
+{{- $hasUserEnv := hasKey $userContainer "env" -}}
+{{- if or $hasDefaultEnv $hasUserEnv -}}
+{{- $defaultEnv := get $defaultContainer "env" | default list -}}
+{{- $userEnv := get $userContainer "env" | default list -}}
+{{- if and (kindIs "slice" $defaultEnv) (kindIs "slice" $userEnv) -}}
+{{- $userEnvByName := dict -}}
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $userEnvByName $envName $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultEnvNames := dict -}}
+{{- $mergedEnv := list -}}
+{{- range $item := $defaultEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $defaultEnvNames $envName true -}}
+{{- end -}}
+{{- if and (ne $envName "") (hasKey $userEnvByName $envName) -}}
+{{- $mergedEnv = append $mergedEnv (get $userEnvByName $envName) -}}
+{{- else -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if or (eq $envName "") (not (hasKey $defaultEnvNames $envName)) -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $mergedContainer "env" $mergedEnv -}}
+{{- end -}}
+{{- end -}}
+{{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+{{- else -}}
+{{- $mergedContainers = append $mergedContainers $defaultContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultNames $name)) -}}
+{{- $mergedContainers = append $mergedContainers $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultImagePullSecrets := hasKey $default "imagePullSecrets" -}}
+{{- $hasUserImagePullSecrets := hasKey $user "imagePullSecrets" -}}
+{{- if or $hasDefaultImagePullSecrets $hasUserImagePullSecrets -}}
+{{- $defaultImagePullSecrets := get $default "imagePullSecrets" | default list -}}
+{{- $userImagePullSecrets := get $user "imagePullSecrets" | default list -}}
+{{- if and (kindIs "slice" $defaultImagePullSecrets) (kindIs "slice" $userImagePullSecrets) -}}
+{{- $userImagePullSecretsByName := dict -}}
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userImagePullSecretsByName $name $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultImagePullSecretNames := dict -}}
+{{- $mergedImagePullSecrets := list -}}
+{{- range $secret := $defaultImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultImagePullSecretNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userImagePullSecretsByName $name) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets (get $userImagePullSecretsByName $name) -}}
+{{- else -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultImagePullSecretNames $name)) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "imagePullSecrets" $mergedImagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultTolerations := hasKey $default "tolerations" -}}
+{{- $hasUserTolerations := hasKey $user "tolerations" -}}
+{{- if or $hasDefaultTolerations $hasUserTolerations -}}
+{{- $defaultTolerations := get $default "tolerations" | default list -}}
+{{- $userTolerations := get $user "tolerations" | default list -}}
+{{- if and (kindIs "slice" $defaultTolerations) (kindIs "slice" $userTolerations) -}}
+{{- $_ := set $merged "tolerations" (concat $defaultTolerations $userTolerations) -}}
+{{- end -}}
+{{- end -}}
+
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
 Merge default deployment settings with user-provided overrides
 */}}
 {{- define "infrastructureProvider.deployment" -}}
-{{ toYaml (merge (.Values.deployment | default dict) (include "infrastructureProvider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "infrastructureProvider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.deployment | default dict -}}
+{{- include "infrastructureProvider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*

--- a/templates/provider/cluster-api-provider-docker/Chart.yaml
+++ b/templates/provider/cluster-api-provider-docker/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.17
+version: 1.0.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-docker/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-docker/templates/_helpers.tpl
@@ -81,10 +81,152 @@ Build the default deployment settings
 {{- end }}
 
 {{/*
+Merge deployment settings while preserving default containers.
+Containers are merged by name with user values taking precedence.
+*/}}
+{{- define "infrastructureProvider.deployment.merge" -}}
+{{- $default := .default | default dict -}}
+{{- $user := .user | default dict -}}
+{{- $merged := merge (deepCopy $user) (deepCopy $default) -}}
+
+{{- $hasDefaultContainers := hasKey $default "containers" -}}
+{{- $hasUserContainers := hasKey $user "containers" -}}
+{{- if or $hasDefaultContainers $hasUserContainers -}}
+{{- $defaultContainers := get $default "containers" | default list -}}
+{{- $userContainers := get $user "containers" | default list -}}
+{{- if and (kindIs "slice" $defaultContainers) (kindIs "slice" $userContainers) -}}
+{{- $userContainersByName := dict -}}
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userContainersByName $name $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultNames := dict -}}
+{{- $mergedContainers := list -}}
+{{- range $defaultContainer := $defaultContainers -}}
+{{- $name := $defaultContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userContainersByName $name) -}}
+{{- $mergedContainer := merge (deepCopy (get $userContainersByName $name)) (deepCopy $defaultContainer) -}}
+{{- $hasDefaultEnv := hasKey $defaultContainer "env" -}}
+{{- $userContainer := get $userContainersByName $name -}}
+{{- $hasUserEnv := hasKey $userContainer "env" -}}
+{{- if or $hasDefaultEnv $hasUserEnv -}}
+{{- $defaultEnv := get $defaultContainer "env" | default list -}}
+{{- $userEnv := get $userContainer "env" | default list -}}
+{{- if and (kindIs "slice" $defaultEnv) (kindIs "slice" $userEnv) -}}
+{{- $userEnvByName := dict -}}
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $userEnvByName $envName $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultEnvNames := dict -}}
+{{- $mergedEnv := list -}}
+{{- range $item := $defaultEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $defaultEnvNames $envName true -}}
+{{- end -}}
+{{- if and (ne $envName "") (hasKey $userEnvByName $envName) -}}
+{{- $mergedEnv = append $mergedEnv (get $userEnvByName $envName) -}}
+{{- else -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if or (eq $envName "") (not (hasKey $defaultEnvNames $envName)) -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $mergedContainer "env" $mergedEnv -}}
+{{- end -}}
+{{- end -}}
+{{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+{{- else -}}
+{{- $mergedContainers = append $mergedContainers $defaultContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultNames $name)) -}}
+{{- $mergedContainers = append $mergedContainers $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultImagePullSecrets := hasKey $default "imagePullSecrets" -}}
+{{- $hasUserImagePullSecrets := hasKey $user "imagePullSecrets" -}}
+{{- if or $hasDefaultImagePullSecrets $hasUserImagePullSecrets -}}
+{{- $defaultImagePullSecrets := get $default "imagePullSecrets" | default list -}}
+{{- $userImagePullSecrets := get $user "imagePullSecrets" | default list -}}
+{{- if and (kindIs "slice" $defaultImagePullSecrets) (kindIs "slice" $userImagePullSecrets) -}}
+{{- $userImagePullSecretsByName := dict -}}
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userImagePullSecretsByName $name $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultImagePullSecretNames := dict -}}
+{{- $mergedImagePullSecrets := list -}}
+{{- range $secret := $defaultImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultImagePullSecretNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userImagePullSecretsByName $name) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets (get $userImagePullSecretsByName $name) -}}
+{{- else -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultImagePullSecretNames $name)) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "imagePullSecrets" $mergedImagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultTolerations := hasKey $default "tolerations" -}}
+{{- $hasUserTolerations := hasKey $user "tolerations" -}}
+{{- if or $hasDefaultTolerations $hasUserTolerations -}}
+{{- $defaultTolerations := get $default "tolerations" | default list -}}
+{{- $userTolerations := get $user "tolerations" | default list -}}
+{{- if and (kindIs "slice" $defaultTolerations) (kindIs "slice" $userTolerations) -}}
+{{- $_ := set $merged "tolerations" (concat $defaultTolerations $userTolerations) -}}
+{{- end -}}
+{{- end -}}
+
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
 Merge default deployment settings with user-provided overrides
 */}}
 {{- define "infrastructureProvider.deployment" -}}
-{{ toYaml (merge (.Values.deployment | default dict) (include "infrastructureProvider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "infrastructureProvider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.deployment | default dict -}}
+{{- include "infrastructureProvider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*

--- a/templates/provider/cluster-api-provider-gcp/Chart.yaml
+++ b/templates/provider/cluster-api-provider-gcp/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.17
+version: 1.0.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-gcp/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-gcp/templates/_helpers.tpl
@@ -101,10 +101,152 @@ Build the default deployment settings
 {{- end }}
 
 {{/*
+Merge deployment settings while preserving default containers.
+Containers are merged by name with user values taking precedence.
+*/}}
+{{- define "infrastructureProvider.deployment.merge" -}}
+{{- $default := .default | default dict -}}
+{{- $user := .user | default dict -}}
+{{- $merged := merge (deepCopy $user) (deepCopy $default) -}}
+
+{{- $hasDefaultContainers := hasKey $default "containers" -}}
+{{- $hasUserContainers := hasKey $user "containers" -}}
+{{- if or $hasDefaultContainers $hasUserContainers -}}
+{{- $defaultContainers := get $default "containers" | default list -}}
+{{- $userContainers := get $user "containers" | default list -}}
+{{- if and (kindIs "slice" $defaultContainers) (kindIs "slice" $userContainers) -}}
+{{- $userContainersByName := dict -}}
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userContainersByName $name $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultNames := dict -}}
+{{- $mergedContainers := list -}}
+{{- range $defaultContainer := $defaultContainers -}}
+{{- $name := $defaultContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userContainersByName $name) -}}
+{{- $mergedContainer := merge (deepCopy (get $userContainersByName $name)) (deepCopy $defaultContainer) -}}
+{{- $hasDefaultEnv := hasKey $defaultContainer "env" -}}
+{{- $userContainer := get $userContainersByName $name -}}
+{{- $hasUserEnv := hasKey $userContainer "env" -}}
+{{- if or $hasDefaultEnv $hasUserEnv -}}
+{{- $defaultEnv := get $defaultContainer "env" | default list -}}
+{{- $userEnv := get $userContainer "env" | default list -}}
+{{- if and (kindIs "slice" $defaultEnv) (kindIs "slice" $userEnv) -}}
+{{- $userEnvByName := dict -}}
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $userEnvByName $envName $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultEnvNames := dict -}}
+{{- $mergedEnv := list -}}
+{{- range $item := $defaultEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $defaultEnvNames $envName true -}}
+{{- end -}}
+{{- if and (ne $envName "") (hasKey $userEnvByName $envName) -}}
+{{- $mergedEnv = append $mergedEnv (get $userEnvByName $envName) -}}
+{{- else -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if or (eq $envName "") (not (hasKey $defaultEnvNames $envName)) -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $mergedContainer "env" $mergedEnv -}}
+{{- end -}}
+{{- end -}}
+{{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+{{- else -}}
+{{- $mergedContainers = append $mergedContainers $defaultContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultNames $name)) -}}
+{{- $mergedContainers = append $mergedContainers $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultImagePullSecrets := hasKey $default "imagePullSecrets" -}}
+{{- $hasUserImagePullSecrets := hasKey $user "imagePullSecrets" -}}
+{{- if or $hasDefaultImagePullSecrets $hasUserImagePullSecrets -}}
+{{- $defaultImagePullSecrets := get $default "imagePullSecrets" | default list -}}
+{{- $userImagePullSecrets := get $user "imagePullSecrets" | default list -}}
+{{- if and (kindIs "slice" $defaultImagePullSecrets) (kindIs "slice" $userImagePullSecrets) -}}
+{{- $userImagePullSecretsByName := dict -}}
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userImagePullSecretsByName $name $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultImagePullSecretNames := dict -}}
+{{- $mergedImagePullSecrets := list -}}
+{{- range $secret := $defaultImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultImagePullSecretNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userImagePullSecretsByName $name) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets (get $userImagePullSecretsByName $name) -}}
+{{- else -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultImagePullSecretNames $name)) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "imagePullSecrets" $mergedImagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultTolerations := hasKey $default "tolerations" -}}
+{{- $hasUserTolerations := hasKey $user "tolerations" -}}
+{{- if or $hasDefaultTolerations $hasUserTolerations -}}
+{{- $defaultTolerations := get $default "tolerations" | default list -}}
+{{- $userTolerations := get $user "tolerations" | default list -}}
+{{- if and (kindIs "slice" $defaultTolerations) (kindIs "slice" $userTolerations) -}}
+{{- $_ := set $merged "tolerations" (concat $defaultTolerations $userTolerations) -}}
+{{- end -}}
+{{- end -}}
+
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
 Merge default deployment settings with user-provided overrides
 */}}
 {{- define "infrastructureProvider.deployment" -}}
-{{ toYaml (merge (.Values.deployment | default dict) (include "infrastructureProvider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "infrastructureProvider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.deployment | default dict -}}
+{{- include "infrastructureProvider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*

--- a/templates/provider/cluster-api-provider-infoblox/Chart.yaml
+++ b/templates/provider/cluster-api-provider-infoblox/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-infoblox/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-infoblox/templates/_helpers.tpl
@@ -81,10 +81,152 @@ Build the default deployment settings
 {{- end }}
 
 {{/*
+Merge deployment settings while preserving default containers.
+Containers are merged by name with user values taking precedence.
+*/}}
+{{- define "ipamProvider.deployment.merge" -}}
+{{- $default := .default | default dict -}}
+{{- $user := .user | default dict -}}
+{{- $merged := merge (deepCopy $user) (deepCopy $default) -}}
+
+{{- $hasDefaultContainers := hasKey $default "containers" -}}
+{{- $hasUserContainers := hasKey $user "containers" -}}
+{{- if or $hasDefaultContainers $hasUserContainers -}}
+{{- $defaultContainers := get $default "containers" | default list -}}
+{{- $userContainers := get $user "containers" | default list -}}
+{{- if and (kindIs "slice" $defaultContainers) (kindIs "slice" $userContainers) -}}
+{{- $userContainersByName := dict -}}
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userContainersByName $name $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultNames := dict -}}
+{{- $mergedContainers := list -}}
+{{- range $defaultContainer := $defaultContainers -}}
+{{- $name := $defaultContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userContainersByName $name) -}}
+{{- $mergedContainer := merge (deepCopy (get $userContainersByName $name)) (deepCopy $defaultContainer) -}}
+{{- $hasDefaultEnv := hasKey $defaultContainer "env" -}}
+{{- $userContainer := get $userContainersByName $name -}}
+{{- $hasUserEnv := hasKey $userContainer "env" -}}
+{{- if or $hasDefaultEnv $hasUserEnv -}}
+{{- $defaultEnv := get $defaultContainer "env" | default list -}}
+{{- $userEnv := get $userContainer "env" | default list -}}
+{{- if and (kindIs "slice" $defaultEnv) (kindIs "slice" $userEnv) -}}
+{{- $userEnvByName := dict -}}
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $userEnvByName $envName $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultEnvNames := dict -}}
+{{- $mergedEnv := list -}}
+{{- range $item := $defaultEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $defaultEnvNames $envName true -}}
+{{- end -}}
+{{- if and (ne $envName "") (hasKey $userEnvByName $envName) -}}
+{{- $mergedEnv = append $mergedEnv (get $userEnvByName $envName) -}}
+{{- else -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if or (eq $envName "") (not (hasKey $defaultEnvNames $envName)) -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $mergedContainer "env" $mergedEnv -}}
+{{- end -}}
+{{- end -}}
+{{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+{{- else -}}
+{{- $mergedContainers = append $mergedContainers $defaultContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultNames $name)) -}}
+{{- $mergedContainers = append $mergedContainers $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultImagePullSecrets := hasKey $default "imagePullSecrets" -}}
+{{- $hasUserImagePullSecrets := hasKey $user "imagePullSecrets" -}}
+{{- if or $hasDefaultImagePullSecrets $hasUserImagePullSecrets -}}
+{{- $defaultImagePullSecrets := get $default "imagePullSecrets" | default list -}}
+{{- $userImagePullSecrets := get $user "imagePullSecrets" | default list -}}
+{{- if and (kindIs "slice" $defaultImagePullSecrets) (kindIs "slice" $userImagePullSecrets) -}}
+{{- $userImagePullSecretsByName := dict -}}
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userImagePullSecretsByName $name $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultImagePullSecretNames := dict -}}
+{{- $mergedImagePullSecrets := list -}}
+{{- range $secret := $defaultImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultImagePullSecretNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userImagePullSecretsByName $name) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets (get $userImagePullSecretsByName $name) -}}
+{{- else -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultImagePullSecretNames $name)) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "imagePullSecrets" $mergedImagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultTolerations := hasKey $default "tolerations" -}}
+{{- $hasUserTolerations := hasKey $user "tolerations" -}}
+{{- if or $hasDefaultTolerations $hasUserTolerations -}}
+{{- $defaultTolerations := get $default "tolerations" | default list -}}
+{{- $userTolerations := get $user "tolerations" | default list -}}
+{{- if and (kindIs "slice" $defaultTolerations) (kindIs "slice" $userTolerations) -}}
+{{- $_ := set $merged "tolerations" (concat $defaultTolerations $userTolerations) -}}
+{{- end -}}
+{{- end -}}
+
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
 Merge default deployment settings with user-provided overrides
 */}}
 {{- define "ipamProvider.deployment" -}}
-{{ toYaml (merge (.Values.deployment | default dict) (include "ipamProvider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "ipamProvider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.deployment | default dict -}}
+{{- include "ipamProvider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*

--- a/templates/provider/cluster-api-provider-ipam/Chart.yaml
+++ b/templates/provider/cluster-api-provider-ipam/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-ipam/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-ipam/templates/_helpers.tpl
@@ -81,10 +81,152 @@ Build the default deployment settings
 {{- end }}
 
 {{/*
+Merge deployment settings while preserving default containers.
+Containers are merged by name with user values taking precedence.
+*/}}
+{{- define "ipamProvider.deployment.merge" -}}
+{{- $default := .default | default dict -}}
+{{- $user := .user | default dict -}}
+{{- $merged := merge (deepCopy $user) (deepCopy $default) -}}
+
+{{- $hasDefaultContainers := hasKey $default "containers" -}}
+{{- $hasUserContainers := hasKey $user "containers" -}}
+{{- if or $hasDefaultContainers $hasUserContainers -}}
+{{- $defaultContainers := get $default "containers" | default list -}}
+{{- $userContainers := get $user "containers" | default list -}}
+{{- if and (kindIs "slice" $defaultContainers) (kindIs "slice" $userContainers) -}}
+{{- $userContainersByName := dict -}}
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userContainersByName $name $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultNames := dict -}}
+{{- $mergedContainers := list -}}
+{{- range $defaultContainer := $defaultContainers -}}
+{{- $name := $defaultContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userContainersByName $name) -}}
+{{- $mergedContainer := merge (deepCopy (get $userContainersByName $name)) (deepCopy $defaultContainer) -}}
+{{- $hasDefaultEnv := hasKey $defaultContainer "env" -}}
+{{- $userContainer := get $userContainersByName $name -}}
+{{- $hasUserEnv := hasKey $userContainer "env" -}}
+{{- if or $hasDefaultEnv $hasUserEnv -}}
+{{- $defaultEnv := get $defaultContainer "env" | default list -}}
+{{- $userEnv := get $userContainer "env" | default list -}}
+{{- if and (kindIs "slice" $defaultEnv) (kindIs "slice" $userEnv) -}}
+{{- $userEnvByName := dict -}}
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $userEnvByName $envName $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultEnvNames := dict -}}
+{{- $mergedEnv := list -}}
+{{- range $item := $defaultEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $defaultEnvNames $envName true -}}
+{{- end -}}
+{{- if and (ne $envName "") (hasKey $userEnvByName $envName) -}}
+{{- $mergedEnv = append $mergedEnv (get $userEnvByName $envName) -}}
+{{- else -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if or (eq $envName "") (not (hasKey $defaultEnvNames $envName)) -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $mergedContainer "env" $mergedEnv -}}
+{{- end -}}
+{{- end -}}
+{{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+{{- else -}}
+{{- $mergedContainers = append $mergedContainers $defaultContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultNames $name)) -}}
+{{- $mergedContainers = append $mergedContainers $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultImagePullSecrets := hasKey $default "imagePullSecrets" -}}
+{{- $hasUserImagePullSecrets := hasKey $user "imagePullSecrets" -}}
+{{- if or $hasDefaultImagePullSecrets $hasUserImagePullSecrets -}}
+{{- $defaultImagePullSecrets := get $default "imagePullSecrets" | default list -}}
+{{- $userImagePullSecrets := get $user "imagePullSecrets" | default list -}}
+{{- if and (kindIs "slice" $defaultImagePullSecrets) (kindIs "slice" $userImagePullSecrets) -}}
+{{- $userImagePullSecretsByName := dict -}}
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userImagePullSecretsByName $name $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultImagePullSecretNames := dict -}}
+{{- $mergedImagePullSecrets := list -}}
+{{- range $secret := $defaultImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultImagePullSecretNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userImagePullSecretsByName $name) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets (get $userImagePullSecretsByName $name) -}}
+{{- else -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultImagePullSecretNames $name)) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "imagePullSecrets" $mergedImagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultTolerations := hasKey $default "tolerations" -}}
+{{- $hasUserTolerations := hasKey $user "tolerations" -}}
+{{- if or $hasDefaultTolerations $hasUserTolerations -}}
+{{- $defaultTolerations := get $default "tolerations" | default list -}}
+{{- $userTolerations := get $user "tolerations" | default list -}}
+{{- if and (kindIs "slice" $defaultTolerations) (kindIs "slice" $userTolerations) -}}
+{{- $_ := set $merged "tolerations" (concat $defaultTolerations $userTolerations) -}}
+{{- end -}}
+{{- end -}}
+
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
 Merge default deployment settings with user-provided overrides
 */}}
 {{- define "ipamProvider.deployment" -}}
-{{ toYaml (merge (.Values.deployment | default dict) (include "ipamProvider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "ipamProvider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.deployment | default dict -}}
+{{- include "ipamProvider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/_helpers.tpl
@@ -81,24 +81,170 @@ Build the default deployment settings
 {{- end }}
 
 {{/*
+Merge deployment settings while preserving default containers.
+Containers are merged by name with user values taking precedence.
+*/}}
+{{- define "provider.deployment.merge" -}}
+{{- $default := .default | default dict -}}
+{{- $user := .user | default dict -}}
+{{- $merged := merge (deepCopy $user) (deepCopy $default) -}}
+
+{{- $hasDefaultContainers := hasKey $default "containers" -}}
+{{- $hasUserContainers := hasKey $user "containers" -}}
+{{- if or $hasDefaultContainers $hasUserContainers -}}
+{{- $defaultContainers := get $default "containers" | default list -}}
+{{- $userContainers := get $user "containers" | default list -}}
+{{- if and (kindIs "slice" $defaultContainers) (kindIs "slice" $userContainers) -}}
+{{- $userContainersByName := dict -}}
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userContainersByName $name $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultNames := dict -}}
+{{- $mergedContainers := list -}}
+{{- range $defaultContainer := $defaultContainers -}}
+{{- $name := $defaultContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userContainersByName $name) -}}
+{{- $mergedContainer := merge (deepCopy (get $userContainersByName $name)) (deepCopy $defaultContainer) -}}
+{{- $hasDefaultEnv := hasKey $defaultContainer "env" -}}
+{{- $userContainer := get $userContainersByName $name -}}
+{{- $hasUserEnv := hasKey $userContainer "env" -}}
+{{- if or $hasDefaultEnv $hasUserEnv -}}
+{{- $defaultEnv := get $defaultContainer "env" | default list -}}
+{{- $userEnv := get $userContainer "env" | default list -}}
+{{- if and (kindIs "slice" $defaultEnv) (kindIs "slice" $userEnv) -}}
+{{- $userEnvByName := dict -}}
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $userEnvByName $envName $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultEnvNames := dict -}}
+{{- $mergedEnv := list -}}
+{{- range $item := $defaultEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $defaultEnvNames $envName true -}}
+{{- end -}}
+{{- if and (ne $envName "") (hasKey $userEnvByName $envName) -}}
+{{- $mergedEnv = append $mergedEnv (get $userEnvByName $envName) -}}
+{{- else -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if or (eq $envName "") (not (hasKey $defaultEnvNames $envName)) -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $mergedContainer "env" $mergedEnv -}}
+{{- end -}}
+{{- end -}}
+{{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+{{- else -}}
+{{- $mergedContainers = append $mergedContainers $defaultContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultNames $name)) -}}
+{{- $mergedContainers = append $mergedContainers $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultImagePullSecrets := hasKey $default "imagePullSecrets" -}}
+{{- $hasUserImagePullSecrets := hasKey $user "imagePullSecrets" -}}
+{{- if or $hasDefaultImagePullSecrets $hasUserImagePullSecrets -}}
+{{- $defaultImagePullSecrets := get $default "imagePullSecrets" | default list -}}
+{{- $userImagePullSecrets := get $user "imagePullSecrets" | default list -}}
+{{- if and (kindIs "slice" $defaultImagePullSecrets) (kindIs "slice" $userImagePullSecrets) -}}
+{{- $userImagePullSecretsByName := dict -}}
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userImagePullSecretsByName $name $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultImagePullSecretNames := dict -}}
+{{- $mergedImagePullSecrets := list -}}
+{{- range $secret := $defaultImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultImagePullSecretNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userImagePullSecretsByName $name) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets (get $userImagePullSecretsByName $name) -}}
+{{- else -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultImagePullSecretNames $name)) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "imagePullSecrets" $mergedImagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultTolerations := hasKey $default "tolerations" -}}
+{{- $hasUserTolerations := hasKey $user "tolerations" -}}
+{{- if or $hasDefaultTolerations $hasUserTolerations -}}
+{{- $defaultTolerations := get $default "tolerations" | default list -}}
+{{- $userTolerations := get $user "tolerations" | default list -}}
+{{- if and (kindIs "slice" $defaultTolerations) (kindIs "slice" $userTolerations) -}}
+{{- $_ := set $merged "tolerations" (concat $defaultTolerations $userTolerations) -}}
+{{- end -}}
+{{- end -}}
+
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
 Merge default infrastructure provider deployment settings with user-provided overrides
 */}}
 {{- define "infrastructureProvider.deployment" -}}
-{{ toYaml (merge (.Values.infrastructure.deployment | default dict) (include "provider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "provider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.infrastructure.deployment | default dict -}}
+{{- include "provider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*
 Merge default bootstrap provider deployment settings with user-provided overrides
 */}}
 {{- define "bootstrapProvider.deployment" -}}
-{{ toYaml (merge (.Values.bootstrap.deployment | default dict) (include "provider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "provider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.bootstrap.deployment | default dict -}}
+{{- include "provider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*
 Merge default control plane provider deployment settings with user-provided overrides
 */}}
 {{- define "controlPlaneProvider.deployment" -}}
-{{ toYaml (merge (.Values.controlPlane.deployment | default dict) (include "provider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "provider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.controlPlane.deployment | default dict -}}
+{{- include "provider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/tests/deployment_merge_test.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/tests/deployment_merge_test.yaml
@@ -1,0 +1,187 @@
+suite: K0smotron provider deployment merge
+templates:
+  - templates/providers.yaml
+
+tests:
+  - it: "omits deployment for all providers when no defaults and no deployment overrides are provided"
+    asserts:
+      - isNull:
+          path: spec.deployment
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider
+      - isNull:
+          path: spec.deployment
+        documentSelector:
+          path: kind
+          value: BootstrapProvider
+      - isNull:
+          path: spec.deployment
+        documentSelector:
+          path: kind
+          value: ControlPlaneProvider
+
+  - it: "preserves default manager imageUrl when overriding infrastructure manager env"
+    set:
+      global.registry: registry.example.com
+      infrastructure.deployment.containers:
+        - name: manager
+          env:
+            - name: SSH_KNOWN_HOSTS
+              value: ""
+    asserts:
+      - isKind:
+          of: InfrastructureProvider
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider
+      - equal:
+          path: spec.deployment.containers[?(@.name=="manager")].name
+          value: manager
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider
+      - matchRegex:
+          path: spec.deployment.containers[?(@.name=="manager")].imageUrl
+          pattern: '^registry\.example\.com/capi/k0smotron:.*$'
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider
+      - contains:
+          path: spec.deployment.containers[?(@.name=="manager")].env
+          content:
+            name: SSH_KNOWN_HOSTS
+            value: ""
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider
+
+  - it: "keeps manager imageUrl and appends sidecars for bootstrap and controlPlane"
+    set:
+      global.registry: registry.example.com
+      bootstrap.deployment.containers:
+        - name: sidecar-bootstrap
+          imageUrl: example.com/sidecar-bootstrap:v1
+      controlPlane.deployment.containers:
+        - name: sidecar-controlplane
+          imageUrl: example.com/sidecar-controlplane:v1
+    asserts:
+      - matchRegex:
+          path: spec.deployment.containers[?(@.name=="manager")].imageUrl
+          pattern: '^registry\.example\.com/capi/k0smotron:.*$'
+        documentSelector:
+          path: kind
+          value: BootstrapProvider
+      - equal:
+          path: spec.deployment.containers[?(@.name=="sidecar-bootstrap")].imageUrl
+          value: example.com/sidecar-bootstrap:v1
+        documentSelector:
+          path: kind
+          value: BootstrapProvider
+      - matchRegex:
+          path: spec.deployment.containers[?(@.name=="manager")].imageUrl
+          pattern: '^registry\.example\.com/capi/k0smotron:.*$'
+        documentSelector:
+          path: kind
+          value: ControlPlaneProvider
+      - equal:
+          path: spec.deployment.containers[?(@.name=="sidecar-controlplane")].imageUrl
+          value: example.com/sidecar-controlplane:v1
+        documentSelector:
+          path: kind
+          value: ControlPlaneProvider
+
+  - it: "preserves proxy env when user adds infrastructure manager env"
+    set:
+      global.proxy.secretName: proxy-secret
+      infrastructure.deployment.containers:
+        - name: manager
+          env:
+            - name: SSH_KNOWN_HOSTS
+              value: ""
+    asserts:
+      - contains:
+          path: spec.deployment.containers[?(@.name=="manager")].env
+          content:
+            name: HTTP_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: proxy-secret
+                key: HTTP_PROXY
+                optional: true
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider
+      - contains:
+          path: spec.deployment.containers[?(@.name=="manager")].env
+          content:
+            name: HTTPS_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: proxy-secret
+                key: HTTPS_PROXY
+                optional: true
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider
+      - contains:
+          path: spec.deployment.containers[?(@.name=="manager")].env
+          content:
+            name: NO_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: proxy-secret
+                key: NO_PROXY
+                optional: true
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider
+      - contains:
+          path: spec.deployment.containers[?(@.name=="manager")].env
+          content:
+            name: SSH_KNOWN_HOSTS
+            value: ""
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider
+
+  - it: "preserves default imagePullSecrets and appends infrastructure user secrets"
+    set:
+      global.imagePullSecrets:
+        - name: default-pull-secret
+      infrastructure.deployment.imagePullSecrets:
+        - name: user-pull-secret
+    asserts:
+      - contains:
+          path: spec.deployment.imagePullSecrets
+          content:
+            name: default-pull-secret
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider
+      - contains:
+          path: spec.deployment.imagePullSecrets
+          content:
+            name: user-pull-secret
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider
+
+  - it: "renders infrastructure deployment tolerations"
+    set:
+      infrastructure.deployment.tolerations:
+        - key: dedicated
+          operator: Equal
+          value: hmc-test
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.deployment.tolerations
+          content:
+            key: dedicated
+            operator: Equal
+            value: hmc-test
+            effect: NoSchedule
+        documentSelector:
+          path: kind
+          value: InfrastructureProvider

--- a/templates/provider/cluster-api-provider-kubevirt/Chart.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-kubevirt/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-kubevirt/templates/_helpers.tpl
@@ -81,10 +81,152 @@ Build the default deployment settings
 {{- end }}
 
 {{/*
+Merge deployment settings while preserving default containers.
+Containers are merged by name with user values taking precedence.
+*/}}
+{{- define "infrastructureProvider.deployment.merge" -}}
+{{- $default := .default | default dict -}}
+{{- $user := .user | default dict -}}
+{{- $merged := merge (deepCopy $user) (deepCopy $default) -}}
+
+{{- $hasDefaultContainers := hasKey $default "containers" -}}
+{{- $hasUserContainers := hasKey $user "containers" -}}
+{{- if or $hasDefaultContainers $hasUserContainers -}}
+{{- $defaultContainers := get $default "containers" | default list -}}
+{{- $userContainers := get $user "containers" | default list -}}
+{{- if and (kindIs "slice" $defaultContainers) (kindIs "slice" $userContainers) -}}
+{{- $userContainersByName := dict -}}
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userContainersByName $name $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultNames := dict -}}
+{{- $mergedContainers := list -}}
+{{- range $defaultContainer := $defaultContainers -}}
+{{- $name := $defaultContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userContainersByName $name) -}}
+{{- $mergedContainer := merge (deepCopy (get $userContainersByName $name)) (deepCopy $defaultContainer) -}}
+{{- $hasDefaultEnv := hasKey $defaultContainer "env" -}}
+{{- $userContainer := get $userContainersByName $name -}}
+{{- $hasUserEnv := hasKey $userContainer "env" -}}
+{{- if or $hasDefaultEnv $hasUserEnv -}}
+{{- $defaultEnv := get $defaultContainer "env" | default list -}}
+{{- $userEnv := get $userContainer "env" | default list -}}
+{{- if and (kindIs "slice" $defaultEnv) (kindIs "slice" $userEnv) -}}
+{{- $userEnvByName := dict -}}
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $userEnvByName $envName $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultEnvNames := dict -}}
+{{- $mergedEnv := list -}}
+{{- range $item := $defaultEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $defaultEnvNames $envName true -}}
+{{- end -}}
+{{- if and (ne $envName "") (hasKey $userEnvByName $envName) -}}
+{{- $mergedEnv = append $mergedEnv (get $userEnvByName $envName) -}}
+{{- else -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if or (eq $envName "") (not (hasKey $defaultEnvNames $envName)) -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $mergedContainer "env" $mergedEnv -}}
+{{- end -}}
+{{- end -}}
+{{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+{{- else -}}
+{{- $mergedContainers = append $mergedContainers $defaultContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultNames $name)) -}}
+{{- $mergedContainers = append $mergedContainers $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultImagePullSecrets := hasKey $default "imagePullSecrets" -}}
+{{- $hasUserImagePullSecrets := hasKey $user "imagePullSecrets" -}}
+{{- if or $hasDefaultImagePullSecrets $hasUserImagePullSecrets -}}
+{{- $defaultImagePullSecrets := get $default "imagePullSecrets" | default list -}}
+{{- $userImagePullSecrets := get $user "imagePullSecrets" | default list -}}
+{{- if and (kindIs "slice" $defaultImagePullSecrets) (kindIs "slice" $userImagePullSecrets) -}}
+{{- $userImagePullSecretsByName := dict -}}
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userImagePullSecretsByName $name $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultImagePullSecretNames := dict -}}
+{{- $mergedImagePullSecrets := list -}}
+{{- range $secret := $defaultImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultImagePullSecretNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userImagePullSecretsByName $name) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets (get $userImagePullSecretsByName $name) -}}
+{{- else -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultImagePullSecretNames $name)) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "imagePullSecrets" $mergedImagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultTolerations := hasKey $default "tolerations" -}}
+{{- $hasUserTolerations := hasKey $user "tolerations" -}}
+{{- if or $hasDefaultTolerations $hasUserTolerations -}}
+{{- $defaultTolerations := get $default "tolerations" | default list -}}
+{{- $userTolerations := get $user "tolerations" | default list -}}
+{{- if and (kindIs "slice" $defaultTolerations) (kindIs "slice" $userTolerations) -}}
+{{- $_ := set $merged "tolerations" (concat $defaultTolerations $userTolerations) -}}
+{{- end -}}
+{{- end -}}
+
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
 Merge default deployment settings with user-provided overrides
 */}}
 {{- define "infrastructureProvider.deployment" -}}
-{{ toYaml (merge (.Values.deployment | default dict) (include "infrastructureProvider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "infrastructureProvider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.deployment | default dict -}}
+{{- include "infrastructureProvider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.23
+version: 1.0.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-openstack/templates/_helpers.tpl
@@ -81,10 +81,152 @@ Build the default deployment settings
 {{- end }}
 
 {{/*
+Merge deployment settings while preserving default containers.
+Containers are merged by name with user values taking precedence.
+*/}}
+{{- define "infrastructureProvider.deployment.merge" -}}
+{{- $default := .default | default dict -}}
+{{- $user := .user | default dict -}}
+{{- $merged := merge (deepCopy $user) (deepCopy $default) -}}
+
+{{- $hasDefaultContainers := hasKey $default "containers" -}}
+{{- $hasUserContainers := hasKey $user "containers" -}}
+{{- if or $hasDefaultContainers $hasUserContainers -}}
+{{- $defaultContainers := get $default "containers" | default list -}}
+{{- $userContainers := get $user "containers" | default list -}}
+{{- if and (kindIs "slice" $defaultContainers) (kindIs "slice" $userContainers) -}}
+{{- $userContainersByName := dict -}}
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userContainersByName $name $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultNames := dict -}}
+{{- $mergedContainers := list -}}
+{{- range $defaultContainer := $defaultContainers -}}
+{{- $name := $defaultContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userContainersByName $name) -}}
+{{- $mergedContainer := merge (deepCopy (get $userContainersByName $name)) (deepCopy $defaultContainer) -}}
+{{- $hasDefaultEnv := hasKey $defaultContainer "env" -}}
+{{- $userContainer := get $userContainersByName $name -}}
+{{- $hasUserEnv := hasKey $userContainer "env" -}}
+{{- if or $hasDefaultEnv $hasUserEnv -}}
+{{- $defaultEnv := get $defaultContainer "env" | default list -}}
+{{- $userEnv := get $userContainer "env" | default list -}}
+{{- if and (kindIs "slice" $defaultEnv) (kindIs "slice" $userEnv) -}}
+{{- $userEnvByName := dict -}}
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $userEnvByName $envName $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultEnvNames := dict -}}
+{{- $mergedEnv := list -}}
+{{- range $item := $defaultEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $defaultEnvNames $envName true -}}
+{{- end -}}
+{{- if and (ne $envName "") (hasKey $userEnvByName $envName) -}}
+{{- $mergedEnv = append $mergedEnv (get $userEnvByName $envName) -}}
+{{- else -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if or (eq $envName "") (not (hasKey $defaultEnvNames $envName)) -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $mergedContainer "env" $mergedEnv -}}
+{{- end -}}
+{{- end -}}
+{{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+{{- else -}}
+{{- $mergedContainers = append $mergedContainers $defaultContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultNames $name)) -}}
+{{- $mergedContainers = append $mergedContainers $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultImagePullSecrets := hasKey $default "imagePullSecrets" -}}
+{{- $hasUserImagePullSecrets := hasKey $user "imagePullSecrets" -}}
+{{- if or $hasDefaultImagePullSecrets $hasUserImagePullSecrets -}}
+{{- $defaultImagePullSecrets := get $default "imagePullSecrets" | default list -}}
+{{- $userImagePullSecrets := get $user "imagePullSecrets" | default list -}}
+{{- if and (kindIs "slice" $defaultImagePullSecrets) (kindIs "slice" $userImagePullSecrets) -}}
+{{- $userImagePullSecretsByName := dict -}}
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userImagePullSecretsByName $name $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultImagePullSecretNames := dict -}}
+{{- $mergedImagePullSecrets := list -}}
+{{- range $secret := $defaultImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultImagePullSecretNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userImagePullSecretsByName $name) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets (get $userImagePullSecretsByName $name) -}}
+{{- else -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultImagePullSecretNames $name)) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "imagePullSecrets" $mergedImagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultTolerations := hasKey $default "tolerations" -}}
+{{- $hasUserTolerations := hasKey $user "tolerations" -}}
+{{- if or $hasDefaultTolerations $hasUserTolerations -}}
+{{- $defaultTolerations := get $default "tolerations" | default list -}}
+{{- $userTolerations := get $user "tolerations" | default list -}}
+{{- if and (kindIs "slice" $defaultTolerations) (kindIs "slice" $userTolerations) -}}
+{{- $_ := set $merged "tolerations" (concat $defaultTolerations $userTolerations) -}}
+{{- end -}}
+{{- end -}}
+
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
 Merge default deployment settings with user-provided overrides
 */}}
 {{- define "infrastructureProvider.deployment" -}}
-{{ toYaml (merge (.Values.deployment | default dict) (include "infrastructureProvider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "infrastructureProvider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.deployment | default dict -}}
+{{- include "infrastructureProvider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*

--- a/templates/provider/cluster-api-provider-vsphere/Chart.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.16
+version: 1.0.17
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-vsphere/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-vsphere/templates/_helpers.tpl
@@ -81,10 +81,152 @@ Build the default deployment settings
 {{- end }}
 
 {{/*
+Merge deployment settings while preserving default containers.
+Containers are merged by name with user values taking precedence.
+*/}}
+{{- define "infrastructureProvider.deployment.merge" -}}
+{{- $default := .default | default dict -}}
+{{- $user := .user | default dict -}}
+{{- $merged := merge (deepCopy $user) (deepCopy $default) -}}
+
+{{- $hasDefaultContainers := hasKey $default "containers" -}}
+{{- $hasUserContainers := hasKey $user "containers" -}}
+{{- if or $hasDefaultContainers $hasUserContainers -}}
+{{- $defaultContainers := get $default "containers" | default list -}}
+{{- $userContainers := get $user "containers" | default list -}}
+{{- if and (kindIs "slice" $defaultContainers) (kindIs "slice" $userContainers) -}}
+{{- $userContainersByName := dict -}}
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userContainersByName $name $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultNames := dict -}}
+{{- $mergedContainers := list -}}
+{{- range $defaultContainer := $defaultContainers -}}
+{{- $name := $defaultContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userContainersByName $name) -}}
+{{- $mergedContainer := merge (deepCopy (get $userContainersByName $name)) (deepCopy $defaultContainer) -}}
+{{- $hasDefaultEnv := hasKey $defaultContainer "env" -}}
+{{- $userContainer := get $userContainersByName $name -}}
+{{- $hasUserEnv := hasKey $userContainer "env" -}}
+{{- if or $hasDefaultEnv $hasUserEnv -}}
+{{- $defaultEnv := get $defaultContainer "env" | default list -}}
+{{- $userEnv := get $userContainer "env" | default list -}}
+{{- if and (kindIs "slice" $defaultEnv) (kindIs "slice" $userEnv) -}}
+{{- $userEnvByName := dict -}}
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $userEnvByName $envName $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultEnvNames := dict -}}
+{{- $mergedEnv := list -}}
+{{- range $item := $defaultEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $defaultEnvNames $envName true -}}
+{{- end -}}
+{{- if and (ne $envName "") (hasKey $userEnvByName $envName) -}}
+{{- $mergedEnv = append $mergedEnv (get $userEnvByName $envName) -}}
+{{- else -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if or (eq $envName "") (not (hasKey $defaultEnvNames $envName)) -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $mergedContainer "env" $mergedEnv -}}
+{{- end -}}
+{{- end -}}
+{{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+{{- else -}}
+{{- $mergedContainers = append $mergedContainers $defaultContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultNames $name)) -}}
+{{- $mergedContainers = append $mergedContainers $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultImagePullSecrets := hasKey $default "imagePullSecrets" -}}
+{{- $hasUserImagePullSecrets := hasKey $user "imagePullSecrets" -}}
+{{- if or $hasDefaultImagePullSecrets $hasUserImagePullSecrets -}}
+{{- $defaultImagePullSecrets := get $default "imagePullSecrets" | default list -}}
+{{- $userImagePullSecrets := get $user "imagePullSecrets" | default list -}}
+{{- if and (kindIs "slice" $defaultImagePullSecrets) (kindIs "slice" $userImagePullSecrets) -}}
+{{- $userImagePullSecretsByName := dict -}}
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userImagePullSecretsByName $name $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultImagePullSecretNames := dict -}}
+{{- $mergedImagePullSecrets := list -}}
+{{- range $secret := $defaultImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultImagePullSecretNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userImagePullSecretsByName $name) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets (get $userImagePullSecretsByName $name) -}}
+{{- else -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultImagePullSecretNames $name)) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "imagePullSecrets" $mergedImagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultTolerations := hasKey $default "tolerations" -}}
+{{- $hasUserTolerations := hasKey $user "tolerations" -}}
+{{- if or $hasDefaultTolerations $hasUserTolerations -}}
+{{- $defaultTolerations := get $default "tolerations" | default list -}}
+{{- $userTolerations := get $user "tolerations" | default list -}}
+{{- if and (kindIs "slice" $defaultTolerations) (kindIs "slice" $userTolerations) -}}
+{{- $_ := set $merged "tolerations" (concat $defaultTolerations $userTolerations) -}}
+{{- end -}}
+{{- end -}}
+
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
 Merge default deployment settings with user-provided overrides
 */}}
 {{- define "infrastructureProvider.deployment" -}}
-{{ toYaml (merge (.Values.deployment | default dict) (include "infrastructureProvider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "infrastructureProvider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.deployment | default dict -}}
+{{- include "infrastructureProvider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*

--- a/templates/provider/cluster-api/Chart.yaml
+++ b/templates/provider/cluster-api/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.10
+version: 1.1.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api/templates/_helpers.tpl
+++ b/templates/provider/cluster-api/templates/_helpers.tpl
@@ -81,10 +81,152 @@ Build the default deployment settings
 {{- end }}
 
 {{/*
+Merge deployment settings while preserving default containers.
+Containers are merged by name with user values taking precedence.
+*/}}
+{{- define "coreProvider.deployment.merge" -}}
+{{- $default := .default | default dict -}}
+{{- $user := .user | default dict -}}
+{{- $merged := merge (deepCopy $user) (deepCopy $default) -}}
+
+{{- $hasDefaultContainers := hasKey $default "containers" -}}
+{{- $hasUserContainers := hasKey $user "containers" -}}
+{{- if or $hasDefaultContainers $hasUserContainers -}}
+{{- $defaultContainers := get $default "containers" | default list -}}
+{{- $userContainers := get $user "containers" | default list -}}
+{{- if and (kindIs "slice" $defaultContainers) (kindIs "slice" $userContainers) -}}
+{{- $userContainersByName := dict -}}
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userContainersByName $name $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultNames := dict -}}
+{{- $mergedContainers := list -}}
+{{- range $defaultContainer := $defaultContainers -}}
+{{- $name := $defaultContainer.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userContainersByName $name) -}}
+{{- $mergedContainer := merge (deepCopy (get $userContainersByName $name)) (deepCopy $defaultContainer) -}}
+{{- $hasDefaultEnv := hasKey $defaultContainer "env" -}}
+{{- $userContainer := get $userContainersByName $name -}}
+{{- $hasUserEnv := hasKey $userContainer "env" -}}
+{{- if or $hasDefaultEnv $hasUserEnv -}}
+{{- $defaultEnv := get $defaultContainer "env" | default list -}}
+{{- $userEnv := get $userContainer "env" | default list -}}
+{{- if and (kindIs "slice" $defaultEnv) (kindIs "slice" $userEnv) -}}
+{{- $userEnvByName := dict -}}
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $userEnvByName $envName $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultEnvNames := dict -}}
+{{- $mergedEnv := list -}}
+{{- range $item := $defaultEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if ne $envName "" -}}
+{{- $_ := set $defaultEnvNames $envName true -}}
+{{- end -}}
+{{- if and (ne $envName "") (hasKey $userEnvByName $envName) -}}
+{{- $mergedEnv = append $mergedEnv (get $userEnvByName $envName) -}}
+{{- else -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $item := $userEnv -}}
+{{- $envName := $item.name | default "" -}}
+{{- if or (eq $envName "") (not (hasKey $defaultEnvNames $envName)) -}}
+{{- $mergedEnv = append $mergedEnv $item -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $mergedContainer "env" $mergedEnv -}}
+{{- end -}}
+{{- end -}}
+{{- $mergedContainers = append $mergedContainers $mergedContainer -}}
+{{- else -}}
+{{- $mergedContainers = append $mergedContainers $defaultContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $userContainer := $userContainers -}}
+{{- $name := $userContainer.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultNames $name)) -}}
+{{- $mergedContainers = append $mergedContainers $userContainer -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "containers" $mergedContainers -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultImagePullSecrets := hasKey $default "imagePullSecrets" -}}
+{{- $hasUserImagePullSecrets := hasKey $user "imagePullSecrets" -}}
+{{- if or $hasDefaultImagePullSecrets $hasUserImagePullSecrets -}}
+{{- $defaultImagePullSecrets := get $default "imagePullSecrets" | default list -}}
+{{- $userImagePullSecrets := get $user "imagePullSecrets" | default list -}}
+{{- if and (kindIs "slice" $defaultImagePullSecrets) (kindIs "slice" $userImagePullSecrets) -}}
+{{- $userImagePullSecretsByName := dict -}}
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $userImagePullSecretsByName $name $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $defaultImagePullSecretNames := dict -}}
+{{- $mergedImagePullSecrets := list -}}
+{{- range $secret := $defaultImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if ne $name "" -}}
+{{- $_ := set $defaultImagePullSecretNames $name true -}}
+{{- end -}}
+{{- if and (ne $name "") (hasKey $userImagePullSecretsByName $name) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets (get $userImagePullSecretsByName $name) -}}
+{{- else -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $secret := $userImagePullSecrets -}}
+{{- $name := $secret.name | default "" -}}
+{{- if or (eq $name "") (not (hasKey $defaultImagePullSecretNames $name)) -}}
+{{- $mergedImagePullSecrets = append $mergedImagePullSecrets $secret -}}
+{{- end -}}
+{{- end -}}
+
+{{- $_ := set $merged "imagePullSecrets" $mergedImagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{- $hasDefaultTolerations := hasKey $default "tolerations" -}}
+{{- $hasUserTolerations := hasKey $user "tolerations" -}}
+{{- if or $hasDefaultTolerations $hasUserTolerations -}}
+{{- $defaultTolerations := get $default "tolerations" | default list -}}
+{{- $userTolerations := get $user "tolerations" | default list -}}
+{{- if and (kindIs "slice" $defaultTolerations) (kindIs "slice" $userTolerations) -}}
+{{- $_ := set $merged "tolerations" (concat $defaultTolerations $userTolerations) -}}
+{{- end -}}
+{{- end -}}
+
+{{- toYaml $merged -}}
+{{- end }}
+
+{{/*
 Merge default deployment settings with user-provided overrides
 */}}
 {{- define "coreProvider.deployment" -}}
-{{ toYaml (merge (.Values.deployment | default dict) (include "coreProvider.deployment.default" . | fromYaml | default dict)) }}
+{{- $default := include "coreProvider.deployment.default" . | fromYaml | default dict -}}
+{{- $user := .Values.deployment | default dict -}}
+{{- include "coreProvider.deployment.merge" (dict "default" $default "user" $user) -}}
 {{- end }}
 
 {{/*

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -11,27 +11,27 @@ spec:
   regional:
     template: kcm-regional-1-9-0
   capi:
-    template: cluster-api-1-1-10
+    template: cluster-api-1-1-11
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
-      template: cluster-api-provider-k0sproject-k0smotron-1-0-24
+      template: cluster-api-provider-k0sproject-k0smotron-1-0-25
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-1-0-23
+      template: cluster-api-provider-azure-1-0-24
     - name: cluster-api-provider-vsphere
-      template: cluster-api-provider-vsphere-1-0-16
+      template: cluster-api-provider-vsphere-1-0-17
     - name: cluster-api-provider-aws
-      template: cluster-api-provider-aws-1-0-20
+      template: cluster-api-provider-aws-1-0-21
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-1-0-23
+      template: cluster-api-provider-openstack-1-0-24
     - name: cluster-api-provider-docker
-      template: cluster-api-provider-docker-1-0-17
+      template: cluster-api-provider-docker-1-0-18
     - name: cluster-api-provider-gcp
-      template: cluster-api-provider-gcp-1-0-17
+      template: cluster-api-provider-gcp-1-0-18
     - name: cluster-api-provider-ipam
-      template: cluster-api-provider-ipam-1-0-11
+      template: cluster-api-provider-ipam-1-0-12
     - name: cluster-api-provider-infoblox
-      template: cluster-api-provider-infoblox-1-0-10
+      template: cluster-api-provider-infoblox-1-0-11
     - name: cluster-api-provider-kubevirt
-      template: cluster-api-provider-kubevirt-1-0-6
+      template: cluster-api-provider-kubevirt-1-0-7
     - name: projectsveltos
       template: projectsveltos-1-9-0

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-aws-1-0-20
+  name: cluster-api-provider-aws-1-0-21
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-aws
-      version: 1.0.20
+      version: 1.0.21
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-1-0-23
+  name: cluster-api-provider-azure-1-0-24
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-azure
-      version: 1.0.23
+      version: 1.0.24
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-docker-1-0-17
+  name: cluster-api-provider-docker-1-0-18
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-docker
-      version: 1.0.17
+      version: 1.0.18
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-gcp-1-0-17
+  name: cluster-api-provider-gcp-1-0-18
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-gcp
-      version: 1.0.17
+      version: 1.0.18
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-infoblox.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-infoblox.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-infoblox-1-0-10
+  name: cluster-api-provider-infoblox-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-infoblox
-      version: 1.0.10
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-ipam.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-ipam.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-ipam-1-0-11
+  name: cluster-api-provider-ipam-1-0-12
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-ipam
-      version: 1.0.11
+      version: 1.0.12
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-k0sproject-k0smotron-1-0-24
+  name: cluster-api-provider-k0sproject-k0smotron-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-k0sproject-k0smotron
-      version: 1.0.24
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-kubevirt-1-0-6
+  name: cluster-api-provider-kubevirt-1-0-7
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-kubevirt
-      version: 1.0.6
+      version: 1.0.7
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-1-0-23
+  name: cluster-api-provider-openstack-1-0-24
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 1.0.23
+      version: 1.0.24
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-vsphere-1-0-16
+  name: cluster-api-provider-vsphere-1-0-17
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-vsphere
-      version: 1.0.16
+      version: 1.0.17
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-1-1-10
+  name: cluster-api-1-1-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api
-      version: 1.1.10
+      version: 1.1.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Use a deployment merge helper in provider charts that merges containers by name instead of replacing container arrays.

This preserves default manager fields (including global registry image URLs) while keeping user overrides and sidecars.

Also add Helm unittest automation with AWS and k0smotron providers regression suite.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2709 