### PR TITLE
chore: make default AWS AMI filter architecture-agnostic

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-32
+  template: aws-standalone-cp-1-0-33
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.32
+version: 1.0.33
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -58,7 +58,7 @@ controlPlane: # @schema description: The configuration of the control plane mach
   instanceType: "" # @schema description: The type of instance to create. Example: m4.xlarge; type: string; required: true
   rootVolumeSize: 8 # @schema description: Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater); type: integer; minimum: 8
   imageLookup: # @schema description: AMI lookup parameters; type: object
-    format: "al2023-ami-*-x86_64" # @schema description: The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set; type: string; required: true
+    format: "al2023-ami-*" # @schema description: The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set; type: string; required: true
     org: "137112412989" # @schema description: The AWS Organization ID to use for image lookup if AMI is not set; type: string; required: true
     baseOS: "" # @schema description: The name of the base operating system to use for image lookup the AMI is not set; type: string
   uncompressedUserData: false # @schema description: Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed; type: boolean
@@ -70,7 +70,7 @@ worker: # @schema description: The configuration of the worker machines; type: o
   instanceType: "" # @schema description: The type of instance to create. Example: m4.xlarge; type: string; required: true
   rootVolumeSize: 8 # @schema description: Specifies size (in Gi) of the root storage device. Must be greater than the image snapshot size or 8 (whichever is greater); type: integer; minimum: 8
   imageLookup: # @schema description: AMI lookup parameters; type: object
-    format: "al2023-ami-*-x86_64" # @schema description: The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set; type: string; required: true
+    format: "al2023-ami-*" # @schema description: The AMI naming format to look up the image for this machine. It will be ignored if an explicit AMI is set; type: string; required: true
     org: "137112412989" # @schema description: The AWS Organization ID to use for image lookup if AMI is not set; type: string; required: true
     baseOS: "" # @schema description: The name of the base operating system to use for image lookup the AMI is not set; type: string
   uncompressedUserData: false # @schema description: Specify whether the user data is gzip-compressed before it is sent to ec2 instance. Cloud-init has built-in support for gzip-compressed user data. User data stored in aws secret manager is always gzip-compressed; type: boolean

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-33.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-33.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-32
+  name: aws-standalone-cp-1-0-33
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: aws-standalone-cp
-      version: 1.0.32
+      version: 1.0.33
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
The previous filter (`al2023-ami-*-x86_64`) was restricted to x86_64 images. Use the broader pattern (`al2023-ami-*`) so arm64 and future architecture variants can also be discovered.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
