### PR TITLE
fix: svc key collisions in FilteredDependencies func

### DIFF
--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -291,43 +291,11 @@ func FilterServiceDependencies(
 		}
 	}
 
-	// Fetch serviceSet.
-	// We can rely on the state of the services reported in the ServiceSet because:
-	//
-	// 1. We have configured a poller in the Sveltos ServiceSet controller which
-	// polls the Sveltos ClusterSummary and triggers the ServiceSet Controller if
-	// there is a change in the state of the services.
-	//
-	// 2. The ServiceSet Controller then captures the latest state of the services
-	// from the ClusterSummary and updates the status of the relevant ServiceSet.
-	//
-	// 3. The change in the ServiceSet then triggers the ClusterDeployment or MultiClusterService
-	// controller to reconcile in which this function is called and we can then can fetch the
-	// latest state of the services directly from the relevant ServiceSet.
-	//
-	// 4. Without the poller triggering the ServiceSet controller, we would have to fetch
-	// the state of the services directly from the Sveltos ClusterSummary objects here.
-	//
-	// 5. Therefore, it is important for any state management adapter to implement a
-	// mechanism similar to the poller for the Sveltos ServiceSet controller for this
-	// function to work as intended.
 	sset, err := fetchServiceSet(ctx, c, systemNamespace, mcs, cd)
 	if err != nil {
 		return nil, err
 	}
 
-	// Build version maps from the existing ServiceSet(s) so we can compare each
-	// service's currently-promised spec step against what the cluster actually
-	// runs and against the user's final desired version. Spec and status entries
-	// are normalised the same way so the comparison is symmetric: prefer Version,
-	// fall back to Template when Version is nil/empty.
-	//
-	// NOTE: When more than one ServiceSet matches (cd-only call with multiple
-	// MCS targeting the same cluster, or analogous), values overwrite on key
-	// collision. Current reconciler wiring guarantees at most one relevant
-	// ServiceSet per call (the MCS reconciler scopes by both cluster and MCS;
-	// the CD reconciler operates on the CD's own spec/ServiceSet only), so the
-	// overwrite is not observable in practice. Revisit if that wiring changes.
 	specVersion := make(map[client.ObjectKey]string)
 	statusVersion := make(map[client.ObjectKey]string)
 	statusState := make(map[client.ObjectKey]string)
@@ -438,6 +406,26 @@ func fetchServiceSet(ctx context.Context, c client.Client, systemNamespace strin
 		namespace = cd.GetNamespace()
 	}
 
+	// Fetch serviceSet.
+	// We can rely on the state of the services reported in the ServiceSet because:
+	//
+	// 1. We have configured a poller in the Sveltos ServiceSet controller which
+	// polls the Sveltos ClusterSummary and triggers the ServiceSet Controller if
+	// there is a change in the state of the services.
+	//
+	// 2. The ServiceSet Controller then captures the latest state of the services
+	// from the ClusterSummary and updates the status of the relevant ServiceSet.
+	//
+	// 3. The change in the ServiceSet then triggers the ClusterDeployment or MultiClusterService
+	// controller to reconcile in which this function is called and we can then can fetch the
+	// latest state of the services directly from the relevant ServiceSet.
+	//
+	// 4. Without the poller triggering the ServiceSet controller, we would have to fetch
+	// the state of the services directly from the Sveltos ClusterSummary objects here.
+	//
+	// 5. Therefore, it is important for any state management adapter to implement a
+	// mechanism similar to the poller for the Sveltos ServiceSet controller for this
+	// function to work as intended.
 	serviceSetList := new(kcmv1.ServiceSetList)
 	sel := fields.Everything()
 	if cdName != "" {
@@ -463,10 +451,12 @@ func fetchServiceSet(ctx context.Context, c client.Client, systemNamespace strin
 					cd set are returned, which means the ServiceSets for all mcs matching the cd are also returned.
 			case 3) cd == "" && mcs != "":
 					This is a unique self-management ServiceSet created by the MultiClusterController for the mcs.
+					Here again ALL ServiceSets that have mcs set are returned even those belonging to any cd existing
+					in the system namespace.
 			case 4) cd != "" && mcs != "":
 					This is a unique Serviceset created by the MultiClusterController for mcs matching cd.
 
