### PR TITLE
feat(controller): retry transient errs in watchers

### DIFF
--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -345,17 +345,21 @@ func (r *ServiceSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			RateLimiter:             ratelimitutil.DefaultFastSlow(),
 		}).
 		Named("ksm-sveltos-adapter").
-		Watches(&kcmv1.ServiceSet{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
+		Watches(&kcmv1.ServiceSet{}, kubeutil.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) ([]ctrl.Request, error) {
 			serviceSet, ok := o.(*kcmv1.ServiceSet)
 			if !ok {
-				return nil
+				return nil, nil
 			}
 			provider := new(kcmv1.StateManagementProvider)
 			if err := r.Get(ctx, client.ObjectKey{Name: serviceSet.Spec.Provider.Name}, provider); err != nil {
-				return nil
+				if apierrors.IsNotFound(err) {
+					return nil, nil
+				}
+				return nil, fmt.Errorf("failed to get StateManagementProvider %s: %w", serviceSet.Spec.Provider.Name, err)
 			}
-			if provider.Spec.Adapter.Name != r.AdapterName && provider.Spec.Adapter.Namespace != r.AdapterNamespace {
-				return nil
+			if provider.Spec.Adapter.Name != r.AdapterName ||
+				provider.Spec.Adapter.Namespace != r.AdapterNamespace {
+				return nil, nil
 			}
 			return []ctrl.Request{
 				{
@@ -364,21 +368,22 @@ func (r *ServiceSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						Namespace: serviceSet.Namespace,
 					},
 				},
-			}
+			}, nil
 		})).
-		Watches(&kcmv1.StateManagementProvider{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
+		Watches(&kcmv1.StateManagementProvider{}, kubeutil.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) ([]ctrl.Request, error) {
 			provider, ok := o.(*kcmv1.StateManagementProvider)
 			if !ok {
-				return nil
+				return nil, nil
 			}
-			if provider.Spec.Adapter.Name != r.AdapterName && provider.Spec.Adapter.Namespace != r.AdapterNamespace {
-				return nil
+			if provider.Spec.Adapter.Name != r.AdapterName ||
+				provider.Spec.Adapter.Namespace != r.AdapterNamespace {
+				return nil, nil
 			}
 
 			selector := fields.OneTermEqualSelector(kcmv1.ServiceSetProviderIndexKey, provider.Name)
 			serviceSets := new(kcmv1.ServiceSetList)
 			if err := r.List(ctx, serviceSets, client.MatchingFieldsSelector{Selector: selector}); err != nil {
-				return nil
+				return nil, fmt.Errorf("failed to list ServiceSets for StateManagementProvider %s: %w", provider.Name, err)
 			}
 			requests := make([]ctrl.Request, 0, len(serviceSets.Items))
 			for _, serviceSet := range serviceSets.Items {
@@ -389,7 +394,7 @@ func (r *ServiceSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					},
 				})
 			}
-			return requests
+			return requests, nil
 		})).
 		WatchesRawSource(source.Channel(r.eventChan, &handler.EnqueueRequestForObject{})).
 		Complete(r)

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -50,7 +50,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/yaml"
@@ -2011,10 +2010,10 @@ func (*ClusterDeploymentReconciler) templatesValidUpdateSource(cl client.Client,
 		panic(fmt.Sprintf("unexpected type %T, expected one of [%T, %T]", obj, new(kcmv1.ServiceTemplate), new(kcmv1.ClusterTemplate)))
 	}
 
-	return source.TypedKind(cache, obj, handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
+	return source.TypedKind(cache, obj, kubeutil.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) ([]ctrl.Request, error) {
 		clds := new(kcmv1.ClusterDeploymentList)
 		if err := cl.List(ctx, clds, client.InNamespace(o.GetNamespace()), client.MatchingFields{indexKey: o.GetName()}); err != nil {
-			return nil
+			return nil, fmt.Errorf("failed to list ClusterDeployments by %s: %w", indexKey, err)
 		}
 
 		resp := make([]ctrl.Request, 0, len(clds.Items))
@@ -2022,7 +2021,7 @@ func (*ClusterDeploymentReconciler) templatesValidUpdateSource(cl client.Client,
 			resp = append(resp, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&v)})
 		}
 
