### PR TITLE
chore: migrate to k0smotron v2.0.2

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-36
+  template: aws-standalone-cp-1-0-37
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-38
+  template: azure-standalone-cp-1-0-39
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/docker-clusterdeployment.yaml
+++ b/config/dev/docker-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: docker-hosted-cp-1-0-13
+  template: docker-hosted-cp-1-0-14
   credential: docker-stub-credential
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-34
+  template: gcp-standalone-cp-1-0-35
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-14
+  template: kubevirt-standalone-cp-1-0-15
   credential: kubevirt-cred
   propagateCredentials: false
   config:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-39
+  template: openstack-standalone-cp-1-0-40
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-31
+  template: remote-cluster-1-0-32
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-35
+  template: vsphere-standalone-cp-1-0-36
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -1927,6 +1927,9 @@ func (*ClusterDeploymentReconciler) getProviderCluster(ctx context.Context, rgnC
 		itemsList := &metav1.PartialObjectMetadataList{}
 		itemsList.SetGroupVersionKind(gvk)
 		if err := rgnClient.List(ctx, itemsList, client.InNamespace(namespace), client.MatchingLabels{kcmv1.FluxHelmChartNameKey: name}); err != nil {
+			if apimeta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+				continue
+			}
 			return nil, fmt.Errorf("failed to list %s in namespace %s: %w", gvk.Kind, namespace, err)
 		}
 

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.39
+version: 1.0.40
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -15,6 +15,6 @@ version: 1.0.39
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0smotronControlPlane
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
@@ -13,17 +13,6 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
-  {{- end }}
-  {{- if not .Values.dataSource.kineDataSourceSecretName }}
-  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
-  etcd:
-    {{- if $global.registry }}
-    image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
-    {{- end }}
-    {{- if .Values.storage.etcd.autoDeletePVCs }}
-    autoDeletePVCs: true
-    {{- end }}
-  {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:
@@ -73,8 +62,21 @@ spec:
         name: {{ .Values.audit.policyRef.name  | quote }}
     {{- end }}
   {{- end }}
-  {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+  {{- if or .Values.dataSource.kineDataSourceSecretName $global.registry .Values.storage.etcd.autoDeletePVCs }}
+  storage:
+    {{- if .Values.dataSource.kineDataSourceSecretName }}
+    type: kine
+    kine:
+      dataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+    {{- else }}
+    etcd:
+      {{- if $global.registry }}
+      image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+      {{- end }}
+      {{- if .Values.storage.etcd.autoDeletePVCs }}
+      autoDeletePVCs: true
+      {{- end }}
+    {{- end }}
   {{- end }}
   manifests:
     - name: manifests
@@ -88,10 +90,10 @@ spec:
           - key: registryCredential
             path: helm-registry-credentials.yaml
     {{- end }}
-  controllerPlaneFlags:
+  controlPlaneFlags:
     - --enable-cloud-provider=true
     - --debug=true
-    {{- range $arg := .Values.k0smotron.controllerPlaneFlags }}
+    {{- range $arg := .Values.k0smotron.controlPlaneFlags }}
     - {{ toYaml $arg }}
     {{- end }}
   k0sConfig:

--- a/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}
@@ -32,7 +32,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      preStartCommands:
+      preK0sCommands:
       - "sudo update-ca-certificates"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}

