### PR TITLE
fix: proper aso version for capz

### DIFF
--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-azure/templates/_helpers.tpl
+++ b/templates/provider/cluster-api-provider-azure/templates/_helpers.tpl
@@ -247,7 +247,7 @@ or the providers are guaranteed to be isolated so selector collisions cannot hap
 */}}
 {{- define "infrastructureProvider.patches.default" -}}
 {{- $global := .Values.global | default dict -}}
-{{- $asoVersion := "v2.13.0" -}}
+{{- $asoVersion := "v2.16.1" -}}
 {{- $proxyEnv := include "infrastructureProvider.proxyEnv" . | fromYaml -}}
 {{- $enableProvidersReloadSet := hasKey $global "enableProvidersReload" -}}
 {{- $enableProvidersReload := and $enableProvidersReloadSet $global.enableProvidersReload -}}

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -16,7 +16,7 @@ spec:
     - name: cluster-api-provider-k0sproject-k0smotron
       template: cluster-api-provider-k0sproject-k0smotron-1-0-26
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-1-0-26
+      template: cluster-api-provider-azure-1-0-27
     - name: cluster-api-provider-vsphere
       template: cluster-api-provider-vsphere-1-0-19
     - name: cluster-api-provider-aws

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-1-0-26
+  name: cluster-api-provider-azure-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-azure
-      version: 1.0.26
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes incorrect aso version after provider bump https://github.com/k0rdent/kcm/pull/2771

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
