### PR TITLE
chore: update k0s version to v1.36.1+k0s.0

### DIFF
--- a/config/dev/aks-clusterdeployment.yaml
+++ b/config/dev/aks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-aks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-aks-1-0-8
+  template: azure-aks-1-0-9
   credential: azure-aks-credential
   propagateCredentials: false
   config:

--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-35
+  template: aws-standalone-cp-1-0-36
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-37
+  template: azure-standalone-cp-1-0-38
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/docker-clusterdeployment.yaml
+++ b/config/dev/docker-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: docker-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: docker-hosted-cp-1-0-12
+  template: docker-hosted-cp-1-0-13
   credential: docker-stub-credential
   config:
     clusterLabels: {}

--- a/config/dev/eks-clusterdeployment.yaml
+++ b/config/dev/eks-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eks-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-eks-1-0-10
+  template: aws-eks-1-0-11
   credential: "aws-cluster-identity-cred"
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-33
+  template: gcp-standalone-cp-1-0-34
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-13
+  template: kubevirt-standalone-cp-1-0-14
   credential: kubevirt-cred
   propagateCredentials: false
   config:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-38
+  template: openstack-standalone-cp-1-0-39
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-30
+  template: remote-cluster-1-0-31
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-34
+  template: vsphere-standalone-cp-1-0-35
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-eks/Chart.yaml
+++ b/templates/cluster/aws-eks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/infrastructure-aws: v1beta2

--- a/templates/cluster/aws-eks/values.yaml
+++ b/templates/cluster/aws-eks/values.yaml
@@ -61,4 +61,4 @@ addons: # @schema description: The EKS addons to enable with the EKS cluster; ty
 
 # Kubernetes version
 kubernetes: # @schema description: Kubernetes parameters; type: object
-  version: v1.35.4 # @schema description: Kubernetes version to use; type: string; required: true
+  version: v1.36.1 # @schema description: Kubernetes version to use; type: string; required: true

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.38
+version: 1.0.39
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/aws-hosted-cp/values.yaml
+++ b/templates/cluster/aws-hosted-cp/values.yaml
@@ -81,7 +81,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.35
+version: 1.0.36
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/aws-standalone-cp/values.yaml
+++ b/templates/cluster/aws-standalone-cp/values.yaml
@@ -79,7 +79,7 @@ worker: # @schema description: The configuration of the worker machines; type: o
 # K0s parameters
 # # NOTE: .k0s additional properties are to support prior .k0s.auth implementation
 k0s: # @schema description: K0s parameters; type: object; additionalProperties: true
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/cluster/azure-aks/Chart.yaml
+++ b/templates/cluster/azure-aks/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure
   cluster.x-k8s.io/infrastructure-azure: v1beta1

--- a/templates/cluster/azure-aks/values.yaml
+++ b/templates/cluster/azure-aks/values.yaml
@@ -106,4 +106,4 @@ machinePools:
 kubernetes:
   networkPolicy: azure
   networkPlugin: azure
-  version: v1.35.4 # used in both ASO (patch is not required) and CAPI (patch is required) objects
+  version: v1.36.0 # used in both ASO (patch is not required) and CAPI (patch is required) objects

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.41
+version: 1.0.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/azure-hosted-cp/values.yaml
+++ b/templates/cluster/azure-hosted-cp/values.yaml
@@ -79,7 +79,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.37
+version: 1.0.38
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-azure, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/azure-standalone-cp/values.yaml
+++ b/templates/cluster/azure-standalone-cp/values.yaml
@@ -76,7 +76,7 @@ worker: # @schema description: Worker nodes parameters; type: object; required: 
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/cluster/docker-hosted-cp/Chart.yaml
+++ b/templates/cluster/docker-hosted-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.1+k0s.1"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-docker, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/docker-hosted-cp/values.yaml
+++ b/templates/cluster/docker-hosted-cp/values.yaml
@@ -34,7 +34,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
   # NOTE: Update with caution – see: PR https://github.com/k0rdent/kcm/pull/1057#issuecomment-2668629616
-  version: v1.35.1+k0s.1 # @schema description: K0s version; type: string
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
 
 storage:

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.36
+version: 1.0.37
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/gcp-hosted-cp/values.yaml
+++ b/templates/cluster/gcp-hosted-cp/values.yaml
@@ -80,7 +80,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.33
+version: 1.0.34
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/gcp-standalone-cp/values.yaml
+++ b/templates/cluster/gcp-standalone-cp/values.yaml
@@ -87,7 +87,7 @@ worker: # @schema description: Worker parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-kubevirt, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/kubevirt-hosted-cp/values.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/values.yaml
@@ -95,7 +95,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.0.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-kubevirt, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/kubevirt-standalone-cp/values.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/values.yaml
@@ -119,7 +119,7 @@ worker: # @schema description: Worker parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.33
+version: 1.0.34
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-openstack, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/openstack-hosted-cp/values.yaml
+++ b/templates/cluster/openstack-hosted-cp/values.yaml
@@ -118,7 +118,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.38
+version: 1.0.39
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-openstack, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/openstack-standalone-cp/values.yaml
+++ b/templates/cluster/openstack-standalone-cp/values.yaml
@@ -113,7 +113,7 @@ worker: # @schema description: Configuration of the worker instances; type: obje
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string; required: true
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string; required: true
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.30
+version: 1.0.31
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   cluster.x-k8s.io/bootstrap-k0sproject-k0smotron: v1beta1

