### PR TITLE
fix: limit ClusterDeployment name to 22 characters for cloud compatibility

### DIFF
--- a/api/v1beta1/clusterdeployment_types.go
+++ b/api/v1beta1/clusterdeployment_types.go
@@ -185,7 +185,9 @@ type ClusterDeploymentStatus struct {
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Time elapsed since object creation",priority=0
 // +kubebuilder:printcolumn:name="DryRun",type="string",JSONPath=`.spec.dryRun`,description="Dry Run",priority=1
 
-// ClusterDeployment is the Schema for the ClusterDeployments API
+// ClusterDeployment is the Schema for the ClusterDeployments API.
+// Note: The name of the ClusterDeployment is limited to 22 characters to ensure compatibility
+// with cloud providers (e.g., AWS and Azure) that use the cluster name as a prefix for other resources.
 type ClusterDeployment struct { //nolint:govet // false-positive
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/internal/util/validation/cd.go
+++ b/internal/util/validation/cd.go
@@ -28,6 +28,18 @@ import (
 	schemeutil "github.com/K0rdent/kcm/internal/util/scheme"
 )
 
+const MaxClusterDeploymentNameLength = 22
+
+// ValidateClusterDeploymentName validates the length of the ClusterDeployment name.
+// Cloud providers like AWS and Azure have limits on resource names (e.g., Load Balancers)
+// that often include the cluster name as a prefix.
+func ValidateClusterDeploymentName(name string) error {
+	if len(name) > MaxClusterDeploymentNameLength {
+		return fmt.Errorf("ClusterDeployment name %q is too long: maximum allowed length is %d characters", name, MaxClusterDeploymentNameLength)
+	}
+	return nil
+}
+
 // ClusterDeployCredential validates a [github.com/K0rdent/kcm/api/v1beta1.Credential] object referred
 // in the given [github.com/K0rdent/kcm/api/v1beta1.ClusterDeployment] is ready and
 // supported by the given [github.com/K0rdent/kcm/api/v1beta1.ClusterTemplate].

--- a/internal/webhook/clusterdeployment_webhook.go
+++ b/internal/webhook/clusterdeployment_webhook.go
@@ -56,6 +56,10 @@ var (
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (v *ClusterDeploymentValidator) ValidateCreate(ctx context.Context, clusterDeployment *kcmv1.ClusterDeployment) (admission.Warnings, error) {
+	if err := validationutil.ValidateClusterDeploymentName(clusterDeployment.Name); err != nil {
+		return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)
+	}
+
 	template, err := v.getClusterDeploymentTemplate(ctx, clusterDeployment.Namespace, clusterDeployment.Spec.Template)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", invalidClusterDeploymentMsg, err)

--- a/internal/webhook/clusterdeployment_webhook_test.go
+++ b/internal/webhook/clusterdeployment_webhook_test.go
@@ -114,6 +114,13 @@ func TestClusterDeploymentValidateCreate(t *testing.T) {
 		warnings          admission.Warnings
 	}{
 		{
+			name: "should fail if the name is too long",
+			ClusterDeployment: clusterdeployment.NewClusterDeployment(
+				clusterdeployment.WithName("this-name-is-longer-than-22-chars"),
+			),
+			err: "the ClusterDeployment is invalid: ClusterDeployment name \"this-name-is-longer-than-22-chars\" is too long: maximum allowed length is 22 characters",
+		},
+		{
 			name:              "should fail if the template is unset",
 			ClusterDeployment: clusterdeployment.NewClusterDeployment(),
 			err:               "the ClusterDeployment is invalid: clustertemplates.k0rdent.mirantis.com \"\" not found",

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
@@ -47,7 +47,10 @@ spec:
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description: ClusterDeployment is the Schema for the ClusterDeployments API
+          description: |-
+            ClusterDeployment is the Schema for the ClusterDeployments API.
+            Note: The name of the ClusterDeployment is limited to 22 characters to ensure compatibility
+            with cloud providers (e.g., AWS and Azure) that use the cluster name as a prefix for other resources.
           properties:
             apiVersion:
               description: |-


### PR DESCRIPTION
 This PR adds a validation check to the ClusterDeployment admission webhook to limit the name length to 22 characters. This prevents provisioning failures in cloud providers like AWS and Azure, where the cluster name is used as a prefix for resources (e.g., Load Balancers) that have strict naming limits.
