### PR TITLE
fix: surface errors to ServiceSet status

### DIFF
--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -174,7 +174,7 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				err = errors.Join(err, updateErr)
 			}
 		}
-		l.Info("ServiceSet reconciled", "duration", time.Since(start))
+		l.Info("Finished reconciling ServiceSet", "duration", time.Since(start), "err", err)
 	}()
 
 	serviceSet.Status.Cluster = clusterReference(serviceSet)

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -158,22 +158,21 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	clone := serviceSet.DeepCopy()
 	defer func() {
-		// we won't update serviceSet anyhow in case of any error
-		// occurred during reconciliation, by returning error
-		// serviceSet object being reconciled will be requeued
-		// with respect of rate limits
-		if err != nil {
-			return
+		if err == nil {
+			// fillNotDeployedServices relies on the service type having
+			// already been resolved for every service reachable from spec,
+			// which only holds once the profile was built successfully.
+			fillNotDeployedServices(serviceSet, r.timeFunc)
 		}
-
-		fillNotDeployedServices(serviceSet, r.timeFunc)
-		// if serviceSet status changed we'll update object's
-		// status, so object being reconciled will be requeued,
-		// otherwise we'll do nothing since the poller will
-		// enqueue serviceSet object in case any changes in
-		// corresponding ClusterSummary object.
+		// we'll update serviceSet status even in case of an error occurred
+		// during reconciliation, so that the failure is surfaced on the
+		// object instead of being visible only in the reconciler logs.
+		// By returning the original error, the object being reconciled
+		// will still be requeued with respect of rate limits.
 		if !equality.Semantic.DeepEqual(clone.Status, serviceSet.Status) {
-			err = r.Status().Update(ctx, serviceSet)
+			if updateErr := r.Status().Update(ctx, serviceSet); updateErr != nil {
+				err = errors.Join(err, updateErr)
+			}
 		}
 		l.Info("ServiceSet reconciled", "duration", time.Since(start))
 	}()
@@ -411,9 +410,10 @@ func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient clie
 	message := kcmv1.ServiceSetProfileNotReadyMessage
 
 	defer func(initialStatus metav1.ConditionStatus) {
+		updated := updateCondition(serviceSet, profileCondition, status, reason, message, r.timeFunc())
 		// we'll emit event only if the status changed from the initial value and it's now true.
 		conditionStatusChangedToTrue := initialStatus != status && status == metav1.ConditionTrue
-		if conditionStatusChangedToTrue && updateCondition(serviceSet, profileCondition, status, reason, message, r.timeFunc()) {
+		if conditionStatusChangedToTrue && updated {
 			l.Info("Successfully ensured ProjectSveltos Profile")
 			record.Eventf(serviceSet, nil, kcmv1.ServiceSetEnsureProfileSuccessEvent, kcmv1.ServiceSetEnsureProfileEventAction,
 				"Successfully ensured ProjectSveltos Profile for ServiceSet %s", serviceSet.Name)
@@ -679,9 +679,10 @@ func (r *ServiceSetReconciler) collectServiceStatuses(ctx context.Context, rgnCl
 	message := kcmv1.ServiceSetStatusesNotCollectedMessage
 
 	defer func(initialStatus metav1.ConditionStatus) {
+		updated := updateCondition(serviceSet, statusesCollectedCondition, status, reason, message, r.timeFunc())
 		// we'll emit event only if the status changed from the initial value and it's now true.
 		conditionStatusChangedToTrue := initialStatus != status && status == metav1.ConditionTrue
-		if conditionStatusChangedToTrue && updateCondition(serviceSet, statusesCollectedCondition, status, reason, message, r.timeFunc()) {
+		if conditionStatusChangedToTrue && updated {
 			l.Info("Successfully collected services statuses")
 			record.Eventf(serviceSet, nil, kcmv1.ServiceSetCollectServiceStatusesSuccessEvent, kcmv1.ServiceSetCollectServiceStatusesEventAction,
 				"Successfully collected service statuses for ServiceSet %s", serviceSet.Name)

--- a/internal/controller/adapters/sveltos/serviceset_controller_test.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller_test.go
@@ -420,6 +420,56 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 		})
 	})
 
+	Context("When ServiceSet provider configuration has an invalid priority", func() {
+		It("should surface the build failure in the ServiceSet status", func() {
+			By("updating the StateManagementProvider to be ready", func() {
+				stateManagementProvider.Status.Ready = true
+				Expect(cl.Status().Update(ctx, &stateManagementProvider)).To(Succeed())
+				Expect(Object(&stateManagementProvider)()).Should(SatisfyAll(
+					HaveField("Status.Ready", BeTrue()),
+				))
+			})
+
+			By("updating the ServiceSet with an invalid priority in the provider config and a pending service", func() {
+				providerConfig := `
+{
+	"priority": 0
+}
+`
+				serviceSet.Spec.Provider.Config = &apiextv1.JSON{
+					Raw: []byte(providerConfig),
+				}
+				// a service declared in spec but not yet reflected in status
+				// reproduces the case where fillNotDeployedServices would run
+				// before the service type was ever resolved.
+				serviceSet.Spec.Services = []kcmv1.ServiceWithValues{
+					{Name: "test-svc", Namespace: namespace.Name, Template: "does-not-exist"},
+				}
+				Expect(cl.Update(ctx, &serviceSet)).To(Succeed())
+				Expect(Object(&serviceSet)()).Should(SatisfyAll(
+					HaveField("Spec.Provider.Config", Not(BeNil())),
+				))
+			})
+
+			By("reconciling and expecting the failure reason and message on the ServiceSet status", func() {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&serviceSet)})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to build Profile"))
+				// the status update itself must succeed, otherwise the failure
+				// reason/message never gets persisted to the ServiceSet.
+				Expect(err.Error()).NotTo(ContainSubstring("is invalid"))
+				Expect(Object(&serviceSet)()).Should(SatisfyAll(
+					HaveField("Status.Conditions", ContainElement(SatisfyAll(
+						HaveField("Type", kcmv1.ServiceSetProfileCondition),
+						HaveField("Status", metav1.ConditionFalse),
+						HaveField("Reason", kcmv1.ServiceSetProfileBuildFailedReason),
+						HaveField("Message", ContainSubstring("priority has to be between")),
+					))),
+				))
+			})
+		})
+	})
+
 	Context("When ServiceSet provider configuration got updated", func() {
 		It("should create Profile and update its config on ServiceSet config update", func() {
 			By("updating the StateManagementProvider to be ready", func() {


### PR DESCRIPTION
fixes https://github.com/k0rdent/kcm/issues/2824. Now the invalid priority error (and other such errors) surfaces to the ServiceSet's status instead of just getting logged in the logs:

```yaml
  conditions:
  - lastTransitionTime: "2026-07-06T15:45:40Z"
    message: |-
      Failed to build Profile from ServiceSet management-6ec16280 configuration: failed to build profile from config
      failed to convert priority to tier: invalid value 0, priority has to be between 1 and 2147483646
    observedGeneration: 1
    reason: ServiceSetProfileBuildFailed
    status: "False"
    type: ServiceSetProfile
  deployed: false
  provider:
    ready: true
```