### PR TITLE
chore: migrate to upstream openstack provider

### DIFF
--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-33
+  template: openstack-standalone-cp-1-0-34
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-29
+  template: vsphere-standalone-cp-1-0-30
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.29
+version: 1.0.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/cluster.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -14,10 +14,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: K0smotronControlPlane
     name: {{ include "k0smotroncontrolplane.name" .  }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: OpenStackCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/openstack-hosted-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: {{ include "machinedeployment.name" . }}
@@ -17,10 +17,10 @@ spec:
       clusterName: {{ include "cluster.name" . }}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: K0sWorkerConfigTemplate
           name: {{ include "k0sworkerconfigtemplate.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: OpenStackMachineTemplate
         name: {{ include "openstackmachinetemplate.name" . }}

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.33
+version: 1.0.34
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/cluster.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: {{ include "cluster.name" . }}
@@ -14,10 +14,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: K0sControlPlane
     name: {{ include "k0scontrolplane.name" .  }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: OpenStackCluster
     name: {{ include "cluster.name" . }}

--- a/templates/cluster/openstack-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/machinedeployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: {{ include "machinedeployment.name" . }}
@@ -19,11 +19,11 @@ spec:
       version: {{ regexReplaceAll "\\+k0s.+$" .Values.k0s.version ""  | quote }}
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: K0sWorkerConfigTemplate
           name: {{ include "k0sworkerconfigtemplate.name" . }}
       clusterName: {{ include "cluster.name" . }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: OpenStackMachineTemplate
-        name: {{ include "openstackmachinetemplate.worker.name" . }}  
+        name: {{ include "openstackmachinetemplate.worker.name" . }}

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.29
+version: 1.0.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -266,7 +266,7 @@ spec:
         {{- end }}
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiGroup: infrastructure.cluster.x-k8s.io
       kind: VSphereMachineTemplate
       name: {{ include "vspheremachinetemplate.controlplane.name" . }}
       namespace: {{ .Release.Namespace }}

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -266,7 +266,7 @@ spec:
         {{- end }}
   machineTemplate:
     infrastructureRef:
-      apiGroup: infrastructure.cluster.x-k8s.io
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: VSphereMachineTemplate
       name: {{ include "vspheremachinetemplate.controlplane.name" . }}
       namespace: {{ .Release.Namespace }}

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.24
+version: 1.0.25
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.13.0-mirantis.0"
+appVersion: "v0.14.4"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-openstack
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/provider.yaml
@@ -15,9 +15,6 @@ spec:
   {{- if $global.registry }}
   fetchConfig:
     oci: {{ $global.registry }}/capi/cluster-api-provider-openstack-components:{{ $version }}
-  {{- else }}
-  fetchConfig:
-    url: https://github.com/Mirantis/cluster-api-provider-openstack/releases/download/{{ $version }}/infrastructure-components.yaml
   {{- end }}
   {{- with (include "infrastructureProvider.deployment" . | fromYaml) }}
   deployment: {{ toYaml . | nindent 4 }}

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -22,7 +22,7 @@ spec:
     - name: cluster-api-provider-aws
       template: cluster-api-provider-aws-1-0-22
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-1-0-24
+      template: cluster-api-provider-openstack-1-0-25
     - name: cluster-api-provider-docker
       template: cluster-api-provider-docker-1-0-20
     - name: cluster-api-provider-gcp

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-1-0-24
+  name: cluster-api-provider-openstack-1-0-25
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 1.0.24
+      version: 1.0.25
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-30.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-30.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-29
+  name: openstack-hosted-cp-1-0-30
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.29
+      chart: openstack-hosted-cp
+      version: 1.0.30
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-34.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-34.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-33
+  name: openstack-standalone-cp-1-0-34
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: openstack-standalone-cp
-      version: 1.0.33
+      version: 1.0.34
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-30.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-30.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-29
+  name: vsphere-standalone-cp-1-0-30
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.29
+      chart: vsphere-standalone-cp
+      version: 1.0.30
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR migrates the OpenStack provider to the latest upstream version, v0.14.4.

Verified:
1. Deployed the latest k0rdent/kcm and successfully created clusters using both Secret and OpenStackClusterIdentity credential resources
2. Deployed k0rdent/kcm v1.9.0, created clusters using both Secret and OpenStackClusterIdentity resources, then upgraded k0rdent/kcm to the latest version successfully

Additionally contains:
1. CAPI resources update from v1beta1 -> v1beta2 for openstack templates
2. Fixes vsphere standalone infrastructure ref

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2774
