### PR TITLE
feat(templates): expose storage.etcd.autoDeletePVCs in hosted-cp templates

### DIFF
--- a/config/dev/docker-clusterdeployment.yaml
+++ b/config/dev/docker-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: docker-hosted-cp-1-0-11
+  template: docker-hosted-cp-1-0-12
   credential: docker-stub-credential
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.36
+version: 1.0.37
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -13,8 +13,15 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
+  {{- end }}
+  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
   etcd:
+    {{- if $global.registry }}
     image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+    {{- end }}
+    {{- if .Values.storage.etcd.autoDeletePVCs }}
+    autoDeletePVCs: true
+    {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:

--- a/templates/cluster/aws-hosted-cp/values.schema.json
+++ b/templates/cluster/aws-hosted-cp/values.schema.json
@@ -397,6 +397,20 @@
         "null"
       ]
     },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "etcd": {
+          "type": "object",
+          "properties": {
+            "autoDeletePVCs": {
+              "description": "Automatically delete etcd PVCs on cluster deletion",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "subnets": {
       "description": "Subnets configuration",
       "type": "array",

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -90,3 +90,7 @@ k0s: # @schema description: K0s parameters; type: object
     provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
       mode: ipip # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+
+storage:
+  etcd:
+    autoDeletePVCs: false  # @schema description: Automatically delete etcd PVCs on cluster deletion; type: boolean

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.39
+version: 1.0.40
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -12,8 +12,15 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
+  {{- end }}
+  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
   etcd:
+    {{- if $global.registry }}
     image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+    {{- end }}
+    {{- if .Values.storage.etcd.autoDeletePVCs }}
+    autoDeletePVCs: true
+    {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:

--- a/templates/cluster/azure-hosted-cp/values.schema.json
+++ b/templates/cluster/azure-hosted-cp/values.schema.json
@@ -344,6 +344,20 @@
     "sshPublicKey": {
       "type": "string"
     },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "etcd": {
+          "type": "object",
+          "properties": {
+            "autoDeletePVCs": {
+              "description": "Automatically delete etcd PVCs on cluster deletion",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "subscriptionID": {
       "description": "Subscription ID where all cluster resources will be created",
       "type": "string"

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -88,3 +88,7 @@ k0s: # @schema description: K0s parameters; type: object
     provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
       mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+
+storage:
+  etcd:
+    autoDeletePVCs: false  # @schema description: Automatically delete etcd PVCs on cluster deletion; type: boolean

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/docker-hosted-cp/values.schema.json
+++ b/templates/cluster/docker-hosted-cp/values.schema.json
@@ -139,6 +139,20 @@
         }
       }
     },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "etcd": {
+          "type": "object",
+          "properties": {
+            "autoDeletePVCs": {
+              "description": "Automatically delete etcd PVCs on cluster deletion",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "workersNumber": {
       "type": "integer"
     }

--- a/templates/cluster/docker-hosted-cp/values.yaml
+++ b/templates/cluster/docker-hosted-cp/values.yaml
@@ -36,3 +36,7 @@ k0s: # @schema description: K0s parameters; type: object
   # NOTE: Update with caution – see: PR https://github.com/k0rdent/kcm/pull/1057#issuecomment-2668629616
   version: v1.35.1+k0s.1 # @schema description: K0s version; type: string
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
+
+storage:
+  etcd:
+    autoDeletePVCs: false  # @schema description: Automatically delete etcd PVCs on cluster deletion; type: boolean

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.34
+version: 1.0.35
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -12,8 +12,15 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
+  {{- end }}
+  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
   etcd:
+    {{- if $global.registry }}
     image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+    {{- end }}
+    {{- if .Values.storage.etcd.autoDeletePVCs }}
+    autoDeletePVCs: true
+    {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:

--- a/templates/cluster/gcp-hosted-cp/values.schema.json
+++ b/templates/cluster/gcp-hosted-cp/values.schema.json
@@ -322,6 +322,20 @@
       "description": "The GCP Region the cluster lives in",
       "type": "string"
     },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "etcd": {
+          "type": "object",
+          "properties": {
+            "autoDeletePVCs": {
+              "description": "Automatically delete etcd PVCs on cluster deletion",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "worker": {
       "description": "Worker parameters",
       "type": "object",

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -89,3 +89,7 @@ k0s: # @schema description: K0s parameters; type: object
     provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
       mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+
+storage:
+  etcd:
+    autoDeletePVCs: false  # @schema description: Automatically delete etcd PVCs on cluster deletion; type: boolean

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -12,8 +12,15 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
+  {{- end }}
+  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
   etcd:
+    {{- if $global.registry }}
     image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+    {{- end }}
+    {{- if .Values.storage.etcd.autoDeletePVCs }}
+    autoDeletePVCs: true
+    {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:

--- a/templates/cluster/kubevirt-hosted-cp/values.schema.json
+++ b/templates/cluster/kubevirt-hosted-cp/values.schema.json
@@ -379,6 +379,20 @@
         }
       }
     },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "etcd": {
+          "type": "object",
+          "properties": {
+            "autoDeletePVCs": {
+              "description": "Automatically delete etcd PVCs on cluster deletion",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "worker": {
       "description": "Worker parameters",
       "type": "object",

--- a/templates/cluster/kubevirt-hosted-cp/values.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/values.yaml
@@ -113,3 +113,7 @@ k0s: # @schema description: K0s parameters; type: object
     helm: # @schema description: K0s helm repositories and charts configuration; type: object
       repositories: [] # @schema description: The list of Helm repositories for deploying charts during cluster bootstrap; type: array; item: object
       charts: [] # @schema description: The list of helm charts to deploy during cluster bootstrap; type: array; item: object
+
+storage:
+  etcd:
+    autoDeletePVCs: false  # @schema description: Automatically delete etcd PVCs on cluster deletion; type: boolean

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.31
+version: 1.0.32
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -25,8 +25,15 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
+  {{- end }}
+  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
   etcd:
+    {{- if $global.registry }}
     image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+    {{- end }}
+    {{- if .Values.storage.etcd.autoDeletePVCs }}
+    autoDeletePVCs: true
+    {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:

--- a/templates/cluster/openstack-hosted-cp/values.schema.json
+++ b/templates/cluster/openstack-hosted-cp/values.schema.json
@@ -579,6 +579,20 @@
       "description": "SSH public key for accessing nodes",
       "type": "string"
     },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "etcd": {
+          "type": "object",
+          "properties": {
+            "autoDeletePVCs": {
+              "description": "Automatically delete etcd PVCs on cluster deletion",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "subnets": {
       "description": "The reference to OpenStack subnet",
       "type": "array",

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -127,3 +127,7 @@ k0s: # @schema description: K0s parameters; type: object
     provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
       mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+
+storage:
+  etcd:
+    autoDeletePVCs: false  # @schema description: Automatically delete etcd PVCs on cluster deletion; type: boolean

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.34
+version: 1.0.35
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -12,8 +12,15 @@ spec:
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s
+  {{- end }}
+  {{- if or $global.registry .Values.storage.etcd.autoDeletePVCs }}
   etcd:
+    {{- if $global.registry }}
     image: "{{ $global.registry }}/k0sproject/etcd:v3.5.13"
+    {{- end }}
+    {{- if .Values.storage.etcd.autoDeletePVCs }}
+    autoDeletePVCs: true
+    {{- end }}
   {{- end }}
   {{- if or $global.registryCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name .Values.dataSource.caSecret.name .Values.audit.policyRef.name }}
   mounts:

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -288,6 +288,20 @@
         }
       }
     },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "etcd": {
+          "type": "object",
+          "properties": {
+            "autoDeletePVCs": {
+              "description": "Automatically delete etcd PVCs on cluster deletion",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "vmTemplate": {
       "type": "string"
     },

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -80,3 +80,7 @@ k0s: # @schema description: K0s parameters; type: object
     provider: calico # @schema description: Network provider to use; type: string; examples: [kuberouter, calico, custom]; minLength: 1
     calico: # @schema description: Calico-specific configuration; type: object; additionalProperties: true
       mode: vxlan # @schema description: Calico network mode; type: string; examples: [ipip, vxlan, never]; minLength: 1
+
+storage:
+  etcd:
+    autoDeletePVCs: false  # @schema description: Automatically delete etcd PVCs on cluster deletion; type: boolean

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-37.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-37.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-34
+  name: aws-hosted-cp-1-0-37
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.34
+      chart: aws-hosted-cp
+      version: 1.0.37
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-40.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-40.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-34
+  name: azure-hosted-cp-1-0-40
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.34
+      chart: azure-hosted-cp
+      version: 1.0.40
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-12.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-12.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-39
+  name: docker-hosted-cp-1-0-12
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.39
+      chart: docker-hosted-cp
+      version: 1.0.12
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-35.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-35.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-31
+  name: gcp-hosted-cp-1-0-35
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.31
+      chart: gcp-hosted-cp
+      version: 1.0.35
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-11.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-11.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-36
+  name: kubevirt-hosted-cp-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.36
+      chart: kubevirt-hosted-cp
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-32.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-32.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: docker-hosted-cp-1-0-11
+  name: openstack-hosted-cp-1-0-32
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: docker-hosted-cp
-      version: 1.0.11
+      chart: openstack-hosted-cp
+      version: 1.0.32
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-35.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-35.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-hosted-cp-1-0-10
+  name: vsphere-hosted-cp-1-0-35
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-hosted-cp
-      version: 1.0.10
+      chart: vsphere-hosted-cp
+      version: 1.0.35
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
The template changes lets us opt in to deleting etcd PVCs on cluster teardown, which avoids name reuse issues caused by leftover PVCs.

Added storage.etcd.autoDeletePVCs to hosted-cp templates (default false) and wires it through to K0smotronControlPlane.spec.etcd.

Includeed generated updates (values.schema.json, hosted-cp chart version bumps and regenerated kcm-templates provider template files).