### PR TITLE
feat(templates): allow 0 workers in standalone-cp charts

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-32
+  template: aws-standalone-cp-1-0-33
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-34
+  template: azure-standalone-cp-1-0-35
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-30
+  template: gcp-standalone-cp-1-0-31
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-10
+  template: kubevirt-standalone-cp-1-0-11
   credential: kubevirt-cred
   propagateCredentials: false
   config:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-35
+  template: openstack-standalone-cp-1-0-36
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-31
+  template: vsphere-standalone-cp-1-0-32
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.32
+version: 1.0.33
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-worker.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/awsmachinetemplate-worker.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSMachineTemplate
 metadata:
@@ -28,3 +29,4 @@ spec:
       nonRootVolumes: {{- toYaml . | nindent 8 }}
       {{- end }}
       uncompressedUserData: {{ .Values.worker.uncompressedUserData }}
+{{- end }}

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -12,6 +12,9 @@ spec:
     {{- end }}
     args:
       - --enable-worker
+      {{- if eq (int .Values.workersNumber) 0 }}
+      - --no-taints
+      {{- end }}
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       - --disable-components=konnectivity-server

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
@@ -42,3 +43,4 @@ spec:
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}
+{{- end }}

--- a/templates/cluster/aws-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/machinedeployment.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
@@ -27,3 +28,4 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: AWSMachineTemplate
         name: {{ include "awsmachinetemplate.worker.name" . }}
+{{- end }}

--- a/templates/cluster/aws-standalone-cp/values.schema.json
+++ b/templates/cluster/aws-standalone-cp/values.schema.json
@@ -435,9 +435,9 @@
       }
     },
     "workersNumber": {
-      "description": "The number of the worker machines",
+      "description": "The number of the worker machines. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes",
       "type": "integer",
-      "minimum": 1
+      "minimum": 0
     }
   }
 }

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -1,6 +1,6 @@
 # Cluster parameters
 controlPlaneNumber: 3 # @schema description: The number of the control-plane machines; minimum: 1; type: integer; required: true
-workersNumber: 2 # @schema description: The number of the worker machines; minimum: 1; type: integer; required: true
+workersNumber: 2 # @schema description: The number of the worker machines. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes; minimum: 0; type: integer; required: true
 
 clusterNetwork: # @schema description: The cluster network configuration; type: object
   pods: # @schema description: The network ranges from which Pod networks are allocated; type: object

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.34
+version: 1.0.35
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-worker.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/azuremachinetemplate-worker.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureMachineTemplate
 metadata:
@@ -24,3 +25,4 @@ spec:
           {{- toYaml .marketplace | nindent 10 }}
         {{- end }}
       {{- end }}
+{{- end }}

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -176,6 +176,9 @@ spec:
     {{- end }}
     args:
       - --enable-worker
+      {{- if eq (int .Values.workersNumber) 0 }}
+      - --no-taints
+      {{- end }}
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       - --disable-components=konnectivity-server

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
@@ -42,3 +43,4 @@ spec:
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}
+{{- end }}

--- a/templates/cluster/azure-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/machinedeployment.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
@@ -27,3 +28,4 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: AzureMachineTemplate
         name: {{ include "azuremachinetemplate.worker.name" . }}
+{{- end }}

--- a/templates/cluster/azure-standalone-cp/values.schema.json
+++ b/templates/cluster/azure-standalone-cp/values.schema.json
@@ -3,6 +3,8 @@
   "description": "A KCM cluster azure-standalone-cp template",
   "type": "object",
   "required": [
+    "controlPlaneNumber",
+    "workersNumber",
     "location",
     "subscriptionID",
     "controlPlane",
@@ -188,7 +190,9 @@
       }
     },
     "controlPlaneNumber": {
-      "type": "integer"
+      "description": "The number of the control-plane machines",
+      "type": "integer",
+      "minimum": 1
     },
     "encryption": {
       "description": "Encryption-at-rest settings for kube-apiserver storage config",
@@ -355,7 +359,9 @@
       }
     },
     "workersNumber": {
-      "type": "integer"
+      "description": "The number of the worker machines. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes",
+      "type": "integer",
+      "minimum": 0
     }
   }
 }

--- a/templates/cluster/azure-standalone-cp/values.yaml
+++ b/templates/cluster/azure-standalone-cp/values.yaml
@@ -1,6 +1,6 @@
 # Cluster parameters
-controlPlaneNumber: 3
-workersNumber: 2
+controlPlaneNumber: 3 # @schema description: The number of the control-plane machines; minimum: 1; type: integer; required: true
+workersNumber: 2 # @schema description: The number of the worker machines. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes; minimum: 0; type: integer; required: true
 
 clusterNetwork:
   pods:

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.30
+version: 1.0.31
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/gcpmachinetemplate-worker.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/gcpmachinetemplate-worker.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: GCPMachineTemplate
 metadata:
@@ -25,3 +26,4 @@ spec:
         scopes: {{- toYaml .serviceAccount.scopes | nindent 10 }}
       ipForwarding: {{ .ipForwarding }}
       {{- end }}