-		return resp
+		return resp, nil
 	}), predicate.TypedFuncs[client.Object]{
 		GenericFunc: func(event.TypedGenericEvent[client.Object]) bool { return false },
 		DeleteFunc:  func(event.TypedDeleteEvent[client.Object]) bool { return false },
@@ -2249,13 +2248,13 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	r.defaultRequeueTime = 10 * time.Second
 
-	mapObjectsToClusterDeployments := func(indexKey string) func(ctx context.Context, o client.Object) []ctrl.Request {
-		return func(ctx context.Context, o client.Object) []ctrl.Request {
+	mapObjectsToClusterDeployments := func(indexKey string) func(ctx context.Context, o client.Object) ([]ctrl.Request, error) {
+		return func(ctx context.Context, o client.Object) ([]ctrl.Request, error) {
 			clusterDeployments := new(kcmv1.ClusterDeploymentList)
 			if err := r.MgmtClient.List(ctx, clusterDeployments,
 				client.InNamespace(o.GetNamespace()),
 				client.MatchingFields{indexKey: o.GetName()}); err != nil {
-				return nil
+				return nil, fmt.Errorf("failed to list ClusterDeployments by %s: %w", indexKey, err)
 			}
 			req := make([]ctrl.Request, len(clusterDeployments.Items))
 			for i, cluster := range clusterDeployments.Items {
@@ -2266,7 +2265,7 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					},
 				}
 			}
-			return req
+			return req, nil
 		}
 	}
 
@@ -2292,30 +2291,32 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			},
 		})).
 		Watches(&helmcontrollerv2.HelmRelease{},
-			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
+			kubeutil.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) ([]ctrl.Request, error) {
 				clusterDeploymentRef := client.ObjectKeyFromObject(o)
 				if err := r.MgmtClient.Get(ctx, clusterDeploymentRef, &kcmv1.ClusterDeployment{}); err != nil {
-					return []ctrl.Request{}
+					if apierrors.IsNotFound(err) {
+						return nil, nil
+					}
+					return nil, fmt.Errorf("failed to get ClusterDeployment %s: %w", clusterDeploymentRef, err)
 				}
 
-				return []ctrl.Request{{NamespacedName: clusterDeploymentRef}}
+				return []ctrl.Request{{NamespacedName: clusterDeploymentRef}}, nil
 			}),
 		).
 		Watches(&kcmv1.ClusterTemplateChain{},
-			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
+			kubeutil.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) ([]ctrl.Request, error) {
 				chain, ok := o.(*kcmv1.ClusterTemplateChain)
 				if !ok {
-					return nil
+					return nil, nil
 				}
 
 				var req []ctrl.Request
 				for _, template := range getTemplateNamesManagedByChain(chain) {
 					clusterDeployments := &kcmv1.ClusterDeploymentList{}
-					err := r.MgmtClient.List(ctx, clusterDeployments,
+					if err := r.MgmtClient.List(ctx, clusterDeployments,
 						client.InNamespace(chain.Namespace),
-						client.MatchingFields{kcmv1.ClusterDeploymentTemplateIndexKey: template})
-					if err != nil {
-						return []ctrl.Request{}
+						client.MatchingFields{kcmv1.ClusterDeploymentTemplateIndexKey: template}); err != nil {
+						return nil, fmt.Errorf("failed to list ClusterDeployments by template %s: %w", template, err)
 					}
 					for _, cluster := range clusterDeployments.Items {
 						req = append(req, ctrl.Request{
@@ -2326,7 +2327,7 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						})
 					}
 				}
-				return req
+				return req, nil
 			}),
 			builder.WithPredicates(predicate.Funcs{
 				UpdateFunc:  func(event.UpdateEvent) bool { return false },
@@ -2334,10 +2335,10 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}),
 		).
 		Watches(&kcmv1.Credential{},
-			handler.EnqueueRequestsFromMapFunc(mapObjectsToClusterDeployments(kcmv1.ClusterDeploymentCredentialIndexKey)),
+			kubeutil.EnqueueRequestsFromMapFunc(mapObjectsToClusterDeployments(kcmv1.ClusterDeploymentCredentialIndexKey)),
 		).
 		Watches(&kcmv1.ClusterAuthentication{},
-			handler.EnqueueRequestsFromMapFunc(mapObjectsToClusterDeployments(kcmv1.ClusterDeploymentAuthenticationIndexKey)),
+			kubeutil.EnqueueRequestsFromMapFunc(mapObjectsToClusterDeployments(kcmv1.ClusterDeploymentAuthenticationIndexKey)),
 
 			// NOTE: on deletion of a ClusterAuthentication we should not delete auth-related helm values
 			builder.WithPredicates(predicate.Funcs{
@@ -2348,7 +2349,7 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}),
 		).
 		Watches(&kcmv1.ClusterAuditPolicy{},
-			handler.EnqueueRequestsFromMapFunc(mapObjectsToClusterDeployments(kcmv1.ClusterDeploymentAuditPolicyIndexKey)),
+			kubeutil.EnqueueRequestsFromMapFunc(mapObjectsToClusterDeployments(kcmv1.ClusterDeploymentAuditPolicyIndexKey)),
 
 			// NOTE: on deletion of a ClusterAuditPolicy we should not delete policy-related helm values
 			builder.WithPredicates(predicate.Funcs{
@@ -2358,10 +2359,10 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				CreateFunc:  func(event.TypedCreateEvent[client.Object]) bool { return true },
 			}),
 		).
