### PR TITLE
fix: disallow enabling or removing ClusterDeployment spec.dataSource

### DIFF
--- a/internal/webhook/clusterdeployment_webhook.go
+++ b/internal/webhook/clusterdeployment_webhook.go
@@ -131,6 +131,12 @@ func (v *ClusterDeploymentValidator) ValidateUpdate(ctx context.Context, oldClus
 		}
 	}
 
+	oldHasDataSource := oldClusterDeployment.Spec.DataSource != ""
+	newHasDataSource := newClusterDeployment.Spec.DataSource != ""
+	if oldHasDataSource != newHasDataSource {
+		return nil, fmt.Errorf("%s: spec.dataSource cannot be added or removed after creation", invalidClusterDeploymentMsg)
+	}
+
 	oldServices := oldClusterDeployment.Spec.ServiceSpec.Services
 	newServices := newClusterDeployment.Spec.ServiceSpec.Services
 	if !equality.Semantic.DeepEqual(oldServices, newServices) {

--- a/internal/webhook/clusterdeployment_webhook_test.go
+++ b/internal/webhook/clusterdeployment_webhook_test.go
@@ -693,6 +693,66 @@ func TestClusterDeploymentValidateUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "should fail if spec.dataSource is removed",
+			oldClusterDeployment: clusterdeployment.NewClusterDeployment(
+				clusterdeployment.WithClusterTemplate(testTemplateName),
+				clusterdeployment.WithCredential(testCredentialName),
+				clusterdeployment.WithDataSource("ds-test"),
+			),
+			newClusterDeployment: clusterdeployment.NewClusterDeployment(
+				clusterdeployment.WithClusterTemplate(testTemplateName),
+				clusterdeployment.WithCredential(testCredentialName),
+			),
+			existingObjects: []runtime.Object{
+				mgmt,
+				cred,
+				providerInterface,
+				template.NewClusterTemplate(
+					template.WithName(testTemplateName),
+					template.WithValidationStatus(kcmv1.TemplateValidationStatus{
+						Valid:           false,
+						ValidationError: "validation error example",
+					}),
+					template.WithProvidersStatus(
+						"infrastructure-aws",
+						"control-plane-k0smotron",
+						"bootstrap-k0smotron",
+					),
+				),
+			},
+			err: "the ClusterDeployment is invalid: spec.dataSource cannot be added or removed after creation",
+		},
+		{
+			name: "should fail if spec.dataSource is added",
+			oldClusterDeployment: clusterdeployment.NewClusterDeployment(
+				clusterdeployment.WithClusterTemplate(testTemplateName),
+				clusterdeployment.WithCredential(testCredentialName),
+			),
+			newClusterDeployment: clusterdeployment.NewClusterDeployment(
+				clusterdeployment.WithClusterTemplate(testTemplateName),
+				clusterdeployment.WithCredential(testCredentialName),
+				clusterdeployment.WithDataSource("ds-test"),
+			),
+			existingObjects: []runtime.Object{
+				mgmt,
+				cred,
+				providerInterface,
+				template.NewClusterTemplate(
+					template.WithName(testTemplateName),
+					template.WithValidationStatus(kcmv1.TemplateValidationStatus{
+						Valid:           false,
+						ValidationError: "validation error example",
+					}),
+					template.WithProvidersStatus(
+						"infrastructure-aws",
+						"control-plane-k0smotron",
+						"bootstrap-k0smotron",
+					),
+				),
+			},
+			err: "the ClusterDeployment is invalid: spec.dataSource cannot be added or removed after creation",
+		},
+		{
 			name: "should succeed if serviceTemplates are added",
 			oldClusterDeployment: clusterdeployment.NewClusterDeployment(
 				clusterdeployment.WithClusterTemplate(testTemplateName),

--- a/test/objects/clusterdeployment/clusterdeployment.go
+++ b/test/objects/clusterdeployment/clusterdeployment.go
@@ -94,6 +94,12 @@ func WithCredential(credName string) Opt {
 	}
 }
 
+func WithDataSource(dsName string) Opt {
+	return func(p *kcmv1.ClusterDeployment) {
+		p.Spec.DataSource = dsName
+	}
+}
+
 func WithClusterAuthentication(clAuthName string) Opt {
 	return func(p *kcmv1.ClusterDeployment) {
 		p.Spec.ClusterAuth = clAuthName


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new validation rule to prevent the removal or addition of `spec.dataSource` on an existing cluster.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2841
