### PR TITLE
fix: delete orphaned provider config and cld registry secrets

### DIFF
--- a/api/v1beta1/management_types.go
+++ b/api/v1beta1/management_types.go
@@ -61,6 +61,11 @@ const (
 	HasIncompatibleContractsReason = "HasIncompatibleContracts"
 )
 
+const (
+	// RegistryCredentialSecretReadyCondition indicates the registry credential secret has been created.
+	RegistryCredentialSecretReadyCondition = "RegistryCredentialSecretReady"
+)
+
 // Core represents a structure describing core Management components.
 type Core struct {
 	// KCM represents the core KCM component and references the KCM template.

--- a/internal/controller/components/cleanup.go
+++ b/internal/controller/components/cleanup.go
@@ -21,6 +21,8 @@ import (
 	"slices"
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +37,7 @@ import (
 func Cleanup(
 	ctx context.Context,
 	mgmtClient client.Client,
+	rgnClient client.Client,
 	cluster clusterInterface,
 	release *kcmv1.Release,
 	labelSelector *metav1.LabelSelector,
@@ -98,6 +101,24 @@ func Cleanup(
 			continue
 		}
 		l.V(1).Info("Removed HelmRelease", "reference", client.ObjectKeyFromObject(&hr).String())
+
+		providerConfigSecretName := getProviderConfigSecretName(componentName)
+		providerConfigSecret := &corev1.Secret{}
+		providerConfigSecretKey := client.ObjectKey{Name: providerConfigSecretName, Namespace: namespace}
+		if err := rgnClient.Get(ctx, providerConfigSecretKey, providerConfigSecret); err != nil {
+			if !apierrors.IsNotFound(err) {
+				errs = errors.Join(errs, fmt.Errorf("failed to get provider config secret %s: %w", providerConfigSecretKey.String(), err))
+			}
+			continue
+		}
+		if providerConfigSecret.Labels[kcmv1.KCMManagedLabelKey] != kcmv1.KCMManagedLabelValue {
+			continue
+		}
+		if err := rgnClient.Delete(ctx, providerConfigSecret); client.IgnoreNotFound(err) != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to delete provider config secret %s: %w", providerConfigSecretKey.String(), err))
+			continue
+		}
+		l.V(1).Info("Removed provider config secret", "reference", providerConfigSecretKey.String())
 	}
 
 	return errs

--- a/internal/controller/components/cleanup_test.go
+++ b/internal/controller/components/cleanup_test.go
@@ -1,0 +1,367 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package components
+
+import (
+	"context"
+	"testing"
+
+	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+)
+
+// fakeCluster implements clusterInterface for testing Cleanup.
+type fakeCluster struct {
+	client.Object
+	components       kcmv1.ComponentsCommonSpec
+	status           kcmv1.ComponentsCommonStatus
+	kcmComponentInfo kcmv1.KCMComponentInfo
+	hrPrefix         string
+}
+
+func (f *fakeCluster) Components() kcmv1.ComponentsCommonSpec {
+	return f.components
+}
+
+func (f *fakeCluster) GetComponentsStatus() *kcmv1.ComponentsCommonStatus {
+	return &f.status
+}
+
+func (f *fakeCluster) KCMComponentInfo(_ *kcmv1.Release, _ string) kcmv1.KCMComponentInfo {
+	return f.kcmComponentInfo
+}
+
+func (f *fakeCluster) HelmReleasePrefix() string {
+	return f.hrPrefix
+}
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, helmcontrollerv2.AddToScheme(s))
+	require.NoError(t, sourcev1.AddToScheme(s))
+	require.NoError(t, kcmv1.AddToScheme(s))
+	return s
+}
+
+func makeHelmRelease(name, namespace string, labels map[string]string, ownerRefs []metav1.OwnerReference) *helmcontrollerv2.HelmRelease { //nolint:unparam
+	return &helmcontrollerv2.HelmRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			OwnerReferences: ownerRefs,
+		},
+		Spec: helmcontrollerv2.HelmReleaseSpec{
+			ChartRef: &helmcontrollerv2.CrossNamespaceSourceReference{
+				Kind:      sourcev1.HelmChartKind,
+				Name:      "chart-" + name,
+				Namespace: namespace,
+			},
+		},
+	}
+}
+
+func makeSecret(name, namespace string, labels map[string]string) *corev1.Secret { //nolint:unparam
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Data: map[string][]byte{"key": []byte("value")},
+	}
+}
+
+func Test_Cleanup(t *testing.T) {
+	const (
+		namespace = "test-ns"
+		kcmChart  = "kcm"
+	)
+
+	managedLabels := map[string]string{kcmv1.KCMManagedLabelKey: kcmv1.KCMManagedLabelValue}
+
+	tests := []struct {
+		name string
+		// Objects present in the management cluster client.
+		mgmtObjects []client.Object
+		// Objects present in the regional cluster client.
+		rgnObjects []client.Object
+		// Cluster spec providers (components still desired).
+		providers []kcmv1.Provider
+		// Label selector to pass to `Cleanup`.
+		labelSelector *metav1.LabelSelector
+		// HelmRelease prefix for the cluster.
+		hrPrefix string
+
+		wantErr bool
+		// HelmReleases expected to remain after `Cleanup`.
+		expectHRsRemain []string
+		// HelmReleases expected to be deleted after `Cleanup`.
+		expectHRsDeleted []string
+		// Secrets expected to remain on the regional client.
+		expectSecretsRemain []string
+		// Secrets expected to be deleted from the regional client.
+		expectSecretsDeleted []string
+	}{
+		{
+			name: "deletes orphaned HelmRelease and its KCM-managed provider config secret",
+			mgmtObjects: []client.Object{
+				makeHelmRelease("orphaned-provider", namespace, managedLabels, nil),
+			},
+			rgnObjects: []client.Object{
+				makeSecret("orphaned-provider-variables", namespace, managedLabels),
+			},
+			expectHRsDeleted:     []string{"orphaned-provider"},
+			expectSecretsDeleted: []string{"orphaned-provider-variables"},
+		},
+		{
+			name: "skips provider config secret without KCM managed label",
+			mgmtObjects: []client.Object{
+				makeHelmRelease("orphaned-provider", namespace, managedLabels, nil),
+			},
+			rgnObjects: []client.Object{
+				makeSecret("orphaned-provider-variables", namespace, nil), // no managed label
+			},
+			expectHRsDeleted:    []string{"orphaned-provider"},
+			expectSecretsRemain: []string{"orphaned-provider-variables"},
+		},
+		{
+			name: "skips HelmRelease with owner references (non-orphaned)",
+			mgmtObjects: []client.Object{
+				makeHelmRelease("owned-provider", namespace, managedLabels, []metav1.OwnerReference{
+					{APIVersion: kcmv1.GroupVersion.String(), Kind: kcmv1.ClusterDeploymentKind, Name: "some-owner", UID: types.UID("uid")},
+				}),
+			},
+			rgnObjects: []client.Object{
+				makeSecret("owned-provider-variables", namespace, managedLabels),
+			},
+			expectHRsRemain:     []string{"owned-provider"},
+			expectSecretsRemain: []string{"owned-provider-variables"},
+		},
+		{
+			name: "no error when provider config secret does not exist",
+			mgmtObjects: []client.Object{
+				makeHelmRelease("orphaned-no-secret", namespace, managedLabels, nil),
+			},
+			rgnObjects:       []client.Object{}, // no secret
+			expectHRsDeleted: []string{"orphaned-no-secret"},
+		},
+		{
+			name: "uses rgnClient for secret operations (secret only on regional)",
+			mgmtObjects: []client.Object{
+				makeHelmRelease("rgn-orphaned", namespace, managedLabels, nil),
+			},
+			rgnObjects: []client.Object{
+				makeSecret("rgn-orphaned-variables", namespace, managedLabels),
+			},
+			expectHRsDeleted:     []string{"rgn-orphaned"},
+			expectSecretsDeleted: []string{"rgn-orphaned-variables"},
+		},
+		{
+			name: "skips HelmRelease matching core CAPI name",
+			mgmtObjects: []client.Object{
+				makeHelmRelease(kcmv1.CoreCAPIName, namespace, managedLabels, nil),
+			},
+			rgnObjects: []client.Object{
+				makeSecret(kcmv1.CoreCAPIName+"-variables", namespace, managedLabels),
+			},
+			expectHRsRemain:     []string{kcmv1.CoreCAPIName},
+			expectSecretsRemain: []string{kcmv1.CoreCAPIName + "-variables"},
+		},
+		{
+			name: "skips HelmRelease matching KCM chart name",
+			mgmtObjects: []client.Object{
+				makeHelmRelease(kcmChart, namespace, managedLabels, nil),
+			},
+			rgnObjects: []client.Object{
+				makeSecret(kcmChart+"-variables", namespace, managedLabels),
+			},
+			expectHRsRemain:     []string{kcmChart},
+			expectSecretsRemain: []string{kcmChart + "-variables"},
+		},
+		{
+			name: "skips HelmRelease matching a provider still in spec",
+			mgmtObjects: []client.Object{
+				makeHelmRelease("my-infra-provider", namespace, managedLabels, nil),
+			},
+			rgnObjects: []client.Object{
+				makeSecret("my-infra-provider-variables", namespace, managedLabels),
+			},
+			providers:           []kcmv1.Provider{{Name: "my-infra-provider"}},
+			expectHRsRemain:     []string{"my-infra-provider"},
+			expectSecretsRemain: []string{"my-infra-provider-variables"},
+		},
+		{
+			name: "respects HelmRelease prefix when matching providers",
+			mgmtObjects: []client.Object{
+				makeHelmRelease("region1-my-provider", namespace, managedLabels, nil),
+				makeHelmRelease("region1-orphaned", namespace, managedLabels, nil),
+			},
+			rgnObjects: []client.Object{
+				makeSecret("region1-my-provider-variables", namespace, managedLabels),
+				makeSecret("region1-orphaned-variables", namespace, managedLabels),
+			},
+			providers:            []kcmv1.Provider{{Name: "my-provider"}},
+			hrPrefix:             "region1",
+			expectHRsRemain:      []string{"region1-my-provider"},
+			expectSecretsRemain:  []string{"region1-my-provider-variables"},
+			expectHRsDeleted:     []string{"region1-orphaned"},
+			expectSecretsDeleted: []string{"region1-orphaned-variables"},
+		},
+		{
+			name: "deletes multiple orphaned HelmReleases and their secrets",
+			mgmtObjects: []client.Object{
+				makeHelmRelease("orphan-1", namespace, managedLabels, nil),
+				makeHelmRelease("orphan-2", namespace, managedLabels, nil),
+			},
+			rgnObjects: []client.Object{
+				makeSecret("orphan-1-variables", namespace, managedLabels),
+				makeSecret("orphan-2-variables", namespace, managedLabels),
+			},
+			expectHRsDeleted:     []string{"orphan-1", "orphan-2"},
+			expectSecretsDeleted: []string{"orphan-1-variables", "orphan-2-variables"},
+		},
+		{
+			name: "filters by label selector",
+			mgmtObjects: []client.Object{
+				// This HR has the managed label + the extra label that matches the selector.
+				makeHelmRelease("labeled-orphan", namespace, map[string]string{
+					kcmv1.KCMManagedLabelKey: kcmv1.KCMManagedLabelValue,
+					"env":                    "test",
+				}, nil),
+				// This HR has the managed label but NOT the extra label.
+				makeHelmRelease("unlabeled-orphan", namespace, managedLabels, nil),
+			},
+			rgnObjects: []client.Object{
+				makeSecret("labeled-orphan-variables", namespace, managedLabels),
+				makeSecret("unlabeled-orphan-variables", namespace, managedLabels),
+			},
+			labelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "test"},
+			},
+			expectHRsDeleted:     []string{"labeled-orphan"},
+			expectSecretsDeleted: []string{"labeled-orphan-variables"},
+			// The one without the extra label won't be listed due to selector filtering.
+			expectHRsRemain:     []string{"unlabeled-orphan"},
+			expectSecretsRemain: []string{"unlabeled-orphan-variables"},
+		},
+		{
+			name:        "no HelmReleases present, no error",
+			mgmtObjects: []client.Object{},
+			rgnObjects:  []client.Object{},
+			wantErr:     false,
+		},
+		{
+			name: "skips HelmRelease matching a Release templates chart name",
+			mgmtObjects: []client.Object{
+				// "my-release-tpl" is the TemplatesChartFromReleaseName for "my-release"
+				makeHelmRelease("my-release-tpl", namespace, managedLabels, nil),
+				// Release object whose TemplatesChartFromReleaseName("my-release") == "my-release-tpl"
+				&kcmv1.Release{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-release",
+					},
+					Spec: kcmv1.ReleaseSpec{
+						Version: "v0.0.1",
+						KCM:     kcmv1.CoreProviderTemplate{Template: "kcm-template"},
+						CAPI:    kcmv1.CoreProviderTemplate{Template: "capi-template"},
+					},
+				},
+			},
+			rgnObjects: []client.Object{
+				makeSecret("my-release-tpl-variables", namespace, managedLabels),
+			},
+			expectHRsRemain:     []string{"my-release-tpl"},
+			expectSecretsRemain: []string{"my-release-tpl-variables"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newScheme(t)
+
+			mgmtClient := fake.NewClientBuilder().WithScheme(s).
+				WithObjects(tt.mgmtObjects...).
+				Build()
+			rgnClient := fake.NewClientBuilder().WithScheme(s).
+				WithObjects(tt.rgnObjects...).
+				Build()
+
+			release := &kcmv1.Release{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-release"},
+				Spec: kcmv1.ReleaseSpec{
+					KCM:  kcmv1.CoreProviderTemplate{Template: "kcm-template"},
+					CAPI: kcmv1.CoreProviderTemplate{Template: "capi-template"},
+				},
+			}
+
+			cluster := &fakeCluster{
+				Object: &kcmv1.Management{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-mgmt"},
+				},
+				components: kcmv1.ComponentsCommonSpec{
+					Providers: tt.providers,
+				},
+				kcmComponentInfo: kcmv1.KCMComponentInfo{ChartName: kcmChart},
+				hrPrefix:         tt.hrPrefix,
+			}
+
+			err := Cleanup(context.Background(), mgmtClient, rgnClient, cluster, release, tt.labelSelector, namespace)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			ctx := context.Background()
+
+			for _, name := range tt.expectHRsDeleted {
+				hr := &helmcontrollerv2.HelmRelease{}
+				err := mgmtClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, hr)
+				require.Error(t, err, "HelmRelease %q should have been deleted", name)
+			}
+
+			for _, name := range tt.expectHRsRemain {
+				hr := &helmcontrollerv2.HelmRelease{}
+				err := mgmtClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, hr)
+				require.NoError(t, err, "HelmRelease %q should still exist", name)
+			}
+
+			for _, name := range tt.expectSecretsDeleted {
+				secret := &corev1.Secret{}
+				err := rgnClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret)
+				require.Error(t, err, "Secret %q should have been deleted from rgnClient", name)
+			}
+
+			for _, name := range tt.expectSecretsRemain {
+				secret := &corev1.Secret{}
+				err := rgnClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret)
+				assert.NoError(t, err, "Secret %q should still exist on rgnClient", name)
+			}
+		})
+	}
+}

