### PR TITLE
fix: always requeue cld controller on hr update

### DIFF
--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -570,6 +570,13 @@ func (r *ClusterDeploymentReconciler) reconcileHelmRelease(
 		r.eventf(cd, "HelmReleaseUpdated", "Successfully updated HelmRelease %s/%s", cd.Namespace, cd.Name)
 	}
 
+	// When the HelmRelease was just created or updated, always requeue to ensure subsequent reconciles catch
+	// the CAPI cluster state changes.
+	if operation == controllerutil.OperationResultCreated ||
+		operation == controllerutil.OperationResultUpdated {
+		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, err
+	}
+
 	hrReadyCondition := fluxconditions.Get(hr, fluxmeta.ReadyCondition)
 	if hrReadyCondition != nil {
 		if apimeta.SetStatusCondition(cd.GetConditions(), metav1.Condition{


### PR DESCRIPTION
**What this PR does / why we need it**:
When the HelmRelease was just created or updated, we need to requeue to ensure subsequent reconciles catch the CAPI cluster state changes that will inevitably follow from the helm chart update.
Without it, the controller can check CAPI Cluster readiness before the HelmRelease update takes effect, causing the ClusterDeployment to remain Ready temporarily while the CAPI Cluster transitions to NotReady.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Was found while trying to reproduce #2788 (not a fix for #2788)
