### PR TITLE
fix(templates): update CAPI resources

### DIFF
--- a/config/dev/aks-clusterdeployment.yaml
+++ b/config/dev/aks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-aks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-aks-1-0-6
+  template: azure-aks-1-0-7
   credential: azure-aks-credential
   propagateCredentials: false
   config:

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-29
+  template: azure-standalone-cp-1-0-30
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/docker-clusterdeployment.yaml
+++ b/config/dev/docker-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: docker-hosted-cp-1-0-9
+  template: docker-hosted-cp-1-0-10
   credential: docker-stub-credential
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-26
+  template: gcp-standalone-cp-1-0-27
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/gke-clusterdeployment.yaml
+++ b/config/dev/gke-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-gke-1-0-12
+  template: gcp-gke-1-0-13
   credential: gcp-credential
   propagateCredentials: false
   config:

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-26
+  template: remote-cluster-1-0-27
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-26
+  template: vsphere-standalone-cp-1-0-27
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/vsphere-credentials.yaml
+++ b/config/dev/vsphere-credentials.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VSphereClusterIdentity
 metadata:
   name: vsphere-cluster-identity
@@ -31,7 +31,7 @@ metadata:
 spec:
   description: vSphere credentials
   identityRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: VSphereClusterIdentity
     name: vsphere-cluster-identity
     namespace: ${NAMESPACE}

--- a/hack/lint-quoted-values.bash
+++ b/hack/lint-quoted-values.bash
@@ -18,8 +18,8 @@ set -euo pipefail
 
 : "${YQ:?YQ must be set to the yq binary path}"
 
-if ! command -v rg >/dev/null 2>&1; then
-  echo "rg is required but was not found in PATH" >&2
+if ! command -v grep >/dev/null 2>&1; then
+  echo "grep is required but was not found in PATH" >&2
   exit 1
 fi
 
@@ -33,49 +33,51 @@ fi
 
 declare -a violations=()
 
-while IFS=: read -r file line text; do
-  expr="${text#*:}"
-  key_prefix="${text%%:*}"
+while IFS= read -r -d '' file; do
+  while IFS=: read -r line text; do
+    expr="${text#*:}"
+    key_prefix="${text%%:*}"
 
-  # Skip non-YAML-key template lines like '{{- end }}:{{ ... }}'.
-  if [[ "$key_prefix" == *"{{"* ]] || [[ "$key_prefix" == *"}}"* ]]; then
-    continue
-  fi
+    # Skip non-YAML-key template lines like '{{- end }}:{{ ... }}'.
+    if [[ "$key_prefix" == *"{{"* ]] || [[ "$key_prefix" == *"}}"* ]]; then
+      continue
+    fi
 
-  # Already-quoted values are safe in YAML scalar positions.
-  if [[ "$expr" == *"| quote"* ]] || [[ "$expr" == *"| squote"* ]] || [[ "$expr" == *" quote .Values"* ]]; then
-    continue
-  fi
+    # Already-quoted values are safe in YAML scalar positions.
+    if [[ "$expr" == *"| quote"* ]] || [[ "$expr" == *"| squote"* ]] || [[ "$expr" == *" quote .Values"* ]]; then
+      continue
+    fi
 