--- a/internal/controller/components/reconciler.go
+++ b/internal/controller/components/reconciler.go
@@ -688,6 +688,10 @@ func reconcileProviderConfigSecret(
 		}
 
 		op, err := ctrl.CreateOrUpdate(ctx, rgnlClient, providerSecret, func() error {
+			if providerSecret.Labels == nil {
+				providerSecret.Labels = make(map[string]string)
+			}
+			providerSecret.Labels[kcmv1.KCMManagedLabelKey] = kcmv1.KCMManagedLabelValue
 			providerSecret.Data = providerSecretData
 			return nil
 		})

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -153,7 +153,7 @@ func (r *ManagementReconciler) update(ctx context.Context, management *kcmv1.Man
 			},
 		},
 	}
-	if err := components.Cleanup(ctx, r.Client, management, release, labelSelector, r.SystemNamespace); err != nil {
+	if err := components.Cleanup(ctx, r.Client, r.Client, management, release, labelSelector, r.SystemNamespace); err != nil {
 		r.warnf(management, "ComponentsCleanupFailed", "failed to cleanup removed components: %v", err)
 		l.Error(err, "failed to cleanup removed components")
 		return ctrl.Result{}, err
@@ -206,12 +206,14 @@ func (r *ManagementReconciler) update(ctx context.Context, management *kcmv1.Man
 		requeue = true
 	}
 
-	if r.RegistryCredentialsSecretName != "" && r.GlobalRegistry != "" {
-		if err := r.createCldRegistryCredSecret(ctx); err != nil {
-			r.warnf(management, "RegistryCredentialSecretCreationFailed", "Failed to create registry credential secret: %v", err)
-			l.Error(err, "failed to create registry credential secret")
-			return ctrl.Result{}, err
+	if err := r.ensureCldRegistryCredSecret(ctx, management); err != nil {
+		var statusErr error
+		if r.setCondition(management, kcmv1.RegistryCredentialSecretReadyCondition, kcmv1.FailedReason, metav1.ConditionFalse, err) {
+			r.warnf(management, "RegistryCredentialSecretError", err.Error())
+			statusErr = r.updateStatus(ctx, management)
 		}
+		l.Error(err, "failed to process registry credential secret")
+		return ctrl.Result{}, errors.Join(err, statusErr)
 	}
 
 	shouldRequeue, err := r.startDependentControllers(ctx, management)
@@ -836,7 +838,28 @@ func makeContainerdAuth(registry, user, pass string) ([]byte, error) {
 	return toml.Marshal(cfg)
 }
 
-func (r *ManagementReconciler) createCldRegistryCredSecret(ctx context.Context) error {
+func (r *ManagementReconciler) ensureCldRegistryCredSecret(ctx context.Context, management *kcmv1.Management) error {
+	// secret that will be passed to clusterdeployment on management cluster
+	cldSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cldRegSecretName,
+			Namespace: r.SystemNamespace,
+		},
+	}
+
+	if r.RegistryCredentialsSecretName == "" || r.GlobalRegistry == "" {
+		err := r.Client.Delete(ctx, cldSecret)
+		if client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("failed to delete cld registry credential Secret %s/%s: %w", r.SystemNamespace, cldRegSecretName, err)
+		}
+		if err == nil { // secret existed and was actually deleted
+			r.eventf(management, "RegistryCredentialSecretDeleted", "Deleted cld registry credential secret %s/%s", r.SystemNamespace, cldRegSecretName)
+		}
+
+		meta.RemoveStatusCondition(management.GetConditions(), kcmv1.RegistryCredentialSecretReadyCondition)
+		return nil
+	}
+
 	regSecret := new(corev1.Secret)
 	if err := r.Client.Get(ctx, client.ObjectKey{Name: r.RegistryCredentialsSecretName, Namespace: r.SystemNamespace}, regSecret); err != nil {
 		return fmt.Errorf("failed to get registry credential secret %s/%s: %w", r.SystemNamespace, r.RegistryCredentialsSecretName, err)
@@ -873,28 +896,45 @@ data:
 		base64.StdEncoding.EncodeToString(user),
 		base64.StdEncoding.EncodeToString(pass))
 
-	// secret that will be passed to clusterdeployment on management cluster
-	cldSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cldRegSecretName,
-			Namespace: r.SystemNamespace,
-		},
-	}
-
 	cldSecretData := map[string][]byte{
 		"registryCredential": []byte(helmCredsSecret),
 		"containerdAuth":     containerdAuth,
 	}
 
-	_, err = ctrl.CreateOrUpdate(ctx, r.Client, cldSecret, func() error {
+	operation, err := ctrl.CreateOrUpdate(ctx, r.Client, cldSecret, func() error {
 		cldSecret.Data = cldSecretData
+
+		if err := controllerutil.SetOwnerReference(management, cldSecret, r.Client.Scheme()); err != nil {
+			return fmt.Errorf("failed to add OwnerReference on Secret %s/%s: %w", r.SystemNamespace, cldRegSecretName, err)
+		}
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create cld credential secret %s: %w", cldRegSecretName, err)
+		return fmt.Errorf("failed to create or update cld credential secret %s/%s: %w", r.SystemNamespace, cldRegSecretName, err)
 	}
+	if operation == controllerutil.OperationResultCreated {
+		r.eventf(management, "RegistryCredentialSecretCreated", "Successfully created Secret with the cld registry credential %s/%s", r.SystemNamespace, cldRegSecretName)
+	}
+	if operation == controllerutil.OperationResultUpdated {
+		r.eventf(management, "RegistryCredentialSecretUpdated", "Successfully updated Secret with the cld registry credential %s/%s", r.SystemNamespace, cldRegSecretName)
+	}
+	_ = r.setCondition(management, kcmv1.RegistryCredentialSecretReadyCondition, kcmv1.SucceededReason, metav1.ConditionTrue, nil)
 
 	return nil
+}
+
+func (*ManagementReconciler) setCondition(management *kcmv1.Management, typ, reason string, status metav1.ConditionStatus, err error) (changed bool) { //nolint:unparam
+	var msg string
+	if err != nil {
+		msg = err.Error()
+	}
+	return meta.SetStatusCondition(&management.Status.Conditions, metav1.Condition{
+		Type:               typ,
+		Status:             status,
+		Reason:             reason,
+		Message:            msg,
+		ObservedGeneration: management.Generation,
+	})
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/management_controller_test.go
+++ b/internal/controller/management_controller_test.go
@@ -15,7 +15,9 @@
 package controller
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -594,6 +596,268 @@ var _ = Describe("Management Controller", func() {
 			again := &appsv1.Deployment{}
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(addonController), again)).To(Succeed())
 			Expect(again.Spec.Template.Annotations[restartAnnotation]).To(Equal(firstTS))
+		})
+	})
+
+	Context("ensureCldRegistryCredSecret", func() {
+		const (
+			systemNamespace    = "kcm-system-cld-test"
+			registrySecretName = "registry-creds"
+			globalRegistry     = "registry.example.com"
+		)
+
+		var mgmt *kcmv1.Management
+
+		BeforeEach(func() {
+			By("ensuring the system namespace exists")
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: systemNamespace},
+			}))).To(Succeed())
+			Eventually(k8sClient.Get).WithArguments(ctx, client.ObjectKey{Name: systemNamespace}, &corev1.Namespace{}).
+				WithTimeout(3 * time.Second).WithPolling(pollingInterval).Should(Succeed())
+
+			mgmt = &kcmv1.Management{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-mgmt-cld-reg-" + strconv.FormatInt(time.Now().UnixNano(), 10),
+				},
+				Spec: kcmv1.ManagementSpec{
+					Release: "test-release",
+				},
+			}
+			Expect(k8sClient.Create(ctx, mgmt)).To(Succeed())
+			Eventually(k8sClient.Get).WithArguments(ctx, client.ObjectKeyFromObject(mgmt), mgmt).
+				WithTimeout(3 * time.Second).WithPolling(pollingInterval).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up management and secrets")
+			mgmt.Finalizers = nil
+			_ = k8sClient.Update(ctx, mgmt)
+			_ = k8sClient.Delete(ctx, mgmt)
+			_ = k8sClient.Delete(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: cldRegSecretName, Namespace: systemNamespace},
+			})
+			_ = k8sClient.Delete(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: registrySecretName, Namespace: systemNamespace},
+			})
+		})
+
+		It("should return nil and do nothing when registry config is empty and no prior condition exists", func() {
+			r := &ManagementReconciler{
+				Client:                        k8sClient,
+				SystemNamespace:               systemNamespace,
+				RegistryCredentialsSecretName: "",
+				GlobalRegistry:                "",
+			}
+
+			err := r.ensureCldRegistryCredSecret(ctx, mgmt)
+			Expect(err).NotTo(HaveOccurred())
+
+			secret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: cldRegSecretName, Namespace: systemNamespace}, secret)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cld secret should not exist")
+		})
+
+		It("should create the cld registry credential secret when registry config is provided", func() {
+			regSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      registrySecretName,
+					Namespace: systemNamespace,
+				},
+				Data: map[string][]byte{
+					"username": []byte("testuser"),
+					"password": []byte("testpass"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, regSecret)).To(Succeed())
+
+			r := &ManagementReconciler{
+				Client:                        k8sClient,
+				SystemNamespace:               systemNamespace,
+				RegistryCredentialsSecretName: registrySecretName,
+				GlobalRegistry:                globalRegistry,
+			}
+
+			err := r.ensureCldRegistryCredSecret(ctx, mgmt)
+			Expect(err).NotTo(HaveOccurred())
+
+			cldSecret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: cldRegSecretName, Namespace: systemNamespace}, cldSecret)).To(Succeed())
+			Expect(cldSecret.Data).To(HaveKey("registryCredential"))
+			Expect(cldSecret.Data).To(HaveKey("containerdAuth"))
+
+			By("checking the RegistryCredentialSecretReady condition is set on the in-memory object")
+			// The condition is set in-memory by ensureCldRegistryCredSecret; the caller (update) persists it later.
+			cond := meta.FindStatusCondition(mgmt.Status.Conditions, kcmv1.RegistryCredentialSecretReadyCondition)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(kcmv1.SucceededReason))
+		})
+
+		It("should delete the cld secret when registry config is removed after it was set", func() {
+			regSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      registrySecretName,
+					Namespace: systemNamespace,
+				},
+				Data: map[string][]byte{
+					"username": []byte("testuser"),
+					"password": []byte("testpass"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, regSecret)).To(Succeed())
+
+			r := &ManagementReconciler{
+				Client:                        k8sClient,
+				SystemNamespace:               systemNamespace,
+				RegistryCredentialsSecretName: registrySecretName,
+				GlobalRegistry:                globalRegistry,
+			}
+
+			By("first creating the secret")
+			err := r.ensureCldRegistryCredSecret(ctx, mgmt)
+			Expect(err).NotTo(HaveOccurred())
+
+			cldSecret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: cldRegSecretName, Namespace: systemNamespace}, cldSecret)).To(Succeed())
+
+			By("checking the condition was set on the in-memory object")
+			cond := meta.FindStatusCondition(mgmt.Status.Conditions, kcmv1.RegistryCredentialSecretReadyCondition)
+			Expect(cond).NotTo(BeNil())
+
+			By("simulating removal of the registry config")
+			r.RegistryCredentialsSecretName = ""
+			r.GlobalRegistry = ""
+
+			err = r.ensureCldRegistryCredSecret(ctx, mgmt)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("the cld secret should be deleted")
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: cldRegSecretName, Namespace: systemNamespace}, cldSecret)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cld secret should have been deleted")
+
+			By("the condition should be removed")
+			cond = meta.FindStatusCondition(mgmt.Status.Conditions, kcmv1.RegistryCredentialSecretReadyCondition)
+			Expect(cond).To(BeNil(), "RegistryCredentialSecretReady condition should have been removed")
+		})
+
+		It("should return error when the registry credential secret is missing", func() {
+			r := &ManagementReconciler{
+				Client:                        k8sClient,
+				SystemNamespace:               systemNamespace,
+				RegistryCredentialsSecretName: "nonexistent-secret",
+				GlobalRegistry:                globalRegistry,
+			}
+
+			err := r.ensureCldRegistryCredSecret(ctx, mgmt)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get registry credential secret"))
+		})
+
+		It("should return error when registry credential secret is missing username", func() {
+			regSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      registrySecretName,
+					Namespace: systemNamespace,
+				},
+				Data: map[string][]byte{
+					"password": []byte("testpass"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, regSecret)).To(Succeed())
+
+			r := &ManagementReconciler{
+				Client:                        k8sClient,
+				SystemNamespace:               systemNamespace,
+				RegistryCredentialsSecretName: registrySecretName,
+				GlobalRegistry:                globalRegistry,
+			}
+
+			err := r.ensureCldRegistryCredSecret(ctx, mgmt)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("username"))
+		})
+
+		It("should return error when registry credential secret is missing password", func() {
+			regSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      registrySecretName,
+					Namespace: systemNamespace,
+				},
+				Data: map[string][]byte{
+					"username": []byte("testuser"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, regSecret)).To(Succeed())
+
+			r := &ManagementReconciler{
+				Client:                        k8sClient,
+				SystemNamespace:               systemNamespace,
+				RegistryCredentialsSecretName: registrySecretName,
+				GlobalRegistry:                globalRegistry,
+			}
+
+			err := r.ensureCldRegistryCredSecret(ctx, mgmt)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("password"))
+		})
+	})
+
+	Context("setCondition", func() {
+		It("should set a condition with error message", func() {
+			mgmt := &kcmv1.Management{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-mgmt-set-cond",
+					Generation: 2,
+				},
+			}
+
+			r := &ManagementReconciler{}
+			changed := r.setCondition(mgmt, kcmv1.RegistryCredentialSecretReadyCondition, kcmv1.FailedReason, metav1.ConditionFalse, errors.New("something went wrong"))
+			Expect(changed).To(BeTrue())
+
+			cond := meta.FindStatusCondition(mgmt.Status.Conditions, kcmv1.RegistryCredentialSecretReadyCondition)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(kcmv1.FailedReason))
+			Expect(cond.Message).To(Equal("something went wrong"))
+			Expect(cond.ObservedGeneration).To(Equal(int64(2)))
+		})
+
+		It("should set a condition with empty message when err is nil", func() {
+			mgmt := &kcmv1.Management{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-mgmt-set-cond-nil",
+					Generation: 3,
+				},
+			}
+
+			r := &ManagementReconciler{}
+			changed := r.setCondition(mgmt, kcmv1.RegistryCredentialSecretReadyCondition, kcmv1.SucceededReason, metav1.ConditionTrue, nil)
+			Expect(changed).To(BeTrue())
+
+			cond := meta.FindStatusCondition(mgmt.Status.Conditions, kcmv1.RegistryCredentialSecretReadyCondition)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(kcmv1.SucceededReason))
+			Expect(cond.Message).To(BeEmpty())
+			Expect(cond.ObservedGeneration).To(Equal(int64(3)))
+		})
+
+		It("should return false when setting the same condition again", func() {
+			mgmt := &kcmv1.Management{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-mgmt-set-cond-nochange",
+					Generation: 1,
+				},
+			}
+
+			r := &ManagementReconciler{}
+			changed := r.setCondition(mgmt, kcmv1.RegistryCredentialSecretReadyCondition, kcmv1.SucceededReason, metav1.ConditionTrue, nil)
+			Expect(changed).To(BeTrue())
+
+			changed = r.setCondition(mgmt, kcmv1.RegistryCredentialSecretReadyCondition, kcmv1.SucceededReason, metav1.ConditionTrue, nil)
+			Expect(changed).To(BeFalse(), "setting the same condition twice should return false")
 		})
 	})
 })

--- a/internal/controller/region/controller.go
+++ b/internal/controller/region/controller.go
@@ -153,7 +153,7 @@ func (r *Reconciler) update(ctx context.Context, rgnlClient client.Client, restC
 			},
 		},
 	}
-	if err := components.Cleanup(ctx, r.MgmtClient, region, release, labelSelector, r.SystemNamespace); err != nil {
+	if err := components.Cleanup(ctx, r.MgmtClient, rgnlClient, region, release, labelSelector, r.SystemNamespace); err != nil {
 		r.warnf(region, "ComponentsCleanupFailed", "failed to cleanup removed components: %v", err)
 		l.Error(err, "failed to cleanup removed components")
 		return ctrl.Result{}, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue that could leave the cld registry credential secret and provider configuration variable secrets orphaned after configuration changes (for example, when a provider is removed from the Management or Region object).
It also contains unit tests for the new functionality and for the components Cleanup function.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2839
Fixes #2840