-		Watches(&kcmv1.Region{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
+		Watches(&kcmv1.Region{}, kubeutil.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) ([]ctrl.Request, error) {
 			creds := new(kcmv1.CredentialList)
 			if err := r.MgmtClient.List(ctx, creds, client.MatchingFields{kcmv1.CredentialRegionIndexKey: o.GetName()}); err != nil {
-				return nil
+				return nil, fmt.Errorf("failed to list Credentials for Region %s: %w", o.GetName(), err)
 			}
 
 			reqs := []ctrl.Request{}
@@ -2370,14 +2371,14 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				if err := r.MgmtClient.List(ctx, clds,
 					client.MatchingFields{kcmv1.ClusterDeploymentCredentialIndexKey: cred.Name},
 					client.InNamespace(cred.Namespace)); err != nil {
-					continue
+					return nil, fmt.Errorf("failed to list ClusterDeployments for Credential %s/%s: %w", cred.Namespace, cred.Name, err)
 				}
 				for _, cld := range clds.Items {
 					reqs = append(reqs, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&cld)})
 				}
 			}
 
-			return reqs
+			return reqs, nil
 		}),
 			builder.WithPredicates(predicate.Funcs{
 				GenericFunc: func(event.TypedGenericEvent[client.Object]) bool { return false },

--- a/internal/controller/credential_controller.go
+++ b/internal/controller/credential_controller.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
@@ -214,10 +213,10 @@ func (r *CredentialReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			RateLimiter: ratelimitutil.DefaultFastSlow(),
 		}).
 		For(&kcmv1.Credential{}).
-		Watches(&kcmv1.Region{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
+		Watches(&kcmv1.Region{}, kubeutil.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) ([]ctrl.Request, error) {
 			creds := new(kcmv1.CredentialList)
 			if err := r.MgmtClient.List(ctx, creds, client.MatchingFields{kcmv1.CredentialRegionIndexKey: o.GetName()}); err != nil {
-				return nil
+				return nil, fmt.Errorf("failed to list Credentials for Region %s: %w", o.GetName(), err)
 			}
 
 			requests := make([]ctrl.Request, 0, len(creds.Items))
@@ -227,7 +226,7 @@ func (r *CredentialReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				})
 			}
 
-			return requests
+			return requests, nil
 		}), builder.WithPredicates(predicate.Funcs{
 			GenericFunc: func(event.TypedGenericEvent[client.Object]) bool { return false },
 			UpdateFunc: func(tue event.TypedUpdateEvent[client.Object]) bool {

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
@@ -41,6 +40,7 @@ import (
 	"github.com/K0rdent/kcm/internal/record"
 	"github.com/K0rdent/kcm/internal/serviceset"
 	conditionsutil "github.com/K0rdent/kcm/internal/util/conditions"
+	kubeutil "github.com/K0rdent/kcm/internal/util/kube"
 	labelsutil "github.com/K0rdent/kcm/internal/util/labels"
 	ratelimitutil "github.com/K0rdent/kcm/internal/util/ratelimit"
 	validationutil "github.com/K0rdent/kcm/internal/util/validation"
@@ -470,27 +470,30 @@ func (r *MultiClusterServiceReconciler) SetupWithManager(mgr ctrl.Manager) error
 		}).
 		For(&kcmv1.MultiClusterService{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&kcmv1.ServiceSet{},
-			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
+			kubeutil.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) ([]ctrl.Request, error) {
 				serviceSet, ok := o.(*kcmv1.ServiceSet)
 				if !ok {
-					return nil
+					return nil, nil
 				}
 				if serviceSet.Spec.MultiClusterService == "" {
-					return nil
+					return nil, nil
 				}
 				mcs := new(kcmv1.MultiClusterService)
 				if err := r.Client.Get(ctx, client.ObjectKey{Name: serviceSet.Spec.MultiClusterService}, mcs); err != nil {
-					return nil
+					if apierrors.IsNotFound(err) {
+						return nil, nil
+					}
+					return nil, fmt.Errorf("failed to get MultiClusterService %s: %w", serviceSet.Spec.MultiClusterService, err)
 				}
-				return []ctrl.Request{{NamespacedName: client.ObjectKeyFromObject(mcs)}}
+				return []ctrl.Request{{NamespacedName: client.ObjectKeyFromObject(mcs)}}, nil
 			}),
 		)
 
 	if r.IsDisabledValidationWH {
-		managedController.Watches(&kcmv1.ServiceTemplate{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []ctrl.Request {
+		managedController.Watches(&kcmv1.ServiceTemplate{}, kubeutil.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) ([]ctrl.Request, error) {
 			mcss := new(kcmv1.MultiClusterServiceList)
 			if err := mgr.GetClient().List(ctx, mcss, client.InNamespace(o.GetNamespace()), client.MatchingFields{kcmv1.MultiClusterServiceTemplatesIndexKey: o.GetName()}); err != nil {
-				return nil
+				return nil, fmt.Errorf("failed to list MultiClusterServices by ServiceTemplate %s: %w", o.GetName(), err)
 			}
 
 			resp := make([]ctrl.Request, 0, len(mcss.Items))
@@ -498,7 +501,7 @@ func (r *MultiClusterServiceReconciler) SetupWithManager(mgr ctrl.Manager) error
 				resp = append(resp, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&v)})
 			}
 
-			return resp
+			return resp, nil
 		}), builder.WithPredicates(predicate.Funcs{
 			GenericFunc: func(event.TypedGenericEvent[client.Object]) bool { return false },
 			DeleteFunc:  func(event.TypedDeleteEvent[client.Object]) bool { return false },

--- a/internal/util/kube/enqueue.go
+++ b/internal/util/kube/enqueue.go
@@ -1,0 +1,179 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+// MapFunc maps a watch source object to a set of reconcile requests. Unlike
+// the stock [sigs.k8s.io/controller-runtime/pkg/handler.MapFunc] it may report an error to signal that the mapping
+// itself failed (e.g. a transient API error while listing dependent objects).
+// The wrapping handler retries the call with a bounded exponential backoff
+// instead of silently dropping the event.
+//
+// Returning (nil, nil) is the canonical way to express "no work to enqueue,
+// not an error" (for example: the source object did not match an indexer or
+// failed a type assertion).
+type MapFunc[O client.Object] func(context.Context, O) ([]ctrl.Request, error)
+
+// DefaultBackoff is the bounded exponential backoff applied to [MapFunc] retries.
+// It caps the synchronous retry budget so a misbehaving dependency cannot
+// indefinitely block the informer dispatch goroutine.
+var DefaultBackoff = wait.Backoff{
+	Duration: 250 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.1,
+	Steps:    5,
+	Cap:      5 * time.Second,
+}
+
+// EnqueueRequestsFromMapFunc is a drop-in replacement for
+// [sigs.k8s.io/controller-runtime/pkg/handler.EnqueueRequestsFromMapFunc] that retries transient errors raised by
+// fn using [DefaultBackoff]. When the backoff is exhausted, the error is
+// logged at the dispatch context's logger and the event is dropped, matching
+// the prior best-effort semantics.
+func EnqueueRequestsFromMapFunc(fn MapFunc[client.Object]) handler.EventHandler {
+	return TypedEnqueueRequestsFromMapFunc(fn)
+}
+
+// TypedEnqueueRequestsFromMapFunc is the typed variant of
+// [EnqueueRequestsFromMapFunc] for use with typed sources (see
+// [sigs.k8s.io/controller-runtime/pkg/source.TypedKind]).
+func TypedEnqueueRequestsFromMapFunc[O client.Object](fn MapFunc[O]) handler.TypedEventHandler[O, ctrl.Request] {
+	return typedEnqueue(fn, DefaultBackoff)
+}
+
+func typedEnqueue[O client.Object](fn MapFunc[O], backoff wait.Backoff) handler.TypedEventHandler[O, ctrl.Request] {
+	run := func(ctx context.Context, obj O, q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+		reqs, err := callWithRetry(ctx, backoff, func() ([]ctrl.Request, error) {
+			return fn(ctx, obj)
+		})
+		if err != nil {
+			// normal shutdown signal
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
+
+			ctrl.LoggerFrom(ctx).
+				WithName("watch-mapper").
+				Error(err, "map function failed after retries; dropping watch event",
+					"object", client.ObjectKeyFromObject(obj),
+					"gvk", obj.GetObjectKind().GroupVersionKind())
+			return
+		}
+
+		for _, r := range reqs {
+			q.Add(r)
+		}
+	}
+
+	return handler.TypedFuncs[O, ctrl.Request]{
+		CreateFunc: func(ctx context.Context, e event.TypedCreateEvent[O], q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			run(ctx, e.Object, q)
+		},
+		UpdateFunc: func(ctx context.Context, e event.TypedUpdateEvent[O], q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			run(ctx, e.ObjectNew, q)
+		},
+		DeleteFunc: func(ctx context.Context, e event.TypedDeleteEvent[O], q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			run(ctx, e.Object, q)
+		},
+		GenericFunc: func(ctx context.Context, e event.TypedGenericEvent[O], q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
+			run(ctx, e.Object, q)
+		},
+	}
+}
+
+// callWithRetry invokes fn with the given bounded exponential backoff, retrying
+// while [isRetryable] reports true. When the server attaches a Retry-After
+// hint (see [k8s.io/apimachinery/pkg/api/errors.SuggestsClientDelay]), that delay overrides the
+// backoff step for the next attempt - never sleeping less than the backoff
+// would have, and capped by the backoff Cap to keep the dispatch goroutine
+// responsive. The context is honoured between attempts.
+func callWithRetry(ctx context.Context, backoff wait.Backoff, fn func() ([]ctrl.Request, error)) ([]ctrl.Request, error) {
+	var (
+		reqs []ctrl.Request
+		err  error
+	)
+	for {
+		reqs, err = fn()
+		if !isRetryable(err) {
+			return reqs, err
+		}
+		if backoff.Steps <= 1 {
+			return reqs, err
+		}
+
+		delay := backoff.Step()
+		if hint, ok := apierrors.SuggestsClientDelay(err); ok {
+			suggested := time.Duration(hint) * time.Second
+			if suggested > delay {
+				delay = suggested
+			}
+			if backoff.Cap > 0 && delay > backoff.Cap {
+				delay = backoff.Cap
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+// isRetryable reports whether err is worth retrying inside a [MapFunc]. We use
+// a deny-list: any error not classified as terminal is treated as transient
+// and retried. This matches what most Kubernetes controllers do (including
+// kubectl and the in-tree controllers) and avoids silently dropping events
+// when the apiserver invents a new error shape.
+//
+// Terminal categories:
+//   - context cancellation / deadline (callers will be redriven by the next watch event);
+//   - NotFound / Gone (the dependency does not exist, retrying cannot change that);
+//   - auth/RBAC failures (401, 403) - only a human can fix them;
+//   - client-side request bugs (400, 422, 405, 406, 415, 413) - retrying sends the same broken request.
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return false
+	case apierrors.IsNotFound(err), apierrors.IsGone(err):
+		return false
+	case apierrors.IsUnauthorized(err), apierrors.IsForbidden(err):
+		return false
+	case apierrors.IsBadRequest(err), apierrors.IsInvalid(err):
+		return false
+	case apierrors.IsMethodNotSupported(err),
+		apierrors.IsNotAcceptable(err),
+		apierrors.IsUnsupportedMediaType(err),
+		apierrors.IsRequestEntityTooLargeError(err):
+		return false
+	}
+	return true
+}

--- a/internal/util/kube/enqueue_test.go
+++ b/internal/util/kube/enqueue_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func Test_isRetryable(t *testing.T) {
+	t.Parallel()
+
+	gr := schema.GroupResource{Group: "", Resource: "pods"}
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"context canceled", context.Canceled, false},
+		{"context deadline", context.DeadlineExceeded, false},
+		{"wrapped context canceled", errors.Join(errors.New("x"), context.Canceled), false},
+		{"not found", apierrors.NewNotFound(gr, "p"), false},
+		{"gone", &apierrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusGone, Reason: metav1.StatusReasonGone}}, false},
+		{"unauthorized", apierrors.NewUnauthorized("u"), false},
+		{"forbidden", apierrors.NewForbidden(gr, "p", errors.New("nope")), false},
+		{"bad request", apierrors.NewBadRequest("br"), false},
+		{"invalid", apierrors.NewInvalid(schema.GroupKind{Kind: "Pod"}, "p", nil), false},
+		{"method not supported", apierrors.NewMethodNotSupported(gr, "GET"), false},
+		{"request entity too large", apierrors.NewRequestEntityTooLargeError("big"), false},
+		{"timeout", apierrors.NewTimeoutError("t", 1), true},
+		{"server timeout", apierrors.NewServerTimeout(gr, "list", 1), true},
+		{"too many requests", apierrors.NewTooManyRequestsError("rl"), true},
+		{"service unavailable", apierrors.NewServiceUnavailable("u"), true},
+		{"internal error", apierrors.NewInternalError(errors.New("boom")), true},
+		{"plain", errors.New("plain"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isRetryable(tc.err); got != tc.want {
+				t.Fatalf("isRetryable(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_callWithRetry(t *testing.T) {
+	t.Parallel()
+
+	var (
+		terminal  = apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "p")
+		transient = apierrors.NewServiceUnavailable("temp")
+		okReqs    = []ctrl.Request{{}}
+	)
+
+	cases := []struct {
+		name        string
+		backoff     wait.Backoff
+		ctx         func(t *testing.T) context.Context
+		fn          func(call int) ([]ctrl.Request, error)
+		wantCalls   int
+		wantErrIs   error
+		wantReqsLen int
+	}{
+		{
+			name:      "terminal short-circuits",
+			backoff:   fastBackoff(t, 5),
+			fn:        func(int) ([]ctrl.Request, error) { return nil, terminal },
+			wantCalls: 1,
+			wantErrIs: terminal,
+		},
+		{
+			name:    "retries transient until success",
+			backoff: fastBackoff(t, 5),
+			fn: func(call int) ([]ctrl.Request, error) {
+				if call < 3 {
+					return nil, transient
+				}
+				return okReqs, nil
+			},
+			wantCalls:   3,
+			wantReqsLen: len(okReqs),
+		},
+		{
+			name:      "exhausted steps returns last error",
+			backoff:   fastBackoff(t, 3),
+			fn:        func(int) ([]ctrl.Request, error) { return nil, transient },
+			wantCalls: 3,
+			wantErrIs: transient,
+		},
+		{
+			name: "pre-cancelled context stops after first attempt",
+			// large base so ctx.Done wins the select deterministically; a
+			// short delay would race with time.After since both channels are
+			// ready and select picks at random
+			backoff: wait.Backoff{Duration: time.Hour, Factor: 1, Steps: 5, Cap: time.Hour},
+			ctx: func(t *testing.T) context.Context {
+				t.Helper()
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			fn:        func(int) ([]ctrl.Request, error) { return nil, transient },
+			wantCalls: 1,
+			wantErrIs: context.Canceled,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			if tc.ctx != nil {
+				ctx = tc.ctx(t)
+			}
+
+			calls := 0
+			reqs, err := callWithRetry(ctx, tc.backoff, func() ([]ctrl.Request, error) {
+				calls++
+				return tc.fn(calls)
+			})
+
+			if calls != tc.wantCalls {
+				t.Fatalf("calls = %d, want %d", calls, tc.wantCalls)
+			}
+
+			if tc.wantErrIs == nil {
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+			} else if !errors.Is(err, tc.wantErrIs) {
+				t.Fatalf("err = %v, want errors.Is(%v)", err, tc.wantErrIs)
+			}
+
+			if len(reqs) != tc.wantReqsLen {
+				t.Fatalf("len(reqs) = %d, want %d", len(reqs), tc.wantReqsLen)
+			}
+		})
+	}
+
+	t.Run("honors retry-after", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			// 429 carrying a 3s Retry-After hint; the backoff base is 1ns so the
+			// hint must dominate the sleep
+			rateLimited := &apierrors.StatusError{ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    http.StatusTooManyRequests,
+				Reason:  metav1.StatusReasonTooManyRequests,
+				Message: "slow down",
+				Details: &metav1.StatusDetails{RetryAfterSeconds: 3},
+			}}
+			backoff := wait.Backoff{Duration: time.Nanosecond, Factor: 1, Steps: 2, Cap: 10 * time.Second}
+
+			calls := 0
+			start := time.Now()
+			_, err := callWithRetry(t.Context(), backoff, func() ([]ctrl.Request, error) {
+				calls++
+				return nil, rateLimited
+			})
+			elapsed := time.Since(start)
+
+			if !errors.Is(err, rateLimited) {
+				t.Fatalf("err = %v, want errors.Is(rateLimited)", err)
+			}
+
+			if calls != 2 {
+				t.Fatalf("calls = %d, want 2", calls)
+			}
+
+			if want := 3 * time.Second; elapsed != want {
+				t.Fatalf("elapsed = %s, want exactly %s (Retry-After hint must dominate)", elapsed, want)
+			}
+		})
+	})
+}
+
+func fastBackoff(t *testing.T, steps int) wait.Backoff {
+	t.Helper()
+	return wait.Backoff{Duration: time.Nanosecond, Factor: 1, Steps: steps, Cap: time.Millisecond}
+}

--- a/internal/util/pullsecret/pullsecret.go
+++ b/internal/util/pullsecret/pullsecret.go
@@ -24,25 +24,29 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type DockerConfigFile struct {
-	AuthConfigs map[string]DockerAuthConfig `json:"auths"`
-}
+type (
+	dockerConfigFile struct {
+		AuthConfigs map[string]dockerAuthConfig `json:"auths"`
+	}
 
-type DockerAuthConfig struct {
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Auth     string `json:"auth,omitempty"`
+	dockerAuthConfig struct {
+		Username string `json:"username,omitempty"`
+		Password string `json:"password,omitempty"`
+		Auth     string `json:"auth,omitempty"`
 
-	ServerAddress string `json:"serveraddress,omitempty"`
+		ServerAddress string `json:"serveraddress,omitempty"`
 
-	// IdentityToken is used to authenticate the user and get
-	// an access token for the registry.
-	IdentityToken string `json:"identitytoken,omitempty"`
+		// IdentityToken is used to authenticate the user and get
+		// an access token for the registry.
+		IdentityToken string `json:"identitytoken,omitempty"`
 
-	// RegistryToken is a bearer token to be sent to a registry
-	RegistryToken string `json:"registrytoken,omitempty"`
-}
+		// RegistryToken is a bearer token to be sent to a registry
+		RegistryToken string `json:"registrytoken,omitempty"`
+	}
+)
 
+// GetRegistryCredsFromPullSecret extracts registry credentials from a Docker config JSON pull secret
+// for the provided registry reference.
 func GetRegistryCredsFromPullSecret(secret *corev1.Secret, registry string) (username, password string, err error) {
 	if secret.Type != "kubernetes.io/dockerconfigjson" {
 		return "", "",
@@ -56,7 +60,7 @@ func GetRegistryCredsFromPullSecret(secret *corev1.Secret, registry string) (use
 			errors.New("unable to get .dockerconfigjson from imagePullSecret data")
 	}
 
-	var config DockerConfigFile
+	var config dockerConfigFile
 	if err := json.Unmarshal(configstr, &config); err != nil {
 		return "", "",
 			fmt.Errorf("failed to unmarshal dockerconfig: %w", err)
@@ -64,7 +68,7 @@ func GetRegistryCredsFromPullSecret(secret *corev1.Secret, registry string) (use
 
 	auths := config.AuthConfigs
 
-	registryHost := strings.Split(registry, "/")[0]
+	registryHost, _, _ := strings.Cut(registry, "/")
 
 	authConfig, ok := auths[registryHost]
 	if !ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces a wrapper that retries the mapper with bounded exponential backoff and only bails on terminal errors. All MapFunc-based watchers that hit the API are migrated to the new helper.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #582