### PR TITLE
feat: add `<deployed>/<total>` services printcolumn to ServiceSet

### DIFF
--- a/api/v1beta1/serviceset_types.go
+++ b/api/v1beta1/serviceset_types.go
@@ -268,6 +268,7 @@ type ServiceState struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="cluster",type=string,JSONPath=`.spec.cluster`,description="Corresponding ClusterDeployment name",priority=0
 // +kubebuilder:printcolumn:name="multiClusterServer",type=string,JSONPath=`.spec.multiClusterService`,description="Corresponding MultiClusterService name",priority=0
+// +kubebuilder:printcolumn:name="Services",type="string",JSONPath=`.status.conditions[?(@.type=="ServicesInReadyState")].message`,description="Number of ready out of total services",priority=0
 // +kubebuilder:printcolumn:name="provider",type=string,JSONPath=`.spec.provider.name`,description="StateManagementProvider name",priority=0
 // +kubebuilder:printcolumn:name="self-management",type=boolean,JSONPath=`.spec.provider.selfManagement`,description="Is the ServiceSet for self-management",priority=0
 // +kubebuilder:printcolumn:name="age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time elapsed since object creation",priority=0

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -712,10 +712,30 @@ func (r *ServiceSetReconciler) collectServiceStatuses(ctx context.Context, rgnCl
 		return fmt.Errorf("failed to collect service statuses: %w", err)
 	}
 
+	r.updateServicesInReadyStateCondition(serviceSet)
+
 	status = metav1.ConditionTrue
 	reason = kcmv1.ServiceSetStatusesCollectedReason
 	message = kcmv1.ServiceSetStatusesCollectedMessage
 	return nil
+}
+
+// updateServicesInReadyStateCondition updates the "ServicesInReadyState" condition.
+func (r *ServiceSetReconciler) updateServicesInReadyStateCondition(serviceSet *kcmv1.ServiceSet) {
+	deployedCount := 0
+	for _, svc := range serviceSet.Status.Services {
+		if svc.State == kcmv1.ServiceStateDeployed {
+			deployedCount++
+		}
+	}
+	totalCount := len(serviceSet.Spec.Services)
+	svcReadyCond := findCondition(serviceSet, kcmv1.ServicesInReadyStateCondition)
+	svcReadyStatus := metav1.ConditionFalse
+	if totalCount > 0 && deployedCount == totalCount {
+		svcReadyStatus = metav1.ConditionTrue
+	}
+	updateCondition(serviceSet, svcReadyCond, svcReadyStatus, kcmv1.ServicesInReadyStateCondition,
+		fmt.Sprintf("%d/%d", deployedCount, totalCount), r.timeFunc())
 }
 
 func getClusterSummaryForServiceSet(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet, profileObj client.Object) (*addoncontrollerv1beta1.ClusterSummary, error) {

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
@@ -24,6 +24,10 @@ spec:
           jsonPath: .spec.multiClusterService
           name: multiClusterServer
           type: string
+        - description: Number of ready out of total services
+          jsonPath: .status.conditions[?(@.type=="ServicesInReadyState")].message
+          name: Services
+          type: string
         - description: StateManagementProvider name
           jsonPath: .spec.provider.name
           name: provider


### PR DESCRIPTION
# Description

Implements https://github.com/k0rdent/kcm/issues/2413.

The management ServiceSet deploying 2 services looks like as follows with this change:
```sh
NAME                  CLUSTER   MULTICLUSTERSERVER   SERVICES   PROVIDER             SELF-MANAGEMENT   AGE
management-6ec16280             mcs0                 0/2        ksm-projectsveltos   true              0s
````
And eventually:
```sh
NAME                  CLUSTER   MULTICLUSTERSERVER   SERVICES   PROVIDER             SELF-MANAGEMENT   AGE
management-6ec16280             mcs0                 2/2        ksm-projectsveltos   true              29s
```