+{{- end }}

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -190,6 +190,9 @@ spec:
     {{- end }}
     args:
       - --enable-worker
+      {{- if eq (int .Values.workersNumber) 0 }}
+      - --no-taints
+      {{- end }}
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       - --disable-components=konnectivity-server

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
@@ -42,3 +43,4 @@ spec:
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}
+{{- end }}

--- a/templates/cluster/gcp-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/machinedeployment.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
@@ -27,3 +28,4 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: GCPMachineTemplate
         name: {{ include "gcpmachinetemplate.worker.name" . }}
+{{- end }}

--- a/templates/cluster/gcp-standalone-cp/values.schema.json
+++ b/templates/cluster/gcp-standalone-cp/values.schema.json
@@ -471,9 +471,9 @@
       }
     },
     "workersNumber": {
-      "description": "The number of the worker nodes",
+      "description": "The number of the worker nodes. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes",
       "type": "number",
-      "minimum": 1
+      "minimum": 0
     }
   }
 }

--- a/templates/cluster/gcp-standalone-cp/values.yaml
+++ b/templates/cluster/gcp-standalone-cp/values.yaml
@@ -1,6 +1,6 @@
 # Cluster parameters
 controlPlaneNumber: 3 # @schema description: The number of the control plane nodes; type: number; minimum: 1
-workersNumber: 2 # @schema description: The number of the worker nodes; type: number; minimum: 1
+workersNumber: 2 # @schema description: The number of the worker nodes. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes; type: number; minimum: 0
 
 clusterIdentity: # @schema description: The GCP Service Account credentials secret reference, auto-populated; type: object
   name: "" # @schema description: The GCP Service Account credentials secret name, auto-populated; type: string

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
@@ -75,6 +75,9 @@ spec:
     {{- end }}
     args:
       - --enable-worker
+      {{- if eq (int .Values.workersNumber) 0 }}
+      - --no-taints
+      {{- end }}
       - --disable-components=konnectivity-server
       - --kubelet-extra-args="--fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.cpArgs }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
@@ -41,3 +42,4 @@ spec:
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}
+{{- end }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtMachineTemplate
 metadata:
@@ -67,3 +68,4 @@ spec:
                 {{- toYaml .source | nindent 16 }}
           {{- end }}
           {{- end }}
+{{- end }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/machinedeployment.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
@@ -23,3 +24,4 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: KubevirtMachineTemplate
         name: {{ include "kubevirtmachinetemplate.worker.name" . }}
+{{- end }}

--- a/templates/cluster/kubevirt-standalone-cp/values.schema.json
+++ b/templates/cluster/kubevirt-standalone-cp/values.schema.json
@@ -629,9 +629,9 @@
       }
     },
     "workersNumber": {
-      "description": "The number of the worker machines",
+      "description": "The number of the worker machines. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes",
       "type": "integer",
-      "minimum": 1
+      "minimum": 0
     }
   }
 }

--- a/templates/cluster/kubevirt-standalone-cp/values.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/values.yaml
@@ -1,6 +1,6 @@
 # Cluster parameters
 controlPlaneNumber: 3 # @schema description: The number of the control-plane machines; minimum: 1; type: integer; required: true
-workersNumber: 2 # @schema description: The number of the worker machines; minimum: 1; type: integer; required: true
+workersNumber: 2 # @schema description: The number of the worker machines. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes; minimum: 0; type: integer; required: true
 
 clusterNetwork:  # @schema description: The cluster network configuration; type: object
   pods: # @schema description: The network ranges from which Pod networks are allocated; type: object

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.35
+version: 1.0.36
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -231,6 +231,9 @@ spec:
     {{- end }}
     args:
       - --enable-worker
+      {{- if eq (int .Values.workersNumber) 0 }}
+      - --no-taints
+      {{- end }}
       - --enable-cloud-provider
       - --kubelet-extra-args="--cloud-provider=external --fail-cgroupv1=false"
       - --disable-components=konnectivity-server

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
@@ -42,3 +43,4 @@ spec:
       {{- range $arg := .Values.k0s.workerArgs }}
       - {{ toYaml $arg }}
       {{- end }}
+{{- end }}

--- a/templates/cluster/openstack-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/machinedeployment.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
@@ -27,3 +28,4 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: OpenStackMachineTemplate
         name: {{ include "openstackmachinetemplate.worker.name" . }}
+{{- end }}

--- a/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/openstackmachinetemplate-worker.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
@@ -43,3 +44,4 @@ spec:
       floatingIPPoolRef:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/templates/cluster/openstack-standalone-cp/values.schema.json
+++ b/templates/cluster/openstack-standalone-cp/values.schema.json
@@ -596,9 +596,9 @@
       }
     },
     "workersNumber": {
-      "description": "The number of the worker machines",
+      "description": "The number of the worker machines. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes",
       "type": "integer",
-      "minimum": 1
+      "minimum": 0
     }
   }
 }

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -1,6 +1,6 @@
 # Cluster parameters
 controlPlaneNumber: 3 # @schema description: The number of the control-plane machines; minimum: 1; type: integer; required: true
