### PR TITLE
fix(templates): add missing MachineDeployment version

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-31
+  template: openstack-standalone-cp-1-0-32
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.31
+version: 1.0.32
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/machinedeployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: {{ include "cluster.name" . }}
     spec:
+      version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version ""  | quote }}
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-32.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-32.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-31
+  name: openstack-standalone-cp-1-0-32
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-standalone-cp
-      version: 1.0.31
+      version: 1.0.32
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
Brings openstack-standalone-cp in line with all the other MachineDeployment templates

**What this PR does / why we need it**:
Currently version upgrades only touch K0sWorkerConfigTemplate, which seems to only be read when cluster-api is creating a new machine

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #1389