-			So in all cases except case 2 a max of 1 ServiceSet is returned.
+			So in all cases except cases 2 and 3, a max of 1 ServiceSet is returned.
 		*/
 		if cdName != "" && mcsName == "" && sset.Spec.MultiClusterService != "" {
 			// Handle case 2. We need the ServiceSet which is created only for the cd.
@@ -475,6 +465,15 @@ func fetchServiceSet(ctx context.Context, c client.Client, systemNamespace strin
 			// only ServiceSet which will remain is the one created specifically for the cd.
 			continue
 		}
+		if cdName == "" && mcsName != "" && sset.Spec.Cluster != "" {
+			// Handle case 3. We need the self-management ServiceSet (empty .spec.cluster).
+			// When mcs is set but cd is nil, ALL ServiceSets that have mcs set are returned,
+			// including per-cluster ServiceSets for CDs living in the system namespace.
+			// Ignore any ServiceSet with .spec.cluster set so only the self-management
+			// one (empty .spec.cluster) remains.
+			continue
+		}
+
 		serviceSets = append(serviceSets, sset)
 	}
 

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -230,20 +230,22 @@ func ServicesUpgradePaths(
 // dependents stay locked at their stored versions, ensuring upgrades propagate
 // down the dependency chain in the declared order rather than all at once.
 //
-// NOTE: Every service referenced in a DependsOn field must also appear in
+// CONDITIONS:
+// This function depends on the following conditions to work correctly.
+//
+// 1. Every service referenced in a DependsOn field must also appear in
 // the desired services list; referencing an absent service is an error.
 //
-// NOTE: desiredServices is expected to have its Versions already resolved by
+// 2. desiredServices is expected to have its Versions already resolved by
 // the caller (e.g. via ResolveServiceVersions) so the version-aware gate can
 // compare against the resolved form that previous reconciles persisted in
 // ServiceSet.Spec. Passing unresolved services is tolerated — comparison
 // falls back to Template — but mixing resolved Spec versions with unresolved
 // desired versions will lock dependents.
 //
-// NOTE: This function works under the assumption that there will
-// always be just 1 ServiceSet for every unique combination of CD & MCS.
+// 3. There will always be just 1 ServiceSet for every unique combination of CD & MCS.
 //
-// NOTE: This function depends solely on the ServiceSet to fetch the latest
+// 4. This function depends solely on the ServiceSet to fetch the latest
 // state of the services. Therefore, it works under the assumption that some
 // other mechanism like the poller for the Sveltos adapter will update the
 // ServiceSet by fetching the latest state from the specific state manager's objects.
@@ -255,18 +257,6 @@ func FilterServiceDependencies(
 	cd *kcmv1.ClusterDeployment,
 	desiredServices []kcmv1.Service,
 ) ([]kcmv1.Service, error) {
-	mcsName := ""
-	if mcs != nil {
-		mcsName = mcs.GetName()
-	}
-
-	cdName := ""
-	namespace := systemNamespace
-	if cd != nil {
-		cdName = cd.GetName()
-		namespace = cd.GetNamespace()
-	}
-
 	// Map of services with their indexes.
 	serviceIdx := make(map[client.ObjectKey]int)
 	// Map of services with the count of other services they depend on.
@@ -321,16 +311,9 @@ func FilterServiceDependencies(
 	// 5. Therefore, it is important for any state management adapter to implement a
 	// mechanism similar to the poller for the Sveltos ServiceSet controller for this
 	// function to work as intended.
-	serviceSets := new(kcmv1.ServiceSetList)
-	sel := fields.Everything()
-	if cdName != "" {
-		sel = fields.AndSelectors(sel, fields.OneTermEqualSelector(kcmv1.ServiceSetClusterIndexKey, cdName))
-	}
-	if mcsName != "" {
-		sel = fields.AndSelectors(sel, fields.OneTermEqualSelector(kcmv1.ServiceSetMultiClusterServiceIndexKey, mcsName))
-	}
-	if err := c.List(ctx, serviceSets, client.InNamespace(namespace), client.MatchingFieldsSelector{Selector: sel}); err != nil {
-		return nil, fmt.Errorf("failed to list ServiceSets: %w", err)
+	sset, err := fetchServiceSet(ctx, c, systemNamespace, mcs, cd)
+	if err != nil {
+		return nil, err
 	}
 
 	// Build version maps from the existing ServiceSet(s) so we can compare each
@@ -348,29 +331,27 @@ func FilterServiceDependencies(
 	specVersion := make(map[client.ObjectKey]string)
 	statusVersion := make(map[client.ObjectKey]string)
 	statusState := make(map[client.ObjectKey]string)
-	for _, sset := range serviceSets.Items {
-		for _, svc := range sset.Spec.Services {
-			v := ""
-			if svc.Version != nil {
-				v = *svc.Version
-			}
-			if v == "" {
-				v = svc.Template
-			}
-			specVersion[ServiceKey(svc.Namespace, svc.Name)] = v
+	for _, svc := range sset.Spec.Services {
+		v := ""
+		if svc.Version != nil {
+			v = *svc.Version
 		}
-		for _, svc := range sset.Status.Services {
-			v := ""
-			if svc.Version != nil {
-				v = *svc.Version
-			}
-			if v == "" {
-				v = svc.Template
-			}
-			k := ServiceKey(svc.Namespace, svc.Name)
-			statusVersion[k] = v
-			statusState[k] = svc.State
+		if v == "" {
+			v = svc.Template
 		}
+		specVersion[ServiceKey(svc.Namespace, svc.Name)] = v
+	}
+	for _, svc := range sset.Status.Services {
+		v := ""
+		if svc.Version != nil {
+			v = *svc.Version
+		}
+		if v == "" {
+			v = svc.Template
+		}
+		k := ServiceKey(svc.Namespace, svc.Name)
+		statusVersion[k] = v
+		statusState[k] = svc.State
 	}
 
 	// desiredServices is expected to have Versions resolved by the caller
@@ -441,6 +422,70 @@ func FilterServiceDependencies(
 	})
 
 	return filtered, nil
+}
+
+// fetchServiceSet fetches the ServiceSet associated with the provided mcs and cd.
+func fetchServiceSet(ctx context.Context, c client.Client, systemNamespace string, mcs *kcmv1.MultiClusterService, cd *kcmv1.ClusterDeployment) (kcmv1.ServiceSet, error) {
+	mcsName := ""
+	if mcs != nil {
+		mcsName = mcs.GetName()
+	}
+
+	cdName := ""
+	namespace := systemNamespace
+	if cd != nil {
+		cdName = cd.GetName()
+		namespace = cd.GetNamespace()
+	}
+
+	serviceSetList := new(kcmv1.ServiceSetList)
+	sel := fields.Everything()
+	if cdName != "" {
+		sel = fields.AndSelectors(sel, fields.OneTermEqualSelector(kcmv1.ServiceSetClusterIndexKey, cdName))
+	}
+	if mcsName != "" {
+		sel = fields.AndSelectors(sel, fields.OneTermEqualSelector(kcmv1.ServiceSetMultiClusterServiceIndexKey, mcsName))
+	}
+	if err := c.List(ctx, serviceSetList, client.InNamespace(namespace), client.MatchingFieldsSelector{Selector: sel}); err != nil {
+		return kcmv1.ServiceSet{}, fmt.Errorf("failed to list ServiceSets: %w", err)
+	}
+
+	serviceSets := []kcmv1.ServiceSet{}
+	for _, sset := range serviceSetList.Items {
+		/*
+			We can have the following cases:
+
+			case 1) cd == "" && mcs == "":
+					This is impossible as there cannot be a ServiceSet with neither cd nor mcs set.
+			case 2) cd != "" && mcs == "":
+					This is a unique ServiceSet created by the ClusterDeployment Controller for the cd.
+					However, when querying the kube api service for this case, ALL ServiceSets that have
+					cd set are returned, which means the ServiceSets for all mcs matching the cd are also returned.
+			case 3) cd == "" && mcs != "":
+					This is a unique self-management ServiceSet created by the MultiClusterController for the mcs.
+			case 4) cd != "" && mcs != "":
+					This is a unique Serviceset created by the MultiClusterController for mcs matching cd.
+
+			So in all cases except case 2 a max of 1 ServiceSet is returned.
+		*/
+		if cdName != "" && mcsName == "" && sset.Spec.MultiClusterService != "" {
+			// Handle case 2. We need the ServiceSet which is created only for the cd.
+			// So if cd is set and mcs is not (case 2) then we will ignore all ServiceSets
+			// in the returned list which have its `.spec.multiClusterService` set, so the
+			// only ServiceSet which will remain is the one created specifically for the cd.
+			continue
+		}
+		serviceSets = append(serviceSets, sset)
+	}
+
+	if len(serviceSets) > 1 {
+		return kcmv1.ServiceSet{}, fmt.Errorf("expected 1 ServiceSet for cd=%s/%s && mcs=%s, got %d", namespace, cdName, mcsName, len(serviceSets))
+	}
+	if len(serviceSets) == 0 {
+		// We want 0 ServiceSets to be a no-op.
+		return kcmv1.ServiceSet{}, nil
+	}
+	return serviceSets[0], nil
 }
 
 func makeService(s kcmv1.Service, version, template string) kcmv1.ServiceWithValues {

--- a/internal/serviceset/util_test.go
+++ b/internal/serviceset/util_test.go
@@ -647,56 +647,6 @@ func Test_FilterServiceDependencies(t *testing.T) {
 			expected: []testService{a, b},
 		},
 		{
-			testName:        "service A deployed & B provisioning in different servicesets when B->A",
-			desiredServices: []testService{a, b.dependsOn(a)},
-			objects: []client.Object{
-				&kcmv1.ServiceSet{
-					ObjectMeta: metav1.ObjectMeta{Namespace: cd.GetNamespace(), Name: cd.GetName()},
-					Spec:       kcmv1.ServiceSetSpec{Cluster: cd.GetName()},
-					Status: kcmv1.ServiceSetStatus{
-						Services: []kcmv1.ServiceState{
-							{Namespace: a.Namespace, Name: a.Name, State: kcmv1.ServiceStateDeployed},
-						},
-					},
-				},
-				&kcmv1.ServiceSet{
-					ObjectMeta: metav1.ObjectMeta{Namespace: cd.GetNamespace(), Name: cd.GetName() + "-7sc4gx"},
-					Spec:       kcmv1.ServiceSetSpec{Cluster: cd.GetName()},
-					Status: kcmv1.ServiceSetStatus{
-						Services: []kcmv1.ServiceState{
-							{Namespace: b.Namespace, Name: b.Name, State: kcmv1.ServiceStateProvisioning},
-						},
-					},
-				},
-			},
-			expected: []testService{a, b},
-		},
-		{
-			testName:        "service A & B deployed in different servicesets when B->A",
-			desiredServices: []testService{a, b.dependsOn(a)},
-			objects: []client.Object{
-				&kcmv1.ServiceSet{
-					ObjectMeta: metav1.ObjectMeta{Namespace: cd.GetNamespace(), Name: cd.GetName()},
-					Spec:       kcmv1.ServiceSetSpec{Cluster: cd.GetName()},
-					Status: kcmv1.ServiceSetStatus{
-						Services: []kcmv1.ServiceState{
-							{Namespace: a.Namespace, Name: a.Name, State: kcmv1.ServiceStateDeployed},
-						},
-					},
-				},
-				&kcmv1.ServiceSet{
-					ObjectMeta: metav1.ObjectMeta{Namespace: cd.GetNamespace(), Name: cd.GetName() + "-7sc4gx"},
-					Spec:       kcmv1.ServiceSetSpec{Cluster: cd.GetName()},
-					Status: kcmv1.ServiceSetStatus{
-						Services: []kcmv1.ServiceState{
-							{Namespace: b.Namespace, Name: b.Name, State: kcmv1.ServiceStateDeployed},
-						},
-					},
-				},
-			},
-			expected: []testService{a, b},
-		},
-		{
 			// A is failing. B (depends on A) is deployed at its current version.
 			// C (depends on A) was never deployed.
 			// Because A is not Deployed, B and C both have unsatisfied dependencies and
@@ -1023,28 +973,18 @@ func Test_FilterServiceDependencies_Operation(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Namespace: cd.GetNamespace(), Name: cd.GetName()},
 				Spec:       kcmv1.ServiceSetSpec{Cluster: cd.GetName()},
 			}
-			ssetMCS := &kcmv1.ServiceSet{
-				ObjectMeta: metav1.ObjectMeta{Namespace: cd.GetNamespace(), Name: cd.GetName() + "gswge"},
-				Spec:       kcmv1.ServiceSetSpec{Cluster: cd.GetName()},
-			}
 
 			for itr := range tc.expectedServices {
-				// Divide expected services between 2 ServiceSets targeting the same cluster,
-				// where one serviceset belongs to ClusterDeployment and the other to MultiClusterService.
-				for j, svc := range filtered {
+				for _, svc := range filtered {
 					sstate := kcmv1.ServiceState{
 						Namespace: svc.Namespace, Name: svc.Name, State: kcmv1.ServiceStateDeployed,
 					}
-					if j%2 == 0 {
-						ssetCD.Status.Services = append(ssetCD.Status.Services, sstate)
-					} else {
-						ssetMCS.Status.Services = append(ssetMCS.Status.Services, sstate)
-					}
+					ssetCD.Status.Services = append(ssetCD.Status.Services, sstate)
 				}
 
 				client := fake.NewClientBuilder().
 					WithScheme(scheme).
-					WithObjects(ssetCD, ssetMCS).
+					WithObjects(ssetCD).
 					WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetClusterIndexKey, kcmv1.ExtractServiceSetCluster).
 					Build()
 
@@ -1767,6 +1707,181 @@ func Test_FilterServiceDependencies_UpgradeOrdering(t *testing.T) {
 				names[i] = svc.Name
 			}
 			require.ElementsMatch(t, tc.expected, names)
+		})
+	}
+}
+
+func Test_fetchServiceSet(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(kcmv1.AddToScheme(scheme))
+
+	const (
+		sysNS   = "kcm-system"
+		cdName  = "my-cd"
+		cdNS    = "my-cd-ns"
+		mcsName = "my-mcs"
+	)
+
+	newClient := func(objects ...client.Object) client.Client {
+		return fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(objects...).
+			WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetClusterIndexKey, kcmv1.ExtractServiceSetCluster).
+			WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetMultiClusterServiceIndexKey, kcmv1.ExtractServiceSetMultiClusterService).
+			Build()
+	}
+
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: cdName, Namespace: cdNS},
+	}
+	mcs := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{Name: mcsName},
+	}
+
+	tests := []struct {
+		name    string
+		mcs     *kcmv1.MultiClusterService
+		cd      *kcmv1.ClusterDeployment
+		objects []client.Object
+		// wantEmpty means we expect the zero-value ServiceSet — no ServiceSet found.
+		wantEmpty bool
+		wantErr   bool
+	}{
+		// Case 2: cd set, mcs nil — returns the cd-specific ServiceSet (no .spec.multiClusterService).
+		{
+			name:      "case2: no ServiceSets → nil",
+			cd:        cd,
+			wantEmpty: true,
+		},
+		{
+			name: "case2: one cd-only ServiceSet → returned",
+			cd:   cd,
+			objects: []client.Object{
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: cdNS, Name: "ss-cd"},
+					Spec:       kcmv1.ServiceSetSpec{Cluster: cdName},
+				},
+			},
+		},
+		{
+			name: "case2: cd-only ServiceSet plus mcs ServiceSet for same cluster → cd-only ServiceSet returned",
+			cd:   cd,
+			objects: []client.Object{
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: cdNS, Name: "ss-cd"},
+					Spec:       kcmv1.ServiceSetSpec{Cluster: cdName},
+				},
+				// The mcs ServiceSet is returned by the cluster-index query but must be filtered out
+				// because .spec.multiClusterService is set (case 2 comment in fetchServiceSet).
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: cdNS, Name: "ss-mcs"},
+					Spec:       kcmv1.ServiceSetSpec{Cluster: cdName, MultiClusterService: "other-mcs"},
+				},
+			},
+		},
+		{
+			name: "case2: two cd-only ServiceSets → error",
+			cd:   cd,
+			objects: []client.Object{
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: cdNS, Name: "ss-1"},
+					Spec:       kcmv1.ServiceSetSpec{Cluster: cdName},
+				},
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: cdNS, Name: "ss-2"},
+					Spec:       kcmv1.ServiceSetSpec{Cluster: cdName},
+				},
+			},
+			wantErr: true,
+		},
+
+		// Case 3: mcs set, cd nil — returns the unique self-management ServiceSet for the mcs.
+		{
+			name:      "case3: no ServiceSets → nil",
+			mcs:       mcs,
+			wantEmpty: true,
+		},
+		{
+			name: "case3: one mcs ServiceSet → returned",
+			mcs:  mcs,
+			objects: []client.Object{
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: sysNS, Name: "ss-mcs"},
+					Spec:       kcmv1.ServiceSetSpec{MultiClusterService: mcsName},
+				},
+			},
+		},
+		{
+			name: "case3: two mcs ServiceSets → error",
+			mcs:  mcs,
+			objects: []client.Object{
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: sysNS, Name: "ss-mcs-1"},
+					Spec:       kcmv1.ServiceSetSpec{MultiClusterService: mcsName},
+				},
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: sysNS, Name: "ss-mcs-2"},
+					Spec:       kcmv1.ServiceSetSpec{MultiClusterService: mcsName},
+				},
+			},
+			wantErr: true,
+		},
+
+		// Case 4: both cd and mcs set — returns the unique ServiceSet created by the
+		// MultiClusterController for the mcs matching the cd.
+		{
+			name:      "case4: no ServiceSets → nil",
+			cd:        cd,
+			mcs:       mcs,
+			wantEmpty: true,
+		},
+		{
+			name: "case4: one ServiceSet with both cd and mcs → returned",
+			cd:   cd,
+			mcs:  mcs,
+			objects: []client.Object{
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: cdNS, Name: "ss-cd-mcs"},
+					Spec:       kcmv1.ServiceSetSpec{Cluster: cdName, MultiClusterService: mcsName},
+				},
+			},
+		},
+		{
+			name: "case4: two ServiceSets with same cd and mcs → error",
+			cd:   cd,
+			mcs:  mcs,
+			objects: []client.Object{
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: cdNS, Name: "ss-cd-mcs-1"},
+					Spec:       kcmv1.ServiceSetSpec{Cluster: cdName, MultiClusterService: mcsName},
+				},
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: cdNS, Name: "ss-cd-mcs-2"},
+					Spec:       kcmv1.ServiceSetSpec{Cluster: cdName, MultiClusterService: mcsName},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cl := newClient(tt.objects...)
+			got, err := fetchServiceSet(t.Context(), cl, sysNS, tt.mcs, tt.cd)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantEmpty {
+				require.Empty(t, got.Name, "expected zero-value ServiceSet (not found)")
+			} else {
+				require.NotEmpty(t, got.Name, "expected a ServiceSet to be returned")
+			}
 		})
 	}
 }