-workersNumber: 2 # @schema description: The number of the worker machines; minimum: 1; type: integer; required: true
+workersNumber: 2 # @schema description: The number of the worker machines. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes; minimum: 0; type: integer; required: true
 
 clusterNetwork:  # @schema description: The cluster network configuration; type: object
   pods: # @schema description: The network ranges from which Pod networks are allocated; type: object

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.31
+version: 1.0.32
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -242,6 +242,9 @@ spec:
     {{- end }}
     args:
       - --enable-worker
+      {{- if eq (int .Values.workersNumber) 0 }}
+      - --no-taints
+      {{- end }}
       - --disable-components=konnectivity-server
       - --kubelet-extra-args="--fail-cgroupv1=false"
       {{- range $arg := .Values.k0s.cpArgs }}

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: K0sWorkerConfigTemplate
@@ -45,3 +46,4 @@ spec:
         {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
         - "sudo update-ca-certificates"
         {{- end }}
+{{- end }}

--- a/templates/cluster/vsphere-standalone-cp/templates/machinedeployment.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/machinedeployment.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
@@ -27,3 +28,4 @@ spec:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: VSphereMachineTemplate
         name: {{ include "vspheremachinetemplate.worker.name" . }}
+{{- end }}

--- a/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-worker.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/vspheremachinetemplate-worker.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.workersNumber) 0 }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VSphereMachineTemplate
 metadata:
@@ -29,3 +30,4 @@ spec:
       server: {{ .Values.vsphere.server  | quote }}
       template: {{ .Values.worker.vmTemplate  | quote }}
       thumbprint: {{ .Values.vsphere.thumbprint  | quote }}
+{{- end }}

--- a/templates/cluster/vsphere-standalone-cp/values.schema.json
+++ b/templates/cluster/vsphere-standalone-cp/values.schema.json
@@ -2,6 +2,10 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "A KCM cluster vsphere-standalone-cp template",
   "type": "object",
+  "required": [
+    "controlPlaneNumber",
+    "workersNumber"
+  ],
   "properties": {
     "audit": {
       "description": "Audit logging settings for kube-apiserver, optional",
@@ -150,7 +154,9 @@
       "type": "string"
     },
     "controlPlaneNumber": {
-      "type": "integer"
+      "description": "The number of the control-plane machines",
+      "type": "integer",
+      "minimum": 1
     },
     "encryption": {
       "description": "Encryption-at-rest settings for kube-apiserver storage config",
@@ -322,7 +328,9 @@
       }
     },
     "workersNumber": {
-      "type": "integer"
+      "description": "The number of the worker machines. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes",
+      "type": "integer",
+      "minimum": 0
     }
   }
 }

--- a/templates/cluster/vsphere-standalone-cp/values.yaml
+++ b/templates/cluster/vsphere-standalone-cp/values.yaml
@@ -1,6 +1,6 @@
 # Cluster parameters
-controlPlaneNumber: 3
-workersNumber: 2
+controlPlaneNumber: 3 # @schema description: The number of the control-plane machines; minimum: 1; type: integer; required: true
+workersNumber: 2 # @schema description: The number of the worker machines. Set to 0 to skip provisioning a dedicated worker MachineDeployment and run workloads on the control-plane nodes; minimum: 0; type: integer; required: true
 
 ipamEnabled: false
 

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-33.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-33.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-30
+  name: aws-standalone-cp-1-0-33
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.30
+      chart: aws-standalone-cp
+      version: 1.0.33
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-35.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-35.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-32
+  name: azure-standalone-cp-1-0-35
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.32
+      chart: azure-standalone-cp
+      version: 1.0.35
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-31.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-31.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-31
+  name: gcp-standalone-cp-1-0-31
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
+      chart: gcp-standalone-cp
       version: 1.0.31
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-11.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-11.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-34
+  name: kubevirt-standalone-cp-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.34
+      chart: kubevirt-standalone-cp
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-36.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-36.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-10
+  name: openstack-standalone-cp-1-0-36
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-standalone-cp
-      version: 1.0.10
+      chart: openstack-standalone-cp
+      version: 1.0.36
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-32.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-32.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-35
+  name: vsphere-standalone-cp-1-0-32
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.35
+      chart: vsphere-standalone-cp
+      version: 1.0.32
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -126,7 +126,7 @@ spec:
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.controller.priorityClassName }}
-      priorityClassName: {{ .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName | quote }}
       {{- end }}
       {{- with .Values.controller.topologySpreadConstraints }}
       topologySpreadConstraints: {{ toYaml . | nindent 8 }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Wrap the worker `MachineDeployment`, `K0sWorkerConfigTemplate` and provider-specific worker `MachineTemplate` in each `*-standalone-cp` chart with a `{{ if gt (int .Values.workersNumber) 0 }}` guard so that setting `workersNumber=0` skips the dedicated worker `MachineDeployment` (which rejects `replicas=0`) and schedules workloads on the control-plane nodes, which already run with `--enable-worker`

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #1981 