-  # Skip template control lines and structured YAML render helpers.
-  if [[ "$expr" =~ \{\{[[:space:]]*[-]?[[:space:]]*(if|else|end|range|with)[[:space:]] ]]; then
-    continue
-  fi
-  if [[ "$expr" == *"toYaml"* ]] || [[ "$expr" == *"fromYaml"* ]] || [[ "$expr" == *"nindent"* ]] || [[ "$expr" == *"indent"* ]]; then
-    continue
-  fi
+    # Skip template control lines and structured YAML render helpers.
+    if [[ "$expr" =~ \{\{[[:space:]]*[-]?[[:space:]]*(if|else|end|range|with)[[:space:]] ]]; then
+      continue
+    fi
+    if [[ "$expr" == *"toYaml"* ]] || [[ "$expr" == *"fromYaml"* ]] || [[ "$expr" == *"nindent"* ]] || [[ "$expr" == *"indent"* ]]; then
+      continue
+    fi
 
-  raw_path="$(printf '%s' "$expr" | grep -oE '\$?\.Values(\.[A-Za-z0-9_]+)+' | head -n1 | sed -E 's/^\$?\.Values\.//')"
-  if [[ -z "$raw_path" ]]; then
-    continue
-  fi
+    raw_path="$(printf '%s' "$expr" | grep -oE '\$?\.Values(\.[A-Za-z0-9_]+)+' | head -n1 | sed -E 's/^\$?\.Values\.//')"
+    if [[ -z "$raw_path" ]]; then
+      continue
+    fi
 
-  chart_dir="${file%%/templates/*}"
-  values_file="${chart_dir}/values.yaml"
-  if [[ ! -f "$values_file" ]]; then
-    continue
-  fi
+    chart_dir="${file%%/templates/*}"
+    values_file="${chart_dir}/values.yaml"
+    if [[ ! -f "$values_file" ]]; then
+      continue
+    fi
 
-  is_string="$($YQ eval ".${raw_path} | (type == \"!!str\")" "$values_file" 2>/dev/null || true)"
-  has_string_default="false"
-  if [[ "$expr" =~ \|[[:space:]]*default[[:space:]]*\" ]]; then
-    has_string_default="true"
-  fi
+    is_string="$($YQ eval ".${raw_path} | (type == \"!!str\")" "$values_file" 2>/dev/null || true)"
+    has_string_default="false"
+    if [[ "$expr" =~ \|[[:space:]]*default[[:space:]]*\" ]]; then
+      has_string_default="true"
+    fi
 
-  if [[ "$is_string" == "true" || "$has_string_default" == "true" ]]; then
-    violations+=("${file}:${line}:${text}")
-  fi
-done < <(rg -n --glob 'templates/**/templates/*.yaml' ':\s*\{\{[^}]*\.Values\.[^}]*\}\}\s*$' templates)
+    if [[ "$is_string" == "true" || "$has_string_default" == "true" ]]; then
+      violations+=("${file}:${line}:${text}")
+    fi
+  done < <(grep -nE ':[[:space:]]*\{\{[^}]*\.Values\.[^}]*\}\}[[:space:]]*(#.*)?$' "$file" || true)
+done < <(find templates -type f -path '*/templates/*.yaml' -print0)
 
 if ((${#violations[@]} > 0)); then
   echo "Found unquoted string .Values interpolations in YAML value positions:"

--- a/templates/cluster/azure-aks/Chart.yaml
+++ b/templates/cluster/azure-aks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure
   cluster.x-k8s.io/infrastructure-azure: v1beta1

--- a/templates/cluster/azure-aks/templates/cluster.yaml
+++ b/templates/cluster/azure-aks/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -15,10 +15,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AzureASOManagedControlPlane
     name: {{ include "cluster.name" .  }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AzureASOManagedCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/azure-aks/templates/machinepool-controlplane.yaml
+++ b/templates/cluster/azure-aks/templates/machinepool-controlplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachinePool
 metadata:
   name: {{ include "machinepool.system.name" . }}
@@ -11,7 +11,7 @@ spec:
         dataSecretName: {{ include "machinepool.system.name" . }}
       clusterName: {{ include "cluster.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: AzureASOManagedMachinePool
         name: {{ include "machinepool.system.name" . }}
       version: {{ .Values.kubernetes.version  | quote }}

--- a/templates/cluster/azure-aks/templates/machinepool-worker.yaml
+++ b/templates/cluster/azure-aks/templates/machinepool-worker.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachinePool
 metadata:
   name: {{ include "machinepool.user.name" . }}
@@ -11,7 +11,7 @@ spec:
         dataSecretName: {{ include "machinepool.user.name" . }}
       clusterName: {{ include "cluster.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: AzureASOManagedMachinePool
         name: {{ include "machinepool.user.name" . }}
       version: {{ .Values.kubernetes.version  | quote }}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.34
+version: 1.0.35
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/cluster.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -14,10 +14,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: K0smotronControlPlane
     name: {{ include "k0smotroncontrolplane.name" .  }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AzureCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/azure-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: {{ include "machinedeployment.name" . }}
@@ -20,10 +20,10 @@ spec:
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: K0sWorkerConfigTemplate
           name: {{ include "k0sworkerconfigtemplate.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: AzureMachineTemplate
         name: {{ include "azuremachinetemplate.name" . }}

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.29
+version: 1.0.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/cluster.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -14,10 +14,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: K0sControlPlane
     name: {{ include "k0scontrolplane.name" .  }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: AzureCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/azure-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: {{ include "machinedeployment.name" . }}
@@ -20,10 +20,10 @@ spec:
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: K0sWorkerConfigTemplate
           name: {{ include "k0sworkerconfigtemplate.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: AzureMachineTemplate
         name: {{ include "azuremachinetemplate.worker.name" . }}

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.9
+version: 1.0.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -16,4 +16,4 @@ annotations:
   cluster.x-k8s.io/provider: infrastructure-docker, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
   cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/infrastructure-docker: v1beta1
+  cluster.x-k8s.io/infrastructure-docker: v1beta2

--- a/templates/cluster/gcp-gke/Chart.yaml
+++ b/templates/cluster/gcp-gke/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-gke/templates/cluster.yaml
+++ b/templates/cluster/gcp-gke/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -14,10 +14,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: GCPManagedControlPlane
     name: {{ include "gcpmanagedcontrolplane.name" . }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: GCPManagedCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/gcp-gke/templates/machinepool.yaml
+++ b/templates/cluster/gcp-gke/templates/machinepool.yaml
@@ -1,5 +1,5 @@
 {{- if not .Values.enableAutopilot }}
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachinePool
 metadata:
   name: {{ include "machinepool.name" . }}
@@ -12,7 +12,7 @@ spec:
         dataSecretName: {{ include "machinepool.name" . }}
       clusterName: {{ include "cluster.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: GCPManagedMachinePool
         name: {{ include "machinepool.name" . }}
 {{- end }}

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.30
+version: 1.0.31
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/cluster.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -14,10 +14,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: K0smotronControlPlane
     name: {{ include "k0smotroncontrolplane.name" . }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: GCPCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/gcp-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: {{ include "machinedeployment.name" . }}
@@ -20,10 +20,10 @@ spec:
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: K0sWorkerConfigTemplate
           name: {{ include "k0sworkerconfigtemplate.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: GCPMachineTemplate
         name: {{ include "gcpmachinetemplate.worker.name" . }}

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/cluster.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -14,10 +14,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: K0sControlPlane
     name: {{ include "k0scontrolplane.name" .  }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: GCPCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/gcp-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: {{ include "machinedeployment.name" . }}
@@ -20,10 +20,10 @@ spec:
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: K0sWorkerConfigTemplate
           name: {{ include "k0sworkerconfigtemplate.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: GCPMachineTemplate
         name: {{ include "gcpmachinetemplate.worker.name" . }}

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/templates/cluster.yaml
+++ b/templates/cluster/remote-cluster/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -14,10 +14,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: K0smotronControlPlane
     name: {{ include "k0smotroncontrolplane.name" .  }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: RemoteCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -3,7 +3,7 @@
 {{- $shaSum := sha256sum (printf "%s%s" $machine.address $machine.port) | trunc 6 }}
 {{- $defaultName := printf "%s-%s" (include "cluster.name" $) $shaSum -}}
 {{- $name := default $defaultName $machine.name -}}
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Machine
 metadata:
   name: {{ $name }}
@@ -11,11 +11,11 @@ spec:
   clusterName: {{ include "cluster.name" $ }}
   bootstrap:
     configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+      apiGroup: bootstrap.cluster.x-k8s.io
       kind: K0sWorkerConfig
       name: {{ $name }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: RemoteMachine
     name: {{ $name }}
 ---

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.29
+version: 1.0.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -18,4 +18,4 @@ annotations:
   k0rdent.mirantis.com/type: deployment
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
   cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/infrastructure-vsphere: v1beta1
+  cluster.x-k8s.io/infrastructure-vsphere: v1beta2

--- a/templates/cluster/vsphere-hosted-cp/templates/vspherecluster.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/vspherecluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VSphereCluster
 metadata:
   name: {{ include "cluster.name" . }}

--- a/templates/cluster/vsphere-hosted-cp/templates/vspheremachinetemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/vspheremachinetemplate.yaml
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VSphereMachineTemplate
 metadata:
   name: {{ include "vspheremachinetemplate.name" . }}
@@ -20,6 +20,5 @@ spec:
       powerOffMode: hard
       resourcePool: {{ .Values.vsphere.resourcePool  | quote }}
       server: {{ .Values.vsphere.server  | quote }}
-      storagePolicyName: ""
       template: {{ .Values.vmTemplate  | quote }}
       thumbprint: {{ .Values.vsphere.thumbprint  | quote }}

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -17,4 +17,4 @@ annotations:
   k0rdent.mirantis.com/type: deployment
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
   cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/infrastructure-vsphere: v1beta1
+  cluster.x-k8s.io/infrastructure-vsphere: v1beta2

--- a/templates/cluster/vsphere-standalone-cp/templates/vspherecluster.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/vspherecluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VSphereCluster
 metadata:
   name: {{ include "cluster.name" . }}

--- a/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-controlplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-controlplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VSphereMachineTemplate
 metadata:
   name: {{ include "vspheremachinetemplate.controlplane.name" . }}
@@ -27,6 +27,5 @@ spec:
       powerOffMode: hard
       resourcePool: {{ .Values.vsphere.resourcePool  | quote }}
       server: {{ .Values.vsphere.server  | quote }}
-      storagePolicyName: ""
       template: {{ .Values.controlPlane.vmTemplate  | quote }}
       thumbprint: {{ .Values.vsphere.thumbprint  | quote }}

--- a/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-worker.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-worker.yaml
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VSphereMachineTemplate
 metadata:
   name: {{ include "vspheremachinetemplate.worker.name" . }}
@@ -27,6 +27,5 @@ spec:
       powerOffMode: hard
       resourcePool: {{ .Values.vsphere.resourcePool  | quote }}
       server: {{ .Values.vsphere.server  | quote }}
-      storagePolicyName: ""
       template: {{ .Values.worker.vmTemplate  | quote }}
       thumbprint: {{ .Values.vsphere.thumbprint  | quote }}

--- a/templates/provider/cluster-api-provider-aws/Chart.yaml
+++ b/templates/provider/cluster-api-provider-aws/Chart.yaml
@@ -13,14 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.21
+version: 1.0.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.11.0"
+appVersion: "v2.11.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/v1beta1: v1beta1_v1beta2
-  # NOTE: v2.11.0 does not have this label though the provider does support v1beta2 CAPI
-  cluster.x-k8s.io/v1beta2: v1beta1_v1beta2

--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -13,14 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.23.0"
+appVersion: "v1.24.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure
   cluster.x-k8s.io/v1beta1: v1beta1
-  # NOTE: v1.22.0 does not have this label though the provider does support v1beta2 CAPI
-  cluster.x-k8s.io/v1beta2: v1beta1

--- a/templates/provider/cluster-api-provider-gcp/Chart.yaml
+++ b/templates/provider/cluster-api-provider-gcp/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.19
+version: 1.0.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -22,5 +22,3 @@ appVersion: "v1.11.2"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/v1beta1: v1beta1
-  # NOTE: v1.11.0 does not have this label though the provider does support v1beta2 CAPI
-  cluster.x-k8s.io/v1beta2: v1beta1

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.25
+version: 1.0.26
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -22,5 +22,3 @@ appVersion: "v1.10.6"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron, control-plane-k0sproject-k0smotron
   cluster.x-k8s.io/v1beta1: v1beta1
-  # NOTE: v1.10.6 does not have this label though the provider does support v1beta2 CAPI
-  cluster.x-k8s.io/v1beta2: v1beta1

--- a/templates/provider/cluster-api-provider-kubevirt/Chart.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.11.0"
+appVersion: "v0.11.2"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-kubevirt
   cluster.x-k8s.io/v1beta1: v1alpha1

--- a/templates/provider/cluster-api-provider-vsphere/Chart.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.18
+version: 1.0.19
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -22,5 +22,4 @@ appVersion: "v1.16.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-vsphere
   cluster.x-k8s.io/v1beta1: v1beta1
-  # NOTE: v1.15.1 does not have this label though the provider does support v1beta2 CAPI
-  cluster.x-k8s.io/v1beta2: v1beta1
+  cluster.x-k8s.io/v1beta2: v1beta2

--- a/templates/provider/cluster-api-provider-vsphere/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/templates/interface.yaml
@@ -9,9 +9,20 @@ spec:
     - group: infrastructure.cluster.x-k8s.io
       version: v1beta1
       kind: VSphereCluster
+    - group: infrastructure.cluster.x-k8s.io
+      version: v1beta2
+      kind: VSphereCluster
   clusterIdentities:
     - group: infrastructure.cluster.x-k8s.io
       version: v1beta1
+      kind: VSphereClusterIdentity
+      references:
+        - group: ""
+          version: v1
+          kind: Secret
+          nameFieldPath: spec.secretName
+    - group: infrastructure.cluster.x-k8s.io
+      version: v1beta2
       kind: VSphereClusterIdentity
       references:
         - group: ""

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -14,24 +14,24 @@ spec:
     template: cluster-api-1-1-12
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
-      template: cluster-api-provider-k0sproject-k0smotron-1-0-25
+      template: cluster-api-provider-k0sproject-k0smotron-1-0-26
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-1-0-24
+      template: cluster-api-provider-azure-1-0-25
     - name: cluster-api-provider-vsphere
-      template: cluster-api-provider-vsphere-1-0-18
+      template: cluster-api-provider-vsphere-1-0-19
     - name: cluster-api-provider-aws
-      template: cluster-api-provider-aws-1-0-21
+      template: cluster-api-provider-aws-1-0-22
     - name: cluster-api-provider-openstack
       template: cluster-api-provider-openstack-1-0-24
     - name: cluster-api-provider-docker
       template: cluster-api-provider-docker-1-0-19
     - name: cluster-api-provider-gcp
-      template: cluster-api-provider-gcp-1-0-19
+      template: cluster-api-provider-gcp-1-0-20
     - name: cluster-api-provider-ipam
       template: cluster-api-provider-ipam-1-0-12
     - name: cluster-api-provider-infoblox
       template: cluster-api-provider-infoblox-1-0-11
     - name: cluster-api-provider-kubevirt
-      template: cluster-api-provider-kubevirt-1-0-7
+      template: cluster-api-provider-kubevirt-1-0-8
     - name: projectsveltos
       template: projectsveltos-1-9-0

--- a/templates/provider/kcm-templates/files/templates/azure-aks-1-0-7.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-aks-1-0-7.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-26
+  name: azure-aks-1-0-7
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.26
+      chart: azure-aks
+      version: 1.0.7
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-35.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-35.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-30
+  name: azure-hosted-cp-1-0-35
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.30
+      chart: azure-hosted-cp
+      version: 1.0.35
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-30.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-30.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-29
+  name: azure-standalone-cp-1-0-30
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: azure-standalone-cp
-      version: 1.0.29
+      version: 1.0.30
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-aws-1-0-21
+  name: cluster-api-provider-aws-1-0-22
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-aws
-      version: 1.0.21
+      version: 1.0.22
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-1-0-24
+  name: cluster-api-provider-azure-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-azure
-      version: 1.0.24
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-gcp-1-0-19
+  name: cluster-api-provider-gcp-1-0-20
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-gcp
-      version: 1.0.19
+      version: 1.0.20
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-k0sproject-k0smotron-1-0-25
+  name: cluster-api-provider-k0sproject-k0smotron-1-0-26
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-k0sproject-k0smotron
-      version: 1.0.25
+      version: 1.0.26
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-kubevirt-1-0-7
+  name: cluster-api-provider-kubevirt-1-0-8
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-kubevirt
-      version: 1.0.7
+      version: 1.0.8
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-vsphere-1-0-18
+  name: cluster-api-provider-vsphere-1-0-19
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-vsphere
-      version: 1.0.18
+      version: 1.0.19
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-10.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-10.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-29
+  name: docker-hosted-cp-1-0-10
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.29
+      chart: docker-hosted-cp
+      version: 1.0.10
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-13.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-gke-1-0-13.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-34
+  name: gcp-gke-1-0-13
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.34
+      chart: gcp-gke
+      version: 1.0.13
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-31.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-31.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-26
+  name: gcp-hosted-cp-1-0-31
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.26
+      chart: gcp-hosted-cp
+      version: 1.0.31
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-27.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-27.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-gke-1-0-12
+  name: gcp-standalone-cp-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-gke
-      version: 1.0.12
+      chart: gcp-standalone-cp
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-27.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-27.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-aks-1-0-6
+  name: remote-cluster-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-aks
-      version: 1.0.6
+      chart: remote-cluster
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-30.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-30.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: docker-hosted-cp-1-0-9
+  name: vsphere-hosted-cp-1-0-30
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: docker-hosted-cp
-      version: 1.0.9
+      chart: vsphere-hosted-cp
+      version: 1.0.30
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-27.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-27.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-26
+  name: vsphere-standalone-cp-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.26
+      chart: vsphere-standalone-cp
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/test/e2e/kubeclient/kubeclient.go
+++ b/test/e2e/kubeclient/kubeclient.go
@@ -192,7 +192,7 @@ func (kc *KubeClient) GetCluster(ctx context.Context, clusterName string) (*unst
 func (kc *KubeClient) GetAzureASOManagedCluster(ctx context.Context, name string) (*unstructured.Unstructured, error) {
 	return kc.getResource(ctx, schema.GroupVersionResource{
 		Group:    "infrastructure.cluster.x-k8s.io",
-		Version:  "v1alpha1",
+		Version:  "v1beta1",
 		Resource: "azureasomanagedclusters",
 	}, name)
 }
@@ -201,7 +201,7 @@ func (kc *KubeClient) GetAzureASOManagedCluster(ctx context.Context, name string
 func (kc *KubeClient) GetAzureASOManagedControlPlane(ctx context.Context, name string) (*unstructured.Unstructured, error) {
 	return kc.getResource(ctx, schema.GroupVersionResource{
 		Group:    "infrastructure.cluster.x-k8s.io",
-		Version:  "v1alpha1",
+		Version:  "v1beta1",
 		Resource: "azureasomanagedcontrolplanes",
 	}, name)
 }
@@ -354,7 +354,7 @@ func (kc *KubeClient) ListAzureASOManagedMachinePools(
 
 	return kc.listResource(ctx, schema.GroupVersionResource{
 		Group:    "infrastructure.cluster.x-k8s.io",
-		Version:  "v1alpha1",
+		Version:  "v1beta1",
 		Resource: "azureasomanagedmachinepools",
 	}, clusterName)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates CAPI resources versions across cluster templates where support has been added.

Migrates to CAPV v1beta2 infrastructure provider.

Bumps multiple providers:
- CAPA 2.11.0 -> 2.11.1
- CAPZ 1.23.0 -> 1.24.0
- CAPKubevirt 0.11.0 -> 0.11.2

NOTE: despite k0smotron having `v1beta2` APIs merged to the `main` branch, they are not publicly available yet, thus we cannot migrate and update the corresponding contracts version where applicable

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #2731 
