### PR TITLE
fix: change Deployed comment to indicate if all services were deployed

### DIFF
--- a/api/v1beta1/serviceset_types.go
+++ b/api/v1beta1/serviceset_types.go
@@ -208,7 +208,7 @@ type ServiceSetStatus struct {
 
 	// +kubebuilder:default=false
 
-	// Deployed is true if the ServiceSet has been deployed
+	// Deployed indicates whether all services were successfully deployed
 	Deployed bool `json:"deployed"`
 
 	// Provider is the state of the provider

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
@@ -428,7 +428,7 @@ spec:
                   x-kubernetes-list-type: map
                 deployed:
                   default: false
-                  description: Deployed is true if the ServiceSet has been deployed
+                  description: Deployed indicates whether all services were successfully deployed
                   type: boolean
                 provider:
                   description: Provider is the state of the provider


### PR DESCRIPTION
Small change to the comment for ServiceSet's `.status.deployed` to make it clearer for that this field indicated whether all services defined in the spec were successfully deployed similar to how it is in the MCS object:
https://github.com/k0rdent/kcm/blob/26a263d176e71ebe8edee7da527e23cfaf616971/api/v1beta1/multiclusterservice_types.go#L386-L387