### PR TITLE
fix: support priorityClassName in kcm chart

### DIFF
--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -125,6 +125,9 @@ spec:
       {{- with .Values.controller.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName }}
+      {{- end }}
       {{- with .Values.controller.topologySpreadConstraints }}
       topologySpreadConstraints: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -154,6 +154,10 @@
           "description": "Node selector to constrain the pod to run on specific nodes",
           "type": "object"
         },
+        "priorityClassName": {
+          "description": "Name of the PriorityClass to assign to the pod for scheduling and preemption",
+          "type": "string"
+        },
         "registryCertSecret": {
           "description": "Name of a Secret containing Registry Root CA with ca.crt key",
           "type": "string"

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -27,6 +27,7 @@ controller:
   nodeSelector: {} # @schema type: object; description: Node selector to constrain the pod to run on specific nodes
   affinity: {} # @schema type: object; description: Affinity rules for pod scheduling
   tolerations: [] # @schema type: array; description: Tolerations to allow the pod to schedule on tainted nodes
+  priorityClassName: "" # @schema type: string; description: Name of the PriorityClass to assign to the pod for scheduling and preemption
   topologySpreadConstraints: [] # @schema type: array; description: Topology spread constraints for pod scheduling
   validateClusterUpgradePath: true # @schema type: boolean; description: Specifies whether the ClusterDeployment upgrade path should be validated
   enableSveltosCtrl: true # @schema type: boolean; description: Enables built-in ServiceSet controller to reconcile ProjectSveltos objects


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for configuring priorityClassName for the KCM controller pod through the Helm chart.

Changes included:
	•	Adds controller.priorityClassName to templates/provider/kcm/values.yaml with an empty string default.
	•	Adds the value to templates/provider/kcm/values.schema.json so chart values validation accepts it.
	•	Renders controller.priorityClassName into the controller manager Deployment pod spec when configured.

This lets operators control scheduling and avoid eviction of KCM controller replicas using native Kubernetes scheduling constraints.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
NA

**Testing**:
•	helm lint templates/provider/kcm

