### PR TITLE
fix: ensure kcm helm chart is updated while dev-upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -415,7 +415,6 @@ kcm-deploy: helm ## Deploy/upgrade KCM Helm chart into namespace.
 	$(HELM) upgrade --values $(KCM_VALUES) --reuse-values --install --create-namespace $(KCM_HELM_RELEASE_NAME) $(PROVIDER_TEMPLATES_DIR)/kcm -n $(NAMESPACE)
 
 .PHONY: dev-deploy
-dev-deploy: DEPLOYMENT_NAME := $(if $(findstring kcm,$(KCM_HELM_RELEASE_NAME)),$(KCM_HELM_RELEASE_NAME)-controller-manager,$(KCM_HELM_RELEASE_NAME)-kcm-controller-manager)
 dev-deploy: yq ## Configure and deploy KCM chart for development.
 	@$(YQ) eval -i '.image.repository = "$(IMG_REPO)"' config/dev/kcm_values.yaml
 	@$(YQ) eval -i '.regional.telemetry.controller.image.repository = "$(IMG_TELEMETRY_REPO)"' config/dev/kcm_values.yaml
@@ -433,7 +432,7 @@ dev-deploy: yq ## Configure and deploy KCM chart for development.
 		$(YQ) eval -i '.regional.telemetry.interval = "10m"' config/dev/kcm_values.yaml; \
 	fi;
 	$(MAKE) kcm-deploy KCM_VALUES=config/dev/kcm_values.yaml
-	$(KUBECTL) rollout restart -n $(NAMESPACE) deployment/$(DEPLOYMENT_NAME)
+	$(KUBECTL) rollout restart deployment -n $(NAMESPACE) -l k0rdent.mirantis.com/component=kcm
 
 .PHONY: dev-undeploy
 dev-undeploy: ## Remove KCM release from namespace.

--- a/Makefile
+++ b/Makefile
@@ -476,8 +476,9 @@ dev-apply: kind-deploy registry-deploy dev-push dev-deploy dev-templates dev-rel
 .PHONY: dev-upgrade
 dev-upgrade: VALUES_FILE ?= config/dev/kcm_values.yaml
 dev-upgrade: READINESS_TIMEOUT ?= 30m
-dev-upgrade: yq generate-all dev-push dev-templates ## Upgrade dev environment and wait until Management is ready.
-	@YQ=$(YQ) KUBECTL=$(KUBECTL) VERSION=$(VERSION) FQDN_VERSION=$(FQDN_VERSION) PROVIDER_TEMPLATES_DIR=$(PROVIDER_TEMPLATES_DIR) VALUES_FILE=$(VALUES_FILE) NAMESPACE=$(NAMESPACE) READINESS_TIMEOUT=$(READINESS_TIMEOUT) $(SHELL) hack/dev-upgrade.bash
+dev-upgrade: KCM_DEPLOYMENT_NAME := $(if $(findstring kcm,$(KCM_HELM_RELEASE_NAME)),$(KCM_HELM_RELEASE_NAME)-controller-manager,$(KCM_HELM_RELEASE_NAME)-kcm-controller-manager)
+dev-upgrade: yq set-kcm-version generate-all dev-push dev-templates ## Upgrade dev environment and wait until Management is ready.
+	@YQ=$(YQ) KUBECTL=$(KUBECTL) VERSION=$(VERSION) FQDN_VERSION=$(FQDN_VERSION) PROVIDER_TEMPLATES_DIR=$(PROVIDER_TEMPLATES_DIR) VALUES_FILE=$(VALUES_FILE) NAMESPACE=$(NAMESPACE) READINESS_TIMEOUT=$(READINESS_TIMEOUT) KCM_DEPLOYMENT_NAME=$(KCM_DEPLOYMENT_NAME) $(SHELL) hack/dev-upgrade.bash
 
 PUBLIC_REPO ?= false
 

--- a/hack/dev-upgrade.bash
+++ b/hack/dev-upgrade.bash
@@ -24,6 +24,7 @@ set -euo pipefail
 : "${VALUES_FILE:?VALUES_FILE must be set}"
 : "${NAMESPACE:?NAMESPACE must be set}"
 : "${READINESS_TIMEOUT:?READINESS_TIMEOUT must be set}"
+: "${KCM_DEPLOYMENT_NAME:?KCM_DEPLOYMENT_NAME must be set}"
 
 echo "Applying new Release object: kcm-${FQDN_VERSION}"
 "${YQ}" e ".spec.version = \"${VERSION}\" | .metadata.name = \"kcm-${FQDN_VERSION}\"" "${PROVIDER_TEMPLATES_DIR}/kcm-templates/files/release.yaml" | "${KUBECTL}" apply -f -
@@ -40,7 +41,7 @@ trap 'rm -f "${tmp}"' EXIT
 echo "Patching Management object to use Release: kcm-${FQDN_VERSION}"
 "${KUBECTL}" patch management kcm --type=merge -p '{"spec":{"release":"kcm-'"${FQDN_VERSION}"'"}}'
 
-"${KUBECTL}" rollout restart -n "${NAMESPACE}" deployment/kcm-controller-manager
+"${KUBECTL}" rollout restart -n "${NAMESPACE}" deployment/"${KCM_DEPLOYMENT_NAME}"
 
 echo "Waiting for Management object status.release to match kcm-${FQDN_VERSION}..."
 "${KUBECTL}" wait management kcm --for="jsonpath={.status.release}=kcm-${FQDN_VERSION}" --timeout="${READINESS_TIMEOUT}"

--- a/hack/dev-upgrade.bash
+++ b/hack/dev-upgrade.bash
@@ -24,7 +24,6 @@ set -euo pipefail
 : "${VALUES_FILE:?VALUES_FILE must be set}"
 : "${NAMESPACE:?NAMESPACE must be set}"
 : "${READINESS_TIMEOUT:?READINESS_TIMEOUT must be set}"
-: "${KCM_DEPLOYMENT_NAME:?KCM_DEPLOYMENT_NAME must be set}"
 
 echo "Applying new Release object: kcm-${FQDN_VERSION}"
 "${YQ}" e ".spec.version = \"${VERSION}\" | .metadata.name = \"kcm-${FQDN_VERSION}\"" "${PROVIDER_TEMPLATES_DIR}/kcm-templates/files/release.yaml" | "${KUBECTL}" apply -f -
@@ -41,7 +40,7 @@ trap 'rm -f "${tmp}"' EXIT
 echo "Patching Management object to use Release: kcm-${FQDN_VERSION}"
 "${KUBECTL}" patch management kcm --type=merge -p '{"spec":{"release":"kcm-'"${FQDN_VERSION}"'"}}'
 
-"${KUBECTL}" rollout restart -n "${NAMESPACE}" deployment/"${KCM_DEPLOYMENT_NAME}"
+"${KUBECTL}" rollout restart deployment -n "${NAMESPACE}" -l k0rdent.mirantis.com/component=kcm
 
 echo "Waiting for Management object status.release to match kcm-${FQDN_VERSION}..."
 "${KUBECTL}" wait management kcm --for="jsonpath={.status.release}=kcm-${FQDN_VERSION}" --timeout="${READINESS_TIMEOUT}"


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Ensure kcm helm chart is updated during `make dev-upgrade`.
2. Use kcm label selector to ensure the KCM controller Deployment is correctly rollout-restarted even when a custom Helm release name is used.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2747