--- a/templates/cluster/aws-hosted-cp/values.schema.json
+++ b/templates/cluster/aws-hosted-cp/values.schema.json
@@ -320,7 +320,7 @@
       "type": "object",
       "properties": {
         "controlPlaneFlags": {
-          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,
           "items": {

--- a/templates/cluster/aws-hosted-cp/values.schema.json
+++ b/templates/cluster/aws-hosted-cp/values.schema.json
@@ -319,7 +319,7 @@
       "description": "K0smotron parameters",
       "type": "object",
       "properties": {
-        "controllerPlaneFlags": {
+        "controlPlaneFlags": {
           "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -73,7 +73,7 @@ nonRootVolumes: [] # @schema title: Non-root storage volumes; description: Confi
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -73,7 +73,7 @@ nonRootVolumes: [] # @schema title: Non-root storage volumes; description: Confi
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.36
+version: 1.0.37
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -14,6 +14,6 @@ version: 1.0.36
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0sControlPlane
 metadata:
   name: {{ include "k0scontrolplane.name" . }}

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -33,7 +33,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      preStartCommands:
+      preK0sCommands:
       - "sudo update-ca-certificates"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,6 +1,6 @@
 {{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.42
+version: 1.0.43
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -15,6 +15,6 @@ version: 1.0.42
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-azure: v1beta1

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0smotronControlPlane
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
@@ -12,17 +12,6 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
-  {{- end }}
-  {{- if not .Values.dataSource.kineDataSourceSecretName }}
-  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
-  etcd:
-    {{- if $global.registry }}
-    image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
-    {{- end }}
-    {{- if .Values.storage.etcd.autoDeletePVCs }}
-    autoDeletePVCs: true
-    {{- end }}
-  {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:
@@ -72,8 +61,21 @@ spec:
         name: {{ .Values.audit.policyRef.name  | quote }}
     {{- end }}
   {{- end }}
-  {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+  {{- if or .Values.dataSource.kineDataSourceSecretName $global.registry .Values.storage.etcd.autoDeletePVCs }}
+  storage:
+    {{- if .Values.dataSource.kineDataSourceSecretName }}
+    type: kine
+    kine:
+      dataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+    {{- else }}
+    etcd:
+      {{- if $global.registry }}
+      image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+      {{- end }}
+      {{- if .Values.storage.etcd.autoDeletePVCs }}
+      autoDeletePVCs: true
+      {{- end }}
+    {{- end }}
   {{- end }}
   manifests:
     - name: manifests
@@ -87,10 +89,10 @@ spec:
           - key: registryCredential
             path: helm-registry-credentials.yaml
     {{- end }}
-  controllerPlaneFlags:
+  controlPlaneFlags:
     - --enable-cloud-provider=true
     - --debug=true
-    {{- range $arg := .Values.k0smotron.controllerPlaneFlags }}
+    {{- range $arg := .Values.k0smotron.controlPlaneFlags }}
     - {{ toYaml $arg }}
     {{- end }}
   k0sConfig:

--- a/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}
@@ -32,7 +32,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      preStartCommands:
+      preK0sCommands:
       - "sudo update-ca-certificates"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}

--- a/templates/cluster/azure-hosted-cp/values.schema.json
+++ b/templates/cluster/azure-hosted-cp/values.schema.json
@@ -277,7 +277,7 @@
       "type": "object",
       "properties": {
         "controlPlaneFlags": {
-          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,
           "items": {

--- a/templates/cluster/azure-hosted-cp/values.schema.json
+++ b/templates/cluster/azure-hosted-cp/values.schema.json
@@ -276,7 +276,7 @@
       "description": "K0smotron parameters",
       "type": "object",
       "properties": {
-        "controllerPlaneFlags": {
+        "controlPlaneFlags": {
           "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -71,7 +71,7 @@ image:
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -71,7 +71,7 @@ image:
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.38
+version: 1.0.39
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -14,6 +14,6 @@ version: 1.0.38
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-azure: v1beta1

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0sControlPlane
 metadata:
   name: {{ include "k0scontrolplane.name" . }}

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -33,7 +33,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      preStartCommands:
+      preK0sCommands:
       - "sudo update-ca-certificates"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,6 +1,6 @@
 {{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -14,6 +14,6 @@ version: 1.0.13
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-docker, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-docker: v1beta2

--- a/templates/cluster/docker-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/docker-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0smotronControlPlane
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
@@ -49,6 +49,6 @@ spec:
           audit-policy-file: {{ include "audit-policy.fullpath" . }}
           audit-log-path: "-"
           {{- end }}
-  {{- with .Values.k0smotron.controllerPlaneFlags }}
-  controllerPlaneFlags: {{ toYaml . | nindent 4 }}
+  {{- with .Values.k0smotron.controlPlaneFlags }}
+  controlPlaneFlags: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/templates/cluster/docker-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/docker-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}

--- a/templates/cluster/docker-hosted-cp/values.schema.json
+++ b/templates/cluster/docker-hosted-cp/values.schema.json
@@ -114,7 +114,7 @@
       "type": "object",
       "properties": {
         "controlPlaneFlags": {
-          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,
           "items": {

--- a/templates/cluster/docker-hosted-cp/values.schema.json
+++ b/templates/cluster/docker-hosted-cp/values.schema.json
@@ -113,7 +113,7 @@
       "description": "K0smotron parameters",
       "type": "object",
       "properties": {
-        "controllerPlaneFlags": {
+        "controlPlaneFlags": {
           "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,

--- a/templates/cluster/docker-hosted-cp/values.yaml
+++ b/templates/cluster/docker-hosted-cp/values.yaml
@@ -27,7 +27,7 @@ clusterNetwork:
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: NodePort # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: NodePort
 

--- a/templates/cluster/docker-hosted-cp/values.yaml
+++ b/templates/cluster/docker-hosted-cp/values.yaml
@@ -27,7 +27,7 @@ clusterNetwork:
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: NodePort # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: NodePort
 

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.37
+version: 1.0.38
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -15,6 +15,6 @@ version: 1.0.37
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0smotronControlPlane
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
@@ -12,17 +12,6 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
-  {{- end }}
-  {{- if not .Values.dataSource.kineDataSourceSecretName }}
-  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
-  etcd:
-    {{- if $global.registry }}
-    image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
-    {{- end }}
-    {{- if .Values.storage.etcd.autoDeletePVCs }}
-    autoDeletePVCs: true
-    {{- end }}
-  {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:
@@ -72,8 +61,21 @@ spec:
         name: {{ .Values.audit.policyRef.name  | quote }}
     {{- end }}
   {{- end }}
-  {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+  {{- if or .Values.dataSource.kineDataSourceSecretName $global.registry .Values.storage.etcd.autoDeletePVCs }}
+  storage:
+    {{- if .Values.dataSource.kineDataSourceSecretName }}
+    type: kine
+    kine:
+      dataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+    {{- else }}
+    etcd:
+      {{- if $global.registry }}
+      image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+      {{- end }}
+      {{- if .Values.storage.etcd.autoDeletePVCs }}
+      autoDeletePVCs: true
+      {{- end }}
+    {{- end }}
   {{- end }}
   manifests:
     - name: manifests
@@ -87,10 +89,10 @@ spec:
           - key: registryCredential
             path: helm-registry-credentials.yaml
     {{- end }}
-  controllerPlaneFlags:
+  controlPlaneFlags:
     - --enable-cloud-provider=true
     - --debug=true
-    {{- range $arg := .Values.k0smotron.controllerPlaneFlags }}
+    {{- range $arg := .Values.k0smotron.controlPlaneFlags }}
     - {{ toYaml $arg }}
     {{- end }}
   k0sConfig:

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}
@@ -32,7 +32,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      preStartCommands:
+      preK0sCommands:
       - "sudo update-ca-certificates"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}

--- a/templates/cluster/gcp-hosted-cp/values.schema.json
+++ b/templates/cluster/gcp-hosted-cp/values.schema.json
@@ -258,7 +258,7 @@
       "type": "object",
       "properties": {
         "controlPlaneFlags": {
-          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,
           "items": {

--- a/templates/cluster/gcp-hosted-cp/values.schema.json
+++ b/templates/cluster/gcp-hosted-cp/values.schema.json
@@ -257,7 +257,7 @@
       "description": "K0smotron parameters",
       "type": "object",
       "properties": {
-        "controllerPlaneFlags": {
+        "controlPlaneFlags": {
           "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -72,7 +72,7 @@ worker: # @schema description: Worker parameters; type: object
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -72,7 +72,7 @@ worker: # @schema description: Worker parameters; type: object
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.34
+version: 1.0.35
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -14,6 +14,6 @@ version: 1.0.34
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-gcp: v1beta1

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0sControlPlane
 metadata:
   name: {{ include "k0scontrolplane.name" . }}

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -33,7 +33,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      preStartCommands:
+      preK0sCommands:
       - "sudo update-ca-certificates"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,6 +1,6 @@
 {{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -15,6 +15,6 @@ version: 1.0.13
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-kubevirt, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-kubevirt: v1alpha1

--- a/templates/cluster/kubevirt-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0smotronControlPlane
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
@@ -12,17 +12,6 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
-  {{- end }}
-  {{- if not .Values.dataSource.kineDataSourceSecretName }}
-  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
-  etcd:
-    {{- if $global.registry }}
-    image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
-    {{- end }}
-    {{- if .Values.storage.etcd.autoDeletePVCs }}
-    autoDeletePVCs: true
-    {{- end }}
-  {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:
@@ -72,12 +61,25 @@ spec:
         name: {{ .Values.audit.policyRef.name  | quote }}
     {{- end }}
   {{- end }}
-  {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+  {{- if or .Values.dataSource.kineDataSourceSecretName $global.registry .Values.storage.etcd.autoDeletePVCs }}
+  storage:
+    {{- if .Values.dataSource.kineDataSourceSecretName }}
+    type: kine
+    kine:
+      dataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+    {{- else }}
+    etcd:
+      {{- if $global.registry }}
+      image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+      {{- end }}
+      {{- if .Values.storage.etcd.autoDeletePVCs }}
+      autoDeletePVCs: true
+      {{- end }}
+    {{- end }}
   {{- end }}
-  controllerPlaneFlags:
+  controlPlaneFlags:
     - --debug=true
-    {{- range $arg := .Values.k0smotron.controllerPlaneFlags }}
+    {{- range $arg := .Values.k0smotron.controlPlaneFlags }}
     - {{ toYaml $arg }}
     {{- end }}
   k0sConfig:

--- a/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}
@@ -32,7 +32,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      preStartCommands:
+      preK0sCommands:
       - "sudo update-ca-certificates"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}

--- a/templates/cluster/kubevirt-hosted-cp/values.schema.json
+++ b/templates/cluster/kubevirt-hosted-cp/values.schema.json
@@ -342,7 +342,7 @@
       "type": "object",
       "properties": {
         "controlPlaneFlags": {
-          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,
           "items": {

--- a/templates/cluster/kubevirt-hosted-cp/values.schema.json
+++ b/templates/cluster/kubevirt-hosted-cp/values.schema.json
@@ -341,7 +341,7 @@
       "description": "K0smotron parameters",
       "type": "object",
       "properties": {
-        "controllerPlaneFlags": {
+        "controlPlaneFlags": {
           "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,

--- a/templates/cluster/kubevirt-hosted-cp/values.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/values.yaml
@@ -87,7 +87,7 @@ worker: # @schema description: Worker parameters; type: object
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/kubevirt-hosted-cp/values.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/values.yaml
@@ -87,7 +87,7 @@ worker: # @schema description: Worker parameters; type: object
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -14,6 +14,6 @@ version: 1.0.14
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-kubevirt, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-kubevirt: v1alpha1

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0sControlPlane
 metadata:
   name: {{ include "k0scontrolplane.name" . }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -33,7 +33,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      preStartCommands:
+      preK0sCommands:
       - "sudo update-ca-certificates"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,6 +1,6 @@
 {{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.34
+version: 1.0.35
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -15,6 +15,6 @@ version: 1.0.34
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-openstack, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-openstack: v1beta1

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,6 +1,6 @@
 {{- $global := .Values.global | default dict }}
 {{- $ingressEnabled := and .Values.ingress.enabled .Values.ingress.apiHost .Values.ingress.konnectivityHost }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0smotronControlPlane
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
@@ -25,17 +25,6 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
-  {{- end }}
-  {{- if not .Values.dataSource.kineDataSourceSecretName }}
-  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
-  etcd:
-    {{- if $global.registry }}
-    image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
-    {{- end }}
-    {{- if .Values.storage.etcd.autoDeletePVCs }}
-    autoDeletePVCs: true
-    {{- end }}
-  {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:
@@ -85,8 +74,21 @@ spec:
         name: {{ .Values.audit.policyRef.name  | quote }}
     {{- end }}
   {{- end }}
-  {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+  {{- if or .Values.dataSource.kineDataSourceSecretName $global.registry .Values.storage.etcd.autoDeletePVCs }}
+  storage:
+    {{- if .Values.dataSource.kineDataSourceSecretName }}
+    type: kine
+    kine:
+      dataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+    {{- else }}
+    etcd:
+      {{- if $global.registry }}
+      image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+      {{- end }}
+      {{- if .Values.storage.etcd.autoDeletePVCs }}
+      autoDeletePVCs: true
+      {{- end }}
+    {{- end }}
   {{- end }}
   manifests:
     - name: manifests
@@ -100,10 +102,10 @@ spec:
           - key: registryCredential
             path: helm-registry-credentials.yaml
     {{- end }}
-  controllerPlaneFlags:
+  controlPlaneFlags:
     - --enable-cloud-provider=true
     - --debug=true
-    {{- range $arg := .Values.k0smotron.controllerPlaneFlags }}
+    {{- range $arg := .Values.k0smotron.controlPlaneFlags }}
     - {{ toYaml $arg }}
     {{- end }}
   k0sConfig:

--- a/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}
@@ -32,7 +32,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      preStartCommands:
+      preK0sCommands:
       - "sudo update-ca-certificates"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}

--- a/templates/cluster/openstack-hosted-cp/values.schema.json
+++ b/templates/cluster/openstack-hosted-cp/values.schema.json
@@ -445,7 +445,7 @@
       "description": "K0smotron parameters",
       "type": "object",
       "properties": {
-        "controllerPlaneFlags": {
+        "controlPlaneFlags": {
           "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,

--- a/templates/cluster/openstack-hosted-cp/values.schema.json
+++ b/templates/cluster/openstack-hosted-cp/values.schema.json
@@ -446,7 +446,7 @@
       "type": "object",
       "properties": {
         "controlPlaneFlags": {
-          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,
           "items": {

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -110,7 +110,7 @@ floatingIPPoolRef: {} # @schema description: Reference to an OpenStackFloatingIP
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -110,7 +110,7 @@ floatingIPPoolRef: {} # @schema description: Reference to an OpenStackFloatingIP
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.39
+version: 1.0.40
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -14,6 +14,6 @@ version: 1.0.39
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-openstack, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-openstack: v1beta1

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0sControlPlane
 metadata:
   name: {{ include "k0scontrolplane.name" . }}

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -33,7 +33,7 @@ spec:
         {{- end }}
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      preStartCommands:
+      preK0sCommands:
       - "sudo update-ca-certificates"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,6 +1,6 @@
 {{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.31
+version: 1.0.32
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -14,6 +14,6 @@ version: 1.0.31
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/infrastructure-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/infrastructure-k0sproject-k0smotron: v1beta2

--- a/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/remote-cluster/templates/k0smotroncontrolplane.yaml
@@ -1,13 +1,13 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0smotronControlPlane
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
   version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
-  {{- with .Values.k0smotron.controllerPlaneFlags }}
-  controllerPlaneFlags:
+  {{- with .Values.k0smotron.controlPlaneFlags }}
+  controlPlaneFlags:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.k0smotron.service }}
@@ -16,10 +16,6 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
-  {{- if not .Values.dataSource.kineDataSourceSecretName }}
-  etcd:
-    image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
-  {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:
@@ -69,8 +65,21 @@ spec:
         name: {{ .Values.audit.policyRef.name  | quote }}
     {{- end }}
   {{- end }}
-  {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+  {{- if or .Values.dataSource.kineDataSourceSecretName $global.registry .Values.storage.etcd.autoDeletePVCs }}
+  storage:
+    {{- if .Values.dataSource.kineDataSourceSecretName }}
+    type: kine
+    kine:
+      dataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+    {{- else }}
+    etcd:
+      {{- if $global.registry }}
+      image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+      {{- end }}
+      {{- if .Values.storage.etcd.autoDeletePVCs }}
+      autoDeletePVCs: true
+      {{- end }}
+    {{- end }}
   {{- end }}
   k0sConfig:
     apiVersion: k0s.k0sproject.io/v1beta1

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -19,7 +19,7 @@ spec:
     kind: RemoteMachine
     name: {{ $name }}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfig
 metadata:
   name: {{ $name }}
@@ -64,7 +64,7 @@ spec:
     {{- toYaml $machine.k0s.args | nindent 4 }}
   {{- end }}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: RemoteMachine
 metadata:
   name: {{ $name }}

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -55,7 +55,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-  preStartCommands:
+  preK0sCommands:
     - {{ printf "%supdate-ca-certificates" (ternary "sudo " "" $machine.useSudo) | quote }}
   {{- end }}
   {{- if and $machine.k0s $machine.k0s.args }}

--- a/templates/cluster/remote-cluster/templates/remotecluster.yaml
+++ b/templates/cluster/remote-cluster/templates/remotecluster.yaml
@@ -2,4 +2,4 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: RemoteCluster
 metadata:
   name: {{ include "cluster.name" . }}
-spec:
+spec: {}

--- a/templates/cluster/remote-cluster/templates/remotecluster.yaml
+++ b/templates/cluster/remote-cluster/templates/remotecluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: RemoteCluster
 metadata:
   name: {{ include "cluster.name" . }}

--- a/templates/cluster/remote-cluster/values.schema.json
+++ b/templates/cluster/remote-cluster/values.schema.json
@@ -227,7 +227,7 @@
       "type": "object",
       "properties": {
         "controlPlaneFlags": {
-          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,
           "items": {

--- a/templates/cluster/remote-cluster/values.schema.json
+++ b/templates/cluster/remote-cluster/values.schema.json
@@ -226,7 +226,7 @@
       "description": "K0smotron parameters",
       "type": "object",
       "properties": {
-        "controllerPlaneFlags": {
+        "controlPlaneFlags": {
           "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,
@@ -359,6 +359,20 @@
             "description": "The user to use when connecting to the remote machine",
             "default": "root",
             "type": "string"
+          }
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "etcd": {
+          "type": "object",
+          "properties": {
+            "autoDeletePVCs": {
+              "description": "Automatically delete etcd PVCs on cluster deletion",
+              "type": "boolean"
+            }
           }
         }
       }

--- a/templates/cluster/remote-cluster/values.yaml
+++ b/templates/cluster/remote-cluster/values.yaml
@@ -59,7 +59,7 @@ machines: # @schema description: The list of remote machines configurations; typ
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   persistence: # @schema description: The persistence configuration; type: object
     type: EmptyDir # @schema description: The persistence type; type: string; default: EmptyDir
   service: # @schema description: The API service configuration; type: object
@@ -78,3 +78,7 @@ k0s: # @schema description: K0s parameters; type: object
     helm: # @schema description: K0s helm repositories and charts configuration; type: object
       repositories: [] # @schema description: The list of Helm repositories for deploying charts during cluster bootstrap; type: array; item: object
       charts: [] # @schema description: The list of helm charts to deploy during cluster bootstrap; type: array; item: object
+
+storage:
+  etcd:
+    autoDeletePVCs: false  # @schema description: Automatically delete etcd PVCs on cluster deletion; type: boolean

--- a/templates/cluster/remote-cluster/values.yaml
+++ b/templates/cluster/remote-cluster/values.yaml
@@ -59,7 +59,7 @@ machines: # @schema description: The list of remote machines configurations; typ
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   persistence: # @schema description: The persistence configuration; type: object
     type: EmptyDir # @schema description: The persistence type; type: string; default: EmptyDir
   service: # @schema description: The API service configuration; type: object

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.37
+version: 1.0.38
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -15,7 +15,6 @@ version: 1.0.37
 appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-vsphere, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
-  k0rdent.mirantis.com/type: deployment
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-vsphere: v1beta2

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0smotronControlPlane
 metadata:
   name: {{ include "k0smotroncontrolplane.name" . }}
@@ -12,17 +12,6 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
-  {{- end }}
-  {{- if not .Values.dataSource.kineDataSourceSecretName }}
-  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
-  etcd:
-    {{- if $global.registry }}
-    image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
-    {{- end }}
-    {{- if .Values.storage.etcd.autoDeletePVCs }}
-    autoDeletePVCs: true
-    {{- end }}
-  {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:
@@ -72,8 +61,21 @@ spec:
         name: {{ .Values.audit.policyRef.name  | quote }}
     {{- end }}
   {{- end }}
-  {{- if .Values.dataSource.kineDataSourceSecretName }}
-  kineDataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+  {{- if or .Values.dataSource.kineDataSourceSecretName $global.registry .Values.storage.etcd.autoDeletePVCs }}
+  storage:
+    {{- if .Values.dataSource.kineDataSourceSecretName }}
+    type: kine
+    kine:
+      dataSourceSecretName: {{ .Values.dataSource.kineDataSourceSecretName  | quote }}
+    {{- else }}
+    etcd:
+      {{- if $global.registry }}
+      image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+      {{- end }}
+      {{- if .Values.storage.etcd.autoDeletePVCs }}
+      autoDeletePVCs: true
+      {{- end }}
+    {{- end }}
   {{- end }}
   manifests:
     - name: manifests
@@ -87,10 +89,10 @@ spec:
           - key: registryCredential
             path: helm-registry-credentials.yaml
     {{- end }}
-  controllerPlaneFlags:
+  controlPlaneFlags:
     - --enable-cloud-provider=true
     - --debug=true
-    {{- range $arg := .Values.k0smotron.controllerPlaneFlags }}
+    {{- range $arg := .Values.k0smotron.controlPlaneFlags }}
     - {{ toYaml $arg }}
     {{- end }}
   k0sConfig:

--- a/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}
@@ -40,7 +40,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-      preStartCommands:
+      preK0sCommands:
         - chown {{ .Values.ssh.user }} /home/{{ .Values.ssh.user }}/.ssh/authorized_keys
         {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
         - "sudo update-ca-certificates"

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -230,7 +230,7 @@
       "description": "K0smotron parameters",
       "type": "object",
       "properties": {
-        "controllerPlaneFlags": {
+        "controlPlaneFlags": {
           "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -231,7 +231,7 @@
       "type": "object",
       "properties": {
         "controlPlaneFlags": {
-          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
+          "description": "ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument",
           "type": "array",
           "uniqueItems": true,
           "items": {

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -63,7 +63,7 @@ network: ""
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -63,7 +63,7 @@ network: ""
 
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
-  controllerPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overriden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.35
+version: 1.0.36
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -15,6 +15,6 @@ appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-vsphere, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   k0rdent.mirantis.com/type: deployment
-  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1
-  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta1
+  cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta2
+  cluster.x-k8s.io/control-plane-k0sproject-k0smotron: v1beta2
   cluster.x-k8s.io/infrastructure-vsphere: v1beta2

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -1,5 +1,5 @@
 {{- $global := .Values.global | default dict }}
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: K0sControlPlane
 metadata:
   name: {{ include "k0scontrolplane.name" . }}

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -41,7 +41,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-      preStartCommands:
+      preK0sCommands:
         - chown {{ .Values.worker.ssh.user }} /home/{{ .Values.worker.ssh.user }}/.ssh/authorized_keys
         {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
         - "sudo update-ca-certificates"

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -1,6 +1,6 @@
 {{- if gt (int .Values.workersNumber) 0 }}
 {{- $global := .Values.global | default dict }}
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: K0sWorkerConfigTemplate
 metadata:
   name: {{ include "k0sworkerconfigtemplate.name" . }}

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
@@ -18,7 +18,7 @@ version: 1.0.28
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.0.1"
+appVersion: "v2.0.2"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron, control-plane-k0sproject-k0smotron
   cluster.x-k8s.io/v1beta1: v1beta1_v1beta2

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.27
+version: 1.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.10.8"
+appVersion: "v2.0.1"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron, control-plane-k0sproject-k0smotron
-  cluster.x-k8s.io/v1beta1: v1beta1
+  cluster.x-k8s.io/v1beta1: v1beta1_v1beta2

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/interface.yaml
@@ -9,6 +9,9 @@ spec:
     - group: infrastructure.cluster.x-k8s.io
       version: v1beta1
       kind: RemoteCluster
+    - group: infrastructure.cluster.x-k8s.io
+      version: v1beta2
+      kind: RemoteCluster
   clusterIdentities:
     - group: ""
       version: v1

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -14,7 +14,7 @@ spec:
     template: cluster-api-1-1-14
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
-      template: cluster-api-provider-k0sproject-k0smotron-1-0-27
+      template: cluster-api-provider-k0sproject-k0smotron-1-0-28
     - name: cluster-api-provider-azure
       template: cluster-api-provider-azure-1-0-27
     - name: cluster-api-provider-vsphere

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-40.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-40.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-36
+  name: aws-hosted-cp-1-0-40
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.36
+      chart: aws-hosted-cp
+      version: 1.0.40
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-37.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-37.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-42
+  name: aws-standalone-cp-1-0-37
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.42
+      chart: aws-standalone-cp
+      version: 1.0.37
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-43.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-43.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-37
+  name: azure-hosted-cp-1-0-43
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.37
+      chart: azure-hosted-cp
+      version: 1.0.43
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-39.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-39.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-34
+  name: azure-standalone-cp-1-0-39
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.34
+      chart: azure-standalone-cp
+      version: 1.0.39
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-k0sproject-k0smotron-1-0-27
+  name: cluster-api-provider-k0sproject-k0smotron-1-0-28
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-k0sproject-k0smotron
-      version: 1.0.27
+      version: 1.0.28
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-14.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-14.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-39
+  name: docker-hosted-cp-1-0-14
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.39
+      chart: docker-hosted-cp
+      version: 1.0.14
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-38.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-38.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-hosted-cp-1-0-13
+  name: gcp-hosted-cp-1-0-38
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-hosted-cp
-      version: 1.0.13
+      chart: gcp-hosted-cp
+      version: 1.0.38
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-35.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-35.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-34
+  name: gcp-standalone-cp-1-0-35
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-standalone-cp
-      version: 1.0.34
+      version: 1.0.35
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-14.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-14.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-38
+  name: kubevirt-hosted-cp-1-0-14
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.38
+      chart: kubevirt-hosted-cp
+      version: 1.0.14
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-15.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-15.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-37
+  name: kubevirt-standalone-cp-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.37
+      chart: kubevirt-standalone-cp
+      version: 1.0.15
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-35.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-35.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: docker-hosted-cp-1-0-13
+  name: openstack-hosted-cp-1-0-35
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: docker-hosted-cp
-      version: 1.0.13
+      chart: openstack-hosted-cp
+      version: 1.0.35
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-40.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-40.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-31
+  name: openstack-standalone-cp-1-0-40
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.31
+      chart: openstack-standalone-cp
+      version: 1.0.40
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-32.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-32.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-14
+  name: remote-cluster-1-0-32
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-standalone-cp
-      version: 1.0.14
+      chart: remote-cluster
+      version: 1.0.32
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-38.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-38.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-35
+  name: vsphere-hosted-cp-1-0-38
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.35
+      chart: vsphere-hosted-cp
+      version: 1.0.38
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-36.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-36.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-39
+  name: vsphere-standalone-cp-1-0-36
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.39
+      chart: vsphere-standalone-cp
+      version: 1.0.36
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/test/e2e/kubeclient/kubeclient.go
+++ b/test/e2e/kubeclient/kubeclient.go
@@ -292,7 +292,7 @@ func (kc *KubeClient) ListRemoteMachines(ctx context.Context, clusterName string
 
 	return kc.listResource(ctx, schema.GroupVersionResource{
 		Group:    "infrastructure.cluster.x-k8s.io",
-		Version:  "v1beta1",
+		Version:  "v1beta2",
 		Resource: "remotemachines",
 	}, clusterName)
 }
@@ -318,7 +318,7 @@ func (kc *KubeClient) ListK0sControlPlanes(
 
 	return kc.listResource(ctx, schema.GroupVersionResource{
 		Group:    "controlplane.cluster.x-k8s.io",
-		Version:  "v1beta1",
+		Version:  "v1beta2",
 		Resource: "k0scontrolplanes",
 	}, clusterName)
 }
@@ -330,7 +330,7 @@ func (kc *KubeClient) ListK0smotronControlPlanes(
 
 	return kc.listResource(ctx, schema.GroupVersionResource{
 		Group:    "controlplane.cluster.x-k8s.io",
-		Version:  "v1beta1",
+		Version:  "v1beta2",
 		Resource: "k0smotroncontrolplanes",
 	}, clusterName)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Migration to k0smotron v2.0.2.

#### Summary of Changes Applied
API Version Updates (`v1beta1` -> `v1beta2`):
[controlplane.cluster.x-k8s.io](http://controlplane.cluster.x-k8s.io/) - Updated in all K0smotronControlPlane and K0sControlPlane files.
[bootstrap.cluster.x-k8s.io](http://bootstrap.cluster.x-k8s.io/) - Updated in all K0sWorkerConfigTemplate files

1. Field Renames:
`controllerPlaneFlags` -> `controlPlaneFlags` updated in:
* All `hosted-cp` k0smotroncontrolplane.yaml files
* All `hosted-cp` values.yaml files
* All `hosted-cp` values.schema.json files
* `remote-cluster` template + values

2. Storage Structure Changes (hosted-cp only):
Moved `etcd` and `kineDataSourceSecretName` under `storage` block in all `hosted-cp` templates

3. Command Renames:
`preStartCommands` -> `preK0sCommands` in `hosted-cp` K0sWorkerConfigTemplate files.

#### Verification
1. Deployed k0rdent/kcm based on this PR and validated standalone clusters using the new templates on the AWS and OpenStack providers.
2. Deployed the latest stable k0rdent/kcm (v1.10.0), created an OpenStack standalone cluster, an OpenStack region, and an OpenStack hosted cluster with a custom data source, then upgraded k0rdent/kcm to the version from this PR.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2802 
