### PR TITLE
fix(charts): pin vsphere-cpi Helm chart to 1.35.1

### DIFF
--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-28
+  template: vsphere-standalone-cp-1-0-29
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.31
+version: 1.0.32
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -135,7 +135,7 @@ data:
       {{- else }}
       chartName: vsphere-cpi/vsphere-cpi
       {{- end }}
-      version: 1.36.0
+      version: 1.35.1
       releaseName: vsphere-cpi
       namespace: kube-system
       order: 1

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.28
+version: 1.0.29
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -132,7 +132,7 @@ spec:
             {{- else }}
             chartName: vsphere-cpi/vsphere-cpi
             {{- end }}
-            version: 1.36.0
+            version: 1.35.1
             releaseName: vsphere-cpi
             namespace: kube-system
             order: 2

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-32.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-32.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-28
+  name: vsphere-hosted-cp-1-0-32
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.28
+      chart: vsphere-hosted-cp
+      version: 1.0.32
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-29.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-29.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-31
+  name: vsphere-standalone-cp-1-0-29
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.31
+      chart: vsphere-standalone-cp
+      version: 1.0.29
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
 ## Summary
  Pins the embedded **`vsphere-cpi`** Helm chart version from **`1.36.0`** to **`1.35.1`** in **`vsphere-standalone-cp`** and **`vsphere-hosted-cp`** templates.
  ## Problem
  The **`v1.36.0`** chart sources exist under the **`kubernetes/cloud-provider-vsphere`** Git tag (for example under `charts/` at `v1.36.0`), but the published Helm repository at **`https://kubernetes.github.io/cloud-provider-vsphere`** did not yet ship a  **`vsphere-cpi`** package version **`1.36.0`** in **`index.yaml`**.
  Flows that resolve charts via that repository (for example **`helm repo add`** + **`helm pull --version 1.36.0`**) therefore fail with an error like “chart matching 1.36.0 not found.” The same applies to tooling that pulls external Helm charts during dependency collection.
  ## Solution
  Set **`spec.version`** to **`1.35.1`**, matching the latest **`vsphere-cpi`** chart version published in that Helm repository at the time of this change.
  ## Files changed
  - `templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml`
  - `templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml`
  ---
  **What this PR does / why we need it**
  - Updates the **`vsphere-cpi`** chart pin so it matches a chart version that exists in **`https://kubernetes.github.io/cloud-provider-vsphere/index.yaml`**, restoring successful **`helm pull`** and downstream external-chart mirroring until **`1.36.0`** is published there.
  
  Fixes #2761