--- a/templates/cluster/remote-cluster/values.yaml
+++ b/templates/cluster/remote-cluster/values.yaml
@@ -69,7 +69,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   api: # @schema description: Kubernetes API server parameters; type: object
     extraArgs: {} # @schema description: Map of key-values (strings) for any extra arguments to pass down to Kubernetes api-server process; type: object; additionalProperties: true

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,12 +7,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.36
+version: 1.0.37
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-vsphere, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   k0rdent.mirantis.com/type: deployment

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -71,7 +71,7 @@ k0smotron: # @schema description: K0smotron parameters; type: object
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true
   api: # @schema description: Kubernetes API server parameters; type: object

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,12 +6,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.34
+version: 1.0.35
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.35.4+k0s.0"
+appVersion: "v1.36.1+k0s.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-vsphere, control-plane-k0sproject-k0smotron, bootstrap-k0sproject-k0smotron
   k0rdent.mirantis.com/type: deployment

--- a/templates/cluster/vsphere-standalone-cp/values.yaml
+++ b/templates/cluster/vsphere-standalone-cp/values.yaml
@@ -75,7 +75,7 @@ worker:
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object
-  version: v1.35.4+k0s.0 # @schema description: K0s version; type: string
+  version: v1.36.1+k0s.0 # @schema description: K0s version; type: string
   arch: amd64 # @schema description: K0s Download URL Arch; type: string; enum: amd64, arm64, arm; default: amd64
   cpArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s controller. See: https://docs.k0sproject.io/stable/cli/k0s_controller/; type: array; item: string; uniqueItems: true
   workerArgs: [] # @schema description: Args specifies extra arguments to be passed to k0s worker. See: https://docs.k0sproject.io/stable/worker-node-config/ See: https://docs.k0sproject.io/stable/cli/k0s_worker/; type: array; item: string; uniqueItems: true

--- a/templates/provider/kcm-templates/files/templates/aws-eks-1-0-11.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-eks-1-0-11.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-eks-1-0-10
+  name: aws-eks-1-0-11
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: aws-eks
-      version: 1.0.10
+      version: 1.0.11
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-39.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-39.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-30
+  name: aws-hosted-cp-1-0-39
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.30
+      chart: aws-hosted-cp
+      version: 1.0.39
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-36.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-36.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-41
+  name: aws-standalone-cp-1-0-36
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.41
+      chart: aws-standalone-cp
+      version: 1.0.36
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-aks-1-0-9.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-aks-1-0-9.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-38
+  name: azure-aks-1-0-9
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.38
+      chart: azure-aks
+      version: 1.0.9
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-42.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-42.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-35
+  name: azure-hosted-cp-1-0-42
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.35
+      chart: azure-hosted-cp
+      version: 1.0.42
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-38.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-38.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-hosted-cp-1-0-12
+  name: azure-standalone-cp-1-0-38
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-hosted-cp
-      version: 1.0.12
+      chart: azure-standalone-cp
+      version: 1.0.38
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-13.yaml
+++ b/templates/provider/kcm-templates/files/templates/docker-hosted-cp-1-0-13.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-38
+  name: docker-hosted-cp-1-0-13
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.38
+      chart: docker-hosted-cp
+      version: 1.0.13
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-37.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-37.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: docker-hosted-cp-1-0-12
+  name: gcp-hosted-cp-1-0-37
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: docker-hosted-cp
-      version: 1.0.12
+      chart: gcp-hosted-cp
+      version: 1.0.37
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-34.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-34.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-37
+  name: gcp-standalone-cp-1-0-34
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.37
+      chart: gcp-standalone-cp
+      version: 1.0.34
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-13.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-13.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-34
+  name: kubevirt-hosted-cp-1-0-13
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.34
+      chart: kubevirt-hosted-cp
+      version: 1.0.13
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-14.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-14.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-36
+  name: kubevirt-standalone-cp-1-0-14
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.36
+      chart: kubevirt-standalone-cp
+      version: 1.0.14
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-34.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-34.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-36
+  name: openstack-hosted-cp-1-0-34
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.36
+      chart: openstack-hosted-cp
+      version: 1.0.34
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-39.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-39.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-aks-1-0-8
+  name: openstack-standalone-cp-1-0-39
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-aks
-      version: 1.0.8
+      chart: openstack-standalone-cp
+      version: 1.0.39
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-31.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-31.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-13
+  name: remote-cluster-1-0-31
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-standalone-cp
-      version: 1.0.13
+      chart: remote-cluster
+      version: 1.0.31
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-37.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-37.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-33
+  name: vsphere-hosted-cp-1-0-37
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.33
+      chart: vsphere-hosted-cp
+      version: 1.0.37
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-35.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-35.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-33
+  name: vsphere-standalone-cp-1-0-35
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.33
+      chart: vsphere-standalone-cp
+      version: 1.0.35
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains:
1. k0s version update to v1.36.1+k0s.0
2. EKS version update to v1.36.1
3. AKS version update to v1.36.0

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2828 
