### PR TITLE
test(e2e): fail fast on stuck cluster deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ tidy: ## Run go mod tidy.
 
 .PHONY: test
 test: generate-all envtest tidy external-crd ## Run unit and env tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v '/e2e$$') -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling
 # compatibility with other vendors.

--- a/test/e2e/clusterdeployment/providervalidator.go
+++ b/test/e2e/clusterdeployment/providervalidator.go
@@ -16,32 +16,46 @@ package clusterdeployment
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 
 	"github.com/K0rdent/kcm/test/e2e/config"
 	"github.com/K0rdent/kcm/test/e2e/kubeclient"
 	"github.com/K0rdent/kcm/test/e2e/templates"
 )
 
+// deletionStuckGrace bounds how long a deletion validator may keep returning
+// [ErrClusterNotDeleting] before the surrounding Eventually is aborted via
+// [gomega.StopTrying].
+const deletionStuckGrace = 60 * time.Second
+
 // ProviderValidator is a struct that contains the necessary information to
 // validate a provider's resources.  Some providers do not support all of the
 // resources that can potentially be validated.
 type ProviderValidator struct {
-	// Template is the type of the template being validated.
-	templateType templates.Type
-	// ClusterName is the name of the cluster to validate.
-	clusterName string
-	// ResourcesToValidate is a map of resource names to their validation
-	// function.
-	resourcesToValidate map[string]resourceValidationFunc
-	// ResourceOrder is a slice of resource names that determines the order in
-	// which resources are validated.
-	resourceOrder []string
+	// stuckSince is the first time [ErrClusterNotDeleting] was observed in the
+	// current run; zero means the timer is not armed. Only used for delete
+	// validations
+	stuckSince time.Time
+	// now is overridable so tests can advance time without sleeping
+	now func() time.Time
 
+	// resourcesToValidate is a map of resource names to their validation
+	// function
+	resourcesToValidate map[string]resourceValidationFunc
+	// templateType is the type of the template being validated
+	templateType templates.Type
+	// clusterName is the name of the cluster to validate
+	clusterName string
 	// arch denotes the type of architecture a cluster to be validated has
 	arch config.Architecture
+	// resourceOrder is a slice of resource names that determines the order in
+	// which resources are validated
+	resourceOrder []string
 }
 
 type ValidationAction string
@@ -68,6 +82,7 @@ func NewProviderValidator(templateType templates.Type, clusterName string, actio
 	validator := &ProviderValidator{
 		clusterName:  clusterName,
 		templateType: templateType,
+		now:          time.Now,
 	}
 	for _, o := range opts {
 		o(validator)
@@ -220,12 +235,35 @@ func (p *ProviderValidator) Validate(ctx context.Context, kc *kubeclient.KubeCli
 
 		if err := validator(ctx, kc, p.clusterName); err != nil {
 			_, _ = fmt.Fprintf(GinkgoWriter, "[%s/%s] validation error: %v\n", p.templateType, name, err)
-			return err
+			return p.failFastIfStuck(err)
 		}
 
 		_, _ = fmt.Fprintf(GinkgoWriter, "[%s/%s] validation succeeded\n", p.templateType, name)
 		delete(p.resourcesToValidate, name)
 	}
 
+	p.stuckSince = time.Time{}
 	return nil
+}
+
+// failFastIfStuck arms a grace timer the first time [ErrClusterNotDeleting] is
+// seen and, once [deletionStuckGrace] has elapsed continuously, converts the
+// error into a terminal [github.com/onsi/gomega.StopTrying] so Eventually aborts immediately.
+// Any other error is returned unchanged.
+func (p *ProviderValidator) failFastIfStuck(err error) error {
+	if !errors.Is(err, ErrClusterNotDeleting) {
+		p.stuckSince = time.Time{}
+		return err
+	}
+
+	if p.stuckSince.IsZero() {
+		p.stuckSince = p.now()
+		return err
+	}
+
+	if elapsed := p.now().Sub(p.stuckSince); elapsed >= deletionStuckGrace {
+		return gomega.StopTrying(fmt.Sprintf("cluster stuck not-Deleting for %s", elapsed.Round(time.Second))).Wrap(err)
+	}
+
+	return err
 }

--- a/test/e2e/clusterdeployment/providervalidator_test.go
+++ b/test/e2e/clusterdeployment/providervalidator_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterdeployment
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+)
+
+func Test_failFastIfStuck(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(0, 0)
+	validator := &ProviderValidator{now: func() time.Time { return now }}
+
+	other := errors.New("transient")
+	if got := validator.failFastIfStuck(other); got != other {
+		t.Fatalf("unrelated error must pass through; got %v", got)
+	}
+	if !validator.stuckSince.IsZero() {
+		t.Fatal("unrelated error must not arm the timer")
+	}
+
+	stuck := fmt.Errorf("wrap: %w", ErrClusterNotDeleting)
+	if got := validator.failFastIfStuck(stuck); got != stuck {
+		t.Fatalf("first hit must return original; got %v", got)
+	}
+
+	now = now.Add(deletionStuckGrace - time.Second)
+	if got := validator.failFastIfStuck(stuck); got != stuck {
+		t.Fatalf("within grace must return original; got %v", got)
+	}
+
+	now = now.Add(time.Second)
+	got := validator.failFastIfStuck(stuck)
+	if _, ok := errors.AsType[gomega.PollingSignalError](got); !ok {
+		t.Fatalf("at threshold must return StopTrying; got %T: %v", got, got)
+	}
+	if !errors.Is(got, ErrClusterNotDeleting) {
+		t.Fatalf("StopTrying must wrap the sentinel; got %v", got)
+	}
+}

--- a/test/e2e/clusterdeployment/validate_deleted.go
+++ b/test/e2e/clusterdeployment/validate_deleted.go
@@ -64,6 +64,12 @@ func validateClusterReachable(cfg *rest.Config) error {
 	return nil
 }
 
+// ErrClusterNotDeleting is returned by [validateClusterDeleted] when the
+// Cluster still exists but is not yet in the Deleting phase. Exposed as a
+// sentinel so [ProviderValidator.Validate] can fail fast once the cluster
+// has been stuck in this state for longer than [deletionStuckGrace].
+var ErrClusterNotDeleting = errors.New("cluster is not in 'Deleting' phase")
+
 // validateClusterDeleted validates that the Cluster resource has been deleted.
 func validateClusterDeleted(ctx context.Context, kc *kubeclient.KubeClient, clusterName string) error {
 	// Validate that the Cluster resource has been deleted
@@ -76,11 +82,7 @@ func validateClusterDeleted(ctx context.Context, kc *kubeclient.KubeClient, clus
 	if cluster != nil {
 		phase, _, _ := unstructured.NestedString(cluster.Object, "status", "phase")
 		if phase != "Deleting" {
-			// TODO(#474): We should have a threshold error system for situations
-			// like this, we probably don't want to wait the full Eventually
-			// for something like this, but we can't immediately fail the test
-			// either.
-			return fmt.Errorf("cluster: %q exists, but is not in 'Deleting' phase", clusterName)
+			return fmt.Errorf("cluster %q exists in phase %q: %w", clusterName, phase, ErrClusterNotDeleting)
 		}
 
 		conditions, err := statusutil.ConditionsFromUnstructured(cluster)


### PR DESCRIPTION
**What this PR does / why we need it**:
Abort the deletion Eventually once the Cluster has stayed out of the Deleting phase for longer than a short grace period, instead of burning the full timeout.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #474 