--- a/internal/serviceset/util_test.go
+++ b/internal/serviceset/util_test.go
@@ -1747,8 +1747,10 @@ func Test_fetchServiceSet(t *testing.T) {
 		cd      *kcmv1.ClusterDeployment
 		objects []client.Object
 		// wantEmpty means we expect the zero-value ServiceSet — no ServiceSet found.
-		wantEmpty bool
-		wantErr   bool
+		wantEmpty   bool
+		wantErr     bool
+		wantCluster string
+		wantMCS     string
 	}{
 		// Case 2: cd set, mcs nil — returns the cd-specific ServiceSet (no .spec.multiClusterService).
 		{
@@ -1765,6 +1767,7 @@ func Test_fetchServiceSet(t *testing.T) {
 					Spec:       kcmv1.ServiceSetSpec{Cluster: cdName},
 				},
 			},
+			wantCluster: cdName,
 		},
 		{
 			name: "case2: cd-only ServiceSet plus mcs ServiceSet for same cluster → cd-only ServiceSet returned",
@@ -1781,6 +1784,7 @@ func Test_fetchServiceSet(t *testing.T) {
 					Spec:       kcmv1.ServiceSetSpec{Cluster: cdName, MultiClusterService: "other-mcs"},
 				},
 			},
+			wantCluster: cdName,
 		},
 		{
 			name: "case2: two cd-only ServiceSets → error",
@@ -1813,6 +1817,26 @@ func Test_fetchServiceSet(t *testing.T) {
 					Spec:       kcmv1.ServiceSetSpec{MultiClusterService: mcsName},
 				},
 			},
