### PR TITLE
fix: rename remaining fields after k0smotron v2beta2 migration

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-37
+  template: aws-standalone-cp-1-0-38
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-39
+  template: azure-standalone-cp-1-0-40
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-35
+  template: gcp-standalone-cp-1-0-36
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-15
+  template: kubevirt-standalone-cp-1-0-16
   credential: kubevirt-cred
   propagateCredentials: false
   config:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-40
+  template: openstack-standalone-cp-1-0-41
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-36
+  template: vsphere-standalone-cp-1-0-37
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.37
+version: 1.0.38
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -184,13 +184,13 @@ spec:
             node:
               kubeletPath: /var/lib/k0s/kubelet
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-    preStartCommands:
+    preK0sCommands:
     - "sudo update-ca-certificates"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}
     {{- $logDir := dir $logPath }}
-    postStartCommands:
+    postK0sCommands:
     - 'sudo mkdir -p {{ $logDir }}'
     - 'sudo chown kube-apiserver:kube-apiserver {{ $logDir }}'
     {{- end }}

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.39
+version: 1.0.40
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -164,13 +164,13 @@ spec:
               windows:
                 enabled: false
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-    preStartCommands:
+    preK0sCommands:
     - "sudo update-ca-certificates"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}
     {{- $logDir := dir $logPath }}
-    postStartCommands:
+    postK0sCommands:
     - 'sudo mkdir -p {{ $logDir }}'
     - 'sudo chown kube-apiserver:kube-apiserver {{ $logDir }}'
     {{- end }}

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.35
+version: 1.0.36
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -178,13 +178,13 @@ spec:
                     repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
               {{- end }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-    preStartCommands:
+    preK0sCommands:
     - "sudo update-ca-certificates"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}
     {{- $logDir := dir $logPath }}
-    postStartCommands:
+    postK0sCommands:
     - 'sudo mkdir -p {{ $logDir }}'
     - 'sudo chown kube-apiserver:kube-apiserver {{ $logDir }}'
     {{- end }}

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.15
+version: 1.0.16
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
@@ -63,13 +63,13 @@ spec:
       {{- end }}
     {{- end }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-    preStartCommands:
+    preK0sCommands:
     - "sudo update-ca-certificates"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}
     {{- $logDir := dir $logPath }}
-    postStartCommands:
+    postK0sCommands:
     - 'sudo mkdir -p {{ $logDir }}'
     - 'sudo chown kube-apiserver:kube-apiserver {{ $logDir }}'
     {{- end }}

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.40
+version: 1.0.41
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -219,13 +219,13 @@ spec:
                     mountPath: {{ .Values.identityRef.caCert.path  | quote }}
                  {{- end }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-    preStartCommands:
+    preK0sCommands:
     - "sudo update-ca-certificates"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}
     {{- $logDir := dir $logPath }}
-    postStartCommands:
+    postK0sCommands:
     - 'sudo mkdir -p {{ $logDir }}'
     - 'sudo chown kube-apiserver:kube-apiserver {{ $logDir }}'
     {{- end }}

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.36
+version: 1.0.37
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -227,7 +227,7 @@ spec:
                 livenessProbe:
                   repo: {{ $global.registry }}/sig-storage/livenessprobe
                 {{- end }}
-    preStartCommands:
+    preK0sCommands:
       - chown {{ .Values.controlPlane.ssh.user }} /home/{{ .Values.controlPlane.ssh.user }}/.ssh/authorized_keys
       - sed -i 's/"externalAddress":"{{ .Values.controlPlaneEndpointIP }}",//' /etc/k0s.yaml
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
@@ -236,7 +236,7 @@ spec:
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}
     {{- $logDir := dir $logPath }}
-    postStartCommands:
+    postK0sCommands:
     - 'sudo mkdir -p {{ $logDir }}'
     - 'sudo chown kube-apiserver:kube-apiserver {{ $logDir }}'
     {{- end }}

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-38.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-38.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-15
+  name: aws-standalone-cp-1-0-38
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-standalone-cp
-      version: 1.0.15
+      chart: aws-standalone-cp
+      version: 1.0.38
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-40.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-40.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-36
+  name: azure-standalone-cp-1-0-40
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.36
+      chart: azure-standalone-cp
+      version: 1.0.40
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-36.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-36.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-37
+  name: gcp-standalone-cp-1-0-36
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-standalone-cp
-      version: 1.0.37
+      chart: gcp-standalone-cp
+      version: 1.0.36
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-16.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-16.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-39
+  name: kubevirt-standalone-cp-1-0-16
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.39
+      chart: kubevirt-standalone-cp
+      version: 1.0.16
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-41.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-41.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-35
+  name: openstack-standalone-cp-1-0-41
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-standalone-cp
-      version: 1.0.35
+      chart: openstack-standalone-cp
+      version: 1.0.41
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-37.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-37.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-40
+  name: vsphere-standalone-cp-1-0-37
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
-      version: 1.0.40
+      chart: vsphere-standalone-cp
+      version: 1.0.37
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
The k0smotron v1beta2 migration updated the apiVersion from v1beta1 to v1beta2 across all templates.
However, it missed renaming `preStartCommands` and `postStartCommands` in the K0sControlPlane resources.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2885