### PR TITLE
Revert "chore(bump): flux to v2.18.3"

### DIFF
--- a/templates/provider/kcm/Chart.lock
+++ b/templates/provider/kcm/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: flux2
   repository: https://fluxcd-community.github.io/helm-charts
-  version: 2.18.3
+  version: 2.17.2
 - name: rbac-manager
   repository: https://charts.fairwinds.com/stable
   version: 1.21.5
 - name: kcm-regional
   repository: file://../kcm-regional
   version: 1.9.0
-digest: sha256:2086d0704f65d2c93facc8ea7422b62181f532e142767bf9f87fb21e90214d71
-generated: "2026-05-26T08:09:16.208924+07:00"
+digest: sha256:edf7a79f3fc6518184abd9b6ac303e945d5ef7f4e893203e89a3bedfe8701622
+generated: "2026-04-27T17:26:04.722988+02:00"

--- a/templates/provider/kcm/Chart.yaml
+++ b/templates/provider/kcm/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 version: 1.9.0
 dependencies:
   - name: flux2
-    version: 2.18.3
+    version: 2.17.2
     repository: https://fluxcd-community.github.io/helm-charts
     condition: flux2.enabled
   - name: rbac-manager


### PR DESCRIPTION
Reverts k0rdent/kcm#2773

Reason: the new helm controller image (v1.5.3) does not process deployed objects properly, resulting in these kinds of errors:

```
HelmReleaseReady     | False    | Helm install failed for release kcm-system/ksi-eks-ksi-n-oss-62-1-62-1 with chart aws-eks@1.0.9: AWSManagedControlPlane.controlplane.cluster.x-k8s.io "ksi-eks-ksi-n-oss-62-1-62-1-cp" is invalid: [spec.addons[0].serviceAccountRoleARN: Invalid value: "null": spec.addons[0].serviceAccountRoleARN in body must be of type string: "null", <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]
```