### PR TITLE
fix: make ServicesInReady condition true when 0 services

### DIFF
--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -730,9 +730,9 @@ func (r *ServiceSetReconciler) updateServicesInReadyStateCondition(serviceSet *k
 	}
 	totalCount := len(serviceSet.Spec.Services)
 	svcReadyCond := findCondition(serviceSet, kcmv1.ServicesInReadyStateCondition)
-	svcReadyStatus := metav1.ConditionFalse
-	if totalCount > 0 && deployedCount == totalCount {
-		svcReadyStatus = metav1.ConditionTrue
+	svcReadyStatus := metav1.ConditionTrue
+	if deployedCount != totalCount {
+		svcReadyStatus = metav1.ConditionFalse
 	}
 	updateCondition(serviceSet, svcReadyCond, svcReadyStatus, kcmv1.ServicesInReadyStateCondition,
 		fmt.Sprintf("%d/%d", deployedCount, totalCount), r.timeFunc())

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -734,8 +734,13 @@ func (r *ServiceSetReconciler) updateServicesInReadyStateCondition(serviceSet *k
 	if deployedCount != totalCount {
 		svcReadyStatus = metav1.ConditionFalse
 	}
-	updateCondition(serviceSet, svcReadyCond, svcReadyStatus, kcmv1.ServicesInReadyStateCondition,
-		fmt.Sprintf("%d/%d", deployedCount, totalCount), r.timeFunc())
+
+	// update condition only if deployed <= total to avoid scenarios where
+	// a service is removed from spec but is still present in the status.
+	if deployedCount <= totalCount {
+		updateCondition(serviceSet, svcReadyCond, svcReadyStatus, kcmv1.ServicesInReadyStateCondition,
+			fmt.Sprintf("%d/%d", deployedCount, totalCount), r.timeFunc())
+	}
 }
 
 func getClusterSummaryForServiceSet(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet, profileObj client.Object) (*addoncontrollerv1beta1.ClusterSummary, error) {


### PR DESCRIPTION
Make the ServicesInReady condition True when the ServiceSet has 0 services defined in spec. Follow-up to https://github.com/k0rdent/kcm/pull/2760.