+			wantMCS: mcsName,
+		},
+		{
+			// Real-world self-management scenario: a per-cluster ServiceSet for the same MCS
+			// exists in the system namespace (a CD also lives in sysNS). The self-management
+			// ServiceSet (empty .spec.cluster) must be returned, not the per-cluster one.
+			name: "case3: self-management ServiceSet plus per-cluster ServiceSet in sysNS → self-management returned",
+			mcs:  mcs,
+			objects: []client.Object{
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: sysNS, Name: "ss-self-mgmt"},
+					Spec:       kcmv1.ServiceSetSpec{MultiClusterService: mcsName},
+				},
+				// Per-cluster ServiceSet for a CD that happens to live in the system namespace.
+				&kcmv1.ServiceSet{
+					ObjectMeta: metav1.ObjectMeta{Namespace: sysNS, Name: "ss-per-cluster"},
+					Spec:       kcmv1.ServiceSetSpec{Cluster: "some-cd-in-sysns", MultiClusterService: mcsName},
+				},
+			},
+			wantMCS: mcsName,
 		},
 		{
 			name: "case3: two mcs ServiceSets → error",
@@ -1848,6 +1872,8 @@ func Test_fetchServiceSet(t *testing.T) {
 					Spec:       kcmv1.ServiceSetSpec{Cluster: cdName, MultiClusterService: mcsName},
 				},
 			},
+			wantCluster: cdName,
+			wantMCS:     mcsName,
 		},
 		{
 			name: "case4: two ServiceSets with same cd and mcs → error",
@@ -1879,9 +1905,11 @@ func Test_fetchServiceSet(t *testing.T) {
 			require.NoError(t, err)
 			if tt.wantEmpty {
 				require.Empty(t, got.Name, "expected zero-value ServiceSet (not found)")
-			} else {
-				require.NotEmpty(t, got.Name, "expected a ServiceSet to be returned")
+				return
 			}
+			require.NotEmpty(t, got.Name, "expected a ServiceSet to be returned")
+			require.Equal(t, tt.wantCluster, got.Spec.Cluster, "unexpected .spec.cluster")
+			require.Equal(t, tt.wantMCS, got.Spec.MultiClusterService, "unexpected .spec.multiClusterService")
 		})
 	}
 }


### PR DESCRIPTION
# Description

Kindly see the detailed description of the problem in https://github.com/k0rdent/kcm/issues/2827. This PR fixes the problem by introducing the `fetchServiceSet` function which returns only 1 ServiceSet for each combination of CD & MCS. 

Previously, for `cd != nil && mcs == nil`, even though we were fetching all ServiceSets where cluster was set but implicitly we were only considering 1 ServiceSet because of not accounting for svc key collisions.

So this PR makes this assumption explicit via `fetchServiceSet` by:
* returning just 1 ServiceSet for any combination of cd && mcs.
* filtering out other ServiceSets and only returning 1 ServiceSet for `cd != nil && mcs == nil`. The other ServiceSets with cd set (that is  `cd != nil && mcs != nil`) will be processed by the MCS controller in other reconcile cycles.
* returning an error if there are more than 1 ServiceSets because there shouldn't be more than 1 ServiceSet for any combination of cd && mcs with the way KSM runs currently.