### PR TITLE
feat(ksm): track deployment state

### DIFF
--- a/api/v1beta1/serviceset_types.go
+++ b/api/v1beta1/serviceset_types.go
@@ -228,13 +228,18 @@ type ProviderState struct {
 
 // ServiceState is the state of a Service
 type ServiceState struct {
+	// LastStateTransitionTime is the time the State was last transitioned
+	LastStateTransitionTime *metav1.Time `json:"lastStateTransitionTime"`
+
+	// +optional
+
+	// Version is the version of the Service
+	Version *string `json:"version,omitempty"`
+
 	// +kubebuilder:validation:Enum=Helm;Kustomize;Resource
 
 	// Type is the type of the deployment method for the Service
 	Type ServiceType `json:"type"`
-
-	// LastStateTransitionTime is the time the State was last transitioned
-	LastStateTransitionTime *metav1.Time `json:"lastStateTransitionTime"`
 
 	// Name is the name of the Service
 	Name string `json:"name"`
@@ -245,17 +250,19 @@ type ServiceState struct {
 	// Template is the name of the ServiceTemplate used to deploy the Service
 	Template string `json:"template"`
 
-	// +optional
-
-	// Version is the version of the Service
-	Version *string `json:"version,omitempty"`
-
 	// State is the state of the Service
 	// +kubebuilder:validation:Enum=Deployed;Provisioning;Failed;Pending;Deleting;Deleted
 	State string `json:"state"`
 
 	// FailureMessage is the reason why the Service failed to deploy
 	FailureMessage string `json:"failureMessage,omitempty"`
+
+	// LastDeployedHash is the verifier's fingerprint of the sveltos-side
+	// configuration this service was most recently confirmed Deployed at.
+	// Used to recognise that a Provisioning state reported by sveltos is
+	// transient noise from an unrelated apply (rather than a real change to
+	// this service) and to promote back to Deployed safely.
+	LastDeployedHash string `json:"lastDeployedHash,omitempty"`
 
 	// +patchMergeKey=type
 	// +patchStrategy=merge
@@ -264,13 +271,6 @@ type ServiceState struct {
 
 	// Conditions is a list of conditions for the Service
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
-
-	// LastDeployedHash is the verifier's fingerprint of the sveltos-side
-	// configuration this service was most recently confirmed Deployed at.
-	// Used to recognise that a Provisioning state reported by sveltos is
-	// transient noise from an unrelated apply (rather than a real change to
-	// this service) and to promote back to Deployed safely.
-	LastDeployedHash string `json:"lastDeployedHash,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/serviceset_types.go
+++ b/api/v1beta1/serviceset_types.go
@@ -257,9 +257,9 @@ type ServiceState struct {
 	// FailureMessage is the reason why the Service failed to deploy
 	FailureMessage string `json:"failureMessage,omitempty"`
 
-	// LastDeployedHash is the verifier's fingerprint of the sveltos-side
+	// LastDeployedHash is the verifier's fingerprint of the provider-side
 	// configuration this service was most recently confirmed Deployed at.
-	// Used to recognise that a Provisioning state reported by sveltos is
+	// Used to recognise that a progressing state reported by the provider is
 	// transient noise from an unrelated apply (rather than a real change to
 	// this service) and to promote back to Deployed safely.
 	LastDeployedHash string `json:"lastDeployedHash,omitempty"`

--- a/api/v1beta1/serviceset_types.go
+++ b/api/v1beta1/serviceset_types.go
@@ -264,6 +264,13 @@ type ServiceState struct {
 
 	// Conditions is a list of conditions for the Service
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// LastDeployedHash is the verifier's fingerprint of the sveltos-side
+	// configuration this service was most recently confirmed Deployed at.
+	// Used to recognise that a Provisioning state reported by sveltos is
+	// transient noise from an unrelated apply (rather than a real change to
+	// this service) and to promote back to Deployed safely.
+	LastDeployedHash string `json:"lastDeployedHash,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/internal/controller/adapters/sveltos/enqueue.go
+++ b/internal/controller/adapters/sveltos/enqueue.go
@@ -17,6 +17,8 @@ package sveltos
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -26,15 +28,129 @@ import (
 	pollerutil "github.com/K0rdent/kcm/internal/util/poller"
 )
 
-// enqueueClusterSummary returns a [pollerutil.EnqueueFunc] that walks every
-// [kcmv1.ServiceSet] and emits each one whose regional ClusterSummary is
-// reachable. The Reconcile loop is responsible for collapsing sveltos's
-// (source-of-truth) view into the ServiceSet status — comparing the two
-// here would be circular, because the verifier deliberately diverges
-// ServiceSet.Status.Services from servicesStateFromSummary when it knows
-// reality on cluster disagrees with sveltos's premature claim. Letting the
-// reconcile run on every tick is cheap (status update is gated on a
-// DeepEqual of the whole status) and avoids that loop.
+const (
+	// enqueueBaseBackoff is the initial polling interval for a ServiceSet
+	// that is in flight (Status.Deployed == false). Also the reset target
+	// on any observed ClusterSummary ResourceVersion change.
+	enqueueBaseBackoff = 10 * time.Second
+
+	// enqueueMaxBackoff caps the in-flight back-off. Beyond this, we stop
+	// slowing further — a genuinely stuck install still gets polled every
+	// enqueueMaxBackoff so the verifier's diagnostic conditions stay fresh.
+	enqueueMaxBackoff = 5 * time.Minute
+)
+
+// enqueueState tracks per-ServiceSet polling metadata across ticks. Its
+// dual purpose: (1) detect ClusterSummary-side changes cheaply via
+// ResourceVersion comparison, and (2) implement exponential back-off on
+// ServiceSets that are still in flight, without hammering the workload
+// cluster on every tick.
+//
+// Field ordering: time.Time first (its embedded *Location has an internal
+// pointer offset that fieldalignment sees), then string, then int64.
+type enqueueState struct {
+	nextEligibleTime  time.Time
+	lastSeenSummaryRV string
+	currentBackoff    time.Duration
+}
+
+// enqueueStates holds live enqueueState values keyed by ServiceSet
+// (namespace, name). Entries are created on first observation and pruned
+// once a ServiceSet disappears from the poller's List.
+var enqueueStates = struct {
+	entries map[client.ObjectKey]*enqueueState
+	sync.Mutex
+}{entries: make(map[client.ObjectKey]*enqueueState)}
+
+// evaluate is the per-tick state-machine decision for a single ServiceSet.
+// It updates the receiver in place and returns whether the ServiceSet
+// should be enqueued this tick.
+//
+// Extracted from enqueueClusterSummary so unit tests can exercise the
+// state transitions directly with an injectable clock, without spinning
+// up envtest. `deployed` is a state-machine axis (the "we are done"
+// arm), not a control-coupling flag.
+//
+//nolint:revive // deployed is an input axis of the state machine, not a caller-driven switch
+func (s *enqueueState) evaluate(now time.Time, summaryRV string, deployed bool) bool {
+	if s.lastSeenSummaryRV != summaryRV {
+		// A real sveltos-side change since we last looked. Enqueue,
+		// reset back-off, remember the new RV.
+		s.lastSeenSummaryRV = summaryRV
+		s.currentBackoff = enqueueBaseBackoff
+		s.nextEligibleTime = now.Add(s.currentBackoff)
+		return true
+	}
+	if deployed {
+		// Quiescent — sveltos unchanged AND every service confirmed
+		// Deployed by the verifier. No health controller exists in this
+		// codebase, so ongoing pod-death detection is out of scope; we
+		// unquiesce automatically when sveltos next bumps CS RV.
+		return false
+	}
+	if now.Before(s.nextEligibleTime) {
+		// In-flight but still within the back-off window from the last
+		// fruitless enqueue.
+		return false
+	}
+	// In-flight and the back-off window has elapsed — enqueue and
+	// double the back-off up to the cap.
+	s.currentBackoff *= 2
+	if s.currentBackoff > enqueueMaxBackoff {
+		s.currentBackoff = enqueueMaxBackoff
+	}
+	s.nextEligibleTime = now.Add(s.currentBackoff)
+	return true
+}
+
+// loadOrCreateEnqueueState returns the state for key, creating a fresh
+// one on first sight. Fresh state has an empty lastSeenSummaryRV so the
+// first observed CS RV triggers the "change detected" arm and enqueues
+// once — the correct behavior on process restart or newly created
+// ServiceSet.
+func loadOrCreateEnqueueState(key client.ObjectKey) *enqueueState {
+	enqueueStates.Lock()
+	defer enqueueStates.Unlock()
+	s, ok := enqueueStates.entries[key]
+	if !ok {
+		s = &enqueueState{}
+		enqueueStates.entries[key] = s
+	}
+	return s
+}
+
+// pruneEnqueueStates drops state entries for ServiceSets that were not
+// observed this tick — deleted, garbage-collected, or moved out of the
+// poller's List scope. Runs under the state map's lock; O(N) in current
+// map size.
+func pruneEnqueueStates(seen map[client.ObjectKey]struct{}) {
+	enqueueStates.Lock()
+	defer enqueueStates.Unlock()
+	for key := range enqueueStates.entries {
+		if _, ok := seen[key]; !ok {
+			delete(enqueueStates.entries, key)
+		}
+	}
+}
+
+// enqueueClusterSummary returns a [pollerutil.EnqueueFunc] that emits a
+// ServiceSet only when it needs work, rather than every tick. Three
+// gates decide, in order:
+//
+//  1. ClusterSummary.ResourceVersion advanced since last enqueue — a
+//     real sveltos-side change (apply, upgrade, patch). Enqueue and
+//     reset back-off to enqueueBaseBackoff.
+//  2. ServiceSet.Status.Deployed == true AND CS RV unchanged — the
+//     verifier confirmed every service is Deployed AND sveltos has not
+//     moved since then. Skip. There is no ongoing health controller in
+//     this codebase — the verifier's role in this PR is apply-time
+//     correctness, not continuous pod-death detection.
+//  3. Otherwise (in flight) — enqueue with exponentially-increasing
+//     back-off from enqueueBaseBackoff up to enqueueMaxBackoff. Any
+//     CS RV change resets to the base.
+//
+// Per-ServiceSet state is retained across ticks in enqueueStates;
+// entries are pruned when a ServiceSet disappears from the poller's List.
 //
 // Regional clients are cached per tick.
 func enqueueClusterSummary(cl client.Client, systemNamespace string) pollerutil.EnqueueFunc[*kcmv1.ServiceSet] {
@@ -50,18 +166,23 @@ func enqueueClusterSummary(cl client.Client, systemNamespace string) pollerutil.
 
 		// cluster object key -> regional client, reused within a single tick
 		rgnClients := make(map[client.ObjectKey]client.Client)
+		seenThisTick := make(map[client.ObjectKey]struct{}, len(serviceSetList.Items))
+		now := time.Now()
 
 		out := make([]*kcmv1.ServiceSet, 0, len(serviceSetList.Items))
 		for i := range serviceSetList.Items {
 			serviceSet := &serviceSetList.Items[i]
+			key := client.ObjectKeyFromObject(serviceSet)
+
 			if !serviceSet.GetDeletionTimestamp().IsZero() {
-				logger.V(1).Info("ServiceSet is being deleted, skipping polling", "service_set", client.ObjectKeyFromObject(serviceSet))
+				logger.V(1).Info("ServiceSet is being deleted, skipping polling", "service_set", key)
 				continue
 			}
+			seenThisTick[key] = struct{}{}
 
 			rgnClient, err := resolveRegionalClient(ctx, cl, serviceSet, systemNamespace, rgnClients)
 			if err != nil {
-				logger.V(1).Error(err, "failed to get regional client", "service_set", client.ObjectKeyFromObject(serviceSet))
+				logger.V(1).Error(err, "failed to get regional client", "service_set", key)
 				continue
 			}
 
@@ -71,8 +192,6 @@ func enqueueClusterSummary(cl client.Client, systemNamespace string) pollerutil.
 			} else {
 				profile = new(addoncontrollerv1beta1.Profile)
 			}
-
-			key := client.ObjectKeyFromObject(serviceSet)
 			if err := rgnClient.Get(ctx, key, profile); err != nil {
 				logger.V(1).Error(err, "failed to get Profile or ClusterProfile", "object_name", key)
 				continue
@@ -84,9 +203,18 @@ func enqueueClusterSummary(cl client.Client, systemNamespace string) pollerutil.
 				continue
 			}
 
-			logger.V(1).Info("Scheduling reconcile", "service_set", key, "cluster_summary", client.ObjectKeyFromObject(summary))
-			out = append(out, serviceSet)
+			state := loadOrCreateEnqueueState(key)
+			if state.evaluate(now, summary.ResourceVersion, serviceSet.Status.Deployed) {
+				logger.V(1).Info("Scheduling reconcile",
+					"service_set", key,
+					"cluster_summary", client.ObjectKeyFromObject(summary),
+					"next_backoff", state.currentBackoff,
+				)
+				out = append(out, serviceSet)
+			}
 		}
+
+		pruneEnqueueStates(seenThisTick)
 
 		return out, nil
 	}

--- a/internal/controller/adapters/sveltos/enqueue.go
+++ b/internal/controller/adapters/sveltos/enqueue.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -28,8 +27,16 @@ import (
 )
 
 // enqueueClusterSummary returns a [pollerutil.EnqueueFunc] that walks every
-// [kcmv1.ServiceSet] and emits the ones whose observed Status.Services drift
-// from the regional ClusterSummary. Regional clients are cached per tick.
+// [kcmv1.ServiceSet] and emits each one whose regional ClusterSummary is
+// reachable. The Reconcile loop is responsible for collapsing sveltos's
+// (source-of-truth) view into the ServiceSet status — comparing the two
+// here would be circular, because the verifier deliberately diverges
+// ServiceSet.Status.Services from servicesStateFromSummary when it knows
+// reality on cluster disagrees with sveltos's premature claim. Letting the
+// reconcile run on every tick is cheap (status update is gated on a
+// DeepEqual of the whole status) and avoids that loop.
+//
+// Regional clients are cached per tick.
 func enqueueClusterSummary(cl client.Client, systemNamespace string) pollerutil.EnqueueFunc[*kcmv1.ServiceSet] {
 	return func(ctx context.Context) ([]*kcmv1.ServiceSet, error) {
 		logger := ctrl.LoggerFrom(ctx)
@@ -77,12 +84,8 @@ func enqueueClusterSummary(cl client.Client, systemNamespace string) pollerutil.
 				continue
 			}
 
-			logger.V(1).Info("Fetched ClusterSummary", "cluster_summary", client.ObjectKeyFromObject(summary))
-			serviceStatesFromSummary := servicesStateFromSummary(logger, summary, serviceSet)
-			if !equality.Semantic.DeepEqual(serviceSet.Status.Services, serviceStatesFromSummary) {
-				logger.V(1).Info("ClusterSummary status does not match observed ServiceSet status, scheduling reconcile", "service_set", key)
-				out = append(out, serviceSet)
-			}
+			logger.V(1).Info("Scheduling reconcile", "service_set", key, "cluster_summary", client.ObjectKeyFromObject(summary))
+			out = append(out, serviceSet)
 		}
 
 		return out, nil

--- a/internal/controller/adapters/sveltos/enqueue_test.go
+++ b/internal/controller/adapters/sveltos/enqueue_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sveltos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestEnqueueState_FirstSightEnqueuesAndSeedsRV asserts that a fresh
+// enqueueState (empty lastSeenSummaryRV) treats any observed CS RV as a
+// change, enqueues, and remembers the RV. This is the correct behavior
+// on process restart or newly-created ServiceSet — we have not verified
+// anything yet, so an initial verify is warranted.
+func TestEnqueueState_FirstSightEnqueuesAndSeedsRV(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	s := &enqueueState{}
+
+	got := s.evaluate(now, "rv-1", false)
+
+	assert.True(t, got, "first sight of any RV must enqueue")
+	assert.Equal(t, "rv-1", s.lastSeenSummaryRV, "RV must be recorded")
+	assert.Equal(t, enqueueBaseBackoff, s.currentBackoff, "back-off starts at base")
+	assert.Equal(t, now.Add(enqueueBaseBackoff), s.nextEligibleTime,
+		"next-eligible must be now+base")
+}
+
+// TestEnqueueState_CSChangedResetsBackoff asserts that any RV change
+// resets an accumulated back-off. Long-running in-flight installs may
+// have back-off at max; when sveltos next moves, we want to react
+// immediately, not wait out the accumulated interval.
+func TestEnqueueState_CSChangedResetsBackoff(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	s := &enqueueState{
+		lastSeenSummaryRV: "rv-1",
+		currentBackoff:    enqueueMaxBackoff,
+		nextEligibleTime:  now.Add(enqueueMaxBackoff),
+	}
+
+	got := s.evaluate(now, "rv-2", false)
+
+	assert.True(t, got, "RV change must enqueue")
+	assert.Equal(t, "rv-2", s.lastSeenSummaryRV, "new RV must be recorded")
+	assert.Equal(t, enqueueBaseBackoff, s.currentBackoff,
+		"back-off must reset to base on RV change")
+}
+
+// TestEnqueueState_QuiescentSkipsWhenDeployed asserts that a Deployed
+// ServiceSet with unchanged CS RV skips entirely, regardless of any
+// back-off state.
+func TestEnqueueState_QuiescentSkipsWhenDeployed(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	// Back-off long expired — a fixed-interval poller would enqueue here,
+	// but Status.Deployed==true and RV unchanged means there is nothing
+	// to verify.
+	s := &enqueueState{
+		lastSeenSummaryRV: "rv-1",
+		currentBackoff:    enqueueBaseBackoff,
+		nextEligibleTime:  now.Add(-time.Hour),
+	}
+	priorNext := s.nextEligibleTime
+	priorBackoff := s.currentBackoff
+
+	got := s.evaluate(now, "rv-1", true)
+
+	assert.False(t, got, "quiescent SS must skip")
+	assert.Equal(t, priorNext, s.nextEligibleTime, "state must not change on skip")
+	assert.Equal(t, priorBackoff, s.currentBackoff, "back-off must not change on skip")
+}
+
+// TestEnqueueState_InflightBackoffElapsedEnqueuesAndDoubles asserts that
+// an in-flight ServiceSet whose back-off window has passed enqueues and
+// doubles its back-off — the whole point of the exponential schedule.
+func TestEnqueueState_InflightBackoffElapsedEnqueuesAndDoubles(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	s := &enqueueState{
+		lastSeenSummaryRV: "rv-1",
+		currentBackoff:    30 * time.Second,
+		nextEligibleTime:  now.Add(-time.Second), // just elapsed
+	}
+
+	got := s.evaluate(now, "rv-1", false)
+
+	assert.True(t, got, "elapsed back-off must enqueue")
+	assert.Equal(t, 60*time.Second, s.currentBackoff, "back-off must double")
+	assert.Equal(t, now.Add(60*time.Second), s.nextEligibleTime,
+		"next-eligible must advance by the new back-off")
+}
+
+// TestEnqueueState_InflightWithinWindowSkips asserts that an in-flight
+// SS whose back-off window has NOT elapsed is skipped and its state is
+// preserved — no needless work on ticks between polls.
+func TestEnqueueState_InflightWithinWindowSkips(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	s := &enqueueState{
+		lastSeenSummaryRV: "rv-1",
+		currentBackoff:    30 * time.Second,
+		nextEligibleTime:  now.Add(time.Second), // still in the window
+	}
+	priorNext := s.nextEligibleTime
+	priorBackoff := s.currentBackoff
+
+	got := s.evaluate(now, "rv-1", false)
+
+	assert.False(t, got, "SS within back-off window must skip")
+	assert.Equal(t, priorNext, s.nextEligibleTime, "state must not change on skip")
+	assert.Equal(t, priorBackoff, s.currentBackoff, "back-off must not change on skip")
+}
+
+// TestEnqueueState_BackoffCapsAtMax asserts that repeated in-flight
+// doubling eventually hits enqueueMaxBackoff and stops growing.
+func TestEnqueueState_BackoffCapsAtMax(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	s := &enqueueState{
+		lastSeenSummaryRV: "rv-1",
+		currentBackoff:    enqueueMaxBackoff, // already at cap
+		nextEligibleTime:  now.Add(-time.Second),
+	}
+
+	got := s.evaluate(now, "rv-1", false)
+
+	assert.True(t, got, "elapsed back-off enqueues even at cap")
+	assert.Equal(t, enqueueMaxBackoff, s.currentBackoff,
+		"back-off must not exceed cap after doubling")
+}
+
+// TestEnqueueState_BackoffDoublePastCapClamps asserts that when back-off
+// is close to (but not at) the cap, doubling clamps to the cap rather
+// than overshooting.
+func TestEnqueueState_BackoffDoublePastCapClamps(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	// Deliberately choose a value where 2× exceeds the cap.
+	preClamp := enqueueMaxBackoff/2 + time.Second
+	require.Greater(t, preClamp*2, enqueueMaxBackoff, "test fixture invariant")
+
+	s := &enqueueState{
+		lastSeenSummaryRV: "rv-1",
+		currentBackoff:    preClamp,
+		nextEligibleTime:  now.Add(-time.Second),
+	}
+
+	_ = s.evaluate(now, "rv-1", false)
+
+	assert.Equal(t, enqueueMaxBackoff, s.currentBackoff,
+		"doubling past cap must clamp exactly to cap")
+}
+
+// TestPruneEnqueueStates_DropsUnseen asserts that pruneEnqueueStates
+// removes entries for ServiceSets that were not observed this tick,
+// covering the "ServiceSet deleted from cluster" garbage path.
+func TestPruneEnqueueStates_DropsUnseen(t *testing.T) {
+	// Isolate from any state a parallel test might have populated.
+	enqueueStates.Lock()
+	original := enqueueStates.entries
+	enqueueStates.entries = make(map[client.ObjectKey]*enqueueState)
+	enqueueStates.Unlock()
+	t.Cleanup(func() {
+		enqueueStates.Lock()
+		enqueueStates.entries = original
+		enqueueStates.Unlock()
+	})
+
+	kept := client.ObjectKey{Namespace: "ns-a", Name: "kept"}
+	dropped := client.ObjectKey{Namespace: "ns-b", Name: "dropped"}
+
+	enqueueStates.Lock()
+	enqueueStates.entries[kept] = &enqueueState{lastSeenSummaryRV: "rv-a"}
+	enqueueStates.entries[dropped] = &enqueueState{lastSeenSummaryRV: "rv-b"}
+	enqueueStates.Unlock()
+
+	pruneEnqueueStates(map[client.ObjectKey]struct{}{kept: {}})
+
+	enqueueStates.Lock()
+	defer enqueueStates.Unlock()
+	_, keptOK := enqueueStates.entries[kept]
+	_, droppedOK := enqueueStates.entries[dropped]
+	assert.True(t, keptOK, "seen entry must survive prune")
+	assert.False(t, droppedOK, "unseen entry must be dropped")
+}

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -292,7 +292,7 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 //     feature status;
 //     fingerprint
 //     unchanged means
-//     healthy resource ARE
+//     healthy resource are
 //     the confirmed
 //     version)
 //   - sveltos=Provisioning, verifier=Deployed, hash!=     → Provisioning

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -311,6 +311,16 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 	}
 	serviceHashes := serviceHashesFromArtifacts(summary, cc, profileKind, profileName)
 
+	// Index spec-side versions so the verifier can stamp Status.Version
+	// with the spec value at the moment it confirms a deploy. The Helm
+	// path makes Status.Version mean "verified on cluster" (not "what spec
+	// says") — Kustomize / Resource still mirror spec eagerly in state.go.
+	specVersions := make(map[client.ObjectKey]*string, len(serviceSet.Spec.Services))
+	for i := range serviceSet.Spec.Services {
+		svc := &serviceSet.Spec.Services[i]
+		specVersions[client.ObjectKey{Namespace: svc.Namespace, Name: svc.Name}] = svc.Version
+	}
+
 	l := ctrl.LoggerFrom(ctx)
 	var errs error
 	stateChanged := false
@@ -330,31 +340,26 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 		serviceKey := client.ObjectKey{Namespace: s.Namespace, Name: s.Name}
 		currentHash := serviceHashes[serviceKey]
 
+		// The verifier's decision is independent of sveltos's per-service
+		// state, which featureHelm above is forced to derive from
+		// sveltos's aggregate Helm-feature status (it can't see per-
+		// release feature status separately). On-cluster rules are the
+		// authoritative signal: if they pass, the service is Deployed;
+		// otherwise Provisioning. The "no resources discovered yet"
+		// outcome (verifierState=Failed) is treated as Provisioning
+		// because sveltos may have started but not finished applying.
 		verifierState, conds, err := verifyHelmServiceOnCluster(ctx, target, rules, s.Name, s.Namespace)
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("verify service %s/%s: %w", s.Namespace, s.Name, err))
 			continue
 		}
 
-		var newState string
+		newState := kcmv1.ServiceStateProvisioning
 		var newConds []metav1.Condition
-		switch s.State {
-		case kcmv1.ServiceStateDeployed:
-			// Trust the verifier — downgrade direction.
-			newState = verifierState
+		if verifierState == kcmv1.ServiceStateDeployed {
+			newState = kcmv1.ServiceStateDeployed
+		} else {
 			newConds = conds
-		case kcmv1.ServiceStateProvisioning:
-			// Promote only when (verifier confirms healthy) AND (this
-			// service's sveltos-side fingerprint matches the one we last
-			// stamped at Deployed). The fingerprint guard distinguishes
-			// "aggregate Helm feature is busy with another service" from
-			// "this service is itself mid-change."
-			if verifierState == kcmv1.ServiceStateDeployed && currentHash != "" && currentHash == s.LastDeployedHash {
-				newState = kcmv1.ServiceStateDeployed
-			} else {
-				// Keep sveltos verdict; no condition rewrite.
-				continue
-			}
 		}
 
 		if newState != s.State {
@@ -369,9 +374,16 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 		}
 		applyVerifyConditions(s, newConds)
 
-		// Stamp / refresh the hash only when this round confirmed Deployed.
-		if newState == kcmv1.ServiceStateDeployed && currentHash != "" {
+		// Stamp Status.Version and Status.LastDeployedHash on a hash
+		// transition while Deployed. The hash advancing while the rules
+		// pass IS the "new version landed on cluster" signal — we don't
+		// need to observe an intermediate Provisioning state in Status to
+		// detect it. Refreshing on a no-op hash (currentHash equal to the
+		// stored one) is a heartbeat that costs nothing because the status
+		// update is gated on a DeepEqual elsewhere; we skip it for clarity.
+		if newState == kcmv1.ServiceStateDeployed && currentHash != "" && currentHash != s.LastDeployedHash {
 			s.LastDeployedHash = currentHash
+			s.Version = specVersions[serviceKey]
 		}
 	}
 
@@ -1015,8 +1027,10 @@ func getHelmCharts(ctx context.Context, c client.Client, serviceSet *kcmv1.Servi
 				Name:                    svc.Name,
 				Namespace:               svc.Namespace,
 				Template:                svc.Template,
-				Version:                 svc.Version,
-				State:                   kcmv1.ServiceStateProvisioning,
+				// Version is intentionally NOT seeded for Helm services —
+				// the verifier owns Status.Version for this type and stamps
+				// it only after confirming the spec version is on cluster.
+				State: kcmv1.ServiceStateProvisioning,
 			}
 			serviceSet.Status.Services = append(serviceSet.Status.Services, serviceStatus)
 		}

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -250,7 +250,91 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	// Verify on-cluster state for services that sveltos reports as
+	// Deployed. The helm SDK can return success before pods are actually
+	// ready, so we cross-check by listing labeled resources on the target
+	// cluster and evaluating their state against the embedded rules.
+	// Verification is best-effort: a failure here is logged but does not
+	// fail the reconcile — keep the sveltos-reported state for that round.
+	if verifyErr := r.verifyServiceStates(ctx, rgnClient, serviceSet); verifyErr != nil {
+		ctrl.LoggerFrom(ctx).Error(verifyErr, "service state verification failed; keeping sveltos-reported state")
+	}
+
 	return ctrl.Result{}, nil
+}
+
+// verifyServiceStates cross-checks sveltos's per-service Deployed verdict
+// against the actual state of resources on the target cluster. For each
+// service in Status.Services whose State is Deployed and whose Type is
+// Helm, it lists every labeled resource sveltos applied and evaluates each
+// against the health rules loaded from ConfigMaps on the management cluster.
+// Verdicts can only downgrade state (Deployed -> Provisioning or Failed),
+// never upgrade it.
+//
+// Rules are loaded from three tiers of ConfigMaps (cluster-global,
+// namespace-global, ServiceSet-targeted) — see rulesFromConfigMaps. Per-rule
+// compile errors are surfaced on the ServiceSet's top-level condition
+// ServiceSetHealthRules; they do not block verification of the still-valid
+// rules.
+func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target client.Client, serviceSet *kcmv1.ServiceSet) error {
+	if target == nil || len(serviceSet.Status.Services) == 0 {
+		return nil
+	}
+
+	rules, loadErrs, err := rulesFromConfigMaps(ctx, r.Client, r.SystemNamespace, serviceSet.Namespace, serviceSet.Name)
+	if err != nil {
+		return fmt.Errorf("load health rules: %w", err)
+	}
+	applyRuleLoadErrorCondition(serviceSet, loadErrs)
+
+	if len(rules) == 0 {
+		// No rules to evaluate against — keep sveltos-reported state.
+		// The ServiceSetHealthRules condition (just set) tells the admin
+		// either "no rules configured" or "rules failed to load".
+		return nil
+	}
+
+	l := ctrl.LoggerFrom(ctx)
+	var errs error
+	stateChanged := false
+
+	for i := range serviceSet.Status.Services {
+		s := &serviceSet.Status.Services[i]
+		if s.State != kcmv1.ServiceStateDeployed {
+			continue
+		}
+		// Kustomize/Resource paths are not yet supported by the verifier:
+		// sveltos does not stamp per-service identity on those, so we
+		// cannot attribute resources back to a specific service from
+		// ClusterConfiguration alone.
+		if s.Type != kcmv1.ServiceTypeHelm {
+			continue
+		}
+
+		newState, conds, err := verifyHelmServiceOnCluster(ctx, target, rules, s.Name, s.Namespace)
+		if err != nil {
+			errs = errors.Join(errs, fmt.Errorf("verify service %s/%s: %w", s.Namespace, s.Name, err))
+			continue
+		}
+
+		if newState != s.State {
+			l.V(1).Info("downgrading service state after on-cluster check",
+				"service", client.ObjectKey{Namespace: s.Namespace, Name: s.Name},
+				"from", s.State, "to", newState)
+			s.State = newState
+			now := metav1.NewTime(r.timeFunc())
+			s.LastStateTransitionTime = &now
+			stateChanged = true
+		}
+		applyVerifyConditions(s, conds)
+	}
+
+	if stateChanged {
+		serviceSet.Status.Deployed = !slices.ContainsFunc(serviceSet.Status.Services, func(s kcmv1.ServiceState) bool {
+			return s.State != kcmv1.ServiceStateDeployed
+		})
+	}
+	return errs
 }
 
 func (r *ServiceSetReconciler) reconcileDelete(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) (ctrl.Result, error) {

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -278,11 +278,11 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 //   - sveltos=Deployed,     verifier=Provisioning         → Provisioning (downgrade)
 //   - sveltos=Deployed,     verifier=Failed (no resources)→ Failed (downgrade)
 //   - sveltos=Provisioning, verifier=Deployed, hashMatch  → Deployed (PROMOTE — sveltos
-//                                                          pessimism from aggregate Helm
-//                                                          feature status)
+//     pessimism from aggregate Helm
+//     feature status)
 //   - sveltos=Provisioning, anything else                 → keep sveltos verdict
 //   - sveltos=Failed/etc                                  → keep sveltos verdict (verifier
-//                                                          must never override these)
+//     must never override these)
 //
 // Rules are loaded from three tiers of ConfigMaps (cluster-global,
 // namespace-global, ServiceSet-targeted) — see rulesFromConfigMaps.
@@ -293,7 +293,7 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 		return nil
 	}
 
-	rules, loadErrs, err := rulesFromConfigMaps(ctx, r.Client, r.SystemNamespace, serviceSet.Namespace, serviceSet.Name)
+	rules, loadErrs, err := rulesFromConfigMaps(ctx, r.Client, r.SystemNamespace, serviceSet)
 	if err != nil {
 		return fmt.Errorf("load health rules: %w", err)
 	}

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -263,19 +263,31 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return ctrl.Result{}, nil
 }
 
-// verifyServiceStates cross-checks sveltos's per-service Deployed verdict
+// verifyServiceStates cross-checks sveltos's per-service state verdict
 // against the actual state of resources on the target cluster. For each
-// service in Status.Services whose State is Deployed and whose Type is
-// Helm, it lists every labeled resource sveltos applied and evaluates each
-// against the health rules loaded from ConfigMaps on the management cluster.
-// Verdicts can only downgrade state (Deployed -> Provisioning or Failed),
-// never upgrade it.
+// service in Status.Services whose Type is Helm, it (a) computes a stable
+// fingerprint over chart identity + values + patches from the sveltos-side
+// artifacts (ClusterSummary + ClusterConfiguration), (b) lists labeled
+// resources on the target cluster and evaluates them against the loaded
+// rules, and (c) decides the final state by combining sveltos's verdict
+// with the on-cluster verdict and the hash gate.
+//
+// Decision table (sveltos verdict, verifier verdict, hash) → final state:
+//
+//   - sveltos=Deployed,     verifier=Deployed             → Deployed (refresh hash)
+//   - sveltos=Deployed,     verifier=Provisioning         → Provisioning (downgrade)
+//   - sveltos=Deployed,     verifier=Failed (no resources)→ Failed (downgrade)
+//   - sveltos=Provisioning, verifier=Deployed, hashMatch  → Deployed (PROMOTE — sveltos
+//                                                          pessimism from aggregate Helm
+//                                                          feature status)
+//   - sveltos=Provisioning, anything else                 → keep sveltos verdict
+//   - sveltos=Failed/etc                                  → keep sveltos verdict (verifier
+//                                                          must never override these)
 //
 // Rules are loaded from three tiers of ConfigMaps (cluster-global,
-// namespace-global, ServiceSet-targeted) — see rulesFromConfigMaps. Per-rule
-// compile errors are surfaced on the ServiceSet's top-level condition
-// ServiceSetHealthRules; they do not block verification of the still-valid
-// rules.
+// namespace-global, ServiceSet-targeted) — see rulesFromConfigMaps.
+// Per-rule compile errors are surfaced on the ServiceSet's top-level
+// condition ServiceSetHealthRules.
 func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target client.Client, serviceSet *kcmv1.ServiceSet) error {
 	if target == nil || len(serviceSet.Status.Services) == 0 {
 		return nil
@@ -288,11 +300,16 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 	applyRuleLoadErrorCondition(serviceSet, loadErrs)
 
 	if len(rules) == 0 {
-		// No rules to evaluate against — keep sveltos-reported state.
-		// The ServiceSetHealthRules condition (just set) tells the admin
-		// either "no rules configured" or "rules failed to load".
+		// No rules — keep sveltos-reported state.
 		return nil
 	}
+
+	// Fingerprint inputs from sveltos's view.
+	summary, cc, profileKind, profileName, err := fetchHelmArtifactsForVerifier(ctx, r.Client, serviceSet)
+	if err != nil {
+		return fmt.Errorf("fetch sveltos artifacts: %w", err)
+	}
+	serviceHashes := serviceHashesFromArtifacts(summary, cc, profileKind, profileName)
 
 	l := ctrl.LoggerFrom(ctx)
 	var errs error
@@ -300,33 +317,62 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 
 	for i := range serviceSet.Status.Services {
 		s := &serviceSet.Status.Services[i]
-		if s.State != kcmv1.ServiceStateDeployed {
-			continue
-		}
 		// Kustomize/Resource paths are not yet supported by the verifier:
-		// sveltos does not stamp per-service identity on those, so we
-		// cannot attribute resources back to a specific service from
-		// ClusterConfiguration alone.
+		// sveltos does not stamp per-service identity on those.
 		if s.Type != kcmv1.ServiceTypeHelm {
 			continue
 		}
+		// Never override Failed / NotDeployed / Deleting / Deleted.
+		if s.State != kcmv1.ServiceStateDeployed && s.State != kcmv1.ServiceStateProvisioning {
+			continue
+		}
 
-		newState, conds, err := verifyHelmServiceOnCluster(ctx, target, rules, s.Name, s.Namespace)
+		serviceKey := client.ObjectKey{Namespace: s.Namespace, Name: s.Name}
+		currentHash := serviceHashes[serviceKey]
+
+		verifierState, conds, err := verifyHelmServiceOnCluster(ctx, target, rules, s.Name, s.Namespace)
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("verify service %s/%s: %w", s.Namespace, s.Name, err))
 			continue
 		}
 
+		var newState string
+		var newConds []metav1.Condition
+		switch s.State {
+		case kcmv1.ServiceStateDeployed:
+			// Trust the verifier — downgrade direction.
+			newState = verifierState
+			newConds = conds
+		case kcmv1.ServiceStateProvisioning:
+			// Promote only when (verifier confirms healthy) AND (this
+			// service's sveltos-side fingerprint matches the one we last
+			// stamped at Deployed). The fingerprint guard distinguishes
+			// "aggregate Helm feature is busy with another service" from
+			// "this service is itself mid-change."
+			if verifierState == kcmv1.ServiceStateDeployed && currentHash != "" && currentHash == s.LastDeployedHash {
+				newState = kcmv1.ServiceStateDeployed
+			} else {
+				// Keep sveltos verdict; no condition rewrite.
+				continue
+			}
+		}
+
 		if newState != s.State {
-			l.V(1).Info("downgrading service state after on-cluster check",
-				"service", client.ObjectKey{Namespace: s.Namespace, Name: s.Name},
-				"from", s.State, "to", newState)
+			l.V(1).Info("verifier transitioning service state",
+				"service", serviceKey,
+				"from", s.State, "to", newState,
+				"currentHash", currentHash, "lastDeployedHash", s.LastDeployedHash)
 			s.State = newState
 			now := metav1.NewTime(r.timeFunc())
 			s.LastStateTransitionTime = &now
 			stateChanged = true
 		}
-		applyVerifyConditions(s, conds)
+		applyVerifyConditions(s, newConds)
+
+		// Stamp / refresh the hash only when this round confirmed Deployed.
+		if newState == kcmv1.ServiceStateDeployed && currentHash != "" {
+			s.LastDeployedHash = currentHash
+		}
 	}
 
 	if stateChanged {
@@ -334,6 +380,13 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 			return s.State != kcmv1.ServiceStateDeployed
 		})
 	}
+	// updateServicesInReadyStateCondition ran earlier (from
+	// collectServiceStatuses) over sveltos-reported states. After the
+	// verifier mutates per-service states, that aggregate is stale —
+	// recompute so the ServicesInReadyState condition agrees with
+	// .status.services[*].state. Runs unconditionally: even when this round
+	// transitioned nothing, the previous round may have left a stale count.
+	r.updateServicesInReadyStateCondition(serviceSet)
 	return errs
 }
 

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -272,17 +272,47 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // rules, and (c) decides the final state by combining sveltos's verdict
 // with the on-cluster verdict and the hash gate.
 //
-// Decision table (sveltos verdict, verifier verdict, hash) → final state:
+// Decision table (sveltos verdict, verifier verdict, hash) → final state.
+// State moves to Deployed only when BOTH signals agree; the stamp block
+// below then advances LastDeployedHash+Version only when they agree AND
+// the hash has actually moved:
 //
-//   - sveltos=Deployed,     verifier=Deployed             → Deployed (refresh hash)
-//   - sveltos=Deployed,     verifier=Provisioning         → Provisioning (downgrade)
-//   - sveltos=Deployed,     verifier=Failed (no resources)→ Failed (downgrade)
-//   - sveltos=Provisioning, verifier=Deployed, hashMatch  → Deployed (PROMOTE — sveltos
-//     pessimism from aggregate Helm
-//     feature status)
-//   - sveltos=Provisioning, anything else                 → keep sveltos verdict
-//   - sveltos=Failed/etc                                  → keep sveltos verdict (verifier
-//     must never override these)
+//   - sveltos=*,            verifier!=Deployed            → Provisioning
+//     (downgrade —
+//     unconditional;
+//     works around
+//     helm SDK's
+//     "deployed too
+//     early" bug)
+//   - sveltos=Provisioning, verifier=Deployed, hashMatch  → Deployed
+//     (PROMOTE —
+//     sveltos-side
+//     pessimism from
+//     aggregate Helm
+//     feature status;
+//     fingerprint
+//     unchanged means
+//     healthy resource ARE
+//     the confirmed
+//     version)
+//   - sveltos=Provisioning, verifier=Deployed, hash!=     → Provisioning
+//     (KEEP — real
+//     apply in progress
+//     for our own
+//     service; healthy
+//     resources may be stale
+//     pre-rollout resources)
+//   - sveltos=Deployed,     verifier=Deployed             → Deployed
+//     (both agree; the
+//     stamp block below
+//     advances hash+
+//     version if the
+//     hash moved)
+//   - sveltos=Failed/etc                                  → skipped upstream
+//     (guard at s.State
+//     check — verifier
+//     never overrides
+//     terminal states)
 //
 // Rules are loaded from three tiers of ConfigMaps (cluster-global,
 // namespace-global, ServiceSet-targeted) — see rulesFromConfigMaps.
@@ -340,26 +370,39 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 		serviceKey := client.ObjectKey{Namespace: s.Namespace, Name: s.Name}
 		currentHash := serviceHashes[serviceKey]
 
-		// The verifier's decision is independent of sveltos's per-service
-		// state, which featureHelm above is forced to derive from
-		// sveltos's aggregate Helm-feature status (it can't see per-
-		// release feature status separately). On-cluster rules are the
-		// authoritative signal: if they pass, the service is Deployed;
-		// otherwise Provisioning. The "no resources discovered yet"
-		// outcome (verifierState=Failed) is treated as Provisioning
-		// because sveltos may have started but not finished applying.
+		// Combine sveltos's verdict with the verifier's on-cluster verdict:
+		//
+		//   1. Verifier says NOT healthy (unhealthy resources, or none found
+		//      under the release labels) → downgrade to Provisioning and
+		//      attach conditions. Unconditional — this is the whole point of
+		//      the verifier, catching sveltos's premature "Deployed" from
+		//      helm SDK's known "success too early" bug.
+		//   2. Verifier says healthy AND sveltos says Provisioning AND the
+		//      current fingerprint matches the last confirmed-Deployed one
+		//      → promote to Deployed. Sveltos is only Provisioning because
+		//      featureHelm's aggregate status was demoted by unrelated
+		//      activity in the same ClusterProfile; our hash hasn't moved,
+		//      so the pods the verifier sees ARE the confirmed version.
+		//   3. Otherwise → keep sveltos's verdict. Critically, when the
+		//      verifier says healthy but our hash HAS advanced, we do NOT
+		//      promote from sveltos-Provisioning: the healthy pods may be
+		//      stale previous-version pods still running before a rollout
+		//      starts. We wait until sveltos itself confirms Deployed.
 		verifierState, conds, err := verifyHelmServiceOnCluster(ctx, target, rules, s.Name, s.Namespace)
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("verify service %s/%s: %w", s.Namespace, s.Name, err))
 			continue
 		}
 
-		newState := kcmv1.ServiceStateProvisioning
+		newState := s.State
 		var newConds []metav1.Condition
-		if verifierState == kcmv1.ServiceStateDeployed {
-			newState = kcmv1.ServiceStateDeployed
-		} else {
+		switch {
+		case verifierState != kcmv1.ServiceStateDeployed:
+			newState = kcmv1.ServiceStateProvisioning
 			newConds = conds
+		case s.State == kcmv1.ServiceStateProvisioning &&
+			currentHash != "" && currentHash == s.LastDeployedHash:
+			newState = kcmv1.ServiceStateDeployed
 		}
 
 		if newState != s.State {
@@ -375,12 +418,14 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 		applyVerifyConditions(s, newConds)
 
 		// Stamp Status.Version and Status.LastDeployedHash on a hash
-		// transition while Deployed. The hash advancing while the rules
-		// pass IS the "new version landed on cluster" signal — we don't
-		// need to observe an intermediate Provisioning state in Status to
-		// detect it. Refreshing on a no-op hash (currentHash equal to the
-		// stored one) is a heartbeat that costs nothing because the status
-		// update is gated on a DeepEqual elsewhere; we skip it for clarity.
+		// transition while Deployed. Under the switch above, `newState ==
+		// Deployed` with `currentHash != LastDeployedHash` is only
+		// reachable via the "sveltos=Deployed AND verifier=Deployed" path
+		// — the promotion arm requires `currentHash == LastDeployedHash`,
+		// which makes the hash-!= guard here false. So this stamp fires
+		// only when BOTH sveltos and the verifier confirm Deployed AND
+		// the fingerprint has actually advanced: the strongest agreement
+		// we can express with the signals sveltos exposes.
 		if newState == kcmv1.ServiceStateDeployed && currentHash != "" && currentHash != s.LastDeployedHash {
 			s.LastDeployedHash = currentHash
 			s.Version = specVersions[serviceKey]

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -256,8 +256,16 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// cluster and evaluating their state against the embedded rules.
 	// Verification is best-effort: a failure here is logged but does not
 	// fail the reconcile — keep the sveltos-reported state for that round.
-	if verifyErr := r.verifyServiceStates(ctx, rgnClient, serviceSet); verifyErr != nil {
+	pendingStamp, verifyErr := r.verifyServiceStates(ctx, rgnClient, serviceSet)
+	if verifyErr != nil {
 		ctrl.LoggerFrom(ctx).Error(verifyErr, "service state verification failed; keeping sveltos-reported state")
+	}
+
+	// A service ended up Deployed but we couldn't stamp its
+	// LastDeployedHash because sveltos-side inputs weren't yet
+	// available. Requeue so we can stamp on a subsequent round.
+	if pendingStamp {
+		return ctrl.Result{RequeueAfter: r.requeueInterval}, nil
 	}
 
 	return ctrl.Result{}, nil
@@ -318,26 +326,33 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // namespace-global, ServiceSet-targeted) — see rulesFromConfigMaps.
 // Per-rule compile errors are surfaced on the ServiceSet's top-level
 // condition ServiceSetHealthRules.
-func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) error {
+// The second return, pendingStamp, is true when at least one Helm
+// service ended up in Deployed state without a stamped LastDeployedHash
+// — typically because the fingerprint inputs weren't yet available on
+// sveltos's side (ClusterConfiguration section not populated with the
+// chart entry, or ClusterSummary missing the HelmReleaseSummary). The
+// caller uses this to requeue and try stamping on a subsequent round
+// rather than leaving the service with a permanent empty hash.
+func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) (bool, error) {
 	if rgnClient == nil || len(serviceSet.Status.Services) == 0 {
-		return nil
+		return false, nil
 	}
 
 	rules, loadErrs, err := rulesFromConfigMaps(ctx, r.Client, r.SystemNamespace, serviceSet)
 	if err != nil {
-		return fmt.Errorf("load health rules: %w", err)
+		return false, fmt.Errorf("load health rules: %w", err)
 	}
 	applyRuleLoadErrorCondition(serviceSet, loadErrs)
 
 	if len(rules) == 0 {
 		// No rules — keep sveltos-reported state.
-		return nil
+		return false, nil
 	}
 
 	// Fingerprint inputs from sveltos's view.
 	summary, cc, profileKind, profileName, err := fetchHelmArtifactsForVerifier(ctx, rgnClient, serviceSet)
 	if err != nil {
-		return fmt.Errorf("fetch sveltos artifacts: %w", err)
+		return false, fmt.Errorf("fetch sveltos artifacts: %w", err)
 	}
 	serviceHashes := serviceHashesFromArtifacts(summary, cc, profileKind, profileName)
 
@@ -353,12 +368,13 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClien
 
 	childClient, err := getChildClient(ctx, r.Client, rgnClient, serviceSet)
 	if err != nil {
-		return fmt.Errorf("get child cluster client: %w", err)
+		return false, fmt.Errorf("get child cluster client: %w", err)
 	}
 
 	l := ctrl.LoggerFrom(ctx)
 	var errs error
 	stateChanged := false
+	pendingStamp := false
 
 	for i := range serviceSet.Status.Services {
 		s := &serviceSet.Status.Services[i]
@@ -410,6 +426,11 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClien
 			newState = kcmv1.ServiceStateDeployed
 		}
 
+		if newState == kcmv1.ServiceStateDeployed && currentHash == "" {
+			newState = kcmv1.ServiceStateProvisioning
+			pendingStamp = true
+		}
+
 		if newState != s.State {
 			l.V(1).Info("verifier transitioning service state",
 				"service", serviceKey,
@@ -449,7 +470,7 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClien
 	// .status.services[*].state. Runs unconditionally: even when this round
 	// transitioned nothing, the previous round may have left a stale count.
 	r.updateServicesInReadyStateCondition(serviceSet)
-	return errs
+	return pendingStamp, errs
 }
 
 func (r *ServiceSetReconciler) reconcileDelete(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) (ctrl.Result, error) {

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -1853,7 +1853,7 @@ func getChildClient(ctx context.Context, cl, rgnClient client.Client, serviceSet
 //
 //   - self-management: no CAPI child exists; return mgmt (cl).
 //   - flat (mgmt hosts CAPI) or regional (Region cluster hosts CAPI):
-//     build the clien using GetChildClient function.
+//     build the client using GetChildClient function.
 func resolveChildClient(
 	ctx context.Context,
 	cl client.Client,

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -1831,13 +1831,8 @@ func getChildClient(ctx context.Context, cl, rgnClient client.Client, serviceSet
 // serviceSet's workloads actually run. Three schemes are handled:
 //
 //   - self-management: no CAPI child exists; return mgmt (cl).
-//   - flat: mgmt hosts CAPI, which provisions the workload cluster
-//     directly. rgnClient (resolved by getRegionalClient) is already
-//     the workload cluster — no further hop; return rgnClient.
-//   - regional: mgmt hosts the Region cluster (returned as rgnClient),
-//     and the Region cluster hosts CAPI which provisions the further
-//     workload cluster. Get the "<Spec.Cluster>-kubeconfig" Secret from
-//     rgnClient (that's where CAPI created it) and build a client.
+//   - flat (mgmt hosts CAPI) or regional (Region cluster hosts CAPI):
+//     build the clien using GetChildClient function.
 func resolveChildClient(
 	ctx context.Context,
 	cl client.Client,
@@ -1849,32 +1844,25 @@ func resolveChildClient(
 	}
 
 	clusterKey := client.ObjectKey{Namespace: serviceSet.Namespace, Name: serviceSet.Spec.Cluster}
-	cd := new(kcmv1.ClusterDeployment)
-	if err := cl.Get(ctx, clusterKey, cd); err != nil {
-		return nil, fmt.Errorf("failed to get ClusterDeployment %s: %w", clusterKey, err)
-	}
-
-	cred := new(kcmv1.Credential)
-	credKey := client.ObjectKey{Namespace: cd.Namespace, Name: cd.Spec.Credential}
-	if err := cl.Get(ctx, credKey, cred); err != nil {
-		return nil, fmt.Errorf("failed to get Credential %s: %w", credKey, err)
-	}
-
-	if cred.Spec.Region == "" {
-		return rgnClient, nil
-	}
-
-	scheme, err := schemeutil.GetRegionalScheme()
-	if err != nil {
-		return nil, fmt.Errorf("build child cluster scheme: %w", err)
-	}
-
 	secretRef := kubeutil.GetKubeconfigSecretKey(clusterKey)
-	child, err := kubeutil.GetChildClient(ctx, rgnClient, secretRef, "value", scheme, kubeutil.DefaultClientFactory)
-	if err != nil {
-		return nil, fmt.Errorf("build child cluster client: %w", err)
+	childCl, err := kubeutil.GetChildClient(ctx, rgnClient, secretRef, "value", rgnClient.Scheme(), kubeutil.DefaultClientFactory)
+	if err == nil {
+		return childCl, nil
 	}
-	return child, nil
+	// NotFound error could be returned in the only case - when the Secret containing
+	// the kubeconfig is not found. This might happen if the cluster is an adopted cluster
+	// and backed by the SveltosCluster object. In this case we'll need to lookup for the
+	// corresponding SveltosCluster and get the secret key from it.
+	// Hence we'll return error in case the error is not the NotFound error.
+	if !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	// Otherwise we'll fallback to sveltos cluster identity.
+	sveltosSecretRef, key, err := resolveSveltosClusterIdentityRef(ctx, rgnClient, serviceSet)
+	if err != nil {
+		return nil, err
+	}
+	return kubeutil.GetChildClient(ctx, rgnClient, sveltosSecretRef, key, rgnClient.Scheme(), kubeutil.DefaultClientFactory)
 }
 
 func clusterReference(serviceSet *kcmv1.ServiceSet) *corev1.ObjectReference {
@@ -1892,4 +1880,44 @@ func clusterReference(serviceSet *kcmv1.ServiceSet) *corev1.ObjectReference {
 		Namespace:  serviceSet.Namespace,
 		APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
 	}
+}
+
+func resolveSveltosClusterIdentityRef(ctx context.Context, cl client.Client, serviceSet *kcmv1.ServiceSet) (client.ObjectKey, string, error) {
+	var (
+		secretRef client.ObjectKey
+		secretKey string
+	)
+	sveltosClusterKey := client.ObjectKey{Namespace: serviceSet.Namespace, Name: serviceSet.Spec.Cluster}
+	sveltosCluster := new(libsveltosv1beta1.SveltosCluster)
+	if err := cl.Get(ctx, sveltosClusterKey, sveltosCluster); err != nil {
+		return secretRef, "", fmt.Errorf("failed to get Sveltos cluster %s: %w", sveltosClusterKey, err)
+	}
+
+	secretRef = client.ObjectKey{Namespace: serviceSet.Namespace, Name: sveltosCluster.Name + "-sveltos-kubeconfig"}
+	if sveltosCluster.Spec.KubeconfigName != "" {
+		secretRef = client.ObjectKey{Namespace: serviceSet.Namespace, Name: sveltosCluster.Spec.KubeconfigName}
+	}
+	secretKey = sveltosCluster.Spec.KubeconfigKeyName
+	// if the key containing kubeconfig is defined, we're good to return
+	// otherwise we'll try to discover the key.
+	if secretKey != "" {
+		return secretRef, secretKey, nil
+	}
+	secret := new(corev1.Secret)
+	if err := cl.Get(ctx, secretRef, secret); err != nil {
+		return secretRef, "", fmt.Errorf("failed to get secret %s: %w", secretRef, err)
+	}
+	// since iteration over map keys is non-deterministic in Go, we can't rely on
+	// Sveltos implementation to "get the first key in the Secret" (sveltoscluster_type.go, L229-232)
+	// instead, we'll reject secrets where there are more than 1 key defined.
+	if len(secret.Data) == 0 {
+		return secretRef, secretKey, fmt.Errorf("secret %s has no data", secretRef)
+	}
+	if len(secret.Data) > 1 {
+		return secretRef, secretKey, fmt.Errorf("secret %s has more than one key", secretRef)
+	}
+	for k := range secret.Data {
+		secretKey = k
+	}
+	return secretRef, secretKey, nil
 }

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -318,8 +318,8 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // namespace-global, ServiceSet-targeted) — see rulesFromConfigMaps.
 // Per-rule compile errors are surfaced on the ServiceSet's top-level
 // condition ServiceSetHealthRules.
-func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target client.Client, serviceSet *kcmv1.ServiceSet) error {
-	if target == nil || len(serviceSet.Status.Services) == 0 {
+func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) error {
+	if rgnClient == nil || len(serviceSet.Status.Services) == 0 {
 		return nil
 	}
 
@@ -335,7 +335,7 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 	}
 
 	// Fingerprint inputs from sveltos's view.
-	summary, cc, profileKind, profileName, err := fetchHelmArtifactsForVerifier(ctx, r.Client, serviceSet)
+	summary, cc, profileKind, profileName, err := fetchHelmArtifactsForVerifier(ctx, rgnClient, serviceSet)
 	if err != nil {
 		return fmt.Errorf("fetch sveltos artifacts: %w", err)
 	}
@@ -349,6 +349,11 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 	for i := range serviceSet.Spec.Services {
 		svc := &serviceSet.Spec.Services[i]
 		specVersions[client.ObjectKey{Namespace: svc.Namespace, Name: svc.Name}] = svc.Version
+	}
+
+	childClient, err := getChildClient(ctx, r.Client, rgnClient, serviceSet)
+	if err != nil {
+		return fmt.Errorf("get child cluster client: %w", err)
 	}
 
 	l := ctrl.LoggerFrom(ctx)
@@ -388,7 +393,7 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, target c
 		//      promote from sveltos-Provisioning: the healthy pods may be
 		//      stale previous-version pods still running before a rollout
 		//      starts. We wait until sveltos itself confirms Deployed.
-		verifierState, conds, err := verifyHelmServiceOnCluster(ctx, target, rules, s.Name, s.Namespace)
+		verifierState, conds, err := verifyHelmServiceOnCluster(ctx, childClient, rules, s.Name, s.Namespace)
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("verify service %s/%s: %w", s.Namespace, s.Name, err))
 			continue
@@ -1757,7 +1762,8 @@ func conditionReasonChanged(conditionOldState, conditionNewState *metav1.Conditi
 
 // getRegionalClient returns the kubernetes client for the cluster where
 // serviceSet's workload runs: the local client cl for self-managed (empty
-// .spec.cluster) ServiceSets, or the regional client otherwise.
+// .spec.cluster) ServiceSets, or the child (in relation to mothership)
+// client otherwise.
 func getRegionalClient(ctx context.Context, cl client.Client, serviceSet *kcmv1.ServiceSet, systemNamespace string) (client.Client, error) {
 	return resolveRegionalClient(ctx, cl, serviceSet, systemNamespace, nil)
 }
@@ -1811,6 +1817,64 @@ func resolveRegionalClient(
 	}
 
 	return rgn, nil
+}
+
+// getChildClient returns the kubernetes client for the cluster where
+// serviceSet's workload runs: the local client cl for self-managed (empty
+// .spec.cluster) ServiceSets, the regional (child in relation to mothership)
+// client or the child (in relation to regional cluster).
+func getChildClient(ctx context.Context, cl, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) (client.Client, error) {
+	return resolveChildClient(ctx, cl, rgnClient, serviceSet)
+}
+
+// resolveChildClient returns the kubernetes client for the cluster where
+// serviceSet's workloads actually run. Three schemes are handled:
+//
+//   - self-management: no CAPI child exists; return mgmt (cl).
+//   - flat: mgmt hosts CAPI, which provisions the workload cluster
+//     directly. rgnClient (resolved by getRegionalClient) is already
+//     the workload cluster — no further hop; return rgnClient.
+//   - regional: mgmt hosts the Region cluster (returned as rgnClient),
+//     and the Region cluster hosts CAPI which provisions the further
+//     workload cluster. Get the "<Spec.Cluster>-kubeconfig" Secret from
+//     rgnClient (that's where CAPI created it) and build a client.
+func resolveChildClient(
+	ctx context.Context,
+	cl client.Client,
+	rgnClient client.Client,
+	serviceSet *kcmv1.ServiceSet,
+) (client.Client, error) {
+	if serviceSet.Spec.Provider.SelfManagement {
+		return cl, nil
+	}
+
+	clusterKey := client.ObjectKey{Namespace: serviceSet.Namespace, Name: serviceSet.Spec.Cluster}
+	cd := new(kcmv1.ClusterDeployment)
+	if err := cl.Get(ctx, clusterKey, cd); err != nil {
+		return nil, fmt.Errorf("failed to get ClusterDeployment %s: %w", clusterKey, err)
+	}
+
+	cred := new(kcmv1.Credential)
+	credKey := client.ObjectKey{Namespace: cd.Namespace, Name: cd.Spec.Credential}
+	if err := cl.Get(ctx, credKey, cred); err != nil {
+		return nil, fmt.Errorf("failed to get Credential %s: %w", credKey, err)
+	}
+
+	if cred.Spec.Region == "" {
+		return rgnClient, nil
+	}
+
+	scheme, err := schemeutil.GetRegionalScheme()
+	if err != nil {
+		return nil, fmt.Errorf("build child cluster scheme: %w", err)
+	}
+
+	secretRef := kubeutil.GetKubeconfigSecretKey(clusterKey)
+	child, err := kubeutil.GetChildClient(ctx, rgnClient, secretRef, "value", scheme, kubeutil.DefaultClientFactory)
+	if err != nil {
+		return nil, fmt.Errorf("build child cluster client: %w", err)
+	}
+	return child, nil
 }
 
 func clusterReference(serviceSet *kcmv1.ServiceSet) *corev1.ObjectReference {

--- a/internal/controller/adapters/sveltos/serviceset_controller_test.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller_test.go
@@ -24,6 +24,7 @@ import (
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/addon-controller/lib/clusterops"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1056,6 +1057,266 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 				Expect(profile.Spec.StopMatchingBehavior).To(Equal(addoncontrollerv1beta1.LeavePolicies))
 				Expect(profile.OwnerReferences).To(BeEmpty())
 			})
+		})
+	})
+
+	// Regression coverage for reviewer comment
+	// https://github.com/k0rdent/kcm/pull/2891#discussion_r3596677308 — the
+	// verifier must never promote a Provisioning service to Deployed when
+	// the sveltos-side fingerprint has advanced past what we last confirmed
+	// on cluster, because the healthy pods the verifier just observed may
+	// be stale pre-rollout pods.
+	Context("Verifier state decision — hash-gated promotion", func() {
+		const (
+			releaseName  = "verifier-hashgate"
+			chartRepo    = "https://example.invalid/charts"
+			chartVersion = "1.0.0"
+			appVersion   = "1.0.0"
+			specVersion  = "1.1.0"
+		)
+		valuesHash := []byte("values-hash-verifier-hashgate")
+
+		// releaseNs is set per-It to the ServiceSet's own namespace so the
+		// helper cleans up alongside the outer AfterEach. Envtest cannot
+		// actually finish namespace teardown (no ns-lifecycle controller),
+		// so reusing a shared release namespace would leak state across
+		// test cases.
+		var releaseNs string
+
+		// prepareVerifierArtifacts wires up everything verifyServiceStates
+		// needs: rules ConfigMap, healthy target Deployment, Profile with
+		// MatchingClusterRefs, ClusterSummary with the release, and a
+		// ClusterConfiguration owned by the Profile carrying the chart
+		// entry. Returns the service hash the verifier will compute from
+		// these artifacts — callers pre-seed LastDeployedHash to make the
+		// hash match or mismatch as required by the test case.
+		prepareVerifierArtifacts := func() string {
+			releaseNs = namespace.Name
+
+			By("targeting the reconciler at the ServiceSet's namespace for tier-1 rules", func() {
+				reconciler.SystemNamespace = namespace.Name
+			})
+
+			By("creating a healthy Deployment labeled with the release name", func() {
+				var replicas int32 = 1
+				d := &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       releaseName,
+						Namespace:  releaseNs,
+						Generation: 1,
+						Labels:     map[string]string{"release": releaseName},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &replicas,
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": releaseName}},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": releaseName}},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "c", Image: "busybox"}},
+							},
+						},
+					},
+				}
+				Expect(cl.Create(ctx, d)).To(Succeed())
+				d.Status = appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					Replicas:           1,
+					ReadyReplicas:      1,
+					UpdatedReplicas:    1,
+				}
+				Expect(cl.Status().Update(ctx, d)).To(Succeed())
+				DeferCleanup(cl.Delete, d)
+			})
+
+			By("creating a namespace-global rules ConfigMap", func() {
+				cm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "verifier-hashgate-rules",
+						Namespace: namespace.Name,
+						Labels:    map[string]string{healthRuleTargetLabel: healthRuleTargetGlobal},
+					},
+					Data: map[string]string{healthRuleConfigMapDataKey: testRulesYAML},
+				}
+				Expect(cl.Create(ctx, cm)).To(Succeed())
+				DeferCleanup(cl.Delete, cm)
+			})
+
+			By("marking the StateManagementProvider ready and reconciling to create the Profile", func() {
+				stateManagementProvider.Status.Ready = true
+				Expect(cl.Status().Update(ctx, &stateManagementProvider)).To(Succeed())
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&serviceSet)})
+				Expect(err).To(Succeed())
+			})
+
+			prof := &addoncontrollerv1beta1.Profile{}
+			By("setting Profile.Status.MatchingClusterRefs and capturing its UID", func() {
+				Expect(cl.Get(ctx, client.ObjectKeyFromObject(&serviceSet), prof)).To(Succeed())
+				prof.Status.MatchingClusterRefs = []corev1.ObjectReference{
+					{
+						APIVersion: clusterapiv1.GroupVersion.String(),
+						Kind:       "Cluster",
+						Name:       clusterDeployment.Name,
+						Namespace:  namespace.Name,
+					},
+				}
+				Expect(cl.Status().Update(ctx, prof)).To(Succeed())
+			})
+
+			var expectedHash string
+			By("creating a ClusterSummary with a HelmReleaseSummary for the release", func() {
+				summaryName := clusterops.GetClusterSummaryName(
+					addoncontrollerv1beta1.ProfileKind,
+					serviceSet.Name,
+					clusterDeployment.Name,
+					false,
+				)
+				summary := &addoncontrollerv1beta1.ClusterSummary{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      summaryName,
+						Namespace: namespace.Name,
+					},
+					Spec: addoncontrollerv1beta1.ClusterSummarySpec{
+						ClusterNamespace: namespace.Name,
+						ClusterName:      clusterDeployment.Name,
+						ClusterType:      libsveltosv1beta1.ClusterTypeCapi,
+					},
+				}
+				Expect(cl.Create(ctx, summary)).To(Succeed())
+				summary.Status.HelmReleaseSummaries = []addoncontrollerv1beta1.HelmChartSummary{
+					{
+						ReleaseName:      releaseName,
+						ReleaseNamespace: releaseNs,
+						Status:           addoncontrollerv1beta1.HelmChartStatusManaging,
+						ValuesHash:       valuesHash,
+					},
+				}
+				Expect(cl.Status().Update(ctx, summary)).To(Succeed())
+				DeferCleanup(cl.Delete, summary)
+
+				now := metav1.NewTime(reconciler.timeFunc())
+				chart := &addoncontrollerv1beta1.Chart{
+					RepoURL:         chartRepo,
+					ReleaseName:     releaseName,
+					Namespace:       releaseNs,
+					ChartVersion:    chartVersion,
+					AppVersion:      appVersion,
+					LastAppliedTime: &now,
+				}
+				expectedHash = computeServiceHash(&summary.Status.HelmReleaseSummaries[0], chart)
+				Expect(expectedHash).ToNot(BeEmpty())
+			})
+
+			By("creating a ClusterConfiguration owned by the Profile with the chart entry", func() {
+				cc := &addoncontrollerv1beta1.ClusterConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cc-" + serviceSet.Name,
+						Namespace: namespace.Name,
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion: addoncontrollerv1beta1.GroupVersion.String(),
+							Kind:       addoncontrollerv1beta1.ProfileKind,
+							Name:       prof.Name,
+							UID:        prof.UID,
+						}},
+					},
+				}
+				Expect(cl.Create(ctx, cc)).To(Succeed())
+				now := metav1.NewTime(reconciler.timeFunc())
+				cc.Status.ProfileResources = []addoncontrollerv1beta1.ProfileResource{
+					{
+						ProfileName: serviceSet.Name,
+						Features: []addoncontrollerv1beta1.Feature{
+							{
+								FeatureID: libsveltosv1beta1.FeatureHelm,
+								Charts: []addoncontrollerv1beta1.Chart{
+									{
+										RepoURL:         chartRepo,
+										ReleaseName:     releaseName,
+										Namespace:       releaseNs,
+										ChartVersion:    chartVersion,
+										AppVersion:      appVersion,
+										LastAppliedTime: &now,
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(cl.Status().Update(ctx, cc)).To(Succeed())
+				DeferCleanup(cl.Delete, cc)
+			})
+
+			return expectedHash
+		}
+
+		// seedServiceStatus prepares the in-memory ServiceSet with a Helm
+		// service in the given state, so verifyServiceStates has a target
+		// to iterate. Spec.Services carries the "next intended version"
+		// used by the stamp block.
+		seedServiceStatus := func(state, lastDeployedHash, currentVersion string) {
+			specVer := specVersion
+			serviceSet.Spec.Services = []kcmv1.ServiceWithValues{{
+				Name:      releaseName,
+				Namespace: releaseNs,
+				Version:   &specVer,
+			}}
+			curVer := currentVersion
+			serviceSet.Status.Services = []kcmv1.ServiceState{{
+				Type:             kcmv1.ServiceTypeHelm,
+				Name:             releaseName,
+				Namespace:        releaseNs,
+				State:            state,
+				LastDeployedHash: lastDeployedHash,
+				Version:          &curVer,
+			}}
+		}
+
+		It("Case A: promotes on hash match (unrelated apply demoted us)", func() {
+			expectedHash := prepareVerifierArtifacts()
+			// Sveltos-side hash equals what we last confirmed → the pods
+			// the verifier sees ARE the confirmed version → safe to
+			// promote back from the aggregate-demoted Provisioning.
+			seedServiceStatus(kcmv1.ServiceStateProvisioning, expectedHash, "1.0.0")
+
+			Expect(reconciler.verifyServiceStates(ctx, cl, &serviceSet)).To(Succeed())
+
+			svc := serviceSet.Status.Services[0]
+			Expect(svc.State).To(Equal(kcmv1.ServiceStateDeployed), "should promote to Deployed on hash match")
+			Expect(svc.LastDeployedHash).To(Equal(expectedHash), "hash unchanged")
+			Expect(*svc.Version).To(Equal("1.0.0"), "version unchanged — no stamp on hash match")
+		})
+
+		It("Case B: does NOT promote when hash advanced (our real apply in progress)", func() {
+			_ = prepareVerifierArtifacts()
+			// Sveltos-side hash has moved past what we last confirmed →
+			// sveltos is applying a new version of THIS service. The
+			// healthy pods the verifier just observed could be stale
+			// previous-version pods. Refuse to promote.
+			staleHash := "sha256:previous-confirmed-hash"
+			seedServiceStatus(kcmv1.ServiceStateProvisioning, staleHash, "1.0.0")
+
+			Expect(reconciler.verifyServiceStates(ctx, cl, &serviceSet)).To(Succeed())
+
+			svc := serviceSet.Status.Services[0]
+			Expect(svc.State).To(Equal(kcmv1.ServiceStateProvisioning), "must stay Provisioning when hash advanced")
+			Expect(svc.LastDeployedHash).To(Equal(staleHash), "hash must NOT advance without sveltos-side confirmation")
+			Expect(*svc.Version).To(Equal("1.0.0"), "version must not advance to spec value prematurely")
+		})
+
+		It("Case C: stamps hash+version when both sveltos and verifier agree on new hash", func() {
+			expectedHash := prepareVerifierArtifacts()
+			// Sveltos already says Deployed, verifier confirms healthy,
+			// hash has advanced since last confirmed. This is the "both
+			// authoritative signals agree" intersection — safe to record
+			// the new version as landed.
+			staleHash := "sha256:previous-confirmed-hash"
+			seedServiceStatus(kcmv1.ServiceStateDeployed, staleHash, "1.0.0")
+
+			Expect(reconciler.verifyServiceStates(ctx, cl, &serviceSet)).To(Succeed())
+
+			svc := serviceSet.Status.Services[0]
+			Expect(svc.State).To(Equal(kcmv1.ServiceStateDeployed), "both agreed → stays Deployed")
+			Expect(svc.LastDeployedHash).To(Equal(expectedHash), "hash advances to sveltos-side fingerprint")
+			Expect(*svc.Version).To(Equal(specVersion), "version stamps to Spec.Services[i].Version")
 		})
 	})
 })

--- a/internal/controller/adapters/sveltos/serviceset_controller_test.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller_test.go
@@ -15,6 +15,7 @@
 package sveltos
 
 import (
+	"fmt"
 	"reflect"
 	"time"
 
@@ -30,6 +31,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	clusterapiv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
@@ -1245,6 +1249,24 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 				DeferCleanup(cl.Delete, cc)
 			})
 
+			By("creating the CAPI kubeconfig Secret that resolveChildClient reads", func() {
+				// resolveChildClient always dereferences the "<cluster>-kubeconfig"
+				// Secret on rgnClient (which in this test is the envtest apiserver).
+				// Point the child kubeconfig back at the same apiserver so
+				// DefaultClientFactory builds a working client — collapsing all
+				// three logical clusters (mgmt / regional / child) onto one
+				// envtest is the standard shape for this test suite.
+				kc := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      clusterDeployment.Name + "-kubeconfig",
+						Namespace: namespace.Name,
+					},
+					Data: map[string][]byte{"value": kubeconfigForRestConfig(config)},
+				}
+				Expect(cl.Create(ctx, kc)).To(Succeed())
+				DeferCleanup(cl.Delete, kc)
+			})
+
 			return expectedHash
 		}
 
@@ -1413,4 +1435,35 @@ func prepareCAPICluster(name, namespace string) clusterapiv1.Cluster {
 		},
 		Spec: clusterapiv1.ClusterSpec{Paused: new(false)},
 	}
+}
+
+// kubeconfigForRestConfig synthesises a kubeconfig YAML pointing at the
+// given rest.Config. Used by verifier tests to seed the CAPI
+// "<cluster>-kubeconfig" Secret that resolveChildClient reads —
+// pointing back at the same envtest apiserver so DefaultClientFactory
+// builds a working "child" client that queries the same fake used by
+// the mgmt path.
+func kubeconfigForRestConfig(cfg *rest.Config) []byte {
+	const ctxName = "envtest"
+	apiCfg := clientcmdapi.NewConfig()
+	apiCfg.Clusters[ctxName] = &clientcmdapi.Cluster{
+		Server:                   cfg.Host,
+		CertificateAuthorityData: cfg.CAData,
+		InsecureSkipTLSVerify:    cfg.Insecure,
+	}
+	apiCfg.AuthInfos[ctxName] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: cfg.CertData,
+		ClientKeyData:         cfg.KeyData,
+		Token:                 cfg.BearerToken,
+	}
+	apiCfg.Contexts[ctxName] = &clientcmdapi.Context{
+		Cluster:  ctxName,
+		AuthInfo: ctxName,
+	}
+	apiCfg.CurrentContext = ctxName
+	out, err := clientcmd.Write(*apiCfg)
+	if err != nil {
+		panic(fmt.Errorf("serialize kubeconfig: %w", err))
+	}
+	return out
 }

--- a/internal/controller/adapters/sveltos/serviceset_controller_test.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller_test.go
@@ -1299,7 +1299,9 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 			// promote back from the aggregate-demoted Provisioning.
 			seedServiceStatus(kcmv1.ServiceStateProvisioning, expectedHash, "1.0.0")
 
-			Expect(reconciler.verifyServiceStates(ctx, cl, &serviceSet)).To(Succeed())
+			pendingStamp, err := reconciler.verifyServiceStates(ctx, cl, &serviceSet)
+			Expect(err).To(Succeed())
+			Expect(pendingStamp).To(BeFalse(), "hash already stamped — no requeue needed")
 
 			svc := serviceSet.Status.Services[0]
 			Expect(svc.State).To(Equal(kcmv1.ServiceStateDeployed), "should promote to Deployed on hash match")
@@ -1316,7 +1318,9 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 			staleHash := "sha256:previous-confirmed-hash"
 			seedServiceStatus(kcmv1.ServiceStateProvisioning, staleHash, "1.0.0")
 
-			Expect(reconciler.verifyServiceStates(ctx, cl, &serviceSet)).To(Succeed())
+			pendingStamp, err := reconciler.verifyServiceStates(ctx, cl, &serviceSet)
+			Expect(err).To(Succeed())
+			Expect(pendingStamp).To(BeFalse(), "service stays Provisioning; pendingStamp only fires on Deployed with empty hash")
 
 			svc := serviceSet.Status.Services[0]
 			Expect(svc.State).To(Equal(kcmv1.ServiceStateProvisioning), "must stay Provisioning when hash advanced")
@@ -1333,7 +1337,9 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 			staleHash := "sha256:previous-confirmed-hash"
 			seedServiceStatus(kcmv1.ServiceStateDeployed, staleHash, "1.0.0")
 
-			Expect(reconciler.verifyServiceStates(ctx, cl, &serviceSet)).To(Succeed())
+			pendingStamp, err := reconciler.verifyServiceStates(ctx, cl, &serviceSet)
+			Expect(err).To(Succeed())
+			Expect(pendingStamp).To(BeFalse(), "stamp fired this round — no requeue needed")
 
 			svc := serviceSet.Status.Services[0]
 			Expect(svc.State).To(Equal(kcmv1.ServiceStateDeployed), "both agreed → stays Deployed")

--- a/internal/controller/adapters/sveltos/state.go
+++ b/internal/controller/adapters/sveltos/state.go
@@ -74,14 +74,20 @@ func servicesStateFromSummary(
 	states := make([]kcmv1.ServiceState, 0, len(serviceSet.Spec.Services))
 	servicesMap := make(map[client.ObjectKey]kcmv1.ServiceState)
 
+	// specVersions indexes the spec-side desired version per service so we
+	// can populate ServiceState.Version selectively below — Kustomize and
+	// Resource flows keep the eager "status mirrors spec" semantic, but the
+	// Helm flow defers the Version write to the verifier so Status.Version
+	// genuinely means "what's been confirmed on cluster".
+	specVersions := make(map[client.ObjectKey]*string, len(serviceSet.Spec.Services))
 	for _, svc := range serviceSet.Spec.Services {
 		servicesMap[serviceset.ServiceKey(svc.Namespace, svc.Name)] = kcmv1.ServiceState{
 			Name:      svc.Name,
 			Namespace: svc.Namespace,
 			Template:  svc.Template,
-			Version:   svc.Version,
 			State:     kcmv1.ServiceStateProvisioning,
 		}
+		specVersions[serviceset.ServiceKey(svc.Namespace, svc.Name)] = svc.Version
 	}
 
 	/*
@@ -109,10 +115,20 @@ func servicesStateFromSummary(
 
 		switch svc.Type {
 		case kcmv1.ServiceTypeKustomize:
+			// Kustomize/Resource paths aren't yet covered by the on-cluster
+			// verifier, so Version still mirrors the spec eagerly here.
+			newState.Version = specVersions[serviceset.ServiceKey(svc.Namespace, svc.Name)]
 			featureKustomize(&newState, summary)
 		case kcmv1.ServiceTypeResource:
+			newState.Version = specVersions[serviceset.ServiceKey(svc.Namespace, svc.Name)]
 			featureResources(&newState, summary)
 		case kcmv1.ServiceTypeHelm:
+			// Helm path: Version is owned by the verifier and means
+			// "what's been confirmed on cluster". Carry forward the prior
+			// status value so the comparison in ServicesToDeploy /
+			// FilterServiceDependencies stays correct across this rebuild;
+			// the verifier overwrites it when it next confirms Deployed.
+			newState.Version = svc.Version
 			featureHelm(&newState, summary)
 		}
 

--- a/internal/controller/adapters/sveltos/state.go
+++ b/internal/controller/adapters/sveltos/state.go
@@ -100,6 +100,12 @@ func servicesStateFromSummary(
 
 		newState.Type = svc.Type
 		newState.LastStateTransitionTime = svc.LastStateTransitionTime
+		// Preserve verifier-owned persistent fields. servicesStateFromSummary
+		// rebuilds the slice from scratch, so anything written outside the
+		// "from sveltos" pipeline (LastDeployedHash, per-service Conditions
+		// touched by the verifier) would otherwise be erased every reconcile.
+		newState.LastDeployedHash = svc.LastDeployedHash
+		newState.Conditions = svc.Conditions
 
 		switch svc.Type {
 		case kcmv1.ServiceTypeKustomize:

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -35,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -64,6 +66,11 @@ const (
 	// healthRuleConfigMapDataKey is the key within a rule ConfigMap's .data
 	// field whose value is the YAML list of rule documents.
 	healthRuleConfigMapDataKey = "rules"
+
+	// maxUnhealthyRefsPerCondition caps resource refs enumerated in a
+	// single ServiceHealth<Kind> condition message. Larger sets are
+	// summarised with "…and N more"; the full list is logged at V(1).
+	maxUnhealthyRefsPerCondition = 3
 )
 
 // discoveryLabels are the well-known label keys chart authors use to tag
@@ -481,27 +488,81 @@ func verifyHelmServiceOnCluster(
 		}}, nil
 	}
 
-	conds := make([]metav1.Condition, 0)
+	// Aggregate unhealthy verdicts by Kind. ServiceState.Conditions is a
+	// listType=map keyed by Type, so duplicates like ServiceHealthPod +
+	// ServiceHealthPod would fail schema validation. One condition per
+	// Kind; refs sorted for stability; capped at maxUnhealthyRefsPerCondition
+	// so a hundred-pod rollout doesn't produce a hundred-kilobyte message.
+	byKind := make(map[string][]resourceVerdict)
+	kindOrder := make([]string, 0)
 	for _, v := range verdicts {
 		if v.Healthy {
 			continue
 		}
-		ref := v.Name
-		if v.Namespace != "" {
-			ref = v.Namespace + "/" + v.Name
+		if _, seen := byKind[v.GVK.Kind]; !seen {
+			kindOrder = append(kindOrder, v.GVK.Kind)
 		}
+		byKind[v.GVK.Kind] = append(byKind[v.GVK.Kind], v)
+	}
+	if len(kindOrder) == 0 {
+		return kcmv1.ServiceStateDeployed, nil, nil
+	}
+
+	logger := ctrl.LoggerFrom(ctx)
+	conds := make([]metav1.Condition, 0, len(kindOrder))
+	for _, kind := range kindOrder {
+		items := byKind[kind]
+		sort.Slice(items, func(i, j int) bool {
+			if items[i].Namespace != items[j].Namespace {
+				return items[i].Namespace < items[j].Namespace
+			}
+			return items[i].Name < items[j].Name
+		})
+
+		shown := items
+		truncated := 0
+		if len(items) > maxUnhealthyRefsPerCondition {
+			shown = items[:maxUnhealthyRefsPerCondition]
+			truncated = len(items) - maxUnhealthyRefsPerCondition
+		}
+
+		parts := make([]string, 0, len(shown))
+		for _, v := range shown {
+			ref := v.Name
+			if v.Namespace != "" {
+				ref = v.Namespace + "/" + v.Name
+			}
+			parts = append(parts, fmt.Sprintf("%s (%s, rule %s)",
+				ref, strings.TrimSpace(v.Reason), v.RuleSrc))
+		}
+		msg := fmt.Sprintf("%d %s unhealthy: %s", len(items), kind, strings.Join(parts, "; "))
+		if truncated > 0 {
+			msg += fmt.Sprintf("; …and %d more", truncated)
+			allRefs := make([]string, 0, len(items))
+			for _, v := range items {
+				r := v.Name
+				if v.Namespace != "" {
+					r = v.Namespace + "/" + v.Name
+				}
+				allRefs = append(allRefs, r)
+			}
+			logger.V(1).Info("verifier: truncated unhealthy refs in condition",
+				"kind", kind,
+				"service", client.ObjectKey{Namespace: serviceNamespace, Name: serviceName},
+				"totalUnhealthy", len(items),
+				"refs", allRefs,
+			)
+		}
+
 		conds = append(conds, metav1.Condition{
-			Type:               serviceHealthConditionPrefix + v.GVK.Kind,
+			Type:               serviceHealthConditionPrefix + kind,
 			Status:             metav1.ConditionFalse,
-			Reason:             v.GVK.Kind + "Unhealthy",
-			Message:            fmt.Sprintf("%s %s: %s (rule %s)", v.GVK.Kind, ref, v.Reason, v.RuleSrc),
+			Reason:             kind + "Unhealthy",
+			Message:            msg,
 			LastTransitionTime: now,
 		})
 	}
 
-	if len(conds) == 0 {
-		return kcmv1.ServiceStateDeployed, nil, nil
-	}
 	return kcmv1.ServiceStateProvisioning, conds, nil
 }
 

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -1,0 +1,611 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sveltos
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+)
+
+const (
+	// serviceHealthConditionPrefix marks conditions owned by the verifier so
+	// they can be replaced atomically without disturbing conditions written by
+	// other parts of the controller.
+	serviceHealthConditionPrefix = "ServiceHealth"
+
+	// healthRuleTargetLabel selects ConfigMaps whose `rules` key contains
+	// CEL health-rule documents to be loaded by the verifier.
+	//
+	//   value == "global"        → applies to every ServiceSet
+	//                              (cluster-global when CM is in SystemNamespace,
+	//                              namespace-global when CM is in the SS's
+	//                              own namespace)
+	//   value == <serviceSet>    → applies only to the named ServiceSet
+	//                              (CM must live in that ServiceSet's namespace)
+	healthRuleTargetLabel = "k0rdent.mirantis.com/health-rule-target"
+
+	// healthRuleTargetGlobal is the label value selecting the "global" tier.
+	healthRuleTargetGlobal = "global"
+
+	// healthRuleConfigMapDataKey is the key within a rule ConfigMap's .data
+	// field whose value is the YAML list of rule documents.
+	healthRuleConfigMapDataKey = "rules"
+)
+
+// discoveryLabels are the well-known label keys chart authors use to tag
+// resources with the release/instance identity. Sveltos does not stamp a
+// per-service label of its own, so we query each of these in turn (value =
+// service name) and union the results. A resource matching any one of them
+// is considered to belong to the service.
+//
+// Order is irrelevant — the discovery does N list calls per rule's GVK and
+// merges them, deduplicating by (namespace, name).
+var discoveryLabels = []string{
+	"release",                    // older bitnami-style charts
+	"app",                        // legacy single-label convention
+	"app.kubernetes.io/instance", // helm/k8s recommended labels
+	"app.kubernetes.io/name",     // some charts put the release name here
+}
+
+// resourceScope mirrors the kubernetes scope of a resource and controls
+// whether the list call attaches a namespace selector.
+type resourceScope string
+
+const (
+	scopeNamespaced resourceScope = "Namespaced"
+	scopeCluster    resourceScope = "Cluster"
+)
+
+// ruleDoc is the wire shape of an entry in a ConfigMap's `rules` list.
+type ruleDoc struct {
+	Group   string        `json:"group"`
+	Version string        `json:"version"`
+	Kind    string        `json:"kind"`
+	Scope   resourceScope `json:"scope"`
+	Healthy string        `json:"healthy"`
+	Message string        `json:"message"`
+}
+
+// sourcedRuleDoc tags a raw ruleDoc with the ConfigMap it came from so
+// compile errors and per-resource conditions can point back to the source.
+type sourcedRuleDoc struct {
+	Doc    ruleDoc
+	Source string // formatted as "<namespace>/<configmap-name>#<index>"
+}
+
+// resourceRule is a compiled rule ready to evaluate.
+type resourceRule struct {
+	GVK     schema.GroupVersionKind
+	Scope   resourceScope
+	Source  string // for diagnostics; mirrors sourcedRuleDoc.Source
+	healthy cel.Program
+	message cel.Program
+}
+
+// ruleSet groups compiled rules by (group, kind). Version is intentionally
+// ignored: a helm-deployed Deployment may be served by any registered
+// version of apps/Deployment and the rule applies regardless.
+//
+// Every rule in the slice for a given GroupKind must evaluate as healthy
+// for a resource to be considered healthy — the rules layer additively,
+// they do NOT override one another.
+type ruleSet map[schema.GroupKind][]resourceRule
+
+// ruleLoadError describes a single failure during rule loading or
+// compilation. Used to surface bad user-provided rules as a condition on
+// the ServiceSet so the cluster admin sees which CM is misconfigured.
+type ruleLoadError struct {
+	Source string // "<namespace>/<configmap-name>[#<index>]"
+	Err    error
+}
+
+func (e ruleLoadError) Error() string {
+	return fmt.Sprintf("%s: %v", e.Source, e.Err)
+}
+
+// resourceVerdict is the per-object outcome of evaluating the rules that
+// apply to its (group, kind).
+type resourceVerdict struct {
+	GVK       schema.GroupVersionKind
+	Name      string
+	Namespace string
+	Healthy   bool
+	Reason    string // empty when Healthy
+	RuleSrc   string // populated when !Healthy; identifies the failing rule
+}
+
+// celEnv is the shared CEL environment all rule programs are compiled
+// against. The `ext.Strings()` extension provides .join(sep) and friends
+// on string lists.
+var celEnv = func() *cel.Env {
+	env, err := cel.NewEnv(
+		cel.Variable("obj", cel.DynType),
+		ext.Strings(),
+	)
+	if err != nil {
+		panic(fmt.Errorf("create CEL env: %w", err))
+	}
+	return env
+}()
+
+// rulesFromDocs compiles a slice of source-tagged rule documents into a
+// ruleSet. Individual compile / validation errors are collected and
+// returned in []ruleLoadError so a single bad rule does not break the rest
+// of the set.
+func rulesFromDocs(docs []sourcedRuleDoc) (ruleSet, []ruleLoadError) {
+	out := make(ruleSet)
+	var loadErrs []ruleLoadError
+
+	for _, sd := range docs {
+		doc := sd.Doc
+		if doc.Kind == "" || doc.Version == "" {
+			loadErrs = append(loadErrs, ruleLoadError{Source: sd.Source, Err: errors.New("kind and version are required")})
+			continue
+		}
+		if doc.Scope != scopeNamespaced && doc.Scope != scopeCluster {
+			loadErrs = append(loadErrs, ruleLoadError{Source: sd.Source, Err: fmt.Errorf("scope must be %q or %q, got %q", scopeNamespaced, scopeCluster, doc.Scope)})
+			continue
+		}
+
+		healthyPrg, err := compileExpr(celEnv, doc.Healthy)
+		if err != nil {
+			loadErrs = append(loadErrs, ruleLoadError{Source: sd.Source, Err: fmt.Errorf("healthy: %w", err)})
+			continue
+		}
+		messagePrg, err := compileExpr(celEnv, doc.Message)
+		if err != nil {
+			loadErrs = append(loadErrs, ruleLoadError{Source: sd.Source, Err: fmt.Errorf("message: %w", err)})
+			continue
+		}
+
+		gvk := schema.GroupVersionKind{Group: doc.Group, Version: doc.Version, Kind: doc.Kind}
+		out[gvk.GroupKind()] = append(out[gvk.GroupKind()], resourceRule{
+			GVK:     gvk,
+			Scope:   doc.Scope,
+			Source:  sd.Source,
+			healthy: healthyPrg,
+			message: messagePrg,
+		})
+	}
+
+	return out, loadErrs
+}
+
+func compileExpr(env *cel.Env, src string) (cel.Program, error) {
+	ast, iss := env.Compile(src)
+	if iss != nil && iss.Err() != nil {
+		return nil, fmt.Errorf("compile: %w", iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("program: %w", err)
+	}
+	return prg, nil
+}
+
+// ruleCacheEntry stores the compiled rules and load errors for a single
+// ConfigMap, keyed by ResourceVersion so a CM edit invalidates the entry.
+type ruleCacheEntry struct {
+	resourceVersion string
+	docs            []sourcedRuleDoc // raw + source-tagged, ready for rulesFromDocs
+	loadErrs        []ruleLoadError  // parse errors (not compile errors — those re-run with a single env)
+}
+
+// ruleParseCache memoises ConfigMap parsing. The CEL compiler is fast but
+// JSON-into-list-into-doc parsing repeats unnecessarily across reconciles
+// when no CM has changed.
+var ruleParseCache = struct {
+	sync.RWMutex
+	entries map[client.ObjectKey]ruleCacheEntry
+}{entries: make(map[client.ObjectKey]ruleCacheEntry)}
+
+// docsFromConfigMap reads a single ConfigMap's `rules` key, parses it as a
+// YAML list of rule documents, and returns the source-tagged slice plus
+// any parse errors. Results are cached on ResourceVersion.
+func docsFromConfigMap(cm *corev1.ConfigMap) ([]sourcedRuleDoc, []ruleLoadError) {
+	key := client.ObjectKey{Namespace: cm.Namespace, Name: cm.Name}
+
+	ruleParseCache.RLock()
+	cached, ok := ruleParseCache.entries[key]
+	ruleParseCache.RUnlock()
+	if ok && cached.resourceVersion == cm.ResourceVersion {
+		return cached.docs, cached.loadErrs
+	}
+
+	rawRules, ok := cm.Data[healthRuleConfigMapDataKey]
+	if !ok || strings.TrimSpace(rawRules) == "" {
+		entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion}
+		ruleParseCache.Lock()
+		ruleParseCache.entries[key] = entry
+		ruleParseCache.Unlock()
+		return nil, nil
+	}
+
+	var docs []ruleDoc
+	if err := yaml.Unmarshal([]byte(rawRules), &docs); err != nil {
+		errs := []ruleLoadError{{
+			Source: fmt.Sprintf("%s/%s", cm.Namespace, cm.Name),
+			Err:    fmt.Errorf("parse %q: %w", healthRuleConfigMapDataKey, err),
+		}}
+		entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion, loadErrs: errs}
+		ruleParseCache.Lock()
+		ruleParseCache.entries[key] = entry
+		ruleParseCache.Unlock()
+		return nil, errs
+	}
+
+	sourced := make([]sourcedRuleDoc, 0, len(docs))
+	for i, d := range docs {
+		sourced = append(sourced, sourcedRuleDoc{
+			Doc:    d,
+			Source: fmt.Sprintf("%s/%s#%d", cm.Namespace, cm.Name, i),
+		})
+	}
+
+	entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion, docs: sourced}
+	ruleParseCache.Lock()
+	ruleParseCache.entries[key] = entry
+	ruleParseCache.Unlock()
+	return sourced, nil
+}
+
+// rulesFromConfigMaps discovers health-rule ConfigMaps for a ServiceSet
+// across the three tiers, parses them, compiles every rule, and returns
+// the merged ruleSet plus per-rule load errors.
+//
+// Tiers (lowest precedence to highest — but because rules layer additively,
+// "precedence" really means "added on top of"):
+//
+//  1. ConfigMaps in systemNamespace labelled health-rule-target=global
+//  2. ConfigMaps in serviceSetNamespace labelled health-rule-target=global
+//  3. ConfigMaps in serviceSetNamespace labelled health-rule-target=<serviceSetName>
+//
+// All discovered rules are loaded; for a given (group, kind) the verifier
+// requires every rule to pass for the resource to be healthy.
+func rulesFromConfigMaps(
+	ctx context.Context,
+	mgmtClient client.Client,
+	systemNamespace, serviceSetNamespace, serviceSetName string,
+) (ruleSet, []ruleLoadError, error) {
+	var sourced []sourcedRuleDoc
+	var loadErrs []ruleLoadError
+
+	seen := make(map[client.ObjectKey]struct{})
+
+	// Tier 1 — kcm-system, global.
+	t1, errs1, err := listAndParse(ctx, mgmtClient, systemNamespace, healthRuleTargetGlobal, seen)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list tier 1 rules: %w", err)
+	}
+	sourced = append(sourced, t1...)
+	loadErrs = append(loadErrs, errs1...)
+
+	// Tier 2 — ServiceSet namespace, global. Skipped if the SS is in
+	// systemNamespace (would re-list the tier 1 CMs).
+	if serviceSetNamespace != systemNamespace {
+		t2, errs2, err := listAndParse(ctx, mgmtClient, serviceSetNamespace, healthRuleTargetGlobal, seen)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list tier 2 rules: %w", err)
+		}
+		sourced = append(sourced, t2...)
+		loadErrs = append(loadErrs, errs2...)
+	}
+
+	// Tier 3 — ServiceSet namespace, target == this ServiceSet's name.
+	t3, errs3, err := listAndParse(ctx, mgmtClient, serviceSetNamespace, serviceSetName, seen)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list tier 3 rules: %w", err)
+	}
+	sourced = append(sourced, t3...)
+	loadErrs = append(loadErrs, errs3...)
+
+	rs, compileErrs := rulesFromDocs(sourced)
+	loadErrs = append(loadErrs, compileErrs...)
+	return rs, loadErrs, nil
+}
+
+// listAndParse fetches every ConfigMap in namespace labelled
+// health-rule-target=<targetValue> and accumulates their parsed rule docs.
+// `seen` is shared across tier calls so a CM is never double-loaded
+// (matters when the SS namespace IS the system namespace, or when a CM
+// somehow matches more than one tier).
+func listAndParse(
+	ctx context.Context,
+	c client.Client,
+	namespace, targetValue string,
+	seen map[client.ObjectKey]struct{},
+) ([]sourcedRuleDoc, []ruleLoadError, error) {
+	list := &corev1.ConfigMapList{}
+	opts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{healthRuleTargetLabel: targetValue},
+	}
+	if err := c.List(ctx, list, opts...); err != nil {
+		return nil, nil, fmt.Errorf("list ConfigMaps in %s with %s=%s: %w", namespace, healthRuleTargetLabel, targetValue, err)
+	}
+
+	var sourced []sourcedRuleDoc
+	var loadErrs []ruleLoadError
+	for i := range list.Items {
+		cm := &list.Items[i]
+		key := client.ObjectKey{Namespace: cm.Namespace, Name: cm.Name}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		docs, errs := docsFromConfigMap(cm)
+		sourced = append(sourced, docs...)
+		loadErrs = append(loadErrs, errs...)
+	}
+	return sourced, loadErrs, nil
+}
+
+// evaluate runs the rule against a single unstructured object and returns
+// the verdict plus a human-readable reason if unhealthy. Pods that are
+// already terminating (deletionTimestamp set) are reported as healthy:
+// a terminating Pod is by definition not Ready, but counting it as
+// unhealthy would make every workload rollout look broken for as long as
+// terminationGracePeriodSeconds.
+func (r resourceRule) evaluate(obj *unstructured.Unstructured) (healthy bool, reason string, err error) {
+	if r.GVK.Group == "" && r.GVK.Kind == "Pod" && obj.GetDeletionTimestamp() != nil {
+		return true, "", nil
+	}
+
+	input := map[string]any{"obj": obj.Object}
+
+	hOut, _, err := r.healthy.Eval(input)
+	if err != nil {
+		return false, "", fmt.Errorf("evaluate healthy: %w", err)
+	}
+	hVal, ok := hOut.Value().(bool)
+	if !ok {
+		return false, "", fmt.Errorf("healthy expression returned %T, want bool", hOut.Value())
+	}
+	if hVal {
+		return true, "", nil
+	}
+
+	mOut, _, err := r.message.Eval(input)
+	if err != nil {
+		// Don't fail the whole verdict if the message expression breaks; we
+		// already know the resource is unhealthy.
+		return false, "", nil
+	}
+	mVal, _ := mOut.Value().(string)
+	return false, mVal, nil
+}
+
+// verifyHelmServiceOnCluster lists every known-type resource on the target
+// cluster that carries any of the well-known chart-author identity labels
+// (release/app/app.kubernetes.io/{instance,name}) with value = serviceName,
+// evaluates each against every rule registered for its (group, kind), and
+// aggregates the result. A resource is considered healthy iff every
+// applicable rule passes; the first failing rule's message wins.
+//
+// Caller must invoke this ONLY when sveltos already reports the service as
+// Deployed. The return is downgrade-only:
+//
+//   - kcmv1.ServiceStateFailed       -> sveltos says Deployed but no labeled
+//                                       resources exist on the target cluster
+//   - kcmv1.ServiceStateProvisioning -> at least one labeled resource is
+//                                       unhealthy per its rule
+//   - kcmv1.ServiceStateDeployed     -> every labeled resource is healthy
+//
+// The returned conditions slice contains one entry per unhealthy resource.
+// The slice is empty when state is Deployed.
+func verifyHelmServiceOnCluster(
+	ctx context.Context,
+	remote client.Client,
+	rules ruleSet,
+	serviceName, serviceNamespace string,
+) (string, []metav1.Condition, error) {
+	verdicts, err := collectVerdicts(ctx, remote, rules, serviceName, serviceNamespace)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if len(verdicts) == 0 {
+		return kcmv1.ServiceStateFailed, []metav1.Condition{{
+			Type:    serviceHealthConditionPrefix,
+			Status:  metav1.ConditionFalse,
+			Reason:  "NoResourcesOnCluster",
+			Message: fmt.Sprintf("no resources matching any of %v=%s found on target cluster", discoveryLabels, serviceName),
+		}}, nil
+	}
+
+	conds := make([]metav1.Condition, 0)
+	for _, v := range verdicts {
+		if v.Healthy {
+			continue
+		}
+		ref := v.Name
+		if v.Namespace != "" {
+			ref = v.Namespace + "/" + v.Name
+		}
+		conds = append(conds, metav1.Condition{
+			Type:    serviceHealthConditionPrefix + v.GVK.Kind,
+			Status:  metav1.ConditionFalse,
+			Reason:  v.GVK.Kind + "Unhealthy",
+			Message: fmt.Sprintf("%s %s: %s (rule %s)", v.GVK.Kind, ref, v.Reason, v.RuleSrc),
+		})
+	}
+
+	if len(conds) == 0 {
+		return kcmv1.ServiceStateDeployed, nil, nil
+	}
+	return kcmv1.ServiceStateProvisioning, conds, nil
+}
+
+// collectVerdicts iterates every (group, kind) in the rule set, lists
+// matching objects on the target cluster across every discovery label, and
+// evaluates each against every rule registered for that (group, kind).
+// A resource is unhealthy if any rule says so; the first failing rule wins.
+//
+// "Scope" disambiguates a namespaced vs. cluster-scoped list. When multiple
+// rules for the same (group, kind) disagree on scope (which shouldn't
+// happen in practice — kubernetes scope is intrinsic to the kind), the
+// first rule's scope is used.
+func collectVerdicts(
+	ctx context.Context,
+	remote client.Client,
+	rules ruleSet,
+	serviceName, serviceNamespace string,
+) ([]resourceVerdict, error) {
+	var verdicts []resourceVerdict
+	var listErrs error
+
+	for gk, gkRules := range rules {
+		if len(gkRules) == 0 {
+			continue
+		}
+		// Take the first rule's GVK + scope for listing — every rule in this
+		// slice targets the same GroupKind so the list will return the same
+		// items regardless of which rule's GVK we use.
+		scope := gkRules[0].Scope
+		listGVK := gkRules[0].GVK
+		listGVK.Kind = gk.Kind + "List"
+
+		// Dedup objects discovered via multiple labels.
+		seen := make(map[client.ObjectKey]struct{})
+
+		for _, labelKey := range discoveryLabels {
+			list := &unstructured.UnstructuredList{}
+			list.SetGroupVersionKind(listGVK)
+
+			opts := []client.ListOption{client.MatchingLabels{labelKey: serviceName}}
+			if scope == scopeNamespaced {
+				opts = append(opts, client.InNamespace(serviceNamespace))
+			}
+			if err := remote.List(ctx, list, opts...); err != nil {
+				// NoMatchError/NoKindMatchError means the API server on the
+				// target cluster does not serve this GVK — treat as zero
+				// matches, not a hard failure.
+				if isNoMatchError(err) {
+					break
+				}
+				listErrs = errors.Join(listErrs, fmt.Errorf("list %s by %s: %w", gk, labelKey, err))
+				continue
+			}
+
+			for i := range list.Items {
+				obj := &list.Items[i]
+				key := client.ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+				if _, dup := seen[key]; dup {
+					continue
+				}
+				seen[key] = struct{}{}
+
+				verdict := resourceVerdict{
+					GVK:       listGVK,
+					Name:      obj.GetName(),
+					Namespace: obj.GetNamespace(),
+					Healthy:   true,
+				}
+				verdict.GVK.Kind = gk.Kind // strip the "List" suffix
+
+				// Evaluate every rule registered for this GroupKind. First
+				// failure wins; we record its message + source.
+				for _, rule := range gkRules {
+					healthy, reason, evalErr := rule.evaluate(obj)
+					if evalErr != nil {
+						listErrs = errors.Join(listErrs, fmt.Errorf("evaluate %s %s/%s (rule %s): %w", gk, obj.GetNamespace(), obj.GetName(), rule.Source, evalErr))
+						continue
+					}
+					if !healthy {
+						verdict.Healthy = false
+						verdict.Reason = reason
+						verdict.RuleSrc = rule.Source
+						break
+					}
+				}
+
+				verdicts = append(verdicts, verdict)
+			}
+		}
+	}
+	return verdicts, listErrs
+}
+
+func isNoMatchError(err error) bool {
+	var noKind *meta.NoKindMatchError
+	var noResource *meta.NoResourceMatchError
+	return errors.As(err, &noKind) || errors.As(err, &noResource)
+}
+
+// serviceSetHealthRulesCondition is the ServiceSet-level condition the
+// verifier writes to surface health-rule load errors. Status=True when all
+// rule ConfigMaps parsed and compiled successfully; False when at least
+// one rule failed and the verifier had to skip it.
+const serviceSetHealthRulesCondition = "ServiceSetHealthRules"
+
+// applyRuleLoadErrorCondition writes (or refreshes) the
+// ServiceSetHealthRules condition on the ServiceSet to reflect the result
+// of the most recent rule load.
+func applyRuleLoadErrorCondition(serviceSet *kcmv1.ServiceSet, loadErrs []ruleLoadError) {
+	cond := metav1.Condition{
+		Type:               serviceSetHealthRulesCondition,
+		ObservedGeneration: serviceSet.Generation,
+	}
+	if len(loadErrs) == 0 {
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = "AllRulesValid"
+		cond.Message = "All health rules loaded successfully"
+	} else {
+		msgs := make([]string, 0, len(loadErrs))
+		for _, e := range loadErrs {
+			msgs = append(msgs, e.Error())
+		}
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "HealthRuleInvalid"
+		cond.Message = strings.Join(msgs, "; ")
+	}
+	apimetaSetStatusCondition(&serviceSet.Status.Conditions, cond)
+}
+
+// apimetaSetStatusCondition is a function variable to keep the
+// apimachinery/api/meta dependency confined to one call site, mirroring
+// the import alias the rest of the controller uses.
+var apimetaSetStatusCondition = meta.SetStatusCondition
+
+// applyVerifyConditions replaces any verifier-owned condition (Type
+// starting with serviceHealthConditionPrefix) on the service state with
+// the supplied new set, leaving non-verifier conditions untouched. Called
+// even when the new set is empty so a recovering service has its old
+// health conditions cleared.
+func applyVerifyConditions(s *kcmv1.ServiceState, newConds []metav1.Condition) {
+	kept := make([]metav1.Condition, 0, len(s.Conditions))
+	for _, c := range s.Conditions {
+		if !strings.HasPrefix(c.Type, serviceHealthConditionPrefix) {
+			kept = append(kept, c)
+		}
+	}
+	s.Conditions = append(kept, newConds...)
+}

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
@@ -226,36 +227,58 @@ func compileExpr(env *cel.Env, src string) (cel.Program, error) {
 
 // ruleCacheEntry stores the compiled rules and load errors for a single
 // ConfigMap, keyed by ResourceVersion so a CM edit invalidates the entry.
+// lastAccess is refreshed on every hit and consulted by sweepRuleParseCache
+// to evict entries whose owning CM has been deleted (or whose ServiceSet
+// no longer reconciles) after ruleParseCacheTTL.
 type ruleCacheEntry struct {
+	lastAccess      time.Time
 	resourceVersion string
 	docs            []sourcedRuleDoc // raw + source-tagged, ready for rulesFromDocs
 	loadErrs        []ruleLoadError  // parse errors (not compile errors — those re-run with a single env)
 }
 
+// ruleParseCacheTTL bounds how long a parsed-rule cache entry survives
+// without being referenced. Refreshed on every cache hit, so hot entries
+// whose ResourceVersion never changes stay cached; a CM that gets deleted
+// (or its owning ServiceSet stops reconciling) ages out on the order of
+// this TTL rather than leaking forever.
+const ruleParseCacheTTL = 5 * time.Minute
+
 // ruleParseCache memoises ConfigMap parsing. The CEL compiler is fast but
 // JSON-into-list-into-doc parsing repeats unnecessarily across reconciles
-// when no CM has changed.
+// when no CM has changed. Entries are keyed by (namespace, name) and
+// invalidated when the CM's ResourceVersion changes; stale entries are
+// swept in sweepRuleParseCache, which rulesFromConfigMaps calls once per
+// reconcile. The mutex protects both the map and the per-entry lastAccess
+// bookkeeping.
 var ruleParseCache = struct {
 	entries map[client.ObjectKey]ruleCacheEntry
-	sync.RWMutex
+	sync.Mutex
 }{entries: make(map[client.ObjectKey]ruleCacheEntry)}
 
 // docsFromConfigMap reads a single ConfigMap's `rules` key, parses it as a
 // YAML list of rule documents, and returns the source-tagged slice plus
-// any parse errors. Results are cached on ResourceVersion.
+// any parse errors. Results are cached on ResourceVersion; every hit
+// refreshes the entry's lastAccess so sweepRuleParseCache keeps hot
+// entries alive and evicts cold ones (deleted CMs, non-reconciling
+// ServiceSets) after ruleParseCacheTTL.
 func docsFromConfigMap(cm *corev1.ConfigMap) ([]sourcedRuleDoc, []ruleLoadError) {
 	key := client.ObjectKey{Namespace: cm.Namespace, Name: cm.Name}
+	now := time.Now()
 
-	ruleParseCache.RLock()
+	ruleParseCache.Lock()
 	cached, ok := ruleParseCache.entries[key]
-	ruleParseCache.RUnlock()
 	if ok && cached.resourceVersion == cm.ResourceVersion {
+		cached.lastAccess = now
+		ruleParseCache.entries[key] = cached
+		ruleParseCache.Unlock()
 		return cached.docs, cached.loadErrs
 	}
+	ruleParseCache.Unlock()
 
 	rawRules, ok := cm.Data[healthRuleConfigMapDataKey]
 	if !ok || strings.TrimSpace(rawRules) == "" {
-		entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion}
+		entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion, lastAccess: now}
 		ruleParseCache.Lock()
 		ruleParseCache.entries[key] = entry
 		ruleParseCache.Unlock()
@@ -268,7 +291,7 @@ func docsFromConfigMap(cm *corev1.ConfigMap) ([]sourcedRuleDoc, []ruleLoadError)
 			Source: fmt.Sprintf("%s/%s", cm.Namespace, cm.Name),
 			Err:    fmt.Errorf("parse %q: %w", healthRuleConfigMapDataKey, err),
 		}}
-		entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion, loadErrs: errs}
+		entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion, loadErrs: errs, lastAccess: now}
 		ruleParseCache.Lock()
 		ruleParseCache.entries[key] = entry
 		ruleParseCache.Unlock()
@@ -283,11 +306,24 @@ func docsFromConfigMap(cm *corev1.ConfigMap) ([]sourcedRuleDoc, []ruleLoadError)
 		})
 	}
 
-	entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion, docs: sourced}
+	entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion, docs: sourced, lastAccess: now}
 	ruleParseCache.Lock()
 	ruleParseCache.entries[key] = entry
 	ruleParseCache.Unlock()
 	return sourced, nil
+}
+
+// sweepRuleParseCache evicts cache entries whose lastAccess timestamp is
+// older than ruleParseCacheTTL.
+func sweepRuleParseCache() {
+	cutoff := time.Now().Add(-ruleParseCacheTTL)
+	ruleParseCache.Lock()
+	defer ruleParseCache.Unlock()
+	for key, entry := range ruleParseCache.entries {
+		if entry.lastAccess.Before(cutoff) {
+			delete(ruleParseCache.entries, key)
+		}
+	}
 }
 
 // rulesFromConfigMaps discovers health-rule ConfigMaps for a ServiceSet
@@ -352,6 +388,11 @@ func rulesFromConfigMaps(
 
 	rs, compileErrs := rulesFromDocs(sourced)
 	loadErrs = append(loadErrs, compileErrs...)
+
+	// Prune stale parse-cache entries synchronously. Runs once per
+	// reconcile — pruning frequency scales with controller activity.
+	sweepRuleParseCache()
+
 	return rs, loadErrs, nil
 }
 

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -72,6 +72,11 @@ const (
 	// single ServiceHealth<Kind> condition message. Larger sets are
 	// summarised with "…and N more"; the full list is logged at V(1).
 	maxUnhealthyRefsPerCondition = 3
+
+	// maxUnservedVersionsLogged caps how many "group/version/Kind" entries
+	// appear in the aggregate "API versions not served" V(1) log line
+	// before truncation with "…and N more".
+	maxUnservedVersionsLogged = 5
 )
 
 // discoveryLabels are the well-known label keys chart authors use to tag
@@ -125,8 +130,14 @@ type resourceRule struct {
 }
 
 // ruleSet groups compiled rules by (group, kind). Version is intentionally
-// ignored: a helm-deployed Deployment may be served by any registered
-// version of apps/Deployment and the rule applies regardless.
+// ignored for grouping: a helm-deployed Deployment may be served by any
+// registered version of apps/Deployment and the rule applies regardless.
+//
+// At query time, collectVerdicts resolves the actual listing version
+// via the target cluster's RESTMapper — the intersection of what any
+// rule in the slice authored and what the cluster serves. A rule
+// authored for a version the cluster does not serve does not silently
+// disappear; the mismatch is surfaced through an aggregate V(1) log line.
 //
 // Every rule in the slice for a given GroupKind must evaluate as healthy
 // for a resource to be considered healthy — the rules layer additively,
@@ -504,11 +515,11 @@ func (r resourceRule) evaluate(obj *unstructured.Unstructured) (healthy bool, re
 // The slice is empty when state is Deployed.
 func verifyHelmServiceOnCluster(
 	ctx context.Context,
-	remote client.Client,
+	rgnClient client.Client,
 	rules ruleSet,
 	serviceName, serviceNamespace string,
 ) (string, []metav1.Condition, error) {
-	verdicts, err := collectVerdicts(ctx, remote, rules, serviceName, serviceNamespace)
+	verdicts, err := collectVerdicts(ctx, rgnClient, rules, serviceName, serviceNamespace)
 	if err != nil {
 		return "", nil, err
 	}
@@ -613,45 +624,65 @@ func verifyHelmServiceOnCluster(
 // evaluates each against every rule registered for that (group, kind).
 // A resource is unhealthy if any rule says so; the first failing rule wins.
 //
+// For each GroupKind the listing version is resolved through the target
+// cluster's discovery (RESTMapper): the intersection of what any rule
+// authored and what the cluster actually serves. If no intersection
+// exists, the GK is skipped and its authored (group, version, kind)
+// tuples accumulate into an aggregate V(1) log line at the end of the
+// call — one summarised line per verifier round, not one per skipped GK.
+//
 // "Scope" disambiguates a namespaced vs. cluster-scoped list. When multiple
 // rules for the same (group, kind) disagree on scope (which shouldn't
 // happen in practice — kubernetes scope is intrinsic to the kind), the
 // first rule's scope is used.
 func collectVerdicts(
 	ctx context.Context,
-	remote client.Client,
+	rgnClient client.Client,
 	rules ruleSet,
 	serviceName, serviceNamespace string,
 ) ([]resourceVerdict, error) {
 	var verdicts []resourceVerdict
 	var listErrs error
+	var unserved []string
 
 	for gk, gkRules := range rules {
 		if len(gkRules) == 0 {
 			continue
 		}
-		// Take the first rule's GVK + scope for listing — every rule in this
-		// slice targets the same GroupKind so the list will return the same
-		// items regardless of which rule's GVK we use.
 		scope := gkRules[0].Scope
-		listGVK := gkRules[0].GVK
-		listGVK.Kind = gk.Kind + "List"
+		authoredVersions := distinctVersions(gkRules)
+
+		listGVK, resolveErr := resolveServedVersion(rgnClient.RESTMapper(), gk, authoredVersions)
+		if resolveErr != nil {
+			listErrs = errors.Join(listErrs, resolveErr)
+			continue
+		}
+		if listGVK == nil {
+			// Either the kind isn't served at all, or the cluster serves
+			// versions the rule set doesn't author for. Accumulate for
+			// the aggregate log at the end of the call.
+			for _, v := range authoredVersions {
+				unserved = append(unserved, formatGroupVersionKind(gk, v))
+			}
+			continue
+		}
 
 		// Dedup objects discovered via multiple labels.
 		seen := make(map[client.ObjectKey]struct{})
 
 		for _, labelKey := range discoveryLabels {
 			list := &unstructured.UnstructuredList{}
-			list.SetGroupVersionKind(listGVK)
+			list.SetGroupVersionKind(*listGVK)
 
 			opts := []client.ListOption{client.MatchingLabels{labelKey: serviceName}}
 			if scope == scopeNamespaced {
 				opts = append(opts, client.InNamespace(serviceNamespace))
 			}
-			if err := remote.List(ctx, list, opts...); err != nil {
-				// NoMatchError/NoKindMatchError means the API server on the
-				// target cluster does not serve this GVK — treat as zero
-				// matches, not a hard failure.
+			if err := rgnClient.List(ctx, list, opts...); err != nil {
+				// NoMatchError/NoKindMatchError from the actual List
+				// remains as defense in depth — the RESTMapper's discovery
+				// cache can be briefly stale during a cluster upgrade even
+				// though it said "served".
 				if isNoMatchError(err) {
 					break
 				}
@@ -668,7 +699,7 @@ func collectVerdicts(
 				seen[key] = struct{}{}
 
 				verdict := resourceVerdict{
-					GVK:       listGVK,
+					GVK:       *listGVK,
 					Name:      obj.GetName(),
 					Namespace: obj.GetNamespace(),
 					Healthy:   true,
@@ -695,7 +726,96 @@ func collectVerdicts(
 			}
 		}
 	}
+
+	if len(unserved) > 0 {
+		sort.Strings(unserved)
+		shown := unserved
+		truncated := 0
+		if len(shown) > maxUnservedVersionsLogged {
+			shown = shown[:maxUnservedVersionsLogged]
+			truncated = len(unserved) - maxUnservedVersionsLogged
+		}
+		msg := "verifier: API versions not served by target cluster: " + strings.Join(shown, ", ")
+		if truncated > 0 {
+			msg += fmt.Sprintf(", …and %d more", truncated)
+		}
+		ctrl.LoggerFrom(ctx).V(1).Info(msg)
+	}
+
 	return verdicts, listErrs
+}
+
+// distinctVersions returns the versions authored across gkRules,
+// preserving first-encountered order and de-duplicating. First-seen
+// order matters for reproducibility: two versions tied on served-ness
+// would otherwise have a nondeterministic winner across process restarts.
+func distinctVersions(gkRules []resourceRule) []string {
+	out := make([]string, 0, len(gkRules))
+	seen := make(map[string]struct{}, len(gkRules))
+	for _, r := range gkRules {
+		if _, ok := seen[r.GVK.Version]; ok {
+			continue
+		}
+		seen[r.GVK.Version] = struct{}{}
+		out = append(out, r.GVK.Version)
+	}
+	return out
+}
+
+// resolveServedVersion returns the (Group, Version, Kind+"List") to
+// use for listing objects of gk on the target cluster. The version is
+// chosen from the intersection of what any rule authored for gk and
+// what the cluster's RESTMapper reports as served.
+//
+// Returns (nil, nil) — no error — when the caller should silently skip
+// this GroupKind. That covers two cases:
+//   - The cluster does not serve gk under any version.
+//   - The cluster serves gk but under versions the rule set does not
+//     author for; the caller aggregates those into an operator-visible
+//     log line rather than evaluating against a version the author
+//     didn't intend.
+//
+// Any other mapper error (permission denied, transport failure) is
+// returned and the caller aggregates it into the reconcile-level error.
+func resolveServedVersion(
+	mapper meta.RESTMapper,
+	gk schema.GroupKind,
+	authoredVersions []string,
+) (*schema.GroupVersionKind, error) {
+	mappings, err := mapper.RESTMappings(gk)
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil //nolint:nilnil // deliberate: caller treats nil GVK + nil error as "silent skip" (kind not served)
+		}
+		return nil, fmt.Errorf("discover versions for %s: %w", gk, err)
+	}
+
+	served := make(map[string]struct{}, len(mappings))
+	for _, m := range mappings {
+		served[m.GroupVersionKind.Version] = struct{}{}
+	}
+
+	for _, v := range authoredVersions {
+		if _, ok := served[v]; ok {
+			return &schema.GroupVersionKind{
+				Group:   gk.Group,
+				Version: v,
+				Kind:    gk.Kind + "List",
+			}, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // deliberate: caller treats nil GVK + nil error as "silent skip" (kind not served or version mismatch)
+}
+
+// formatGroupVersionKind renders "group/version/Kind" with the core
+// group spelled out ("core/v1/Pod") so a log line reads naturally
+// instead of "/v1/Pod".
+func formatGroupVersionKind(gk schema.GroupKind, version string) string {
+	g := gk.Group
+	if g == "" {
+		g = "core"
+	}
+	return fmt.Sprintf("%s/%s/%s", g, version, gk.Kind)
 }
 
 func isNoMatchError(err error) bool {

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -287,19 +287,24 @@ func docsFromConfigMap(cm *corev1.ConfigMap) ([]sourcedRuleDoc, []ruleLoadError)
 // across the three tiers, parses them, compiles every rule, and returns
 // the merged ruleSet plus per-rule load errors.
 //
-// Tiers (lowest precedence to highest — but because rules layer additively,
-// "precedence" really means "added on top of"):
+// Tiers (all layer additively — every applicable rule must pass for a
+// resource to be considered healthy):
 //
-//  1. ConfigMaps in systemNamespace labelled health-rule-target=global
-//  2. ConfigMaps in serviceSetNamespace labelled health-rule-target=global
-//  3. ConfigMaps in serviceSetNamespace labelled health-rule-target=<serviceSetName>
-//
-// All discovered rules are loaded; for a given (group, kind) the verifier
-// requires every rule to pass for the resource to be healthy.
+//  1. ConfigMaps in systemNamespace labelled health-rule-target=global.
+//     These are the cluster-global defaults shipped with kcm.
+//  2. ConfigMaps in serviceSet.Namespace labelled health-rule-target=global.
+//     Tenant-authored defaults, scoped to a single namespace.
+//  3. ConfigMaps in serviceSet.Namespace labelled
+//     health-rule-target=<ownerName>, where ownerName is the name of the
+//     MultiClusterService or ClusterDeployment that owns the ServiceSet.
+//     Rules that speak to a specific workload. Users know the MCS/CD name
+//     at authoring time (the ServiceSet is auto-created, its name is not
+//     stable — the owner's is).
 func rulesFromConfigMaps(
 	ctx context.Context,
 	mgmtClient client.Client,
-	systemNamespace, serviceSetNamespace, serviceSetName string,
+	systemNamespace string,
+	serviceSet *kcmv1.ServiceSet,
 ) (ruleSet, []ruleLoadError, error) {
 	var sourced []sourcedRuleDoc
 	var loadErrs []ruleLoadError
@@ -316,8 +321,8 @@ func rulesFromConfigMaps(
 
 	// Tier 2 — ServiceSet namespace, global. Skipped if the SS is in
 	// systemNamespace (would re-list the tier 1 CMs).
-	if serviceSetNamespace != systemNamespace {
-		t2, errs2, err := listAndParse(ctx, mgmtClient, serviceSetNamespace, healthRuleTargetGlobal, seen)
+	if serviceSet.Namespace != systemNamespace {
+		t2, errs2, err := listAndParse(ctx, mgmtClient, serviceSet.Namespace, healthRuleTargetGlobal, seen)
 		if err != nil {
 			return nil, nil, fmt.Errorf("list tier 2 rules: %w", err)
 		}
@@ -325,17 +330,36 @@ func rulesFromConfigMaps(
 		loadErrs = append(loadErrs, errs2...)
 	}
 
-	// Tier 3 — ServiceSet namespace, target == this ServiceSet's name.
-	t3, errs3, err := listAndParse(ctx, mgmtClient, serviceSetNamespace, serviceSetName, seen)
-	if err != nil {
-		return nil, nil, fmt.Errorf("list tier 3 rules: %w", err)
+	// Tier 3 — ServiceSet namespace, target == the ServiceSet's owning
+	// MultiClusterService or ClusterDeployment name. If the ServiceSet
+	// has no such owner (shouldn't happen in normal flow), tier 3 is
+	// simply skipped rather than treated as an error.
+	if ownerName := serviceSetOwnerName(serviceSet); ownerName != "" {
+		t3, errs3, err := listAndParse(ctx, mgmtClient, serviceSet.Namespace, ownerName, seen)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list tier 3 rules: %w", err)
+		}
+		sourced = append(sourced, t3...)
+		loadErrs = append(loadErrs, errs3...)
 	}
-	sourced = append(sourced, t3...)
-	loadErrs = append(loadErrs, errs3...)
 
 	rs, compileErrs := rulesFromDocs(sourced)
 	loadErrs = append(loadErrs, compileErrs...)
 	return rs, loadErrs, nil
+}
+
+// serviceSetOwnerName returns the name of the MultiClusterService or
+// ClusterDeployment that owns the ServiceSet. Returns "" when neither is
+// present in the owner references — the tier-3 lookup will be skipped in
+// that case rather than matching against an empty string.
+func serviceSetOwnerName(serviceSet *kcmv1.ServiceSet) string {
+	for _, o := range serviceSet.OwnerReferences {
+		switch o.Kind {
+		case kcmv1.MultiClusterServiceKind, kcmv1.ClusterDeploymentKind:
+			return o.Name
+		}
+	}
+	return ""
 }
 
 // listAndParse fetches every ConfigMap in namespace labelled
@@ -421,9 +445,9 @@ func (r resourceRule) evaluate(obj *unstructured.Unstructured) (healthy bool, re
 // Deployed. The return is downgrade-only:
 //
 //   - kcmv1.ServiceStateFailed       -> sveltos says Deployed but no labeled
-//                                       resources exist on the target cluster
+//     resources exist on the target cluster
 //   - kcmv1.ServiceStateProvisioning -> at least one labeled resource is
-//                                       unhealthy per its rule
+//     unhealthy per its rule
 //   - kcmv1.ServiceStateDeployed     -> every labeled resource is healthy
 //
 // The returned conditions slice contains one entry per unhealthy resource.

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -109,11 +109,11 @@ type sourcedRuleDoc struct {
 
 // resourceRule is a compiled rule ready to evaluate.
 type resourceRule struct {
+	healthy cel.Program
+	message cel.Program
 	GVK     schema.GroupVersionKind
 	Scope   resourceScope
 	Source  string // for diagnostics; mirrors sourcedRuleDoc.Source
-	healthy cel.Program
-	message cel.Program
 }
 
 // ruleSet groups compiled rules by (group, kind). Version is intentionally
@@ -129,8 +129,8 @@ type ruleSet map[schema.GroupKind][]resourceRule
 // compilation. Used to surface bad user-provided rules as a condition on
 // the ServiceSet so the cluster admin sees which CM is misconfigured.
 type ruleLoadError struct {
-	Source string // "<namespace>/<configmap-name>[#<index>]"
 	Err    error
+	Source string // "<namespace>/<configmap-name>[#<index>]"
 }
 
 func (e ruleLoadError) Error() string {
@@ -143,9 +143,9 @@ type resourceVerdict struct {
 	GVK       schema.GroupVersionKind
 	Name      string
 	Namespace string
-	Healthy   bool
 	Reason    string // empty when Healthy
 	RuleSrc   string // populated when !Healthy; identifies the failing rule
+	Healthy   bool
 }
 
 // celEnv is the shared CEL environment all rule programs are compiled
@@ -229,8 +229,8 @@ type ruleCacheEntry struct {
 // JSON-into-list-into-doc parsing repeats unnecessarily across reconciles
 // when no CM has changed.
 var ruleParseCache = struct {
-	sync.RWMutex
 	entries map[client.ObjectKey]ruleCacheEntry
+	sync.RWMutex
 }{entries: make(map[client.ObjectKey]ruleCacheEntry)}
 
 // docsFromConfigMap reads a single ConfigMap's `rules` key, parses it as a
@@ -424,13 +424,15 @@ func (r resourceRule) evaluate(obj *unstructured.Unstructured) (healthy bool, re
 		return true, "", nil
 	}
 
-	mOut, _, err := r.message.Eval(input)
-	if err != nil {
-		// Don't fail the whole verdict if the message expression breaks; we
-		// already know the resource is unhealthy.
-		return false, "", nil
+	// The verdict is unhealthy either way. Best-effort resolve the
+	// human-readable message; a message-expression failure or a
+	// non-string result silently degrades to an empty message.
+	mVal := ""
+	if mOut, _, err := r.message.Eval(input); err == nil {
+		if s, ok := mOut.Value().(string); ok {
+			mVal = s
+		}
 	}
-	mVal, _ := mOut.Value().(string)
 	return false, mVal, nil
 }
 
@@ -722,7 +724,9 @@ func fetchHelmArtifactsForVerifier(
 // findOwnedClusterConfiguration returns the ClusterConfiguration in
 // namespace whose OwnerReferences include profileUID. Returns (nil, nil)
 // when none exists yet (sveltos may not have recorded resources for the
-// profile on this cluster yet).
+// profile on this cluster yet). Callers already handle a nil result as
+// "no fingerprint information available" so a sentinel error would only
+// force pointless errors.Is checks at every call site.
 func findOwnedClusterConfiguration(
 	ctx context.Context,
 	rgnClient client.Client,
@@ -740,7 +744,7 @@ func findOwnedClusterConfiguration(
 			}
 		}
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil // deliberate: nil result means "not-found-yet", not an error condition
 }
 
 // serviceHashesFromArtifacts builds a (releaseNamespace, releaseName) →
@@ -830,10 +834,12 @@ func computeServiceHash(release *addoncontrollerv1beta1.HelmChartSummary, chart 
 	}, "|")
 	releaseHash := sha256.Sum256([]byte(releaseInput))
 
+	// sha256.Hash.Write is documented to never return an error; the
+	// blank-assignments silence errcheck without adding real error handling.
 	combined := sha256.New()
-	combined.Write(releaseHash[:])
-	combined.Write(release.ValuesHash)
-	combined.Write(release.PatchesHash)
+	_, _ = combined.Write(releaseHash[:])
+	_, _ = combined.Write(release.ValuesHash)
+	_, _ = combined.Write(release.PatchesHash)
 	return hex.EncodeToString(combined.Sum(nil))
 }
 
@@ -849,5 +855,6 @@ func applyVerifyConditions(s *kcmv1.ServiceState, newConds []metav1.Condition) {
 			kept = append(kept, c)
 		}
 	}
-	s.Conditions = append(kept, newConds...)
+	kept = append(kept, newConds...)
+	s.Conditions = kept
 }

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -504,6 +504,7 @@ func verifyHelmServiceOnCluster(
 		}
 		byKind[v.GVK.Kind] = append(byKind[v.GVK.Kind], v)
 	}
+	sort.Strings(kindOrder)
 	if len(kindOrder) == 0 {
 		return kcmv1.ServiceStateDeployed, nil, nil
 	}

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -16,6 +16,8 @@ package sveltos
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -23,11 +25,16 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	"github.com/projectsveltos/addon-controller/lib/clusterops"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -432,12 +439,19 @@ func verifyHelmServiceOnCluster(
 		return "", nil, err
 	}
 
+	// LastTransitionTime is a required field per the ServiceSet CRD's
+	// metav1.Condition schema; status.Update fails validation if any
+	// condition omits it. Using a single now() value per call keeps the
+	// timestamp consistent across all conditions emitted from this round.
+	now := metav1.Now()
+
 	if len(verdicts) == 0 {
 		return kcmv1.ServiceStateFailed, []metav1.Condition{{
-			Type:    serviceHealthConditionPrefix,
-			Status:  metav1.ConditionFalse,
-			Reason:  "NoResourcesOnCluster",
-			Message: fmt.Sprintf("no resources matching any of %v=%s found on target cluster", discoveryLabels, serviceName),
+			Type:               serviceHealthConditionPrefix,
+			Status:             metav1.ConditionFalse,
+			Reason:             "NoResourcesOnCluster",
+			Message:            fmt.Sprintf("no resources matching any of %v=%s found on target cluster", discoveryLabels, serviceName),
+			LastTransitionTime: now,
 		}}, nil
 	}
 
@@ -451,10 +465,11 @@ func verifyHelmServiceOnCluster(
 			ref = v.Namespace + "/" + v.Name
 		}
 		conds = append(conds, metav1.Condition{
-			Type:    serviceHealthConditionPrefix + v.GVK.Kind,
-			Status:  metav1.ConditionFalse,
-			Reason:  v.GVK.Kind + "Unhealthy",
-			Message: fmt.Sprintf("%s %s: %s (rule %s)", v.GVK.Kind, ref, v.Reason, v.RuleSrc),
+			Type:               serviceHealthConditionPrefix + v.GVK.Kind,
+			Status:             metav1.ConditionFalse,
+			Reason:             v.GVK.Kind + "Unhealthy",
+			Message:            fmt.Sprintf("%s %s: %s (rule %s)", v.GVK.Kind, ref, v.Reason, v.RuleSrc),
+			LastTransitionTime: now,
 		})
 	}
 
@@ -594,6 +609,209 @@ func applyRuleLoadErrorCondition(serviceSet *kcmv1.ServiceSet, loadErrs []ruleLo
 // apimachinery/api/meta dependency confined to one call site, mirroring
 // the import alias the rest of the controller uses.
 var apimetaSetStatusCondition = meta.SetStatusCondition
+
+// fetchHelmArtifactsForVerifier loads the sveltos artifacts the verifier
+// needs to compute per-service hashes:
+//
+//   - ClusterSummary  — for HelmReleaseSummaries[i].{ValuesHash, PatchesHash}
+//   - ClusterConfiguration — for Charts[i].{AppVersion, ChartVersion,
+//     Namespace, ReleaseName, RepoURL}
+//
+// Both are namespaced; both live in the matching cluster's namespace
+// (CAPI Cluster.Namespace for non-self-managed, "mgmt" for self-managed).
+//
+// The ClusterConfiguration is found via owner references rather than
+// reproducing sveltos's unexported name-format helpers: sveltos stamps the
+// Profile/ClusterProfile as an owner ref on the ClusterConfiguration when
+// it first records resources for that (cluster, profile) pair, so the
+// owner UID is a stable identity link.
+//
+// Returns (nil, nil, nil) — without error — when sveltos hasn't picked a
+// matching cluster yet or hasn't created the artifacts. The verifier
+// treats that case as "no fingerprint information available" and falls
+// back to the downgrade-only path.
+func fetchHelmArtifactsForVerifier(
+	ctx context.Context,
+	rgnClient client.Client,
+	serviceSet *kcmv1.ServiceSet,
+) (
+	summary *addoncontrollerv1beta1.ClusterSummary,
+	cc *addoncontrollerv1beta1.ClusterConfiguration,
+	profileKind string,
+	profileName string,
+	err error,
+) {
+	var profileObj client.Object
+	if serviceSet.Spec.Provider.SelfManagement {
+		profileObj = new(addoncontrollerv1beta1.ClusterProfile)
+	} else {
+		profileObj = new(addoncontrollerv1beta1.Profile)
+	}
+	if err := rgnClient.Get(ctx, client.ObjectKeyFromObject(serviceSet), profileObj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil, "", "", nil
+		}
+		return nil, nil, "", "", fmt.Errorf("get sveltos profile %s: %w", client.ObjectKeyFromObject(serviceSet), err)
+	}
+
+	var (
+		matchingRefs []corev1.ObjectReference
+		profileUID   types.UID
+	)
+	switch p := profileObj.(type) {
+	case *addoncontrollerv1beta1.Profile:
+		matchingRefs = p.Status.MatchingClusterRefs
+		profileKind = addoncontrollerv1beta1.ProfileKind
+		profileName = p.Name
+		profileUID = p.UID
+	case *addoncontrollerv1beta1.ClusterProfile:
+		matchingRefs = p.Status.MatchingClusterRefs
+		profileKind = addoncontrollerv1beta1.ClusterProfileKind
+		profileName = p.Name
+		profileUID = p.UID
+	}
+	if len(matchingRefs) == 0 {
+		return nil, nil, "", "", nil
+	}
+
+	cluster := matchingRefs[0]
+	isSveltos := cluster.APIVersion == libsveltosv1beta1.GroupVersion.WithKind(libsveltosv1beta1.SveltosClusterKind).GroupVersion().String()
+
+	// ClusterSummary — sveltos exports a name helper for this one.
+	summaryName := clusterops.GetClusterSummaryName(profileKind, profileName, cluster.Name, isSveltos)
+	summary = new(addoncontrollerv1beta1.ClusterSummary)
+	summaryKey := client.ObjectKey{Name: summaryName, Namespace: cluster.Namespace}
+	if err := rgnClient.Get(ctx, summaryKey, summary); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, nil, "", "", fmt.Errorf("get ClusterSummary %s: %w", summaryKey, err)
+		}
+		summary = nil
+	}
+
+	cc, err = findOwnedClusterConfiguration(ctx, rgnClient, cluster.Namespace, profileUID)
+	if err != nil {
+		return nil, nil, "", "", err
+	}
+	return summary, cc, profileKind, profileName, nil
+}
+
+// findOwnedClusterConfiguration returns the ClusterConfiguration in
+// namespace whose OwnerReferences include profileUID. Returns (nil, nil)
+// when none exists yet (sveltos may not have recorded resources for the
+// profile on this cluster yet).
+func findOwnedClusterConfiguration(
+	ctx context.Context,
+	rgnClient client.Client,
+	namespace string,
+	profileUID types.UID,
+) (*addoncontrollerv1beta1.ClusterConfiguration, error) {
+	list := new(addoncontrollerv1beta1.ClusterConfigurationList)
+	if err := rgnClient.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("list ClusterConfigurations in %s: %w", namespace, err)
+	}
+	for i := range list.Items {
+		for _, owner := range list.Items[i].OwnerReferences {
+			if owner.UID == profileUID {
+				return &list.Items[i], nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// serviceHashesFromArtifacts builds a (releaseNamespace, releaseName) →
+// ServiceHash map for every Helm release sveltos has recorded for the
+// supplied profile. Missing inputs are tolerated: if either summary or cc
+// is nil the result is an empty map.
+func serviceHashesFromArtifacts(
+	summary *addoncontrollerv1beta1.ClusterSummary,
+	cc *addoncontrollerv1beta1.ClusterConfiguration,
+	profileKind, profileName string,
+) map[client.ObjectKey]string {
+	hashes := make(map[client.ObjectKey]string)
+	if summary == nil || cc == nil {
+		return hashes
+	}
+
+	// Locate this profile's section inside the ClusterConfiguration.
+	idx, err := addoncontrollerv1beta1.GetClusterConfigurationSectionIndex(cc, profileKind, profileName)
+	if err != nil {
+		return hashes
+	}
+
+	var features []addoncontrollerv1beta1.Feature
+	if profileKind == addoncontrollerv1beta1.ClusterProfileKind {
+		features = cc.Status.ClusterProfileResources[idx].Features
+	} else {
+		features = cc.Status.ProfileResources[idx].Features
+	}
+
+	var charts []addoncontrollerv1beta1.Chart
+	for i := range features {
+		if features[i].FeatureID == libsveltosv1beta1.FeatureHelm {
+			charts = features[i].Charts
+			break
+		}
+	}
+
+	// Index by (releaseNamespace, releaseName) for cross-source lookup.
+	chartByKey := make(map[client.ObjectKey]*addoncontrollerv1beta1.Chart, len(charts))
+	for i := range charts {
+		chartByKey[client.ObjectKey{Namespace: charts[i].Namespace, Name: charts[i].ReleaseName}] = &charts[i]
+	}
+
+	for i := range summary.Status.HelmReleaseSummaries {
+		rs := &summary.Status.HelmReleaseSummaries[i]
+		key := client.ObjectKey{Namespace: rs.ReleaseNamespace, Name: rs.ReleaseName}
+		chart, ok := chartByKey[key]
+		if !ok {
+			continue
+		}
+		if h := computeServiceHash(rs, chart); h != "" {
+			hashes[key] = h
+		}
+	}
+
+	return hashes
+}
+
+// computeServiceHash produces a stable hex-sha256 fingerprint covering
+// chart identity, rendered values, and sveltos-applied patches for a
+// single helm-deployed service.
+//
+//	ReleaseHash = sha256(appVersion|chartVersion|namespace|releaseName|repoURL)
+//	ServiceHash = sha256(ReleaseHash || ValuesHash || PatchesHash)
+//
+// `lastAppliedTime` is INTENTIONALLY excluded — sveltos rewrites it on every
+// re-touch even when nothing else changed, and including it would defeat
+// the whole point of the fingerprint.
+//
+// Returns "" when either input is nil. Callers MUST treat empty as
+// "no fingerprint available" — never short-circuit comparisons against
+// other empties (e.g. a brand-new service whose ClusterConfiguration
+// entry hasn't appeared yet would otherwise spuriously match a
+// brand-new ServiceState whose LastDeployedHash is also unset).
+func computeServiceHash(release *addoncontrollerv1beta1.HelmChartSummary, chart *addoncontrollerv1beta1.Chart) string {
+	if release == nil || chart == nil {
+		return ""
+	}
+
+	// Stable, explicit field ordering — no map iteration.
+	releaseInput := strings.Join([]string{
+		"appVersion=" + chart.AppVersion,
+		"chartVersion=" + chart.ChartVersion,
+		"namespace=" + chart.Namespace,
+		"releaseName=" + chart.ReleaseName,
+		"repoURL=" + chart.RepoURL,
+	}, "|")
+	releaseHash := sha256.Sum256([]byte(releaseInput))
+
+	combined := sha256.New()
+	combined.Write(releaseHash[:])
+	combined.Write(release.ValuesHash)
+	combined.Write(release.PatchesHash)
+	return hex.EncodeToString(combined.Sum(nil))
+}
 
 // applyVerifyConditions replaces any verifier-owned condition (Type
 // starting with serviceHealthConditionPrefix) on the service state with

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -182,11 +182,13 @@ var celEnv = func() *cel.Env {
 }()
 
 // rulesFromDocs compiles a slice of source-tagged rule documents into a
-// ruleSet. Individual compile / validation errors are collected and
-// returned in []ruleLoadError so a single bad rule does not break the rest
-// of the set.
-func rulesFromDocs(docs []sourcedRuleDoc) (ruleSet, []ruleLoadError) {
-	out := make(ruleSet)
+// flat slice of resourceRule. Individual compile / validation errors
+// are collected and returned in []ruleLoadError so a single bad rule
+// does not break the rest of the set. Callers group by GroupKind at
+// the point they need the ruleSet map — keeping compilation flat
+// makes per-CM caching straightforward.
+func rulesFromDocs(docs []sourcedRuleDoc) ([]resourceRule, []ruleLoadError) {
+	out := make([]resourceRule, 0, len(docs))
 	var loadErrs []ruleLoadError
 
 	for _, sd := range docs {
@@ -211,9 +213,8 @@ func rulesFromDocs(docs []sourcedRuleDoc) (ruleSet, []ruleLoadError) {
 			continue
 		}
 
-		gvk := schema.GroupVersionKind{Group: doc.Group, Version: doc.Version, Kind: doc.Kind}
-		out[gvk.GroupKind()] = append(out[gvk.GroupKind()], resourceRule{
-			GVK:     gvk,
+		out = append(out, resourceRule{
+			GVK:     schema.GroupVersionKind{Group: doc.Group, Version: doc.Version, Kind: doc.Kind},
 			Scope:   doc.Scope,
 			Source:  sd.Source,
 			healthy: healthyPrg,
@@ -238,61 +239,65 @@ func compileExpr(env *cel.Env, src string) (cel.Program, error) {
 
 // ruleCacheEntry stores the compiled rules and load errors for a single
 // ConfigMap, keyed by ResourceVersion so a CM edit invalidates the entry.
-// lastAccess is refreshed on every hit and consulted by sweepRuleParseCache
+// lastAccess is refreshed on every hit and consulted by sweepRuleCache
 // to evict entries whose owning CM has been deleted (or whose ServiceSet
-// no longer reconciles) after ruleParseCacheTTL.
+// no longer reconciles) after ruleCacheTTL.
 type ruleCacheEntry struct {
 	lastAccess      time.Time
 	resourceVersion string
-	docs            []sourcedRuleDoc // raw + source-tagged, ready for rulesFromDocs
-	loadErrs        []ruleLoadError  // parse errors (not compile errors — those re-run with a single env)
+	rules           []resourceRule  // compiled rules — cel.Programs ready to evaluate
+	loadErrs        []ruleLoadError // parse errors + compile errors (deterministic per RV)
 }
 
-// ruleParseCacheTTL bounds how long a parsed-rule cache entry survives
-// without being referenced. Refreshed on every cache hit, so hot entries
-// whose ResourceVersion never changes stay cached; a CM that gets deleted
-// (or its owning ServiceSet stops reconciling) ages out on the order of
+// ruleCacheTTL bounds how long a cache entry survives without being
+// referenced. Refreshed on every cache hit, so hot entries whose
+// ResourceVersion never changes stay cached; a CM that gets deleted (or
+// its owning ServiceSet stops reconciling) ages out on the order of
 // this TTL rather than leaking forever.
-const ruleParseCacheTTL = 5 * time.Minute
+const ruleCacheTTL = 5 * time.Minute
 
-// ruleParseCache memoises ConfigMap parsing. The CEL compiler is fast but
-// JSON-into-list-into-doc parsing repeats unnecessarily across reconciles
-// when no CM has changed. Entries are keyed by (namespace, name) and
-// invalidated when the CM's ResourceVersion changes; stale entries are
-// swept in sweepRuleParseCache, which rulesFromConfigMaps calls once per
-// reconcile. The mutex protects both the map and the per-entry lastAccess
-// bookkeeping.
-var ruleParseCache = struct {
+// ruleCache memoises the (parse + compile) chain for rule ConfigMaps.
+// Both parsing YAML into ruleDocs and compiling their Healthy/Message
+// CEL expressions into cel.Programs happen on cache miss; a hit returns
+// the pre-compiled resourceRule slice directly. Entries are keyed by
+// (namespace, name), invalidated when the CM's ResourceVersion changes,
+// and swept in sweepRuleCache after ruleCacheTTL of no access.
+var ruleCache = struct {
 	entries map[client.ObjectKey]ruleCacheEntry
 	sync.Mutex
 }{entries: make(map[client.ObjectKey]ruleCacheEntry)}
 
-// docsFromConfigMap reads a single ConfigMap's `rules` key, parses it as a
-// YAML list of rule documents, and returns the source-tagged slice plus
-// any parse errors. Results are cached on ResourceVersion; every hit
-// refreshes the entry's lastAccess so sweepRuleParseCache keeps hot
+// rulesFromConfigMap reads a single ConfigMap's `rules` key, parses it
+// as a YAML list of rule documents, compiles every rule's Healthy and
+// Message CEL expressions, and returns the compiled slice plus any
+// parse or compile errors. Results are cached on ResourceVersion; every
+// hit refreshes the entry's lastAccess so sweepRuleCache keeps hot
 // entries alive and evicts cold ones (deleted CMs, non-reconciling
-// ServiceSets) after ruleParseCacheTTL.
-func docsFromConfigMap(cm *corev1.ConfigMap) ([]sourcedRuleDoc, []ruleLoadError) {
+// ServiceSets) after ruleCacheTTL.
+//
+// Compile errors are memoised for the entry's lifetime because celEnv
+// is a static package-level var — a rule that fails to compile at RV=N
+// will fail identically at RV=N until the CM changes.
+func rulesFromConfigMap(cm *corev1.ConfigMap) ([]resourceRule, []ruleLoadError) {
 	key := client.ObjectKey{Namespace: cm.Namespace, Name: cm.Name}
 	now := time.Now()
 
-	ruleParseCache.Lock()
-	cached, ok := ruleParseCache.entries[key]
+	ruleCache.Lock()
+	cached, ok := ruleCache.entries[key]
 	if ok && cached.resourceVersion == cm.ResourceVersion {
 		cached.lastAccess = now
-		ruleParseCache.entries[key] = cached
-		ruleParseCache.Unlock()
-		return cached.docs, cached.loadErrs
+		ruleCache.entries[key] = cached
+		ruleCache.Unlock()
+		return cached.rules, cached.loadErrs
 	}
-	ruleParseCache.Unlock()
+	ruleCache.Unlock()
 
 	rawRules, ok := cm.Data[healthRuleConfigMapDataKey]
 	if !ok || strings.TrimSpace(rawRules) == "" {
 		entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion, lastAccess: now}
-		ruleParseCache.Lock()
-		ruleParseCache.entries[key] = entry
-		ruleParseCache.Unlock()
+		ruleCache.Lock()
+		ruleCache.entries[key] = entry
+		ruleCache.Unlock()
 		return nil, nil
 	}
 
@@ -303,9 +308,9 @@ func docsFromConfigMap(cm *corev1.ConfigMap) ([]sourcedRuleDoc, []ruleLoadError)
 			Err:    fmt.Errorf("parse %q: %w", healthRuleConfigMapDataKey, err),
 		}}
 		entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion, loadErrs: errs, lastAccess: now}
-		ruleParseCache.Lock()
-		ruleParseCache.entries[key] = entry
-		ruleParseCache.Unlock()
+		ruleCache.Lock()
+		ruleCache.entries[key] = entry
+		ruleCache.Unlock()
 		return nil, errs
 	}
 
@@ -317,29 +322,38 @@ func docsFromConfigMap(cm *corev1.ConfigMap) ([]sourcedRuleDoc, []ruleLoadError)
 		})
 	}
 
-	entry := ruleCacheEntry{resourceVersion: cm.ResourceVersion, docs: sourced, lastAccess: now}
-	ruleParseCache.Lock()
-	ruleParseCache.entries[key] = entry
-	ruleParseCache.Unlock()
-	return sourced, nil
+	// Compile every rule. Per-rule failures accumulate into loadErrs so a
+	// single bad rule doesn't disqualify the rest of the CM's rules.
+	rules, compileErrs := rulesFromDocs(sourced)
+
+	entry := ruleCacheEntry{
+		resourceVersion: cm.ResourceVersion,
+		rules:           rules,
+		loadErrs:        compileErrs,
+		lastAccess:      now,
+	}
+	ruleCache.Lock()
+	ruleCache.entries[key] = entry
+	ruleCache.Unlock()
+	return rules, compileErrs
 }
 
-// sweepRuleParseCache evicts cache entries whose lastAccess timestamp is
-// older than ruleParseCacheTTL.
-func sweepRuleParseCache() {
-	cutoff := time.Now().Add(-ruleParseCacheTTL)
-	ruleParseCache.Lock()
-	defer ruleParseCache.Unlock()
-	for key, entry := range ruleParseCache.entries {
+// sweepRuleCache evicts cache entries whose lastAccess timestamp is
+// older than ruleCacheTTL.
+func sweepRuleCache() {
+	cutoff := time.Now().Add(-ruleCacheTTL)
+	ruleCache.Lock()
+	defer ruleCache.Unlock()
+	for key, entry := range ruleCache.entries {
 		if entry.lastAccess.Before(cutoff) {
-			delete(ruleParseCache.entries, key)
+			delete(ruleCache.entries, key)
 		}
 	}
 }
 
 // rulesFromConfigMaps discovers health-rule ConfigMaps for a ServiceSet
-// across the three tiers, parses them, compiles every rule, and returns
-// the merged ruleSet plus per-rule load errors.
+// across the three tiers, resolves each CM through the (parse + compile)
+// cache, and returns the merged ruleSet plus per-rule load errors.
 //
 // Tiers (all layer additively — every applicable rule must pass for a
 // resource to be considered healthy):
@@ -360,27 +374,27 @@ func rulesFromConfigMaps(
 	systemNamespace string,
 	serviceSet *kcmv1.ServiceSet,
 ) (ruleSet, []ruleLoadError, error) {
-	var sourced []sourcedRuleDoc
+	var collected []resourceRule
 	var loadErrs []ruleLoadError
 
 	seen := make(map[client.ObjectKey]struct{})
 
 	// Tier 1 — kcm-system, global.
-	t1, errs1, err := listAndParse(ctx, mgmtClient, systemNamespace, healthRuleTargetGlobal, seen)
+	t1, errs1, err := listAndLoad(ctx, mgmtClient, systemNamespace, healthRuleTargetGlobal, seen)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list tier 1 rules: %w", err)
 	}
-	sourced = append(sourced, t1...)
+	collected = append(collected, t1...)
 	loadErrs = append(loadErrs, errs1...)
 
 	// Tier 2 — ServiceSet namespace, global. Skipped if the SS is in
 	// systemNamespace (would re-list the tier 1 CMs).
 	if serviceSet.Namespace != systemNamespace {
-		t2, errs2, err := listAndParse(ctx, mgmtClient, serviceSet.Namespace, healthRuleTargetGlobal, seen)
+		t2, errs2, err := listAndLoad(ctx, mgmtClient, serviceSet.Namespace, healthRuleTargetGlobal, seen)
 		if err != nil {
 			return nil, nil, fmt.Errorf("list tier 2 rules: %w", err)
 		}
-		sourced = append(sourced, t2...)
+		collected = append(collected, t2...)
 		loadErrs = append(loadErrs, errs2...)
 	}
 
@@ -389,20 +403,26 @@ func rulesFromConfigMaps(
 	// has no such owner (shouldn't happen in normal flow), tier 3 is
 	// simply skipped rather than treated as an error.
 	if ownerName := serviceSetOwnerName(serviceSet); ownerName != "" {
-		t3, errs3, err := listAndParse(ctx, mgmtClient, serviceSet.Namespace, ownerName, seen)
+		t3, errs3, err := listAndLoad(ctx, mgmtClient, serviceSet.Namespace, ownerName, seen)
 		if err != nil {
 			return nil, nil, fmt.Errorf("list tier 3 rules: %w", err)
 		}
-		sourced = append(sourced, t3...)
+		collected = append(collected, t3...)
 		loadErrs = append(loadErrs, errs3...)
 	}
 
-	rs, compileErrs := rulesFromDocs(sourced)
-	loadErrs = append(loadErrs, compileErrs...)
+	// Group the flat, already-compiled slice by GroupKind. Compilation
+	// happened once per CM inside rulesFromConfigMap (memoised); this
+	// grouping is pure O(N) map assembly.
+	rs := make(ruleSet)
+	for _, rule := range collected {
+		gk := rule.GVK.GroupKind()
+		rs[gk] = append(rs[gk], rule)
+	}
 
-	// Prune stale parse-cache entries synchronously. Runs once per
+	// Prune stale cache entries synchronously. Runs once per
 	// reconcile — pruning frequency scales with controller activity.
-	sweepRuleParseCache()
+	sweepRuleCache()
 
 	return rs, loadErrs, nil
 }
@@ -421,17 +441,17 @@ func serviceSetOwnerName(serviceSet *kcmv1.ServiceSet) string {
 	return ""
 }
 
-// listAndParse fetches every ConfigMap in namespace labelled
-// health-rule-target=<targetValue> and accumulates their parsed rule docs.
-// `seen` is shared across tier calls so a CM is never double-loaded
-// (matters when the SS namespace IS the system namespace, or when a CM
-// somehow matches more than one tier).
-func listAndParse(
+// listAndLoad fetches every ConfigMap in namespace labelled
+// health-rule-target=<targetValue> and accumulates their compiled rules
+// (via the ruleCache). `seen` is shared across tier calls so a CM is
+// never double-loaded (matters when the SS namespace IS the system
+// namespace, or when a CM somehow matches more than one tier).
+func listAndLoad(
 	ctx context.Context,
 	c client.Client,
 	namespace, targetValue string,
 	seen map[client.ObjectKey]struct{},
-) ([]sourcedRuleDoc, []ruleLoadError, error) {
+) ([]resourceRule, []ruleLoadError, error) {
 	list := &corev1.ConfigMapList{}
 	opts := []client.ListOption{
 		client.InNamespace(namespace),
@@ -441,7 +461,7 @@ func listAndParse(
 		return nil, nil, fmt.Errorf("list ConfigMaps in %s with %s=%s: %w", namespace, healthRuleTargetLabel, targetValue, err)
 	}
 
-	var sourced []sourcedRuleDoc
+	var rules []resourceRule
 	var loadErrs []ruleLoadError
 	for i := range list.Items {
 		cm := &list.Items[i]
@@ -451,11 +471,11 @@ func listAndParse(
 		}
 		seen[key] = struct{}{}
 
-		docs, errs := docsFromConfigMap(cm)
-		sourced = append(sourced, docs...)
+		cmRules, errs := rulesFromConfigMap(cm)
+		rules = append(rules, cmRules...)
 		loadErrs = append(loadErrs, errs...)
 	}
-	return sourced, loadErrs, nil
+	return rules, loadErrs, nil
 }
 
 // evaluate runs the rule against a single unstructured object and returns

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -187,12 +187,19 @@ type resourceVerdict struct {
 	Healthy   bool
 }
 
+// celObjectVar is the name of the CEL environment variable bound to the
+// k8s object under evaluation. Every default and user-authored rule
+// references it as `<celObjectVar>.status.foo` etc., and objActivation
+// binds this exact name — changing the value here is a breaking change
+// for every shipped rule ConfigMap.
+const celObjectVar = "obj"
+
 // celEnv is the shared CEL environment all rule programs are compiled
 // against. The `ext.Strings()` extension provides .join(sep) and friends
 // on string lists.
 var celEnv = func() *cel.Env {
 	env, err := cel.NewEnv(
-		cel.Variable("obj", cel.DynType),
+		cel.Variable(celObjectVar, cel.DynType),
 		ext.Strings(),
 	)
 	if err != nil {
@@ -200,6 +207,24 @@ var celEnv = func() *cel.Env {
 	}
 	return env
 }()
+
+// objActivation is a cel.Activation binding a single variable named
+// celObjectVar to a k8s object's Object map. Built once per object in
+// collectVerdicts and reused across every rule for that object's Kind —
+// eliminates the per-rule map+wrapper allocation that plain
+// map[string]any input would produce inside Eval's NewActivation.
+type objActivation struct {
+	obj map[string]any
+}
+
+func (a objActivation) ResolveName(name string) (any, bool) {
+	if name == celObjectVar {
+		return a.obj, true
+	}
+	return nil, false
+}
+
+func (objActivation) Parent() cel.Activation { return nil }
 
 // rulesFromDocs compiles a slice of source-tagged rule documents into a
 // flat slice of resourceRule. Individual compile / validation errors
@@ -498,19 +523,16 @@ func listAndLoad(
 	return rules, loadErrs, nil
 }
 
-// evaluate runs the rule against a single unstructured object and returns
-// the verdict plus a human-readable reason if unhealthy. Pods that are
-// already terminating (deletionTimestamp set) are reported as healthy:
-// a terminating Pod is by definition not Ready, but counting it as
-// unhealthy would make every workload rollout look broken for as long as
-// terminationGracePeriodSeconds.
-func (r resourceRule) evaluate(obj *unstructured.Unstructured) (healthy bool, reason string, err error) {
-	if r.GVK.Group == "" && r.GVK.Kind == "Pod" && obj.GetDeletionTimestamp() != nil {
-		return true, "", nil
-	}
-
-	input := map[string]any{"obj": obj.Object}
-
+// evaluate runs the rule against a single pre-built activation (which
+// carries the object under the celObjectVar variable name) and returns
+// the verdict plus a human-readable reason if unhealthy. The activation
+// is built once per object by collectVerdicts and reused across every
+// rule for that object's Kind — see objActivation.
+//
+// Callers are responsible for the terminating-resource fast path (any
+// object with deletionTimestamp set is treated as healthy without ever
+// reaching this function) — see the check in collectVerdicts.
+func (r resourceRule) evaluate(input cel.Activation) (healthy bool, reason string, err error) {
 	hOut, _, err := r.healthy.Eval(input)
 	if err != nil {
 		return false, "", fmt.Errorf("evaluate healthy: %w", err)
@@ -779,10 +801,19 @@ func collectVerdicts(
 				}
 				verdict.GVK.Kind = gk.Kind // strip the "List" suffix
 
+				if obj.GetDeletionTimestamp() != nil {
+					verdicts = append(verdicts, verdict)
+					continue
+				}
+
+				// Build the CEL activation once per object; every rule
+				// for this Kind reuses it.
+				activation := objActivation{obj: obj.Object}
+
 				// Evaluate every rule registered for this GroupKind. First
 				// failure wins; we record its message + source.
 				for _, rule := range gkRules {
-					healthy, reason, evalErr := rule.evaluate(obj)
+					healthy, reason, evalErr := rule.evaluate(activation)
 					if evalErr != nil {
 						listErrs = errors.Join(listErrs, fmt.Errorf("evaluate %s %s/%s (rule %s): %w", gk, obj.GetNamespace(), obj.GetName(), rule.Source, evalErr))
 						continue

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -77,6 +77,26 @@ const (
 	// appear in the aggregate "API versions not served" V(1) log line
 	// before truncation with "…and N more".
 	maxUnservedVersionsLogged = 5
+
+	// maxRuleLoadErrorsInCondition caps how many individual rule-load
+	// errors are enumerated in the ServiceSetHealthRules condition
+	// message. Beyond this the message truncates with "…and N more".
+	// Rationale: 10 broken rules is already enough for an operator to
+	// spot the pattern; beyond that the message becomes unreadable.
+	maxRuleLoadErrorsInCondition = 10
+
+	// maxRuleLoadErrorConditionMessageBytes caps the total ServiceSetHealthRules
+	// condition message length below the CRD's 32 KiB per-condition-message
+	// limit. Set with headroom so accidental over-runs (e.g. a single very
+	// long CEL parser error) still land inside the schema bound.
+	maxRuleLoadErrorConditionMessageBytes = 20 * 1024
+
+	// maxVerdictReasonBytes caps the per-verdict CEL Reason string
+	// embedded in a ServiceHealth<Kind> condition message. Prevents a
+	// runaway user CEL `message` expression from producing a 30 KB
+	// reason that pushes the condition message past the CRD limit.
+	// Truncated with an ellipsis suffix.
+	maxVerdictReasonBytes = 500
 )
 
 // discoveryLabels are the well-known label keys chart authors use to tag
@@ -598,7 +618,7 @@ func verifyHelmServiceOnCluster(
 				ref = v.Namespace + "/" + v.Name
 			}
 			parts = append(parts, fmt.Sprintf("%s (%s, rule %s)",
-				ref, strings.TrimSpace(v.Reason), v.RuleSrc))
+				ref, truncateReason(v.Reason), v.RuleSrc))
 		}
 		msg := fmt.Sprintf("%d %s unhealthy: %s", len(items), kind, strings.Join(parts, "; "))
 		if truncated > 0 {
@@ -886,6 +906,20 @@ func formatGroupVersionKind(gk schema.GroupKind, version string) string {
 	return fmt.Sprintf("%s/%s/%s", g, version, gk.Kind)
 }
 
+// truncateReason bounds a per-verdict CEL Reason string to
+// maxVerdictReasonBytes, appending an ellipsis when truncated. Guards
+// against a runaway user CEL `message` expression pushing a
+// ServiceHealth<Kind> condition message past the CRD's per-message limit.
+// Also strips surrounding whitespace so multi-line CEL messages render
+// as single-line reasons.
+func truncateReason(reason string) string {
+	r := strings.TrimSpace(reason)
+	if len(r) > maxVerdictReasonBytes {
+		return r[:maxVerdictReasonBytes] + "…"
+	}
+	return r
+}
+
 func isNoMatchError(err error) bool {
 	var noKind *meta.NoKindMatchError
 	var noResource *meta.NoResourceMatchError
@@ -901,6 +935,15 @@ const serviceSetHealthRulesCondition = "ServiceSetHealthRules"
 // applyRuleLoadErrorCondition writes (or refreshes) the
 // ServiceSetHealthRules condition on the ServiceSet to reflect the result
 // of the most recent rule load.
+//
+// The condition message is bounded on two axes to keep every write below
+// the CRD's 32 KiB per-message limit:
+//   - At most maxRuleLoadErrorsInCondition individual errors are
+//     enumerated; the tail is summarised with "…and N more".
+//   - The total message is truncated to maxRuleLoadErrorConditionMessageBytes.
+//
+// Both bounds protect against the same failure mode (misconfigured user
+// rules producing many error strings) via two independent mechanisms.
 func applyRuleLoadErrorCondition(serviceSet *kcmv1.ServiceSet, loadErrs []ruleLoadError) {
 	cond := metav1.Condition{
 		Type:               serviceSetHealthRulesCondition,
@@ -911,13 +954,29 @@ func applyRuleLoadErrorCondition(serviceSet *kcmv1.ServiceSet, loadErrs []ruleLo
 		cond.Reason = "AllRulesValid"
 		cond.Message = "All health rules loaded successfully"
 	} else {
-		msgs := make([]string, 0, len(loadErrs))
-		for _, e := range loadErrs {
+		shown := loadErrs
+		truncated := 0
+		if len(shown) > maxRuleLoadErrorsInCondition {
+			shown = shown[:maxRuleLoadErrorsInCondition]
+			truncated = len(loadErrs) - maxRuleLoadErrorsInCondition
+		}
+		msgs := make([]string, 0, len(shown))
+		for _, e := range shown {
 			msgs = append(msgs, e.Error())
+		}
+		msg := strings.Join(msgs, "; ")
+		if truncated > 0 {
+			msg += fmt.Sprintf("; …and %d more", truncated)
+		}
+		// Byte-cap as a second safety net — if a single error's Error()
+		// string is unusually long (e.g. a huge CEL parser error), the
+		// count cap alone wouldn't save us.
+		if len(msg) > maxRuleLoadErrorConditionMessageBytes {
+			msg = msg[:maxRuleLoadErrorConditionMessageBytes] + "…"
 		}
 		cond.Status = metav1.ConditionFalse
 		cond.Reason = "HealthRuleInvalid"
-		cond.Message = strings.Join(msgs, "; ")
+		cond.Message = msg
 	}
 	apimetaSetStatusCondition(&serviceSet.Status.Conditions, cond)
 }

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -660,10 +660,9 @@ func collectVerdicts(
 		if len(gkRules) == 0 {
 			continue
 		}
-		scope := gkRules[0].Scope
 		authoredVersions := distinctVersions(gkRules)
 
-		listGVK, resolveErr := resolveServedVersion(rgnClient.RESTMapper(), gk, authoredVersions)
+		listGVK, actualScope, resolveErr := resolveServedVersion(rgnClient.RESTMapper(), gk, authoredVersions)
 		if resolveErr != nil {
 			listErrs = errors.Join(listErrs, resolveErr)
 			continue
@@ -678,6 +677,49 @@ func collectVerdicts(
 			continue
 		}
 
+		// The rule ConfigMap's declared scope is not trusted: a
+		// Deployment mis-marked "Cluster" would otherwise turn the
+		// per-label List into a cross-namespace scan and pull in
+		// unrelated releases. Validate every rule agrees with the
+		// cluster's actual scope from discovery. One mismatched rule
+		// taints the whole GroupKind — we skip the query and log each
+		// misconfigured rule at Info level. The mismatch is a config
+		// problem, not a reconcile failure, so we do NOT propagate it
+		// as a listErrs entry that would bubble up to the reconciler.
+		scopeOK := true
+		for _, rule := range gkRules {
+			if rule.Scope != actualScope {
+				ctrl.LoggerFrom(ctx).Info(
+					"verifier: rule scope disagrees with target cluster; skipping GroupKind",
+					"rule", rule.Source,
+					"declaredScope", rule.Scope,
+					"groupKind", gk.String(),
+					"actualScope", actualScope,
+				)
+				// Emit one synthetic verdict per mis-scoped rule so the downstream
+				// aggregation surfaces WHICH rule is broken. RuleSrc identifies
+				// the ConfigMap entry; Name/Namespace stay empty because the
+				// verdict speaks about the rule, not any specific object. GVK
+				// uses gk.Kind (not listGVK.Kind, which carries the "List"
+				// suffix) so the emitted condition is ServiceHealth<Kind>,
+				// not ServiceHealth<Kind>List.
+				verdicts = append(verdicts, resourceVerdict{
+					GVK: schema.GroupVersionKind{
+						Group:   listGVK.Group,
+						Version: listGVK.Version,
+						Kind:    gk.Kind,
+					},
+					Healthy: false,
+					Reason:  "HealthRuleScopeMismatch",
+					RuleSrc: rule.Source,
+				})
+				scopeOK = false
+			}
+		}
+		if !scopeOK {
+			continue
+		}
+
 		// Dedup objects discovered via multiple labels.
 		seen := make(map[client.ObjectKey]struct{})
 
@@ -686,7 +728,7 @@ func collectVerdicts(
 			list.SetGroupVersionKind(*listGVK)
 
 			opts := []client.ListOption{client.MatchingLabels{labelKey: serviceName}}
-			if scope == scopeNamespaced {
+			if actualScope == scopeNamespaced {
 				opts = append(opts, client.InNamespace(serviceNamespace))
 			}
 			if err := rgnClient.List(ctx, list, opts...); err != nil {
@@ -774,12 +816,16 @@ func distinctVersions(gkRules []resourceRule) []string {
 }
 
 // resolveServedVersion returns the (Group, Version, Kind+"List") to
-// use for listing objects of gk on the target cluster. The version is
-// chosen from the intersection of what any rule authored for gk and
-// what the cluster's RESTMapper reports as served.
+// use for listing objects of gk on the target cluster, along with the
+// scope reported by the RESTMapper (authoritative — never trust the
+// scope a rule ConfigMap declared, since a Deployment mis-marked
+// "Cluster" would otherwise cross-namespace-List and pull in unrelated
+// releases). The version is chosen from the intersection of what any
+// rule authored for gk and what the cluster's RESTMapper reports as
+// served.
 //
-// Returns (nil, nil) — no error — when the caller should silently skip
-// this GroupKind. That covers two cases:
+// Returns (nil, "", nil) — no error — when the caller should silently
+// skip this GroupKind. That covers two cases:
 //   - The cluster does not serve gk under any version.
 //   - The cluster serves gk but under versions the rule set does not
 //     author for; the caller aggregates those into an operator-visible
@@ -792,30 +838,41 @@ func resolveServedVersion(
 	mapper meta.RESTMapper,
 	gk schema.GroupKind,
 	authoredVersions []string,
-) (*schema.GroupVersionKind, error) {
+) (*schema.GroupVersionKind, resourceScope, error) {
 	mappings, err := mapper.RESTMappings(gk)
 	if err != nil {
 		if meta.IsNoMatchError(err) {
-			return nil, nil //nolint:nilnil // deliberate: caller treats nil GVK + nil error as "silent skip" (kind not served)
+			return nil, "", nil
 		}
-		return nil, fmt.Errorf("discover versions for %s: %w", gk, err)
+		return nil, "", fmt.Errorf("discover versions for %s: %w", gk, err)
 	}
 
-	served := make(map[string]struct{}, len(mappings))
+	served := make(map[string]*meta.RESTMapping, len(mappings))
 	for _, m := range mappings {
-		served[m.GroupVersionKind.Version] = struct{}{}
+		served[m.GroupVersionKind.Version] = m
 	}
 
 	for _, v := range authoredVersions {
-		if _, ok := served[v]; ok {
+		if m, ok := served[v]; ok {
 			return &schema.GroupVersionKind{
 				Group:   gk.Group,
 				Version: v,
 				Kind:    gk.Kind + "List",
-			}, nil
+			}, restScopeToResourceScope(m.Scope), nil
 		}
 	}
-	return nil, nil //nolint:nilnil // deliberate: caller treats nil GVK + nil error as "silent skip" (kind not served or version mismatch)
+	return nil, "", nil
+}
+
+// restScopeToResourceScope maps kubernetes' RESTScope (as reported by
+// the target cluster's discovery) onto our internal resourceScope enum.
+// Any scope name other than Namespace is treated as Cluster — matches
+// how apimachinery itself classifies non-namespaced resources.
+func restScopeToResourceScope(s meta.RESTScope) resourceScope {
+	if s != nil && s.Name() == meta.RESTScopeNameNamespace {
+		return scopeNamespaced
+	}
+	return scopeCluster
 }
 
 // formatGroupVersionKind renders "group/version/Kind" with the core

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -523,16 +523,24 @@ func (r resourceRule) evaluate(obj *unstructured.Unstructured) (healthy bool, re
 // applicable rule passes; the first failing rule's message wins.
 //
 // Caller must invoke this ONLY when sveltos already reports the service as
-// Deployed. The return is downgrade-only:
+// Deployed. Returns:
 //
-//   - kcmv1.ServiceStateFailed       -> sveltos says Deployed but no labeled
-//     resources exist on the target cluster
 //   - kcmv1.ServiceStateProvisioning -> at least one labeled resource is
-//     unhealthy per its rule
-//   - kcmv1.ServiceStateDeployed     -> every labeled resource is healthy
+//     unhealthy per its rule (caller downgrades from sveltos's Deployed).
+//   - kcmv1.ServiceStateDeployed     -> every labeled resource is healthy,
+//     or no labeled resources were discovered at all. The empty case is
+//     ambiguous: we can't distinguish a chart that legitimately deploys
+//     only unmonitored Kinds (Jobs, CRDs, custom kinds) from one whose
+//     monitored Kinds are missing. Sveltos does not expose per-release
+//     GVK inventory, so we defer to sveltos's Deployed verdict rather
+//     than downgrade unfairly. The more common helm-SDK-succeeded-too-
+//     early bug — monitored Kinds present but unhealthy — is still
+//     caught by the Provisioning branch above.
 //
-// The returned conditions slice contains one entry per unhealthy resource.
-// The slice is empty when state is Deployed.
+// Returned per-Kind conditions carry no LastTransitionTime; the downstream
+// applyVerifyConditions delegates to meta.SetStatusCondition which
+// stamps timestamps correctly (preserving on same-Status renewals,
+// refreshing only on real transitions).
 func verifyHelmServiceOnCluster(
 	ctx context.Context,
 	rgnClient client.Client,
@@ -542,22 +550,6 @@ func verifyHelmServiceOnCluster(
 	verdicts, err := collectVerdicts(ctx, rgnClient, rules, serviceName, serviceNamespace)
 	if err != nil {
 		return "", nil, err
-	}
-
-	// LastTransitionTime is a required field per the ServiceSet CRD's
-	// metav1.Condition schema; status.Update fails validation if any
-	// condition omits it. Using a single now() value per call keeps the
-	// timestamp consistent across all conditions emitted from this round.
-	now := metav1.Now()
-
-	if len(verdicts) == 0 {
-		return kcmv1.ServiceStateFailed, []metav1.Condition{{
-			Type:               serviceHealthConditionPrefix,
-			Status:             metav1.ConditionFalse,
-			Reason:             "NoResourcesOnCluster",
-			Message:            fmt.Sprintf("no resources matching any of %v=%s found on target cluster", discoveryLabels, serviceName),
-			LastTransitionTime: now,
-		}}, nil
 	}
 
 	// Aggregate unhealthy verdicts by Kind. ServiceState.Conditions is a
@@ -628,11 +620,10 @@ func verifyHelmServiceOnCluster(
 		}
 
 		conds = append(conds, metav1.Condition{
-			Type:               serviceHealthConditionPrefix + kind,
-			Status:             metav1.ConditionFalse,
-			Reason:             kind + "Unhealthy",
-			Message:            msg,
-			LastTransitionTime: now,
+			Type:    serviceHealthConditionPrefix + kind,
+			Status:  metav1.ConditionFalse,
+			Reason:  kind + "Unhealthy",
+			Message: msg,
 		})
 	}
 

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -1166,18 +1166,48 @@ func computeServiceHash(release *addoncontrollerv1beta1.HelmChartSummary, chart 
 	return hex.EncodeToString(combined.Sum(nil))
 }
 
-// applyVerifyConditions replaces any verifier-owned condition (Type
-// starting with serviceHealthConditionPrefix) on the service state with
-// the supplied new set, leaving non-verifier conditions untouched. Called
-// even when the new set is empty so a recovering service has its old
-// health conditions cleared.
+// applyVerifyConditions merges this round's verifier verdicts onto the
+// ServiceState's Conditions slice:
+//
+//   - Non-verifier conditions (Type not prefixed with
+//     serviceHealthConditionPrefix) pass through untouched.
+//   - Verifier conditions whose Type is also emitted this round survive
+//     into the merged slice, where meta.SetStatusCondition then
+//     replaces them in place — preserving LastTransitionTime when the
+//     Status hasn't changed. This breaks the tight status-write
+//     reconcile loop that persistently-unhealthy services would
+//     otherwise create.
+//   - Verifier conditions whose Type is NOT emitted this round are
+//     dropped (the corresponding Kind recovered — Option A per the
+//     design conversation; matches CRD "conditions are opt-in per
+//     relevance" convention rather than Node's fixed-set flip).
 func applyVerifyConditions(s *kcmv1.ServiceState, newConds []metav1.Condition) {
+	// Index the round's emitted conditions by Type so the per-existing
+	// lookup below is O(1).
+	emitted := make(map[string]struct{}, len(newConds))
+	for _, c := range newConds {
+		emitted[c.Type] = struct{}{}
+	}
+
 	kept := make([]metav1.Condition, 0, len(s.Conditions))
 	for _, c := range s.Conditions {
 		if !strings.HasPrefix(c.Type, serviceHealthConditionPrefix) {
 			kept = append(kept, c)
+			continue
 		}
+		if _, stillEmitted := emitted[c.Type]; stillEmitted {
+			kept = append(kept, c)
+		}
+		// else: verifier-owned but not emitted this round — Kind
+		// recovered; drop it.
 	}
-	kept = append(kept, newConds...)
 	s.Conditions = kept
+
+	// Merge every emitted condition. For those already present in kept
+	// (same Kind unhealthy last round too), SetStatusCondition preserves
+	// LastTransitionTime when Status matches. For genuinely new Types,
+	// it appends and stamps a fresh LastTransitionTime.
+	for _, c := range newConds {
+		meta.SetStatusCondition(&s.Conditions, c)
+	}
 }

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -961,8 +961,42 @@ func fetchHelmArtifactsForVerifier(
 	if err != nil {
 		return nil, nil, "", "", err
 	}
+
+	// Prune the CC cache synchronously — pruning frequency scales with
+	// verifier activity, no goroutines/tickers needed.
+	sweepClusterConfigCache()
+
 	return summary, cc, profileKind, profileName, nil
 }
+
+// clusterConfigCacheTTL bounds how long a found ClusterConfiguration
+// stays in the cache without being referenced. The regional client is
+// NOT cache-backed (bare client.New from kubeconfig bytes), so every
+// List call is a live API request. Sveltos updates a ClusterConfiguration
+// only on apply events — infrequent relative to reconcile rate — so a
+// short TTL trades a small staleness window for eliminating the LIST
+// per verifier round in the steady state.
+const clusterConfigCacheTTL = 30 * time.Second
+
+type ccCacheKey struct {
+	namespace  string
+	profileUID types.UID
+}
+
+// ccCacheEntry pairs the last-observed ClusterConfiguration with a
+// timestamp used by sweepClusterConfigCache to age out cold entries.
+type ccCacheEntry struct {
+	lastAccess time.Time
+	cc         *addoncontrollerv1beta1.ClusterConfiguration
+}
+
+// clusterConfigCache memoises the (namespace, profileUID) → CC lookup
+// so findOwnedClusterConfiguration doesn't LIST the regional namespace
+// on every verifier round.
+var clusterConfigCache = struct {
+	entries map[ccCacheKey]ccCacheEntry
+	sync.Mutex
+}{entries: make(map[ccCacheKey]ccCacheEntry)}
 
 // findOwnedClusterConfiguration returns the ClusterConfiguration in
 // namespace whose OwnerReferences include profileUID. Returns (nil, nil)
@@ -970,24 +1004,70 @@ func fetchHelmArtifactsForVerifier(
 // profile on this cluster yet). Callers already handle a nil result as
 // "no fingerprint information available" so a sentinel error would only
 // force pointless errors.Is checks at every call site.
+//
+// Results are cached with a TTL because the regional client used here
+// is not cache-backed — every miss is a real LIST on the regional API
+// server. See clusterConfigCacheTTL.
 func findOwnedClusterConfiguration(
 	ctx context.Context,
 	rgnClient client.Client,
 	namespace string,
 	profileUID types.UID,
 ) (*addoncontrollerv1beta1.ClusterConfiguration, error) {
+	key := ccCacheKey{namespace: namespace, profileUID: profileUID}
+	now := time.Now()
+
+	clusterConfigCache.Lock()
+	if cached, ok := clusterConfigCache.entries[key]; ok {
+		cached.lastAccess = now
+		clusterConfigCache.entries[key] = cached
+		clusterConfigCache.Unlock()
+		return cached.cc, nil
+	}
+	clusterConfigCache.Unlock()
+
 	list := new(addoncontrollerv1beta1.ClusterConfigurationList)
 	if err := rgnClient.List(ctx, list, client.InNamespace(namespace)); err != nil {
 		return nil, fmt.Errorf("list ClusterConfigurations in %s: %w", namespace, err)
 	}
+	var found *addoncontrollerv1beta1.ClusterConfiguration
 	for i := range list.Items {
 		for _, owner := range list.Items[i].OwnerReferences {
 			if owner.UID == profileUID {
-				return &list.Items[i], nil
+				found = &list.Items[i]
+				break
 			}
 		}
+		if found != nil {
+			break
+		}
 	}
-	return nil, nil //nolint:nilnil // deliberate: nil result means "not-found-yet", not an error condition
+
+	// Cache both hits and misses: a miss (found == nil) is common
+	// during the window between Profile creation and sveltos observing
+	// the cluster, and re-listing every reconcile in that window is
+	// exactly the load we want to shed. Downstream callers already
+	// treat nil as "not yet available" and behave correctly.
+	clusterConfigCache.Lock()
+	clusterConfigCache.entries[key] = ccCacheEntry{cc: found, lastAccess: now}
+	clusterConfigCache.Unlock()
+
+	return found, nil
+}
+
+// sweepClusterConfigCache evicts cache entries whose lastAccess is
+// older than clusterConfigCacheTTL. Called once per verifier round from
+// fetchHelmArtifactsForVerifier so pruning frequency scales with
+// reconcile activity.
+func sweepClusterConfigCache() {
+	cutoff := time.Now().Add(-clusterConfigCacheTTL)
+	clusterConfigCache.Lock()
+	defer clusterConfigCache.Unlock()
+	for key, entry := range clusterConfigCache.entries {
+		if entry.lastAccess.Before(cutoff) {
+			delete(clusterConfigCache.entries, key)
+		}
+	}
 }
 
 // serviceHashesFromArtifacts builds a (releaseNamespace, releaseName) →

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -585,11 +585,11 @@ func (r resourceRule) evaluate(input cel.Activation) (healthy bool, reason strin
 // refreshing only on real transitions).
 func verifyHelmServiceOnCluster(
 	ctx context.Context,
-	rgnClient client.Client,
+	childClient client.Client,
 	rules ruleSet,
 	serviceName, serviceNamespace string,
 ) (string, []metav1.Condition, error) {
-	verdicts, err := collectVerdicts(ctx, rgnClient, rules, serviceName, serviceNamespace)
+	verdicts, err := collectVerdicts(ctx, childClient, rules, serviceName, serviceNamespace)
 	if err != nil {
 		return "", nil, err
 	}
@@ -690,7 +690,7 @@ func verifyHelmServiceOnCluster(
 // first rule's scope is used.
 func collectVerdicts(
 	ctx context.Context,
-	rgnClient client.Client,
+	childClient client.Client,
 	rules ruleSet,
 	serviceName, serviceNamespace string,
 ) ([]resourceVerdict, error) {
@@ -704,7 +704,7 @@ func collectVerdicts(
 		}
 		authoredVersions := distinctVersions(gkRules)
 
-		listGVK, actualScope, resolveErr := resolveServedVersion(rgnClient.RESTMapper(), gk, authoredVersions)
+		listGVK, actualScope, resolveErr := resolveServedVersion(childClient.RESTMapper(), gk, authoredVersions)
 		if resolveErr != nil {
 			listErrs = errors.Join(listErrs, resolveErr)
 			continue
@@ -773,7 +773,7 @@ func collectVerdicts(
 			if actualScope == scopeNamespaced {
 				opts = append(opts, client.InNamespace(serviceNamespace))
 			}
-			if err := rgnClient.List(ctx, list, opts...); err != nil {
+			if err := childClient.List(ctx, list, opts...); err != nil {
 				// NoMatchError/NoKindMatchError from the actual List
 				// remains as defense in depth — the RESTMapper's discovery
 				// cache can be briefly stale during a cluster upgrade even
@@ -1095,14 +1095,16 @@ func fetchHelmArtifactsForVerifier(
 		summary = nil
 	}
 
+	// Prune the CC cache — pruning frequency scales with
+	// verifier activity, no goroutines/tickers needed.
+	// we'll sweep the cache so that next findOwnedClusterConfiguration
+	// call won't return the already expired entry.
+	sweepClusterConfigCache()
+
 	cc, err = findOwnedClusterConfiguration(ctx, rgnClient, cluster.Namespace, profileUID)
 	if err != nil {
 		return nil, nil, "", "", err
 	}
-
-	// Prune the CC cache synchronously — pruning frequency scales with
-	// verifier activity, no goroutines/tickers needed.
-	sweepClusterConfigCache()
 
 	return summary, cc, profileKind, profileName, nil
 }

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -1121,11 +1121,18 @@ type ccCacheKey struct {
 	profileUID types.UID
 }
 
-// ccCacheEntry pairs the last-observed ClusterConfiguration with a
-// timestamp used by sweepClusterConfigCache to age out cold entries.
+// ccCacheEntry pairs the last-observed ClusterConfiguration with the
+// time it was written to the cache. sweepClusterConfigCache evicts
+// entries whose writtenAt is older than clusterConfigCacheTTL — TTL is
+// write-based, not access-based. Access-based refresh would keep a
+// stale snapshot alive indefinitely for hot ServiceSets (poller hits
+// every 10s, TTL 30s → entry never expires), preventing us from
+// observing sveltos's late-arriving updates to Status.ProfileResources
+// (e.g. the per-profile Helm section that appears seconds after the CC
+// itself). Write-based TTL bounds staleness at clusterConfigCacheTTL.
 type ccCacheEntry struct {
-	lastAccess time.Time
-	cc         *addoncontrollerv1beta1.ClusterConfiguration
+	writtenAt time.Time
+	cc        *addoncontrollerv1beta1.ClusterConfiguration
 }
 
 // clusterConfigCache memoises the (namespace, profileUID) → CC lookup
@@ -1157,8 +1164,6 @@ func findOwnedClusterConfiguration(
 
 	clusterConfigCache.Lock()
 	if cached, ok := clusterConfigCache.entries[key]; ok {
-		cached.lastAccess = now
-		clusterConfigCache.entries[key] = cached
 		clusterConfigCache.Unlock()
 		return cached.cc, nil
 	}
@@ -1187,14 +1192,16 @@ func findOwnedClusterConfiguration(
 	// exactly the load we want to shed. Downstream callers already
 	// treat nil as "not yet available" and behave correctly.
 	clusterConfigCache.Lock()
-	clusterConfigCache.entries[key] = ccCacheEntry{cc: found, lastAccess: now}
+	clusterConfigCache.entries[key] = ccCacheEntry{cc: found, writtenAt: now}
 	clusterConfigCache.Unlock()
 
 	return found, nil
 }
 
-// sweepClusterConfigCache evicts cache entries whose lastAccess is
-// older than clusterConfigCacheTTL. Called once per verifier round from
+// sweepClusterConfigCache evicts cache entries whose writtenAt is
+// older than clusterConfigCacheTTL. Write-based TTL — see ccCacheEntry
+// doc-comment for why access-based would keep stale snapshots alive
+// forever. Called once per verifier round from
 // fetchHelmArtifactsForVerifier so pruning frequency scales with
 // reconcile activity.
 func sweepClusterConfigCache() {
@@ -1202,7 +1209,7 @@ func sweepClusterConfigCache() {
 	clusterConfigCache.Lock()
 	defer clusterConfigCache.Unlock()
 	for key, entry := range clusterConfigCache.entries {
-		if entry.lastAccess.Before(cutoff) {
+		if entry.writtenAt.Before(cutoff) {
 			delete(clusterConfigCache.entries, key)
 		}
 	}

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -1,0 +1,705 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sveltos
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+)
+
+// testRulesYAML is the same rule body shipped by the chart at
+// templates/provider/kcm/templates/health-rules/default-rules.yaml under
+// data.rules. Duplicated here so the test suite is self-contained and
+// covers the actual default-rule CEL logic.
+const testRulesYAML = `
+- group: apps
+  version: v1
+  kind: Deployment
+  scope: Namespaced
+  healthy: |
+    has(obj.status.observedGeneration) &&
+    int(obj.status.observedGeneration) >= int(obj.metadata.generation) &&
+    int(has(obj.spec.replicas) ? obj.spec.replicas : 1) ==
+      int(has(obj.status.readyReplicas) ? obj.status.readyReplicas : 0) &&
+    int(has(obj.spec.replicas) ? obj.spec.replicas : 1) ==
+      int(has(obj.status.updatedReplicas) ? obj.status.updatedReplicas : 0)
+  message: |
+    !has(obj.status.observedGeneration) ||
+    int(obj.status.observedGeneration) < int(obj.metadata.generation)
+      ? "deployment controller has not observed latest spec"
+      : string(int(has(obj.status.readyReplicas) ? obj.status.readyReplicas : 0)) + "/" +
+        string(int(has(obj.spec.replicas) ? obj.spec.replicas : 1)) + " replicas ready"
+- group: apps
+  version: v1
+  kind: StatefulSet
+  scope: Namespaced
+  healthy: |
+    has(obj.status.observedGeneration) &&
+    int(obj.status.observedGeneration) >= int(obj.metadata.generation) &&
+    int(has(obj.spec.replicas) ? obj.spec.replicas : 1) ==
+      int(has(obj.status.readyReplicas) ? obj.status.readyReplicas : 0) &&
+    int(has(obj.spec.replicas) ? obj.spec.replicas : 1) ==
+      int(has(obj.status.updatedReplicas) ? obj.status.updatedReplicas : 0) &&
+    has(obj.status.currentRevision) && has(obj.status.updateRevision) &&
+    obj.status.currentRevision == obj.status.updateRevision
+  message: |
+    "statefulset not ready"
+- group: apps
+  version: v1
+  kind: DaemonSet
+  scope: Namespaced
+  healthy: |
+    has(obj.status.observedGeneration) &&
+    int(obj.status.observedGeneration) >= int(obj.metadata.generation) &&
+    has(obj.status.desiredNumberScheduled) &&
+    has(obj.status.numberReady) &&
+    has(obj.status.updatedNumberScheduled) &&
+    int(obj.status.desiredNumberScheduled) == int(obj.status.numberReady) &&
+    int(obj.status.desiredNumberScheduled) == int(obj.status.updatedNumberScheduled)
+  message: |
+    "daemonset not ready"
+- group: ""
+  version: v1
+  kind: Pod
+  scope: Namespaced
+  healthy: |
+    has(obj.status.conditions) &&
+    obj.status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+  message: |
+    "pod not ready"
+- group: ""
+  version: v1
+  kind: PersistentVolumeClaim
+  scope: Namespaced
+  healthy: |
+    has(obj.status.phase) && obj.status.phase == "Bound"
+  message: |
+    has(obj.status.phase) ? "phase=" + obj.status.phase : "no phase reported"
+- group: ""
+  version: v1
+  kind: PersistentVolume
+  scope: Cluster
+  healthy: |
+    has(obj.status.phase) && obj.status.phase == "Bound"
+  message: |
+    has(obj.status.phase) ? "phase=" + obj.status.phase : "no phase reported"
+`
+
+// testRules is the compiled ruleSet built from testRulesYAML. Construction
+// failure is a programming error in the test fixture — panic so the suite
+// fails loudly rather than silently running against a partial rule set.
+var testRules = func() ruleSet {
+	docs := parseRuleYAMLOrPanic(testRulesYAML, "test")
+	rs, errs := rulesFromDocs(docs)
+	if len(errs) > 0 {
+		panic(fmt.Errorf("test rules failed to compile: %v", errs))
+	}
+	return rs
+}()
+
+func parseRuleYAMLOrPanic(yamlBody, sourcePrefix string) []sourcedRuleDoc {
+	var docs []ruleDoc
+	if err := yaml.Unmarshal([]byte(yamlBody), &docs); err != nil {
+		panic(fmt.Errorf("parse test rules yaml: %w", err))
+	}
+	sourced := make([]sourcedRuleDoc, len(docs))
+	for i, d := range docs {
+		sourced[i] = sourcedRuleDoc{Doc: d, Source: fmt.Sprintf("%s#%d", sourcePrefix, i)}
+	}
+	return sourced
+}
+
+// TestTestRules_AllPresent asserts the embedded test rule set has one entry
+// for each expected GroupKind. Acts as a sanity check on the parser as
+// well as the rule set's contents.
+func TestTestRules_AllPresent(t *testing.T) {
+	want := []schema.GroupKind{
+		{Group: "apps", Kind: "Deployment"},
+		{Group: "apps", Kind: "StatefulSet"},
+		{Group: "apps", Kind: "DaemonSet"},
+		{Group: "", Kind: "Pod"},
+		{Group: "", Kind: "PersistentVolumeClaim"},
+		{Group: "", Kind: "PersistentVolume"},
+	}
+	for _, gk := range want {
+		rules, ok := testRules[gk]
+		assert.True(t, ok, "missing rule for %s", gk)
+		assert.Len(t, rules, 1, "expected exactly one default rule for %s", gk)
+	}
+	assert.Equal(t, len(want), len(testRules), "extra rules present")
+}
+
+// evalRule looks up a single rule by group/kind from testRules and
+// evaluates it. Used by per-rule tests that don't care about layering.
+func evalRule(t *testing.T, group, kind string, payload map[string]any) (bool, string) {
+	t.Helper()
+	rules, ok := testRules[schema.GroupKind{Group: group, Kind: kind}]
+	require.True(t, ok, "rule for %s/%s not loaded", group, kind)
+	require.Len(t, rules, 1, "evalRule expects a single rule per GroupKind in testRules")
+	rule := rules[0]
+	u := &unstructured.Unstructured{Object: payload}
+	u.SetGroupVersionKind(rule.GVK)
+	healthy, reason, err := rule.evaluate(u)
+	require.NoError(t, err)
+	return healthy, reason
+}
+
+func TestRule_Deployment(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     map[string]any
+		wantHealthy bool
+	}{
+		{
+			name: "all replicas ready and updated",
+			payload: map[string]any{
+				"metadata": map[string]any{"generation": int64(2)},
+				"spec":     map[string]any{"replicas": int64(3)},
+				"status": map[string]any{
+					"observedGeneration": int64(2),
+					"readyReplicas":      int64(3),
+					"updatedReplicas":    int64(3),
+				},
+			},
+			wantHealthy: true,
+		},
+		{
+			name: "generation lag",
+			payload: map[string]any{
+				"metadata": map[string]any{"generation": int64(3)},
+				"spec":     map[string]any{"replicas": int64(3)},
+				"status": map[string]any{
+					"observedGeneration": int64(2),
+					"readyReplicas":      int64(3),
+					"updatedReplicas":    int64(3),
+				},
+			},
+			wantHealthy: false,
+		},
+		{
+			name: "not enough ready",
+			payload: map[string]any{
+				"metadata": map[string]any{"generation": int64(1)},
+				"spec":     map[string]any{"replicas": int64(3)},
+				"status": map[string]any{
+					"observedGeneration": int64(1),
+					"readyReplicas":      int64(2),
+					"updatedReplicas":    int64(3),
+				},
+			},
+			wantHealthy: false,
+		},
+		{
+			name: "rollout in progress",
+			payload: map[string]any{
+				"metadata": map[string]any{"generation": int64(1)},
+				"spec":     map[string]any{"replicas": int64(3)},
+				"status": map[string]any{
+					"observedGeneration": int64(1),
+					"readyReplicas":      int64(3),
+					"updatedReplicas":    int64(2),
+				},
+			},
+			wantHealthy: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			healthy, _ := evalRule(t, "apps", "Deployment", tt.payload)
+			assert.Equal(t, tt.wantHealthy, healthy)
+		})
+	}
+}
+
+func TestRule_StatefulSet(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     map[string]any
+		wantHealthy bool
+	}{
+		{
+			name: "healthy",
+			payload: map[string]any{
+				"metadata": map[string]any{"generation": int64(1)},
+				"spec":     map[string]any{"replicas": int64(2)},
+				"status": map[string]any{
+					"observedGeneration": int64(1),
+					"readyReplicas":      int64(2),
+					"updatedReplicas":    int64(2),
+					"currentRevision":    "sts-abc",
+					"updateRevision":     "sts-abc",
+				},
+			},
+			wantHealthy: true,
+		},
+		{
+			name: "revision drift",
+			payload: map[string]any{
+				"metadata": map[string]any{"generation": int64(1)},
+				"spec":     map[string]any{"replicas": int64(2)},
+				"status": map[string]any{
+					"observedGeneration": int64(1),
+					"readyReplicas":      int64(2),
+					"updatedReplicas":    int64(2),
+					"currentRevision":    "sts-abc",
+					"updateRevision":     "sts-xyz",
+				},
+			},
+			wantHealthy: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			healthy, _ := evalRule(t, "apps", "StatefulSet", tt.payload)
+			assert.Equal(t, tt.wantHealthy, healthy)
+		})
+	}
+}
+
+func TestRule_DaemonSet(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     map[string]any
+		wantHealthy bool
+	}{
+		{
+			name: "healthy",
+			payload: map[string]any{
+				"metadata": map[string]any{"generation": int64(1)},
+				"status": map[string]any{
+					"observedGeneration":     int64(1),
+					"desiredNumberScheduled": int64(3),
+					"numberReady":            int64(3),
+					"updatedNumberScheduled": int64(3),
+				},
+			},
+			wantHealthy: true,
+		},
+		{
+			name: "not all nodes ready",
+			payload: map[string]any{
+				"metadata": map[string]any{"generation": int64(1)},
+				"status": map[string]any{
+					"observedGeneration":     int64(1),
+					"desiredNumberScheduled": int64(3),
+					"numberReady":            int64(2),
+					"updatedNumberScheduled": int64(3),
+				},
+			},
+			wantHealthy: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			healthy, _ := evalRule(t, "apps", "DaemonSet", tt.payload)
+			assert.Equal(t, tt.wantHealthy, healthy)
+		})
+	}
+}
+
+func TestRule_Pod(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     map[string]any
+		wantHealthy bool
+	}{
+		{
+			name: "ready",
+			payload: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{"type": "Ready", "status": "True"},
+					},
+				},
+			},
+			wantHealthy: true,
+		},
+		{
+			name: "not ready",
+			payload: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{"type": "Ready", "status": "False"},
+					},
+				},
+			},
+			wantHealthy: false,
+		},
+		{
+			name: "no conditions",
+			payload: map[string]any{
+				"status": map[string]any{},
+			},
+			wantHealthy: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			healthy, _ := evalRule(t, "", "Pod", tt.payload)
+			assert.Equal(t, tt.wantHealthy, healthy)
+		})
+	}
+}
+
+func TestRule_Pod_TerminatingIgnored(t *testing.T) {
+	rules := testRules[schema.GroupKind{Group: "", Kind: "Pod"}]
+	require.Len(t, rules, 1)
+	rule := rules[0]
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Ready", "status": "False"},
+			},
+		},
+	}}
+	u.SetGroupVersionKind(rule.GVK)
+	u.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+
+	healthy, _, err := rule.evaluate(u)
+	require.NoError(t, err)
+	assert.True(t, healthy, "terminating pod must be treated as healthy")
+}
+
+func TestRule_PVC(t *testing.T) {
+	tests := []struct {
+		name        string
+		phase       string
+		wantHealthy bool
+	}{
+		{name: "bound", phase: "Bound", wantHealthy: true},
+		{name: "pending", phase: "Pending", wantHealthy: false},
+		{name: "lost", phase: "Lost", wantHealthy: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			healthy, _ := evalRule(t, "", "PersistentVolumeClaim", map[string]any{
+				"status": map[string]any{"phase": tt.phase},
+			})
+			assert.Equal(t, tt.wantHealthy, healthy)
+		})
+	}
+}
+
+func TestRule_PV(t *testing.T) {
+	healthy, _ := evalRule(t, "", "PersistentVolume", map[string]any{
+		"status": map[string]any{"phase": "Bound"},
+	})
+	assert.True(t, healthy)
+	healthy, _ = evalRule(t, "", "PersistentVolume", map[string]any{
+		"status": map[string]any{"phase": "Available"},
+	})
+	assert.False(t, healthy)
+}
+
+// --- verifyHelmServiceOnCluster ---
+
+const (
+	releaseName = "myapp"
+	releaseNs   = "myapp-ns"
+)
+
+func newFakeClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func makeHealthyDeployment(name string) *appsv1.Deployment {
+	var three int32 = 3
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  releaseNs,
+			Generation: 1,
+			Labels:     map[string]string{"release": releaseName},
+		},
+		Spec: appsv1.DeploymentSpec{Replicas: &three},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Replicas:           3,
+			ReadyReplicas:      3,
+			UpdatedReplicas:    3,
+		},
+	}
+}
+
+func makeUnhealthyDeployment(name string) *appsv1.Deployment {
+	d := makeHealthyDeployment(name)
+	d.Status.ReadyReplicas = 1
+	return d
+}
+
+func makeReadyPod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: releaseNs,
+			Labels:    map[string]string{"release": releaseName},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func TestVerifyHelmServiceOnCluster_NoResources(t *testing.T) {
+	c := newFakeClient(t)
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateFailed, state)
+	require.Len(t, conds, 1)
+	assert.Equal(t, "NoResourcesOnCluster", conds[0].Reason)
+}
+
+func TestVerifyHelmServiceOnCluster_AllHealthy(t *testing.T) {
+	c := newFakeClient(t,
+		makeHealthyDeployment("web"),
+		makeReadyPod("web-0"),
+	)
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateDeployed, state)
+	assert.Empty(t, conds)
+}
+
+func TestVerifyHelmServiceOnCluster_DeploymentUnhealthy(t *testing.T) {
+	c := newFakeClient(t, makeUnhealthyDeployment("web"))
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateProvisioning, state)
+	require.Len(t, conds, 1)
+	assert.Equal(t, "ServiceHealthDeployment", conds[0].Type)
+	assert.Contains(t, conds[0].Message, "web")
+	assert.Contains(t, conds[0].Message, "rule test#0", "condition message must cite the failing rule's source")
+}
+
+func TestVerifyHelmServiceOnCluster_TerminatingPodNotCounted(t *testing.T) {
+	terminating := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "web-old",
+			Namespace:         releaseNs,
+			Labels:            map[string]string{"release": releaseName},
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+			Finalizers:        []string{"kubernetes"},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+
+	c := newFakeClient(t, makeHealthyDeployment("web"), terminating)
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateDeployed, state, "terminating pod must not pull state to Provisioning")
+	assert.Empty(t, conds)
+}
+
+func TestVerifyHelmServiceOnCluster_OtherReleaseIgnored(t *testing.T) {
+	other := makeHealthyDeployment("other")
+	other.Labels["release"] = "different"
+
+	c := newFakeClient(t, other)
+	state, _, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateFailed, state)
+}
+
+func TestVerifyHelmServiceOnCluster_DiscoversByAppKubernetesIoInstance(t *testing.T) {
+	d := makeUnhealthyDeployment("web")
+	delete(d.Labels, "release")
+	d.Labels["app.kubernetes.io/instance"] = releaseName
+
+	c := newFakeClient(t, d)
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateProvisioning, state, "object labeled via app.kubernetes.io/instance must be evaluated")
+	require.Len(t, conds, 1)
+	assert.Equal(t, "ServiceHealthDeployment", conds[0].Type)
+}
+
+func TestVerifyHelmServiceOnCluster_DedupesAcrossLabels(t *testing.T) {
+	d := makeUnhealthyDeployment("web")
+	d.Labels["app"] = releaseName
+	d.Labels["app.kubernetes.io/instance"] = releaseName
+	d.Labels["app.kubernetes.io/name"] = releaseName
+
+	c := newFakeClient(t, d)
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateProvisioning, state)
+	require.Len(t, conds, 1, "duplicate labels must not produce duplicate conditions")
+}
+
+// TestVerifyHelmServiceOnCluster_MultiRule_AllMustPass asserts the additive
+// semantics: when two rules target the same GroupKind, both must pass for
+// the resource to be healthy. The second rule below intentionally always
+// reports unhealthy ("false"), so even a perfectly-healthy Deployment
+// must be downgraded.
+func TestVerifyHelmServiceOnCluster_MultiRule_AllMustPass(t *testing.T) {
+	// Build a rule set with the default deployment rule + an extra rule
+	// that always fails.
+	docs := parseRuleYAMLOrPanic(testRulesYAML, "test")
+	docs = append(docs, sourcedRuleDoc{
+		Doc: ruleDoc{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "Deployment",
+			Scope:   scopeNamespaced,
+			Healthy: `false`,
+			Message: `"always unhealthy"`,
+		},
+		Source: "test-extra#0",
+	})
+	rs, errs := rulesFromDocs(docs)
+	require.Empty(t, errs)
+	require.Len(t, rs[schema.GroupKind{Group: "apps", Kind: "Deployment"}], 2)
+
+	c := newFakeClient(t, makeHealthyDeployment("web"))
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, rs, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateProvisioning, state, "any unhealthy rule must downgrade")
+	require.Len(t, conds, 1)
+	assert.Contains(t, conds[0].Message, "always unhealthy")
+	assert.Contains(t, conds[0].Message, "test-extra#0", "failing rule's source must appear in the condition")
+}
+
+// --- rulesFromConfigMaps ---
+
+const systemNamespace = "kcm-system"
+
+func makeRulesConfigMap(t *testing.T, namespace, name, target, rulesBody string) *corev1.ConfigMap {
+	t.Helper()
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{healthRuleTargetLabel: target},
+		},
+		Data: map[string]string{healthRuleConfigMapDataKey: rulesBody},
+	}
+}
+
+const podOnlyRulesYAML = `
+- group: ""
+  version: v1
+  kind: Pod
+  scope: Namespaced
+  healthy: |
+    has(obj.status.conditions) &&
+    obj.status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+  message: |
+    "pod not ready"
+`
+
+func TestRulesFromConfigMaps_AllThreeTiers(t *testing.T) {
+	t1 := makeRulesConfigMap(t, systemNamespace, "cluster-rules", "global", podOnlyRulesYAML)
+	t2 := makeRulesConfigMap(t, releaseNs, "ns-rules", "global", `
+- group: apps
+  version: v1
+  kind: Deployment
+  scope: Namespaced
+  healthy: |
+    has(obj.status.observedGeneration)
+  message: |
+    "no observedGeneration"
+`)
+	// ServiceSet-targeted: name "myset" in releaseNs.
+	t3 := makeRulesConfigMap(t, releaseNs, "set-rules", "myset", `
+- group: apps
+  version: v1
+  kind: StatefulSet
+  scope: Namespaced
+  healthy: |
+    has(obj.status.replicas)
+  message: |
+    "no replicas"
+`)
+
+	c := newFakeClient(t, t1, t2, t3)
+	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, releaseNs, "myset")
+	require.NoError(t, err)
+	assert.Empty(t, loadErrs)
+
+	assert.Len(t, rs[schema.GroupKind{Group: "", Kind: "Pod"}], 1, "Pod from tier 1")
+	assert.Len(t, rs[schema.GroupKind{Group: "apps", Kind: "Deployment"}], 1, "Deployment from tier 2")
+	assert.Len(t, rs[schema.GroupKind{Group: "apps", Kind: "StatefulSet"}], 1, "StatefulSet from tier 3")
+}
+
+func TestRulesFromConfigMaps_SystemNamespaceEqualsServiceSetNamespace(t *testing.T) {
+	// Self-managed scenario: SS namespace IS the system namespace. The
+	// loader must not double-list the same CM.
+	t1 := makeRulesConfigMap(t, systemNamespace, "cluster-rules", "global", podOnlyRulesYAML)
+
+	c := newFakeClient(t, t1)
+	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, systemNamespace, "self-mgmt-ss")
+	require.NoError(t, err)
+	assert.Empty(t, loadErrs)
+	assert.Len(t, rs[schema.GroupKind{Group: "", Kind: "Pod"}], 1, "must not duplicate")
+}
+
+func TestRulesFromConfigMaps_BadCELSurfacesAsLoadError(t *testing.T) {
+	cm := makeRulesConfigMap(t, systemNamespace, "bad-rules", "global", `
+- group: ""
+  version: v1
+  kind: Pod
+  scope: Namespaced
+  healthy: this is not valid CEL
+  message: "bad"
+`)
+	c := newFakeClient(t, cm)
+	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, releaseNs, "ss")
+	require.NoError(t, err)
+	require.Len(t, loadErrs, 1)
+	assert.Equal(t, "kcm-system/bad-rules#0", loadErrs[0].Source)
+	// rule set has no entries because the only candidate failed to compile.
+	assert.Empty(t, rs)
+}
+
+func TestRulesFromConfigMaps_TargetLabelSelectivity(t *testing.T) {
+	matching := makeRulesConfigMap(t, releaseNs, "for-us", "myset", podOnlyRulesYAML)
+	otherSs := makeRulesConfigMap(t, releaseNs, "for-other", "different-ss", podOnlyRulesYAML)
+	unlabeled := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-label", Namespace: releaseNs},
+		Data:       map[string]string{healthRuleConfigMapDataKey: podOnlyRulesYAML},
+	}
+
+	c := newFakeClient(t, matching, otherSs, unlabeled)
+	rs, _, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, releaseNs, "myset")
+	require.NoError(t, err)
+	require.Len(t, rs[schema.GroupKind{Group: "", Kind: "Pod"}], 1,
+		"only the CM whose label value matches the ServiceSet name should contribute")
+}

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -16,6 +16,7 @@ package sveltos
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -453,7 +455,26 @@ func newFakeClient(t *testing.T, objects ...client.Object) client.Client {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, appsv1.AddToScheme(scheme))
-	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+	// Seed a RESTMapper so resolveServedVersion sees the same GVKs the
+	// fake client stores. The default fake-client mapper is empty and
+	// would silent-skip every GroupKind the verifier queries.
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+		appsv1.SchemeGroupVersion,
+		corev1.SchemeGroupVersion,
+	})
+	mapper.Add(appsv1.SchemeGroupVersion.WithKind("Deployment"), meta.RESTScopeNamespace)
+	mapper.Add(appsv1.SchemeGroupVersion.WithKind("StatefulSet"), meta.RESTScopeNamespace)
+	mapper.Add(appsv1.SchemeGroupVersion.WithKind("DaemonSet"), meta.RESTScopeNamespace)
+	mapper.Add(corev1.SchemeGroupVersion.WithKind("Pod"), meta.RESTScopeNamespace)
+	mapper.Add(corev1.SchemeGroupVersion.WithKind("PersistentVolumeClaim"), meta.RESTScopeNamespace)
+	mapper.Add(corev1.SchemeGroupVersion.WithKind("PersistentVolume"), meta.RESTScopeRoot)
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRESTMapper(mapper).
+		WithObjects(objects...).
+		Build()
 }
 
 func makeHealthyDeployment(name string) *appsv1.Deployment {
@@ -1119,4 +1140,152 @@ func TestRulesFromConfigMaps_TargetLabelSelectivity(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rs[schema.GroupKind{Group: "", Kind: "Pod"}], 1,
 		"only the CM whose label value matches the ServiceSet's owner name should contribute")
+}
+
+// --- version-resolution helpers ---
+
+// stubRESTMapper is a minimal meta.RESTMapper for resolveServedVersion
+// tests. Only RESTMappings is meaningfully implemented — the other
+// methods return zero values and are never called by the code under test.
+type stubRESTMapper struct {
+	// perGK maps a GroupKind to the versions the "cluster" serves.
+	perGK map[schema.GroupKind][]string
+	// perGKErr maps a GroupKind to an error the mapper should return
+	// (used for NoMatch and permission-denied cases).
+	perGKErr map[schema.GroupKind]error
+}
+
+func (*stubRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, nil
+}
+
+func (*stubRESTMapper) KindsFor(schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, nil
+}
+
+func (*stubRESTMapper) ResourceFor(schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, nil
+}
+
+func (*stubRESTMapper) ResourcesFor(schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, nil
+}
+
+func (*stubRESTMapper) RESTMapping(schema.GroupKind, ...string) (*meta.RESTMapping, error) {
+	return nil, nil //nolint:nilnil // unused stub method
+}
+
+func (m *stubRESTMapper) RESTMappings(gk schema.GroupKind, _ ...string) ([]*meta.RESTMapping, error) {
+	if err, ok := m.perGKErr[gk]; ok {
+		return nil, err
+	}
+	versions := m.perGK[gk]
+	if len(versions) == 0 {
+		return nil, &meta.NoKindMatchError{GroupKind: gk}
+	}
+	out := make([]*meta.RESTMapping, 0, len(versions))
+	for _, v := range versions {
+		out = append(out, &meta.RESTMapping{
+			GroupVersionKind: schema.GroupVersionKind{Group: gk.Group, Version: v, Kind: gk.Kind},
+		})
+	}
+	return out, nil
+}
+
+func (*stubRESTMapper) ResourceSingularizer(string) (string, error) {
+	return "", nil
+}
+
+func TestDistinctVersions_PreservesFirstSeenOrderAndDedups(t *testing.T) {
+	rules := []resourceRule{
+		{GVK: schema.GroupVersionKind{Version: "v1beta1"}},
+		{GVK: schema.GroupVersionKind{Version: "v1"}},
+		{GVK: schema.GroupVersionKind{Version: "v1beta1"}}, // duplicate of the first
+		{GVK: schema.GroupVersionKind{Version: "v2"}},
+	}
+	got := distinctVersions(rules)
+	assert.Equal(t, []string{"v1beta1", "v1", "v2"}, got,
+		"first-seen order preserved, duplicates removed")
+}
+
+func TestResolveServedVersion_AuthoredAndServedIntersect(t *testing.T) {
+	gk := schema.GroupKind{Group: "apps", Kind: "Deployment"}
+	mapper := &stubRESTMapper{perGK: map[schema.GroupKind][]string{gk: {"v1"}}}
+
+	got, err := resolveServedVersion(mapper, gk, []string{"v1"})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "v1", got.Version)
+	assert.Equal(t, "DeploymentList", got.Kind, "listing GVK must carry the 'List' suffix")
+}
+
+func TestResolveServedVersion_AuthoredOrderPreservedOnServedIntersection(t *testing.T) {
+	gk := schema.GroupKind{Group: "apps", Kind: "Deployment"}
+	// Both v1beta1 and v1 are served; author wrote v1beta1 first, so we
+	// should pick v1beta1 regardless of how the mapper orders its output.
+	mapper := &stubRESTMapper{perGK: map[schema.GroupKind][]string{gk: {"v1", "v1beta1"}}}
+
+	got, err := resolveServedVersion(mapper, gk, []string{"v1beta1", "v1"})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "v1beta1", got.Version, "authored first-seen order beats mapper order")
+}
+
+func TestResolveServedVersion_NoIntersectionReturnsNilNil(t *testing.T) {
+	gk := schema.GroupKind{Group: "apps", Kind: "Deployment"}
+	// Cluster serves v1 only; author wrote v1beta1 only.
+	mapper := &stubRESTMapper{perGK: map[schema.GroupKind][]string{gk: {"v1"}}}
+
+	got, err := resolveServedVersion(mapper, gk, []string{"v1beta1"})
+	require.NoError(t, err, "version mismatch is a silent-skip, not an error")
+	assert.Nil(t, got, "no served version matches → nil listing GVK")
+}
+
+func TestResolveServedVersion_KindNotServedReturnsNilNil(t *testing.T) {
+	gk := schema.GroupKind{Group: "widgets.example.com", Kind: "Widget"}
+	// No entry in perGK → stub returns NoKindMatchError.
+	mapper := &stubRESTMapper{}
+
+	got, err := resolveServedVersion(mapper, gk, []string{"v1"})
+	require.NoError(t, err, "NoKindMatch is a silent-skip, not an error")
+	assert.Nil(t, got)
+}
+
+func TestResolveServedVersion_OtherMapperErrorSurfaces(t *testing.T) {
+	gk := schema.GroupKind{Group: "apps", Kind: "Deployment"}
+	mapper := &stubRESTMapper{
+		perGKErr: map[schema.GroupKind]error{gk: errors.New("permission denied")},
+	}
+
+	got, err := resolveServedVersion(mapper, gk, []string{"v1"})
+	require.Error(t, err, "non-NoMatch mapper errors must surface to the caller")
+	require.ErrorContains(t, err, "permission denied")
+	assert.Nil(t, got)
+}
+
+func TestFormatGroupVersionKind(t *testing.T) {
+	cases := []struct {
+		name    string
+		gk      schema.GroupKind
+		version string
+		want    string
+	}{
+		{
+			name:    "non-empty group",
+			gk:      schema.GroupKind{Group: "apps", Kind: "Deployment"},
+			version: "v1",
+			want:    "apps/v1/Deployment",
+		},
+		{
+			name:    "empty group renders as core",
+			gk:      schema.GroupKind{Group: "", Kind: "Pod"},
+			version: "v1",
+			want:    "core/v1/Pod",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatGroupVersionKind(tc.gk, tc.version))
+		})
+	}
 }

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -58,7 +58,8 @@ const testRulesYAML = `
     int(obj.status.observedGeneration) < int(obj.metadata.generation)
       ? "deployment controller has not observed latest spec"
       : string(int(has(obj.status.readyReplicas) ? obj.status.readyReplicas : 0)) + "/" +
-        string(int(has(obj.spec.replicas) ? obj.spec.replicas : 1)) + " replicas ready"
+        string(int(has(obj.spec.replicas) ? obj.spec.replicas : 1)) + " replicas ready, " +
+        string(int(has(obj.status.updatedReplicas) ? obj.status.updatedReplicas : 0)) + " updated"
 - group: apps
   version: v1
   kind: StatefulSet

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -687,6 +689,159 @@ func TestRulesFromConfigMaps_BadCELSurfacesAsLoadError(t *testing.T) {
 	assert.Equal(t, "kcm-system/bad-rules#0", loadErrs[0].Source)
 	// rule set has no entries because the only candidate failed to compile.
 	assert.Empty(t, rs)
+}
+
+// --- computeServiceHash ---
+
+func sampleHelmRelease() *addoncontrollerv1beta1.HelmChartSummary {
+	return &addoncontrollerv1beta1.HelmChartSummary{
+		ReleaseName:      "mcs-podinfo",
+		ReleaseNamespace: "podinfo",
+		ValuesHash:       []byte("values-abc"),
+		PatchesHash:      []byte("patches-xyz"),
+	}
+}
+
+func sampleChart() *addoncontrollerv1beta1.Chart {
+	return &addoncontrollerv1beta1.Chart{
+		ReleaseName:  "mcs-podinfo",
+		Namespace:    "podinfo",
+		ChartVersion: "6.5.0",
+		AppVersion:   "6.5.0",
+		RepoURL:      "GitRepository://kcm-system/podinfo-6-5-0/charts/podinfo",
+	}
+}
+
+func TestComputeServiceHash_Stable(t *testing.T) {
+	a := computeServiceHash(sampleHelmRelease(), sampleChart())
+	b := computeServiceHash(sampleHelmRelease(), sampleChart())
+	assert.NotEmpty(t, a)
+	assert.Equal(t, a, b, "same input must produce same hash")
+}
+
+func TestComputeServiceHash_NilInputsReturnEmpty(t *testing.T) {
+	assert.Equal(t, "", computeServiceHash(nil, sampleChart()))
+	assert.Equal(t, "", computeServiceHash(sampleHelmRelease(), nil))
+	assert.Equal(t, "", computeServiceHash(nil, nil))
+}
+
+func TestComputeServiceHash_ExcludesLastAppliedTime(t *testing.T) {
+	c1 := sampleChart()
+	c2 := sampleChart()
+	c2.LastAppliedTime = &metav1.Time{Time: time.Now()}
+	a := computeServiceHash(sampleHelmRelease(), c1)
+	b := computeServiceHash(sampleHelmRelease(), c2)
+	assert.Equal(t, a, b, "lastAppliedTime must NOT influence the hash")
+}
+
+func TestComputeServiceHash_DetectsEveryComponentChange(t *testing.T) {
+	base := computeServiceHash(sampleHelmRelease(), sampleChart())
+
+	cases := []struct {
+		name   string
+		mutate func(*addoncontrollerv1beta1.HelmChartSummary, *addoncontrollerv1beta1.Chart)
+	}{
+		{"chart appVersion", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) { c.AppVersion = "6.5.1" }},
+		{"chart chartVersion", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) { c.ChartVersion = "6.6.0" }},
+		{"chart namespace", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) { c.Namespace = "other-ns" }},
+		{"chart releaseName", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) { c.ReleaseName = "other" }},
+		{"chart repoURL", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) { c.RepoURL = "OCIRepository://elsewhere" }},
+		{"release ValuesHash", func(r *addoncontrollerv1beta1.HelmChartSummary, _ *addoncontrollerv1beta1.Chart) { r.ValuesHash = []byte("values-new") }},
+		{"release PatchesHash", func(r *addoncontrollerv1beta1.HelmChartSummary, _ *addoncontrollerv1beta1.Chart) { r.PatchesHash = []byte("patches-new") }},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			r := sampleHelmRelease()
+			c := sampleChart()
+			tt.mutate(r, c)
+			got := computeServiceHash(r, c)
+			assert.NotEqual(t, base, got, "mutating %s must change the hash", tt.name)
+		})
+	}
+}
+
+// --- serviceHashesFromArtifacts ---
+
+func TestServiceHashesFromArtifacts_NilInputs(t *testing.T) {
+	assert.Empty(t, serviceHashesFromArtifacts(nil, nil, addoncontrollerv1beta1.ClusterProfileKind, "p"))
+	assert.Empty(t, serviceHashesFromArtifacts(nil, &addoncontrollerv1beta1.ClusterConfiguration{}, addoncontrollerv1beta1.ClusterProfileKind, "p"))
+	assert.Empty(t, serviceHashesFromArtifacts(&addoncontrollerv1beta1.ClusterSummary{}, nil, addoncontrollerv1beta1.ClusterProfileKind, "p"))
+}
+
+func TestServiceHashesFromArtifacts_BuildsMapForClusterProfile(t *testing.T) {
+	summary := &addoncontrollerv1beta1.ClusterSummary{
+		Status: addoncontrollerv1beta1.ClusterSummaryStatus{
+			HelmReleaseSummaries: []addoncontrollerv1beta1.HelmChartSummary{
+				{ReleaseName: "mcs-podinfo", ReleaseNamespace: "podinfo", ValuesHash: []byte("v1"), PatchesHash: []byte("p1")},
+				{ReleaseName: "mcs-prometheus", ReleaseNamespace: "monitoring", ValuesHash: []byte("v2"), PatchesHash: []byte("p2")},
+			},
+		},
+	}
+	cc := &addoncontrollerv1beta1.ClusterConfiguration{
+		Status: addoncontrollerv1beta1.ClusterConfigurationStatus{
+			ClusterProfileResources: []addoncontrollerv1beta1.ClusterProfileResource{
+				{
+					ClusterProfileName: "myset",
+					Features: []addoncontrollerv1beta1.Feature{
+						{
+							FeatureID: libsveltosv1beta1.FeatureHelm,
+							Charts: []addoncontrollerv1beta1.Chart{
+								{ReleaseName: "mcs-podinfo", Namespace: "podinfo", ChartVersion: "6.5.0", AppVersion: "6.5.0", RepoURL: "git://podinfo"},
+								{ReleaseName: "mcs-prometheus", Namespace: "monitoring", ChartVersion: "27.1.0", AppVersion: "27.1.0", RepoURL: "git://prom"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	hashes := serviceHashesFromArtifacts(summary, cc, addoncontrollerv1beta1.ClusterProfileKind, "myset")
+	require.Len(t, hashes, 2)
+	assert.NotEmpty(t, hashes[client.ObjectKey{Namespace: "podinfo", Name: "mcs-podinfo"}])
+	assert.NotEmpty(t, hashes[client.ObjectKey{Namespace: "monitoring", Name: "mcs-prometheus"}])
+	assert.NotEqual(t,
+		hashes[client.ObjectKey{Namespace: "podinfo", Name: "mcs-podinfo"}],
+		hashes[client.ObjectKey{Namespace: "monitoring", Name: "mcs-prometheus"}],
+		"distinct services must hash distinctly")
+}
+
+func TestServiceHashesFromArtifacts_SkipsReleaseWithoutChartEntry(t *testing.T) {
+	// HelmReleaseSummaries lists a release that ClusterConfiguration has
+	// no Charts[] entry for. The release is skipped.
+	summary := &addoncontrollerv1beta1.ClusterSummary{
+		Status: addoncontrollerv1beta1.ClusterSummaryStatus{
+			HelmReleaseSummaries: []addoncontrollerv1beta1.HelmChartSummary{
+				{ReleaseName: "no-chart", ReleaseNamespace: "ns", ValuesHash: []byte("x")},
+			},
+		},
+	}
+	cc := &addoncontrollerv1beta1.ClusterConfiguration{
+		Status: addoncontrollerv1beta1.ClusterConfigurationStatus{
+			ClusterProfileResources: []addoncontrollerv1beta1.ClusterProfileResource{{
+				ClusterProfileName: "myset",
+				Features:           []addoncontrollerv1beta1.Feature{{FeatureID: libsveltosv1beta1.FeatureHelm}},
+			}},
+		},
+	}
+	hashes := serviceHashesFromArtifacts(summary, cc, addoncontrollerv1beta1.ClusterProfileKind, "myset")
+	assert.Empty(t, hashes)
+}
+
+func TestServiceHashesFromArtifacts_WrongProfileSectionReturnsEmpty(t *testing.T) {
+	cc := &addoncontrollerv1beta1.ClusterConfiguration{
+		Status: addoncontrollerv1beta1.ClusterConfigurationStatus{
+			ClusterProfileResources: []addoncontrollerv1beta1.ClusterProfileResource{{
+				ClusterProfileName: "different-set",
+				Features:           []addoncontrollerv1beta1.Feature{{FeatureID: libsveltosv1beta1.FeatureHelm}},
+			}},
+		},
+	}
+	summary := &addoncontrollerv1beta1.ClusterSummary{}
+	// Asking for "myset" but CC only has "different-set" → no section, no hashes.
+	hashes := serviceHashesFromArtifacts(summary, cc, addoncontrollerv1beta1.ClusterProfileKind, "myset")
+	assert.Empty(t, hashes)
 }
 
 func TestRulesFromConfigMaps_TargetLabelSelectivity(t *testing.T) {

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -74,7 +74,11 @@ const testRulesYAML = `
     has(obj.status.currentRevision) && has(obj.status.updateRevision) &&
     obj.status.currentRevision == obj.status.updateRevision
   message: |
-    "statefulset not ready"
+    has(obj.status.currentRevision) && has(obj.status.updateRevision) &&
+    obj.status.currentRevision != obj.status.updateRevision
+      ? "rolling update in progress (currentRevision != updateRevision)"
+      : string(int(has(obj.status.readyReplicas) ? obj.status.readyReplicas : 0)) + "/" +
+        string(int(has(obj.spec.replicas) ? obj.spec.replicas : 1)) + " replicas ready"
 - group: apps
   version: v1
   kind: DaemonSet
@@ -88,7 +92,9 @@ const testRulesYAML = `
     int(obj.status.desiredNumberScheduled) == int(obj.status.numberReady) &&
     int(obj.status.desiredNumberScheduled) == int(obj.status.updatedNumberScheduled)
   message: |
-    "daemonset not ready"
+    string(int(has(obj.status.numberReady) ? obj.status.numberReady : 0)) + "/" +
+    string(int(has(obj.status.desiredNumberScheduled) ? obj.status.desiredNumberScheduled : 0)) +
+    " nodes ready"
 - group: ""
   version: v1
   kind: Pod
@@ -97,7 +103,15 @@ const testRulesYAML = `
     has(obj.status.conditions) &&
     obj.status.conditions.exists(c, c.type == "Ready" && c.status == "True")
   message: |
-    "pod not ready"
+    has(obj.status.containerStatuses)
+      ? obj.status.containerStatuses
+          .filter(c, !c.ready)
+          .map(c, c.name + ": " +
+            (has(c.state.waiting) && has(c.state.waiting.reason) ? c.state.waiting.reason :
+             (has(c.state.terminated) && has(c.state.terminated.reason) ? c.state.terminated.reason :
+              "not ready")))
+          .join(", ")
+      : "pod not ready"
 - group: ""
   version: v1
   kind: PersistentVolumeClaim

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -615,6 +615,24 @@ func makeRulesConfigMap(t *testing.T, namespace, name, target, rulesBody string)
 	}
 }
 
+// makeServiceSetOwnedByMCS returns a ServiceSet whose OwnerReferences
+// name the given MultiClusterService — matches what the MCS reconciler
+// stamps on ServiceSets it creates. Used to drive the tier-3 lookup in
+// rulesFromConfigMaps tests.
+func makeServiceSetOwnedByMCS(namespace, name, mcsName string) *kcmv1.ServiceSet {
+	return &kcmv1.ServiceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: kcmv1.GroupVersion.String(),
+				Kind:       kcmv1.MultiClusterServiceKind,
+				Name:       mcsName,
+			}},
+		},
+	}
+}
+
 const podOnlyRulesYAML = `
 - group: ""
   version: v1
@@ -639,8 +657,10 @@ func TestRulesFromConfigMaps_AllThreeTiers(t *testing.T) {
   message: |
     "no observedGeneration"
 `)
-	// ServiceSet-targeted: name "myset" in releaseNs.
-	t3 := makeRulesConfigMap(t, releaseNs, "set-rules", "myset", `
+	// Tier 3 is keyed by the ServiceSet's owner (MCS) name, not the
+	// ServiceSet name itself — the ServiceSet name isn't stable enough
+	// to author rules against.
+	t3 := makeRulesConfigMap(t, releaseNs, "set-rules", "my-mcs", `
 - group: apps
   version: v1
   kind: StatefulSet
@@ -652,7 +672,8 @@ func TestRulesFromConfigMaps_AllThreeTiers(t *testing.T) {
 `)
 
 	c := newFakeClient(t, t1, t2, t3)
-	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, releaseNs, "myset")
+	ss := makeServiceSetOwnedByMCS(releaseNs, "myset", "my-mcs")
+	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, ss)
 	require.NoError(t, err)
 	assert.Empty(t, loadErrs)
 
@@ -667,7 +688,8 @@ func TestRulesFromConfigMaps_SystemNamespaceEqualsServiceSetNamespace(t *testing
 	t1 := makeRulesConfigMap(t, systemNamespace, "cluster-rules", "global", podOnlyRulesYAML)
 
 	c := newFakeClient(t, t1)
-	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, systemNamespace, "self-mgmt-ss")
+	ss := makeServiceSetOwnedByMCS(systemNamespace, "self-mgmt-ss", "my-mcs")
+	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, ss)
 	require.NoError(t, err)
 	assert.Empty(t, loadErrs)
 	assert.Len(t, rs[schema.GroupKind{Group: "", Kind: "Pod"}], 1, "must not duplicate")
@@ -683,12 +705,32 @@ func TestRulesFromConfigMaps_BadCELSurfacesAsLoadError(t *testing.T) {
   message: "bad"
 `)
 	c := newFakeClient(t, cm)
-	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, releaseNs, "ss")
+	ss := makeServiceSetOwnedByMCS(releaseNs, "ss", "my-mcs")
+	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, ss)
 	require.NoError(t, err)
 	require.Len(t, loadErrs, 1)
 	assert.Equal(t, "kcm-system/bad-rules#0", loadErrs[0].Source)
 	// rule set has no entries because the only candidate failed to compile.
 	assert.Empty(t, rs)
+}
+
+func TestRulesFromConfigMaps_NoOwnerSkipsTier3(t *testing.T) {
+	// A ServiceSet without an MCS/CD owner reference should still load
+	// tier 1 and tier 2 correctly; tier 3 is simply skipped.
+	t1 := makeRulesConfigMap(t, systemNamespace, "cluster-rules", "global", podOnlyRulesYAML)
+	tSpec := makeRulesConfigMap(t, releaseNs, "spec-rules", "some-owner", podOnlyRulesYAML)
+
+	c := newFakeClient(t, t1, tSpec)
+	ss := &kcmv1.ServiceSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphan", Namespace: releaseNs},
+	}
+	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, ss)
+	require.NoError(t, err)
+	assert.Empty(t, loadErrs)
+	// Only tier 1's rule made it in — tier 3 was skipped because there
+	// is no owner name to match, and the "spec-rules" CM's label value
+	// therefore isn't queried.
+	assert.Len(t, rs[schema.GroupKind{Group: "", Kind: "Pod"}], 1)
 }
 
 // --- computeServiceHash ---
@@ -741,13 +783,27 @@ func TestComputeServiceHash_DetectsEveryComponentChange(t *testing.T) {
 		name   string
 		mutate func(*addoncontrollerv1beta1.HelmChartSummary, *addoncontrollerv1beta1.Chart)
 	}{
-		{"chart appVersion", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) { c.AppVersion = "6.5.1" }},
-		{"chart chartVersion", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) { c.ChartVersion = "6.6.0" }},
-		{"chart namespace", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) { c.Namespace = "other-ns" }},
-		{"chart releaseName", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) { c.ReleaseName = "other" }},
-		{"chart repoURL", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) { c.RepoURL = "OCIRepository://elsewhere" }},
-		{"release ValuesHash", func(r *addoncontrollerv1beta1.HelmChartSummary, _ *addoncontrollerv1beta1.Chart) { r.ValuesHash = []byte("values-new") }},
-		{"release PatchesHash", func(r *addoncontrollerv1beta1.HelmChartSummary, _ *addoncontrollerv1beta1.Chart) { r.PatchesHash = []byte("patches-new") }},
+		{"chart appVersion", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) {
+			c.AppVersion = "6.5.1"
+		}},
+		{"chart chartVersion", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) {
+			c.ChartVersion = "6.6.0"
+		}},
+		{"chart namespace", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) {
+			c.Namespace = "other-ns"
+		}},
+		{"chart releaseName", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) {
+			c.ReleaseName = "other"
+		}},
+		{"chart repoURL", func(_ *addoncontrollerv1beta1.HelmChartSummary, c *addoncontrollerv1beta1.Chart) {
+			c.RepoURL = "OCIRepository://elsewhere"
+		}},
+		{"release ValuesHash", func(r *addoncontrollerv1beta1.HelmChartSummary, _ *addoncontrollerv1beta1.Chart) {
+			r.ValuesHash = []byte("values-new")
+		}},
+		{"release PatchesHash", func(r *addoncontrollerv1beta1.HelmChartSummary, _ *addoncontrollerv1beta1.Chart) {
+			r.PatchesHash = []byte("patches-new")
+		}},
 	}
 
 	for _, tt := range cases {
@@ -845,16 +901,17 @@ func TestServiceHashesFromArtifacts_WrongProfileSectionReturnsEmpty(t *testing.T
 }
 
 func TestRulesFromConfigMaps_TargetLabelSelectivity(t *testing.T) {
-	matching := makeRulesConfigMap(t, releaseNs, "for-us", "myset", podOnlyRulesYAML)
-	otherSs := makeRulesConfigMap(t, releaseNs, "for-other", "different-ss", podOnlyRulesYAML)
+	matching := makeRulesConfigMap(t, releaseNs, "for-us", "my-mcs", podOnlyRulesYAML)
+	otherOwner := makeRulesConfigMap(t, releaseNs, "for-other", "different-mcs", podOnlyRulesYAML)
 	unlabeled := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "no-label", Namespace: releaseNs},
 		Data:       map[string]string{healthRuleConfigMapDataKey: podOnlyRulesYAML},
 	}
 
-	c := newFakeClient(t, matching, otherSs, unlabeled)
-	rs, _, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, releaseNs, "myset")
+	c := newFakeClient(t, matching, otherOwner, unlabeled)
+	ss := makeServiceSetOwnedByMCS(releaseNs, "myset", "my-mcs")
+	rs, _, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, ss)
 	require.NoError(t, err)
 	require.Len(t, rs[schema.GroupKind{Group: "", Kind: "Pod"}], 1,
-		"only the CM whose label value matches the ServiceSet name should contribute")
+		"only the CM whose label value matches the ServiceSet's owner name should contribute")
 }

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -156,7 +156,7 @@ func TestTestRules_AllPresent(t *testing.T) {
 		assert.True(t, ok, "missing rule for %s", gk)
 		assert.Len(t, rules, 1, "expected exactly one default rule for %s", gk)
 	}
-	assert.Equal(t, len(want), len(testRules), "extra rules present")
+	assert.Len(t, testRules, len(want), "extra rules present")
 }
 
 // evalRule looks up a single rule by group/kind from testRules and
@@ -615,11 +615,16 @@ func makeRulesConfigMap(t *testing.T, namespace, name, target, rulesBody string)
 	}
 }
 
+// testMCSOwnerName is the MultiClusterService name that every test
+// ServiceSet claims as its owner. Tier-3 rule CMs point at this name to
+// exercise the owner-matching path.
+const testMCSOwnerName = "my-mcs"
+
 // makeServiceSetOwnedByMCS returns a ServiceSet whose OwnerReferences
-// name the given MultiClusterService — matches what the MCS reconciler
-// stamps on ServiceSets it creates. Used to drive the tier-3 lookup in
+// name testMCSOwnerName — matches what the MCS reconciler stamps on
+// ServiceSets it creates. Used to drive the tier-3 lookup in
 // rulesFromConfigMaps tests.
-func makeServiceSetOwnedByMCS(namespace, name, mcsName string) *kcmv1.ServiceSet {
+func makeServiceSetOwnedByMCS(namespace, name string) *kcmv1.ServiceSet {
 	return &kcmv1.ServiceSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -627,7 +632,7 @@ func makeServiceSetOwnedByMCS(namespace, name, mcsName string) *kcmv1.ServiceSet
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: kcmv1.GroupVersion.String(),
 				Kind:       kcmv1.MultiClusterServiceKind,
-				Name:       mcsName,
+				Name:       testMCSOwnerName,
 			}},
 		},
 	}
@@ -672,7 +677,7 @@ func TestRulesFromConfigMaps_AllThreeTiers(t *testing.T) {
 `)
 
 	c := newFakeClient(t, t1, t2, t3)
-	ss := makeServiceSetOwnedByMCS(releaseNs, "myset", "my-mcs")
+	ss := makeServiceSetOwnedByMCS(releaseNs, "myset")
 	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, ss)
 	require.NoError(t, err)
 	assert.Empty(t, loadErrs)
@@ -688,7 +693,7 @@ func TestRulesFromConfigMaps_SystemNamespaceEqualsServiceSetNamespace(t *testing
 	t1 := makeRulesConfigMap(t, systemNamespace, "cluster-rules", "global", podOnlyRulesYAML)
 
 	c := newFakeClient(t, t1)
-	ss := makeServiceSetOwnedByMCS(systemNamespace, "self-mgmt-ss", "my-mcs")
+	ss := makeServiceSetOwnedByMCS(systemNamespace, "self-mgmt-ss")
 	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, ss)
 	require.NoError(t, err)
 	assert.Empty(t, loadErrs)
@@ -705,7 +710,7 @@ func TestRulesFromConfigMaps_BadCELSurfacesAsLoadError(t *testing.T) {
   message: "bad"
 `)
 	c := newFakeClient(t, cm)
-	ss := makeServiceSetOwnedByMCS(releaseNs, "ss", "my-mcs")
+	ss := makeServiceSetOwnedByMCS(releaseNs, "ss")
 	rs, loadErrs, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, ss)
 	require.NoError(t, err)
 	require.Len(t, loadErrs, 1)
@@ -762,9 +767,9 @@ func TestComputeServiceHash_Stable(t *testing.T) {
 }
 
 func TestComputeServiceHash_NilInputsReturnEmpty(t *testing.T) {
-	assert.Equal(t, "", computeServiceHash(nil, sampleChart()))
-	assert.Equal(t, "", computeServiceHash(sampleHelmRelease(), nil))
-	assert.Equal(t, "", computeServiceHash(nil, nil))
+	assert.Empty(t, computeServiceHash(nil, sampleChart()))
+	assert.Empty(t, computeServiceHash(sampleHelmRelease(), nil))
+	assert.Empty(t, computeServiceHash(nil, nil))
 }
 
 func TestComputeServiceHash_ExcludesLastAppliedTime(t *testing.T) {
@@ -909,7 +914,7 @@ func TestRulesFromConfigMaps_TargetLabelSelectivity(t *testing.T) {
 	}
 
 	c := newFakeClient(t, matching, otherOwner, unlabeled)
-	ss := makeServiceSetOwnedByMCS(releaseNs, "myset", "my-mcs")
+	ss := makeServiceSetOwnedByMCS(releaseNs, "myset")
 	rs, _, err := rulesFromConfigMaps(context.Background(), c, systemNamespace, ss)
 	require.NoError(t, err)
 	require.Len(t, rs[schema.GroupKind{Group: "", Kind: "Pod"}], 1,

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -17,6 +17,7 @@ package sveltos
 import (
 	"context"
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -700,6 +701,102 @@ func TestVerifyHelmServiceOnCluster_TruncatesLargeRefLists(t *testing.T) {
 	assert.NotContains(t, conds[0].Message, "pod-d", "refs past cap must be elided")
 	assert.NotContains(t, conds[0].Message, "pod-e", "refs past cap must be elided")
 	assert.Contains(t, conds[0].Message, "…and 2 more")
+}
+
+// --- ruleParseCache eviction ---
+
+// TestSweepRuleParseCache_EvictsStaleEntries asserts that sweepRuleParseCache
+// drops entries whose lastAccess is older than ruleParseCacheTTL while
+// preserving fresh ones. This is the leak-prevention hatch from PR #2891
+// review — an entry whose owning ConfigMap has been deleted has no way
+// to be invalidated by the ResourceVersion check (there's nothing to
+// re-read), so TTL-based sweeping is the only mechanism keeping the
+// cache bounded on long-lived controllers.
+func TestSweepRuleParseCache_EvictsStaleEntries(t *testing.T) {
+	// Isolate this test from other tests that may have populated the
+	// process-global cache. Snapshot on entry, restore on exit.
+	ruleParseCache.Lock()
+	original := make(map[client.ObjectKey]ruleCacheEntry, len(ruleParseCache.entries))
+	maps.Copy(original, ruleParseCache.entries)
+	ruleParseCache.entries = make(map[client.ObjectKey]ruleCacheEntry)
+	ruleParseCache.Unlock()
+	t.Cleanup(func() {
+		ruleParseCache.Lock()
+		ruleParseCache.entries = original
+		ruleParseCache.Unlock()
+	})
+
+	freshKey := client.ObjectKey{Namespace: "ns-a", Name: "fresh"}
+	staleKey := client.ObjectKey{Namespace: "ns-b", Name: "stale"}
+	now := time.Now()
+
+	ruleParseCache.Lock()
+	ruleParseCache.entries[freshKey] = ruleCacheEntry{
+		resourceVersion: "1",
+		lastAccess:      now.Add(-ruleParseCacheTTL / 2), // half-TTL old, keep
+	}
+	ruleParseCache.entries[staleKey] = ruleCacheEntry{
+		resourceVersion: "1",
+		lastAccess:      now.Add(-2 * ruleParseCacheTTL), // 2×TTL old, evict
+	}
+	ruleParseCache.Unlock()
+
+	sweepRuleParseCache()
+
+	ruleParseCache.Lock()
+	defer ruleParseCache.Unlock()
+	_, freshOK := ruleParseCache.entries[freshKey]
+	_, staleOK := ruleParseCache.entries[staleKey]
+	assert.True(t, freshOK, "fresh entry must survive sweep")
+	assert.False(t, staleOK, "stale entry must be evicted")
+}
+
+// TestDocsFromConfigMap_RefreshesLastAccessOnHit asserts that reading a
+// cached entry refreshes its lastAccess timestamp. Without this, a hot CM
+// whose ResourceVersion never changes would age out and be re-parsed
+// unnecessarily.
+func TestDocsFromConfigMap_RefreshesLastAccessOnHit(t *testing.T) {
+	// Snapshot + isolate.
+	ruleParseCache.Lock()
+	original := make(map[client.ObjectKey]ruleCacheEntry, len(ruleParseCache.entries))
+	maps.Copy(original, ruleParseCache.entries)
+	ruleParseCache.entries = make(map[client.ObjectKey]ruleCacheEntry)
+	ruleParseCache.Unlock()
+	t.Cleanup(func() {
+		ruleParseCache.Lock()
+		ruleParseCache.entries = original
+		ruleParseCache.Unlock()
+	})
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "ns-hit",
+			Name:            "hot-cm",
+			ResourceVersion: "42",
+		},
+		Data: map[string]string{healthRuleConfigMapDataKey: testRulesYAML},
+	}
+
+	// First call populates the cache. Force lastAccess into the past so
+	// we can see whether the second call refreshes it.
+	_, _ = docsFromConfigMap(cm)
+	key := client.ObjectKey{Namespace: cm.Namespace, Name: cm.Name}
+
+	ruleParseCache.Lock()
+	stalePast := time.Now().Add(-ruleParseCacheTTL)
+	entry := ruleParseCache.entries[key]
+	entry.lastAccess = stalePast
+	ruleParseCache.entries[key] = entry
+	ruleParseCache.Unlock()
+
+	// Second call is a cache hit (same RV) and must refresh lastAccess.
+	_, _ = docsFromConfigMap(cm)
+
+	ruleParseCache.Lock()
+	defer ruleParseCache.Unlock()
+	assert.True(t, ruleParseCache.entries[key].lastAccess.After(stalePast),
+		"cache hit must refresh lastAccess (kept: %v, prior: %v)",
+		ruleParseCache.entries[key].lastAccess, stalePast)
 }
 
 // --- rulesFromConfigMaps ---

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -115,6 +115,10 @@ const testRulesYAML = `
     has(obj.status.phase) ? "phase=" + obj.status.phase : "no phase reported"
 `
 
+const (
+	dummyDeployment = "web"
+)
+
 // testRules is the compiled ruleSet built from testRulesYAML. Construction
 // failure is a programming error in the test fixture — panic so the suite
 // fails loudly rather than silently running against a partial rule set.
@@ -455,8 +459,8 @@ func makeHealthyDeployment(name string) *appsv1.Deployment {
 	}
 }
 
-func makeUnhealthyDeployment(name string) *appsv1.Deployment {
-	d := makeHealthyDeployment(name)
+func makeUnhealthyDeployment() *appsv1.Deployment {
+	d := makeHealthyDeployment(dummyDeployment)
 	d.Status.ReadyReplicas = 1
 	return d
 }
@@ -471,6 +475,21 @@ func makeReadyPod(name string) *corev1.Pod {
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{
 				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func makeUnreadyPod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: releaseNs,
+			Labels:    map[string]string{"release": releaseName},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
 			},
 		},
 	}
@@ -497,7 +516,7 @@ func TestVerifyHelmServiceOnCluster_AllHealthy(t *testing.T) {
 }
 
 func TestVerifyHelmServiceOnCluster_DeploymentUnhealthy(t *testing.T) {
-	c := newFakeClient(t, makeUnhealthyDeployment("web"))
+	c := newFakeClient(t, makeUnhealthyDeployment())
 	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
 	require.NoError(t, err)
 	assert.Equal(t, kcmv1.ServiceStateProvisioning, state)
@@ -541,7 +560,7 @@ func TestVerifyHelmServiceOnCluster_OtherReleaseIgnored(t *testing.T) {
 }
 
 func TestVerifyHelmServiceOnCluster_DiscoversByAppKubernetesIoInstance(t *testing.T) {
-	d := makeUnhealthyDeployment("web")
+	d := makeUnhealthyDeployment()
 	delete(d.Labels, "release")
 	d.Labels["app.kubernetes.io/instance"] = releaseName
 
@@ -554,7 +573,7 @@ func TestVerifyHelmServiceOnCluster_DiscoversByAppKubernetesIoInstance(t *testin
 }
 
 func TestVerifyHelmServiceOnCluster_DedupesAcrossLabels(t *testing.T) {
-	d := makeUnhealthyDeployment("web")
+	d := makeUnhealthyDeployment()
 	d.Labels["app"] = releaseName
 	d.Labels["app.kubernetes.io/instance"] = releaseName
 	d.Labels["app.kubernetes.io/name"] = releaseName
@@ -597,6 +616,75 @@ func TestVerifyHelmServiceOnCluster_MultiRule_AllMustPass(t *testing.T) {
 	require.Len(t, conds, 1)
 	assert.Contains(t, conds[0].Message, "always unhealthy")
 	assert.Contains(t, conds[0].Message, "test-extra#0", "failing rule's source must appear in the condition")
+}
+
+// TestVerifyHelmServiceOnCluster_AggregatesByKind asserts that multiple
+// unhealthy resources of the SAME Kind collapse into a single condition
+// with a listType=map-safe Type. Two ServiceHealthPod entries would
+// otherwise fail the ServiceSet status-writeback schema validation
+// (Conditions is +listType=map +listMapKey=type).
+func TestVerifyHelmServiceOnCluster_AggregatesByKind(t *testing.T) {
+	c := newFakeClient(t,
+		makeUnreadyPod("web-a"),
+		makeUnreadyPod("web-b"),
+		makeUnreadyPod("web-c"),
+	)
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateProvisioning, state)
+	require.Len(t, conds, 1, "3 unhealthy Pods must collapse to 1 ServiceHealthPod condition")
+	assert.Equal(t, "ServiceHealthPod", conds[0].Type)
+	assert.Contains(t, conds[0].Message, "3 Pod unhealthy")
+	// All three refs shown because count <= maxUnhealthyRefsPerCondition.
+	assert.Contains(t, conds[0].Message, "web-a")
+	assert.Contains(t, conds[0].Message, "web-b")
+	assert.Contains(t, conds[0].Message, "web-c")
+	assert.NotContains(t, conds[0].Message, "…and", "no truncation expected at count=3")
+}
+
+// TestVerifyHelmServiceOnCluster_AggregatesByKindAcrossKinds asserts that
+// different Kinds produce distinct conditions (one per Kind) — the
+// listMapKey uniqueness is per-Type, not per-Kind-per-resource.
+func TestVerifyHelmServiceOnCluster_AggregatesByKindAcrossKinds(t *testing.T) {
+	c := newFakeClient(t,
+		makeUnhealthyDeployment(),
+		makeUnreadyPod("web-a"),
+		makeUnreadyPod("web-b"),
+	)
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateProvisioning, state)
+	require.Len(t, conds, 2, "one condition per Kind")
+	types := []string{conds[0].Type, conds[1].Type}
+	assert.Contains(t, types, "ServiceHealthDeployment")
+	assert.Contains(t, types, "ServiceHealthPod")
+}
+
+// TestVerifyHelmServiceOnCluster_TruncatesLargeRefLists asserts that a
+// condition message caps ref enumeration at maxUnhealthyRefsPerCondition
+// and appends an "…and N more" summary. Sorting by (namespace, name) is
+// verified transitively: alphabetically-first refs must appear in the
+// message, later ones must not.
+func TestVerifyHelmServiceOnCluster_TruncatesLargeRefLists(t *testing.T) {
+	// 5 unhealthy pods, cap is 3 → 3 shown, 2 elided.
+	c := newFakeClient(t,
+		makeUnreadyPod("pod-a"),
+		makeUnreadyPod("pod-b"),
+		makeUnreadyPod("pod-c"),
+		makeUnreadyPod("pod-d"),
+		makeUnreadyPod("pod-e"),
+	)
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateProvisioning, state)
+	require.Len(t, conds, 1)
+	assert.Contains(t, conds[0].Message, "5 Pod unhealthy")
+	assert.Contains(t, conds[0].Message, "pod-a")
+	assert.Contains(t, conds[0].Message, "pod-b")
+	assert.Contains(t, conds[0].Message, "pod-c")
+	assert.NotContains(t, conds[0].Message, "pod-d", "refs past cap must be elided")
+	assert.NotContains(t, conds[0].Message, "pod-e", "refs past cap must be elided")
+	assert.Contains(t, conds[0].Message, "…and 2 more")
 }
 
 // --- rulesFromConfigMaps ---

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -142,9 +142,14 @@ const (
 // fails loudly rather than silently running against a partial rule set.
 var testRules = func() ruleSet {
 	docs := parseRuleYAMLOrPanic(testRulesYAML, "test")
-	rs, errs := rulesFromDocs(docs)
+	rules, errs := rulesFromDocs(docs)
 	if len(errs) > 0 {
 		panic(fmt.Errorf("test rules failed to compile: %v", errs))
+	}
+	rs := make(ruleSet)
+	for _, r := range rules {
+		gk := r.GVK.GroupKind()
+		rs[gk] = append(rs[gk], r)
 	}
 	return rs
 }()
@@ -642,8 +647,13 @@ func TestVerifyHelmServiceOnCluster_MultiRule_AllMustPass(t *testing.T) {
 		},
 		Source: "test-extra#0",
 	})
-	rs, errs := rulesFromDocs(docs)
+	rules, errs := rulesFromDocs(docs)
 	require.Empty(t, errs)
+	rs := make(ruleSet)
+	for _, r := range rules {
+		gk := r.GVK.GroupKind()
+		rs[gk] = append(rs[gk], r)
+	}
 	require.Len(t, rs[schema.GroupKind{Group: "apps", Kind: "Deployment"}], 2)
 
 	c := newFakeClient(t, makeHealthyDeployment("web"))
@@ -724,69 +734,69 @@ func TestVerifyHelmServiceOnCluster_TruncatesLargeRefLists(t *testing.T) {
 	assert.Contains(t, conds[0].Message, "…and 2 more")
 }
 
-// --- ruleParseCache eviction ---
+// --- ruleCache eviction ---
 
-// TestSweepRuleParseCache_EvictsStaleEntries asserts that sweepRuleParseCache
-// drops entries whose lastAccess is older than ruleParseCacheTTL while
+// TestSweepRuleCache_EvictsStaleEntries asserts that sweepRuleCache
+// drops entries whose lastAccess is older than ruleCacheTTL while
 // preserving fresh ones. This is the leak-prevention hatch from PR #2891
 // review — an entry whose owning ConfigMap has been deleted has no way
 // to be invalidated by the ResourceVersion check (there's nothing to
 // re-read), so TTL-based sweeping is the only mechanism keeping the
 // cache bounded on long-lived controllers.
-func TestSweepRuleParseCache_EvictsStaleEntries(t *testing.T) {
+func TestSweepRuleCache_EvictsStaleEntries(t *testing.T) {
 	// Isolate this test from other tests that may have populated the
 	// process-global cache. Snapshot on entry, restore on exit.
-	ruleParseCache.Lock()
-	original := make(map[client.ObjectKey]ruleCacheEntry, len(ruleParseCache.entries))
-	maps.Copy(original, ruleParseCache.entries)
-	ruleParseCache.entries = make(map[client.ObjectKey]ruleCacheEntry)
-	ruleParseCache.Unlock()
+	ruleCache.Lock()
+	original := make(map[client.ObjectKey]ruleCacheEntry, len(ruleCache.entries))
+	maps.Copy(original, ruleCache.entries)
+	ruleCache.entries = make(map[client.ObjectKey]ruleCacheEntry)
+	ruleCache.Unlock()
 	t.Cleanup(func() {
-		ruleParseCache.Lock()
-		ruleParseCache.entries = original
-		ruleParseCache.Unlock()
+		ruleCache.Lock()
+		ruleCache.entries = original
+		ruleCache.Unlock()
 	})
 
 	freshKey := client.ObjectKey{Namespace: "ns-a", Name: "fresh"}
 	staleKey := client.ObjectKey{Namespace: "ns-b", Name: "stale"}
 	now := time.Now()
 
-	ruleParseCache.Lock()
-	ruleParseCache.entries[freshKey] = ruleCacheEntry{
+	ruleCache.Lock()
+	ruleCache.entries[freshKey] = ruleCacheEntry{
 		resourceVersion: "1",
-		lastAccess:      now.Add(-ruleParseCacheTTL / 2), // half-TTL old, keep
+		lastAccess:      now.Add(-ruleCacheTTL / 2), // half-TTL old, keep
 	}
-	ruleParseCache.entries[staleKey] = ruleCacheEntry{
+	ruleCache.entries[staleKey] = ruleCacheEntry{
 		resourceVersion: "1",
-		lastAccess:      now.Add(-2 * ruleParseCacheTTL), // 2×TTL old, evict
+		lastAccess:      now.Add(-2 * ruleCacheTTL), // 2×TTL old, evict
 	}
-	ruleParseCache.Unlock()
+	ruleCache.Unlock()
 
-	sweepRuleParseCache()
+	sweepRuleCache()
 
-	ruleParseCache.Lock()
-	defer ruleParseCache.Unlock()
-	_, freshOK := ruleParseCache.entries[freshKey]
-	_, staleOK := ruleParseCache.entries[staleKey]
+	ruleCache.Lock()
+	defer ruleCache.Unlock()
+	_, freshOK := ruleCache.entries[freshKey]
+	_, staleOK := ruleCache.entries[staleKey]
 	assert.True(t, freshOK, "fresh entry must survive sweep")
 	assert.False(t, staleOK, "stale entry must be evicted")
 }
 
-// TestDocsFromConfigMap_RefreshesLastAccessOnHit asserts that reading a
+// TestRulesFromConfigMap_RefreshesLastAccessOnHit asserts that reading a
 // cached entry refreshes its lastAccess timestamp. Without this, a hot CM
-// whose ResourceVersion never changes would age out and be re-parsed
-// unnecessarily.
-func TestDocsFromConfigMap_RefreshesLastAccessOnHit(t *testing.T) {
+// whose ResourceVersion never changes would age out and be re-parsed +
+// re-compiled unnecessarily.
+func TestRulesFromConfigMap_RefreshesLastAccessOnHit(t *testing.T) {
 	// Snapshot + isolate.
-	ruleParseCache.Lock()
-	original := make(map[client.ObjectKey]ruleCacheEntry, len(ruleParseCache.entries))
-	maps.Copy(original, ruleParseCache.entries)
-	ruleParseCache.entries = make(map[client.ObjectKey]ruleCacheEntry)
-	ruleParseCache.Unlock()
+	ruleCache.Lock()
+	original := make(map[client.ObjectKey]ruleCacheEntry, len(ruleCache.entries))
+	maps.Copy(original, ruleCache.entries)
+	ruleCache.entries = make(map[client.ObjectKey]ruleCacheEntry)
+	ruleCache.Unlock()
 	t.Cleanup(func() {
-		ruleParseCache.Lock()
-		ruleParseCache.entries = original
-		ruleParseCache.Unlock()
+		ruleCache.Lock()
+		ruleCache.entries = original
+		ruleCache.Unlock()
 	})
 
 	cm := &corev1.ConfigMap{
@@ -800,24 +810,24 @@ func TestDocsFromConfigMap_RefreshesLastAccessOnHit(t *testing.T) {
 
 	// First call populates the cache. Force lastAccess into the past so
 	// we can see whether the second call refreshes it.
-	_, _ = docsFromConfigMap(cm)
+	_, _ = rulesFromConfigMap(cm)
 	key := client.ObjectKey{Namespace: cm.Namespace, Name: cm.Name}
 
-	ruleParseCache.Lock()
-	stalePast := time.Now().Add(-ruleParseCacheTTL)
-	entry := ruleParseCache.entries[key]
+	ruleCache.Lock()
+	stalePast := time.Now().Add(-ruleCacheTTL)
+	entry := ruleCache.entries[key]
 	entry.lastAccess = stalePast
-	ruleParseCache.entries[key] = entry
-	ruleParseCache.Unlock()
+	ruleCache.entries[key] = entry
+	ruleCache.Unlock()
 
 	// Second call is a cache hit (same RV) and must refresh lastAccess.
-	_, _ = docsFromConfigMap(cm)
+	_, _ = rulesFromConfigMap(cm)
 
-	ruleParseCache.Lock()
-	defer ruleParseCache.Unlock()
-	assert.True(t, ruleParseCache.entries[key].lastAccess.After(stalePast),
+	ruleCache.Lock()
+	defer ruleCache.Unlock()
+	assert.True(t, ruleCache.entries[key].lastAccess.After(stalePast),
 		"cache hit must refresh lastAccess (kept: %v, prior: %v)",
-		ruleParseCache.entries[key].lastAccess, stalePast)
+		ruleCache.entries[key].lastAccess, stalePast)
 }
 
 // --- rulesFromConfigMaps ---

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -679,6 +679,58 @@ func TestVerifyHelmServiceOnCluster_MultiRule_AllMustPass(t *testing.T) {
 	assert.Contains(t, conds[0].Message, "test-extra#0", "failing rule's source must appear in the condition")
 }
 
+// TestCollectVerdicts_ScopeMismatchEmitsSyntheticVerdict asserts that a
+// rule declaring the wrong scope (e.g. "Cluster" for a Namespaced Kind
+// like Deployment) is REJECTED for its whole GroupKind — no
+// cross-namespace List runs — and instead a synthetic unhealthy verdict
+// is emitted so the downstream aggregation surfaces the misconfiguration
+// on the ServiceSet as a ServiceHealth<Kind> condition. The reviewer-
+// motivated safeguard: without this, a Deployment rule mis-marked
+// Cluster would List across every namespace and pull in unrelated
+// releases.
+func TestCollectVerdicts_ScopeMismatchEmitsSyntheticVerdict(t *testing.T) {
+	// Rule that ADMITS Cluster scope for apps/Deployment — which is
+	// actually Namespaced on the target cluster (per the RESTMapper
+	// seeded in newFakeClient).
+	docs := []sourcedRuleDoc{{
+		Doc: ruleDoc{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "Deployment",
+			Scope:   scopeCluster,
+			Healthy: `true`,
+			Message: `""`,
+		},
+		Source: "scope-mismatch-test#0",
+	}}
+	rules, compileErrs := rulesFromDocs(docs)
+	require.Empty(t, compileErrs)
+	rs := make(ruleSet)
+	for _, r := range rules {
+		rs[r.GVK.GroupKind()] = append(rs[r.GVK.GroupKind()], r)
+	}
+
+	// Seed the fake with an unhealthy Deployment; if the mis-scoped rule
+	// were accepted, we'd get a real per-object verdict. Under the fix,
+	// the whole GroupKind is skipped and the only verdict is the
+	// synthetic HealthRuleScopeMismatch one. err stays nil — the
+	// mismatch is a config problem surfaced via the verdict, not
+	// propagated as a reconciler error.
+	c := newFakeClient(t, makeUnhealthyDeployment())
+	verdicts, err := collectVerdicts(context.Background(), c, rs, releaseName, releaseNs)
+	require.NoError(t, err, "scope mismatch is not a reconciler error")
+	require.Len(t, verdicts, 1, "one synthetic verdict per mis-scoped rule")
+
+	v := verdicts[0]
+	assert.False(t, v.Healthy, "synthetic verdict must be unhealthy so the aggregation surfaces it")
+	assert.Equal(t, "HealthRuleScopeMismatch", v.Reason)
+	assert.Equal(t, "scope-mismatch-test#0", v.RuleSrc,
+		"RuleSrc must name the offending rule so operators can locate it")
+	assert.Equal(t, "Deployment", v.GVK.Kind, "GVK.Kind identifies the affected Kind on the ServiceSet condition")
+	assert.Empty(t, v.Name, "synthetic verdict speaks about the rule, not any specific object")
+	assert.Empty(t, v.Namespace)
+}
+
 // TestVerifyHelmServiceOnCluster_AggregatesByKind asserts that multiple
 // unhealthy resources of the SAME Kind collapse into a single condition
 // with a listType=map-safe Type. Two ServiceHealthPod entries would
@@ -1302,6 +1354,9 @@ type stubRESTMapper struct {
 	// perGKErr maps a GroupKind to an error the mapper should return
 	// (used for NoMatch and permission-denied cases).
 	perGKErr map[schema.GroupKind]error
+	// perGKScope overrides the scope RESTMappings emits for a GK.
+	// Default is Namespaced when not set.
+	perGKScope map[schema.GroupKind]meta.RESTScope
 }
 
 func (*stubRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
@@ -1332,10 +1387,15 @@ func (m *stubRESTMapper) RESTMappings(gk schema.GroupKind, _ ...string) ([]*meta
 	if len(versions) == 0 {
 		return nil, &meta.NoKindMatchError{GroupKind: gk}
 	}
+	scope := meta.RESTScope(meta.RESTScopeNamespace)
+	if s, ok := m.perGKScope[gk]; ok {
+		scope = s
+	}
 	out := make([]*meta.RESTMapping, 0, len(versions))
 	for _, v := range versions {
 		out = append(out, &meta.RESTMapping{
 			GroupVersionKind: schema.GroupVersionKind{Group: gk.Group, Version: v, Kind: gk.Kind},
+			Scope:            scope,
 		})
 	}
 	return out, nil
@@ -1361,11 +1421,29 @@ func TestResolveServedVersion_AuthoredAndServedIntersect(t *testing.T) {
 	gk := schema.GroupKind{Group: "apps", Kind: "Deployment"}
 	mapper := &stubRESTMapper{perGK: map[schema.GroupKind][]string{gk: {"v1"}}}
 
-	got, err := resolveServedVersion(mapper, gk, []string{"v1"})
+	got, scope, err := resolveServedVersion(mapper, gk, []string{"v1"})
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "v1", got.Version)
 	assert.Equal(t, "DeploymentList", got.Kind, "listing GVK must carry the 'List' suffix")
+	assert.Equal(t, scopeNamespaced, scope, "mapper default is Namespaced")
+}
+
+// TestResolveServedVersion_ReturnsClusterScope asserts that a RESTMapper
+// reporting Root scope surfaces as scopeCluster. This is the load-bearing
+// return value for the scope-mismatch rejection in collectVerdicts:
+// mis-declared rules can't force a cross-namespace List.
+func TestResolveServedVersion_ReturnsClusterScope(t *testing.T) {
+	gk := schema.GroupKind{Kind: "PersistentVolume"}
+	mapper := &stubRESTMapper{
+		perGK:      map[schema.GroupKind][]string{gk: {"v1"}},
+		perGKScope: map[schema.GroupKind]meta.RESTScope{gk: meta.RESTScopeRoot},
+	}
+
+	got, scope, err := resolveServedVersion(mapper, gk, []string{"v1"})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, scopeCluster, scope)
 }
 
 func TestResolveServedVersion_AuthoredOrderPreservedOnServedIntersection(t *testing.T) {
@@ -1374,7 +1452,7 @@ func TestResolveServedVersion_AuthoredOrderPreservedOnServedIntersection(t *test
 	// should pick v1beta1 regardless of how the mapper orders its output.
 	mapper := &stubRESTMapper{perGK: map[schema.GroupKind][]string{gk: {"v1", "v1beta1"}}}
 
-	got, err := resolveServedVersion(mapper, gk, []string{"v1beta1", "v1"})
+	got, _, err := resolveServedVersion(mapper, gk, []string{"v1beta1", "v1"})
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "v1beta1", got.Version, "authored first-seen order beats mapper order")
@@ -1385,9 +1463,10 @@ func TestResolveServedVersion_NoIntersectionReturnsNilNil(t *testing.T) {
 	// Cluster serves v1 only; author wrote v1beta1 only.
 	mapper := &stubRESTMapper{perGK: map[schema.GroupKind][]string{gk: {"v1"}}}
 
-	got, err := resolveServedVersion(mapper, gk, []string{"v1beta1"})
+	got, scope, err := resolveServedVersion(mapper, gk, []string{"v1beta1"})
 	require.NoError(t, err, "version mismatch is a silent-skip, not an error")
 	assert.Nil(t, got, "no served version matches → nil listing GVK")
+	assert.Empty(t, scope, "no served version matches → empty scope")
 }
 
 func TestResolveServedVersion_KindNotServedReturnsNilNil(t *testing.T) {
@@ -1395,9 +1474,10 @@ func TestResolveServedVersion_KindNotServedReturnsNilNil(t *testing.T) {
 	// No entry in perGK → stub returns NoKindMatchError.
 	mapper := &stubRESTMapper{}
 
-	got, err := resolveServedVersion(mapper, gk, []string{"v1"})
+	got, scope, err := resolveServedVersion(mapper, gk, []string{"v1"})
 	require.NoError(t, err, "NoKindMatch is a silent-skip, not an error")
 	assert.Nil(t, got)
+	assert.Empty(t, scope)
 }
 
 func TestResolveServedVersion_OtherMapperErrorSurfaces(t *testing.T) {
@@ -1406,7 +1486,7 @@ func TestResolveServedVersion_OtherMapperErrorSurfaces(t *testing.T) {
 		perGKErr: map[schema.GroupKind]error{gk: errors.New("permission denied")},
 	}
 
-	got, err := resolveServedVersion(mapper, gk, []string{"v1"})
+	got, _, err := resolveServedVersion(mapper, gk, []string{"v1"})
 	require.Error(t, err, "non-NoMatch mapper errors must surface to the caller")
 	require.ErrorContains(t, err, "permission denied")
 	assert.Nil(t, got)

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strings"
 	"testing"
 	"time"
 
@@ -1517,4 +1518,80 @@ func TestFormatGroupVersionKind(t *testing.T) {
 			assert.Equal(t, tc.want, formatGroupVersionKind(tc.gk, tc.version))
 		})
 	}
+}
+
+// TestTruncateReason_TrimsAndCaps asserts the two bounded behaviors:
+// leading/trailing whitespace is stripped (multi-line CEL messages
+// render single-line), and long reasons are capped at
+// maxVerdictReasonBytes with an ellipsis suffix. Guards against
+// a runaway user CEL message pushing a ServiceHealth<Kind> condition
+// past the CRD's 32 KiB per-message limit.
+func TestTruncateReason_TrimsAndCaps(t *testing.T) {
+	t.Run("trims whitespace", func(t *testing.T) {
+		assert.Equal(t, "pod not ready", truncateReason("  pod not ready\n"))
+	})
+	t.Run("short reason passes through", func(t *testing.T) {
+		assert.Equal(t, "phase=Pending", truncateReason("phase=Pending"))
+	})
+	t.Run("long reason is capped with ellipsis", func(t *testing.T) {
+		long := strings.Repeat("x", maxVerdictReasonBytes+100)
+		got := truncateReason(long)
+		assert.Len(t, got, maxVerdictReasonBytes+len("…"))
+		assert.True(t, strings.HasSuffix(got, "…"), "must end with ellipsis")
+		assert.Equal(t, strings.Repeat("x", maxVerdictReasonBytes), got[:maxVerdictReasonBytes],
+			"leading maxVerdictReasonBytes must survive unchanged")
+	})
+}
+
+// TestApplyRuleLoadErrorCondition_BoundsMessage asserts the two caps on
+// the ServiceSetHealthRules condition message: max
+// maxRuleLoadErrorsInCondition individual errors enumerated (rest
+// summarised with "…and N more"), and the total message truncated to
+// maxRuleLoadErrorConditionMessageBytes. Both mechanisms exist so a
+// misconfigured user rule set can't produce a condition message that
+// exceeds the CRD's 32 KiB limit and blocks every status write.
+func TestApplyRuleLoadErrorCondition_BoundsMessage(t *testing.T) {
+	t.Run("count cap enumerates first N and summarises rest", func(t *testing.T) {
+		errs := make([]ruleLoadError, 0, maxRuleLoadErrorsInCondition+5)
+		for i := range maxRuleLoadErrorsInCondition + 5 {
+			errs = append(errs, ruleLoadError{
+				Source: fmt.Sprintf("ns/cm#%d", i),
+				Err:    errors.New("boom"),
+			})
+		}
+		ss := &kcmv1.ServiceSet{}
+		applyRuleLoadErrorCondition(ss, errs)
+		require.Len(t, ss.Status.Conditions, 1)
+		msg := ss.Status.Conditions[0].Message
+		assert.Contains(t, msg, "ns/cm#0")
+		assert.Contains(t, msg, fmt.Sprintf("ns/cm#%d", maxRuleLoadErrorsInCondition-1),
+			"last enumerated entry must be the Nth")
+		assert.NotContains(t, msg, fmt.Sprintf("ns/cm#%d", maxRuleLoadErrorsInCondition),
+			"beyond the cap, entries are summarised, not enumerated")
+		assert.Contains(t, msg, "…and 5 more")
+	})
+
+	t.Run("byte cap truncates when a single error is huge", func(t *testing.T) {
+		// One error whose stringified form alone exceeds the byte cap.
+		huge := strings.Repeat("x", maxRuleLoadErrorConditionMessageBytes+1024)
+		ss := &kcmv1.ServiceSet{}
+		applyRuleLoadErrorCondition(ss, []ruleLoadError{{
+			Source: "ns/cm#huge",
+			Err:    errors.New(huge),
+		}})
+		require.Len(t, ss.Status.Conditions, 1)
+		msg := ss.Status.Conditions[0].Message
+		// Cap+1 because the truncator appends "…" past the cap.
+		assert.LessOrEqual(t, len(msg), maxRuleLoadErrorConditionMessageBytes+len("…"),
+			"message must not exceed byte cap + ellipsis")
+		assert.True(t, strings.HasSuffix(msg, "…"), "truncated message must end with ellipsis")
+	})
+
+	t.Run("no errors yields success condition", func(t *testing.T) {
+		ss := &kcmv1.ServiceSet{}
+		applyRuleLoadErrorCondition(ss, nil)
+		require.Len(t, ss.Status.Conditions, 1)
+		assert.Equal(t, metav1.ConditionTrue, ss.Status.Conditions[0].Status)
+		assert.Equal(t, "AllRulesValid", ss.Status.Conditions[0].Reason)
+	})
 }

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
@@ -702,9 +703,9 @@ func TestVerifyHelmServiceOnCluster_AggregatesByKindAcrossKinds(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, kcmv1.ServiceStateProvisioning, state)
 	require.Len(t, conds, 2, "one condition per Kind")
-	types := []string{conds[0].Type, conds[1].Type}
-	assert.Contains(t, types, "ServiceHealthDeployment")
-	assert.Contains(t, types, "ServiceHealthPod")
+	condTypes := []string{conds[0].Type, conds[1].Type}
+	assert.Contains(t, condTypes, "ServiceHealthDeployment")
+	assert.Contains(t, condTypes, "ServiceHealthPod")
 }
 
 // TestVerifyHelmServiceOnCluster_TruncatesLargeRefLists asserts that a
@@ -828,6 +829,131 @@ func TestRulesFromConfigMap_RefreshesLastAccessOnHit(t *testing.T) {
 	assert.True(t, ruleCache.entries[key].lastAccess.After(stalePast),
 		"cache hit must refresh lastAccess (kept: %v, prior: %v)",
 		ruleCache.entries[key].lastAccess, stalePast)
+}
+
+// --- clusterConfigCache eviction & hit path ---
+
+// listCountingClient wraps a real fake client and counts List calls so
+// findOwnedClusterConfiguration cache-hit behavior can be asserted.
+type listCountingClient struct {
+	client.Client
+	listCount int
+}
+
+func (c *listCountingClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	c.listCount++
+	return c.Client.List(ctx, list, opts...)
+}
+
+// TestFindOwnedClusterConfiguration_CachesResult asserts that a second
+// lookup for the same (namespace, profileUID) hits the process-global
+// cache rather than issuing another LIST against the regional API.
+// This is the reviewer-motivated perf fix: the regional client isn't
+// cache-backed, so uncached lookups amount to a real API call per
+// verifier round.
+func TestFindOwnedClusterConfiguration_CachesResult(t *testing.T) {
+	// Snapshot + isolate the process-global CC cache.
+	clusterConfigCache.Lock()
+	original := maps.Clone(clusterConfigCache.entries)
+	clusterConfigCache.entries = make(map[ccCacheKey]ccCacheEntry)
+	clusterConfigCache.Unlock()
+	t.Cleanup(func() {
+		clusterConfigCache.Lock()
+		clusterConfigCache.entries = original
+		clusterConfigCache.Unlock()
+	})
+
+	const namespace = "cc-cache-test"
+	profileUID := types.UID("profile-uid-123")
+
+	cc := &addoncontrollerv1beta1.ClusterConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "cc-1",
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{{UID: profileUID}},
+		},
+	}
+	scheme := runtime.NewScheme()
+	require.NoError(t, addoncontrollerv1beta1.AddToScheme(scheme))
+	inner := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cc).Build()
+	spy := &listCountingClient{Client: inner}
+
+	first, err := findOwnedClusterConfiguration(context.Background(), spy, namespace, profileUID)
+	require.NoError(t, err)
+	require.NotNil(t, first, "first lookup must find the CC")
+	require.Equal(t, 1, spy.listCount, "first lookup must LIST")
+
+	second, err := findOwnedClusterConfiguration(context.Background(), spy, namespace, profileUID)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	assert.Equal(t, 1, spy.listCount, "second lookup must be served from cache (no additional LIST)")
+	assert.Same(t, first, second, "cache should return the same pointer on hit")
+}
+
+// TestFindOwnedClusterConfiguration_CachesNegativeResult asserts that
+// even a "not found yet" lookup is cached — this is the common case
+// between Profile creation and sveltos observing the cluster, and
+// re-listing the whole namespace in that window is exactly the load
+// the cache is meant to shed.
+func TestFindOwnedClusterConfiguration_CachesNegativeResult(t *testing.T) {
+	clusterConfigCache.Lock()
+	original := maps.Clone(clusterConfigCache.entries)
+	clusterConfigCache.entries = make(map[ccCacheKey]ccCacheEntry)
+	clusterConfigCache.Unlock()
+	t.Cleanup(func() {
+		clusterConfigCache.Lock()
+		clusterConfigCache.entries = original
+		clusterConfigCache.Unlock()
+	})
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, addoncontrollerv1beta1.AddToScheme(scheme))
+	inner := fake.NewClientBuilder().WithScheme(scheme).Build() // no CC exists
+	spy := &listCountingClient{Client: inner}
+
+	first, err := findOwnedClusterConfiguration(context.Background(), spy, "empty-ns", types.UID("nope"))
+	require.NoError(t, err)
+	require.Nil(t, first)
+	require.Equal(t, 1, spy.listCount)
+
+	second, err := findOwnedClusterConfiguration(context.Background(), spy, "empty-ns", types.UID("nope"))
+	require.NoError(t, err)
+	assert.Nil(t, second)
+	assert.Equal(t, 1, spy.listCount, "negative result must also be cached")
+}
+
+// TestSweepClusterConfigCache_EvictsStaleEntries asserts that
+// sweepClusterConfigCache drops entries whose lastAccess is older than
+// clusterConfigCacheTTL while preserving fresh ones. Mirrors
+// TestSweepRuleCache_EvictsStaleEntries.
+func TestSweepClusterConfigCache_EvictsStaleEntries(t *testing.T) {
+	clusterConfigCache.Lock()
+	original := maps.Clone(clusterConfigCache.entries)
+	clusterConfigCache.entries = make(map[ccCacheKey]ccCacheEntry)
+	clusterConfigCache.Unlock()
+	t.Cleanup(func() {
+		clusterConfigCache.Lock()
+		clusterConfigCache.entries = original
+		clusterConfigCache.Unlock()
+	})
+
+	freshKey := ccCacheKey{namespace: "ns-a", profileUID: "fresh"}
+	staleKey := ccCacheKey{namespace: "ns-b", profileUID: "stale"}
+	now := time.Now()
+
+	clusterConfigCache.Lock()
+	clusterConfigCache.entries[freshKey] = ccCacheEntry{lastAccess: now.Add(-clusterConfigCacheTTL / 2)}
+	clusterConfigCache.entries[staleKey] = ccCacheEntry{lastAccess: now.Add(-2 * clusterConfigCacheTTL)}
+	clusterConfigCache.Unlock()
+
+	sweepClusterConfigCache()
+
+	clusterConfigCache.Lock()
+	defer clusterConfigCache.Unlock()
+	_, freshOK := clusterConfigCache.entries[freshKey]
+	_, staleOK := clusterConfigCache.entries[staleKey]
+	assert.True(t, freshOK, "fresh entry must survive sweep")
+	assert.False(t, staleOK, "stale entry must be evicted")
 }
 
 // --- rulesFromConfigMaps ---

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -198,7 +198,7 @@ func evalRule(t *testing.T, group, kind string, payload map[string]any) (bool, s
 	rule := rules[0]
 	u := &unstructured.Unstructured{Object: payload}
 	u.SetGroupVersionKind(rule.GVK)
-	healthy, reason, err := rule.evaluate(u)
+	healthy, reason, err := rule.evaluate(objActivation{obj: u.Object})
 	require.NoError(t, err)
 	return healthy, reason
 }
@@ -400,25 +400,6 @@ func TestRule_Pod(t *testing.T) {
 	}
 }
 
-func TestRule_Pod_TerminatingIgnored(t *testing.T) {
-	rules := testRules[schema.GroupKind{Group: "", Kind: "Pod"}]
-	require.Len(t, rules, 1)
-	rule := rules[0]
-	u := &unstructured.Unstructured{Object: map[string]any{
-		"status": map[string]any{
-			"conditions": []any{
-				map[string]any{"type": "Ready", "status": "False"},
-			},
-		},
-	}}
-	u.SetGroupVersionKind(rule.GVK)
-	u.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
-
-	healthy, _, err := rule.evaluate(u)
-	require.NoError(t, err)
-	assert.True(t, healthy, "terminating pod must be treated as healthy")
-}
-
 func TestRule_PVC(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -595,6 +576,30 @@ func TestVerifyHelmServiceOnCluster_TerminatingPodNotCounted(t *testing.T) {
 	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
 	require.NoError(t, err)
 	assert.Equal(t, kcmv1.ServiceStateDeployed, state, "terminating pod must not pull state to Provisioning")
+	assert.Empty(t, conds)
+}
+
+// TestVerifyHelmServiceOnCluster_TerminatingDeploymentNotCounted asserts
+// the generalized "any Kind with deletionTimestamp is ignored" semantic
+// — the previous narrow "only Pod" scope was under-generalized. A
+// terminating Deployment whose replicas would otherwise fail the CEL
+// rule (updatedReplicas < replicas) must be treated as healthy because
+// the user asked for it to go away; the CEL rule failing is expected
+// behavior during graceful shutdown.
+func TestVerifyHelmServiceOnCluster_TerminatingDeploymentNotCounted(t *testing.T) {
+	// makeUnhealthyDeployment produces a Deployment with ReadyReplicas=1
+	// against Replicas=3 — the CEL rule would classify this as unhealthy
+	// under normal circumstances. Adding a deletionTimestamp reclassifies
+	// it as user-initiated shutdown and must be ignored.
+	terminating := makeUnhealthyDeployment()
+	terminating.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	terminating.Finalizers = []string{"foreground-cascading-deletion"}
+
+	c := newFakeClient(t, terminating)
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	require.NoError(t, err)
+	assert.Equal(t, kcmv1.ServiceStateDeployed, state,
+		"terminating Deployment must not pull state to Provisioning even with failing replica counts")
 	assert.Empty(t, conds)
 }
 

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -994,9 +994,10 @@ func TestFindOwnedClusterConfiguration_CachesNegativeResult(t *testing.T) {
 }
 
 // TestSweepClusterConfigCache_EvictsStaleEntries asserts that
-// sweepClusterConfigCache drops entries whose lastAccess is older than
-// clusterConfigCacheTTL while preserving fresh ones. Mirrors
-// TestSweepRuleCache_EvictsStaleEntries.
+// sweepClusterConfigCache drops entries whose writtenAt is older than
+// clusterConfigCacheTTL while preserving fresh ones. Write-based TTL —
+// unlike the ruleCache, this cache does NOT refresh on read (see
+// ccCacheEntry doc-comment).
 func TestSweepClusterConfigCache_EvictsStaleEntries(t *testing.T) {
 	clusterConfigCache.Lock()
 	original := maps.Clone(clusterConfigCache.entries)
@@ -1013,8 +1014,8 @@ func TestSweepClusterConfigCache_EvictsStaleEntries(t *testing.T) {
 	now := time.Now()
 
 	clusterConfigCache.Lock()
-	clusterConfigCache.entries[freshKey] = ccCacheEntry{lastAccess: now.Add(-clusterConfigCacheTTL / 2)}
-	clusterConfigCache.entries[staleKey] = ccCacheEntry{lastAccess: now.Add(-2 * clusterConfigCacheTTL)}
+	clusterConfigCache.entries[freshKey] = ccCacheEntry{writtenAt: now.Add(-clusterConfigCacheTTL / 2)}
+	clusterConfigCache.entries[staleKey] = ccCacheEntry{writtenAt: now.Add(-2 * clusterConfigCacheTTL)}
 	clusterConfigCache.Unlock()
 
 	sweepClusterConfigCache()

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -538,13 +538,18 @@ func makeUnreadyPod(name string) *corev1.Pod {
 	}
 }
 
-func TestVerifyHelmServiceOnCluster_NoResources(t *testing.T) {
+// TestVerifyHelmServiceOnCluster_NoResources_KeepsDeployed asserts that
+// an empty verdict set (no labeled resources on the target cluster)
+// returns Deployed rather than Failed. Rationale in the function's
+// doc-comment: without sveltos release-inventory, we can't distinguish
+// a chart deploying only unmonitored Kinds from a chart whose monitored
+// Kinds are missing, so we defer to sveltos's Deployed verdict.
+func TestVerifyHelmServiceOnCluster_NoResources_KeepsDeployed(t *testing.T) {
 	c := newFakeClient(t)
 	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
 	require.NoError(t, err)
-	assert.Equal(t, kcmv1.ServiceStateFailed, state)
-	require.Len(t, conds, 1)
-	assert.Equal(t, "NoResourcesOnCluster", conds[0].Reason)
+	assert.Equal(t, kcmv1.ServiceStateDeployed, state)
+	assert.Empty(t, conds)
 }
 
 func TestVerifyHelmServiceOnCluster_AllHealthy(t *testing.T) {
@@ -592,14 +597,22 @@ func TestVerifyHelmServiceOnCluster_TerminatingPodNotCounted(t *testing.T) {
 	assert.Empty(t, conds)
 }
 
+// TestVerifyHelmServiceOnCluster_OtherReleaseIgnored asserts that
+// resources labeled for a DIFFERENT release do not contribute to our
+// verdicts. Under the empty-verdicts-echoes-Deployed semantic (see
+// verifyHelmServiceOnCluster doc-comment), no matching resources for
+// OUR service means we defer to sveltos's Deployed. This is more
+// correct than the previous Failed downgrade — a chart labeled for a
+// different release genuinely isn't relevant to this service.
 func TestVerifyHelmServiceOnCluster_OtherReleaseIgnored(t *testing.T) {
 	other := makeHealthyDeployment("other")
 	other.Labels["release"] = "different"
 
 	c := newFakeClient(t, other)
-	state, _, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
+	state, conds, err := verifyHelmServiceOnCluster(context.Background(), c, testRules, releaseName, releaseNs)
 	require.NoError(t, err)
-	assert.Equal(t, kcmv1.ServiceStateFailed, state)
+	assert.Equal(t, kcmv1.ServiceStateDeployed, state)
+	assert.Empty(t, conds)
 }
 
 func TestVerifyHelmServiceOnCluster_DiscoversByAppKubernetesIoInstance(t *testing.T) {

--- a/internal/util/kube/enqueue_test.go
+++ b/internal/util/kube/enqueue_test.go
@@ -113,11 +113,8 @@ func Test_callWithRetry(t *testing.T) {
 			wantErrIs: transient,
 		},
 		{
-			name: "pre-cancelled context stops after first attempt",
-			// large base so ctx.Done wins the select deterministically; a
-			// short delay would race with time.After since both channels are
-			// ready and select picks at random
-			backoff: wait.Backoff{Duration: time.Hour, Factor: 1, Steps: 5, Cap: time.Hour},
+			name:    "pre-cancelled context stops after first attempt",
+			backoff: fastBackoff(t, 5),
 			ctx: func(t *testing.T) context.Context {
 				t.Helper()
 				ctx, cancel := context.WithCancel(t.Context())
@@ -134,32 +131,34 @@ func Test_callWithRetry(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := t.Context()
-			if tc.ctx != nil {
-				ctx = tc.ctx(t)
-			}
-
-			calls := 0
-			reqs, err := callWithRetry(ctx, tc.backoff, func() ([]ctrl.Request, error) {
-				calls++
-				return tc.fn(calls)
-			})
-
-			if calls != tc.wantCalls {
-				t.Fatalf("calls = %d, want %d", calls, tc.wantCalls)
-			}
-
-			if tc.wantErrIs == nil {
-				if err != nil {
-					t.Fatalf("unexpected err: %v", err)
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
+				if tc.ctx != nil {
+					ctx = tc.ctx(t)
 				}
-			} else if !errors.Is(err, tc.wantErrIs) {
-				t.Fatalf("err = %v, want errors.Is(%v)", err, tc.wantErrIs)
-			}
 
-			if len(reqs) != tc.wantReqsLen {
-				t.Fatalf("len(reqs) = %d, want %d", len(reqs), tc.wantReqsLen)
-			}
+				calls := 0
+				reqs, err := callWithRetry(ctx, tc.backoff, func() ([]ctrl.Request, error) {
+					calls++
+					return tc.fn(calls)
+				})
+
+				if calls != tc.wantCalls {
+					t.Fatalf("calls = %d, want %d", calls, tc.wantCalls)
+				}
+
+				if tc.wantErrIs == nil {
+					if err != nil {
+						t.Fatalf("unexpected err: %v", err)
+					}
+				} else if !errors.Is(err, tc.wantErrIs) {
+					t.Fatalf("err = %v, want errors.Is(%v)", err, tc.wantErrIs)
+				}
+
+				if len(reqs) != tc.wantReqsLen {
+					t.Fatalf("len(reqs) = %d, want %d", len(reqs), tc.wantReqsLen)
+				}
+			})
 		})
 	}
 

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
@@ -1023,9 +1023,9 @@ spec:
                         type: string
                       lastDeployedHash:
                         description: |-
-                          LastDeployedHash is the verifier's fingerprint of the sveltos-side
+                          LastDeployedHash is the verifier's fingerprint of the provider-side
                           configuration this service was most recently confirmed Deployed at.
-                          Used to recognise that a Provisioning state reported by sveltos is
+                          Used to recognise that a progressing state reported by the provider is
                           transient noise from an unrelated apply (rather than a real change to
                           this service) and to promote back to Deployed safely.
                         type: string

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_clusterdeployments.yaml
@@ -1021,6 +1021,14 @@ spec:
                       failureMessage:
                         description: FailureMessage is the reason why the Service failed to deploy
                         type: string
+                      lastDeployedHash:
+                        description: |-
+                          LastDeployedHash is the verifier's fingerprint of the sveltos-side
+                          configuration this service was most recently confirmed Deployed at.
+                          Used to recognise that a Provisioning state reported by sveltos is
+                          transient noise from an unrelated apply (rather than a real change to
+                          this service) and to promote back to Deployed safely.
+                        type: string
                       lastStateTransitionTime:
                         description: LastStateTransitionTime is the time the State was last transitioned
                         format: date-time

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -982,6 +982,14 @@ spec:
                       failureMessage:
                         description: FailureMessage is the reason why the Service failed to deploy
                         type: string
+                      lastDeployedHash:
+                        description: |-
+                          LastDeployedHash is the verifier's fingerprint of the sveltos-side
+                          configuration this service was most recently confirmed Deployed at.
+                          Used to recognise that a Provisioning state reported by sveltos is
+                          transient noise from an unrelated apply (rather than a real change to
+                          this service) and to promote back to Deployed safely.
+                        type: string
                       lastStateTransitionTime:
                         description: LastStateTransitionTime is the time the State was last transitioned
                         format: date-time

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -984,9 +984,9 @@ spec:
                         type: string
                       lastDeployedHash:
                         description: |-
-                          LastDeployedHash is the verifier's fingerprint of the sveltos-side
+                          LastDeployedHash is the verifier's fingerprint of the provider-side
                           configuration this service was most recently confirmed Deployed at.
-                          Used to recognise that a Provisioning state reported by sveltos is
+                          Used to recognise that a progressing state reported by the provider is
                           transient noise from an unrelated apply (rather than a real change to
                           this service) and to promote back to Deployed safely.
                         type: string

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
@@ -511,6 +511,14 @@ spec:
                       failureMessage:
                         description: FailureMessage is the reason why the Service failed to deploy
                         type: string
+                      lastDeployedHash:
+                        description: |-
+                          LastDeployedHash is the verifier's fingerprint of the sveltos-side
+                          configuration this service was most recently confirmed Deployed at.
+                          Used to recognise that a Provisioning state reported by sveltos is
+                          transient noise from an unrelated apply (rather than a real change to
+                          this service) and to promote back to Deployed safely.
+                        type: string
                       lastStateTransitionTime:
                         description: LastStateTransitionTime is the time the State was last transitioned
                         format: date-time

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_servicesets.yaml
@@ -513,9 +513,9 @@ spec:
                         type: string
                       lastDeployedHash:
                         description: |-
-                          LastDeployedHash is the verifier's fingerprint of the sveltos-side
+                          LastDeployedHash is the verifier's fingerprint of the provider-side
                           configuration this service was most recently confirmed Deployed at.
-                          Used to recognise that a Provisioning state reported by sveltos is
+                          Used to recognise that a progressing state reported by the provider is
                           transient noise from an unrelated apply (rather than a real change to
                           this service) and to promote back to Deployed safely.
                         type: string

--- a/templates/provider/kcm/templates/health-rules/default-rules.yaml
+++ b/templates/provider/kcm/templates/health-rules/default-rules.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kcm.fullname" . }}-default-health-rules
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k0rdent.mirantis.com/health-rule-target: global
+  {{- include "kcm.labels" . | nindent 4 }}
+# Default workload-health CEL rules loaded by the sveltos adapter's
+# service-state verifier. These define the cluster-global tier — applied to
+# every ServiceSet on the management cluster. Tenants layer additional,
+# stricter rules in their own namespaces (same label, namespace-global tier)
+# or scoped to a single ServiceSet (label value = ServiceSet name).
+data:
+  rules: |
+    - group: apps
+      version: v1
+      kind: Deployment
+      scope: Namespaced
+      healthy: |
+        has(obj.status.observedGeneration) &&
+        int(obj.status.observedGeneration) >= int(obj.metadata.generation) &&
+        int(has(obj.spec.replicas) ? obj.spec.replicas : 1) ==
+          int(has(obj.status.readyReplicas) ? obj.status.readyReplicas : 0) &&
+        int(has(obj.spec.replicas) ? obj.spec.replicas : 1) ==
+          int(has(obj.status.updatedReplicas) ? obj.status.updatedReplicas : 0)
+      message: |
+        !has(obj.status.observedGeneration) ||
+        int(obj.status.observedGeneration) < int(obj.metadata.generation)
+          ? "deployment controller has not observed latest spec"
+          : string(int(has(obj.status.readyReplicas) ? obj.status.readyReplicas : 0)) + "/" +
+            string(int(has(obj.spec.replicas) ? obj.spec.replicas : 1)) + " replicas ready, " +
+            string(int(has(obj.status.updatedReplicas) ? obj.status.updatedReplicas : 0)) + " updated"
+    - group: apps
+      version: v1
+      kind: StatefulSet
+      scope: Namespaced
+      healthy: |
+        has(obj.status.observedGeneration) &&
+        int(obj.status.observedGeneration) >= int(obj.metadata.generation) &&
+        int(has(obj.spec.replicas) ? obj.spec.replicas : 1) ==
+          int(has(obj.status.readyReplicas) ? obj.status.readyReplicas : 0) &&
+        int(has(obj.spec.replicas) ? obj.spec.replicas : 1) ==
+          int(has(obj.status.updatedReplicas) ? obj.status.updatedReplicas : 0) &&
+        has(obj.status.currentRevision) && has(obj.status.updateRevision) &&
+        obj.status.currentRevision == obj.status.updateRevision
+      message: |
+        has(obj.status.currentRevision) && has(obj.status.updateRevision) &&
+        obj.status.currentRevision != obj.status.updateRevision
+          ? "rolling update in progress (currentRevision != updateRevision)"
+          : string(int(has(obj.status.readyReplicas) ? obj.status.readyReplicas : 0)) + "/" +
+            string(int(has(obj.spec.replicas) ? obj.spec.replicas : 1)) + " replicas ready"
+    - group: apps
+      version: v1
+      kind: DaemonSet
+      scope: Namespaced
+      healthy: |
+        has(obj.status.observedGeneration) &&
+        int(obj.status.observedGeneration) >= int(obj.metadata.generation) &&
+        has(obj.status.desiredNumberScheduled) &&
+        has(obj.status.numberReady) &&
+        has(obj.status.updatedNumberScheduled) &&
+        int(obj.status.desiredNumberScheduled) == int(obj.status.numberReady) &&
+        int(obj.status.desiredNumberScheduled) == int(obj.status.updatedNumberScheduled)
+      message: |
+        string(int(has(obj.status.numberReady) ? obj.status.numberReady : 0)) + "/" +
+        string(int(has(obj.status.desiredNumberScheduled) ? obj.status.desiredNumberScheduled : 0)) +
+        " nodes ready"
+    - group: ""
+      version: v1
+      kind: Pod
+      scope: Namespaced
+      healthy: |
+        has(obj.status.conditions) &&
+        obj.status.conditions.exists(c, c.type == "Ready" && c.status == "True")
+      message: |
+        has(obj.status.containerStatuses)
+          ? obj.status.containerStatuses
+              .filter(c, !c.ready)
+              .map(c, c.name + ": " +
+                (has(c.state.waiting) && has(c.state.waiting.reason) ? c.state.waiting.reason :
+                 (has(c.state.terminated) && has(c.state.terminated.reason) ? c.state.terminated.reason :
+                  "not ready")))
+              .join(", ")
+          : "pod not ready"
+    - group: ""
+      version: v1
+      kind: PersistentVolumeClaim
+      scope: Namespaced
+      healthy: |
+        has(obj.status.phase) && obj.status.phase == "Bound"
+      message: |
+        has(obj.status.phase) ? "phase=" + obj.status.phase : "no phase reported"
+    - group: ""
+      version: v1
+      kind: PersistentVolume
+      scope: Cluster
+      healthy: |
+        has(obj.status.phase) && obj.status.phase == "Bound"
+      message: |
+        has(obj.status.phase) ? "phase=" + obj.status.phase : "no phase reported"

--- a/templates/provider/kcm/templates/health-rules/default-rules.yaml
+++ b/templates/provider/kcm/templates/health-rules/default-rules.yaml
@@ -9,8 +9,19 @@ metadata:
 # Default workload-health CEL rules loaded by the sveltos adapter's
 # service-state verifier. These define the cluster-global tier — applied to
 # every ServiceSet on the management cluster. Tenants layer additional,
-# stricter rules in their own namespaces (same label, namespace-global tier)
-# or scoped to a single ServiceSet (label value = ServiceSet name).
+# stricter rules in their own namespaces (same label, namespace-global
+# tier) or scoped to specific workloads by setting the label value to the
+# name of the owning MultiClusterService or ClusterDeployment — that name
+# is stable at rule-authoring time.
+#
+# RBAC note: kcm's shipped ClusterRole grants read on the six Kinds these
+# defaults cover (Deployment, StatefulSet, DaemonSet, Pod,
+# PersistentVolumeClaim, PersistentVolume). Rules targeting additional
+# Kinds — Jobs, CRDs, custom resources, etc. — require the operator to
+# grant read on those Kinds to the kcm controller ServiceAccount.
+# Otherwise the verifier hits Forbidden on List and logs the error
+# without progressing. Applies to the self-management scheme; CAPI child
+# clusters use admin-equivalent kubeconfigs and are unaffected.
 data:
   rules: |
     - group: apps

--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -277,6 +277,7 @@ rules:
   - profiles
   - clusterprofiles
   - clustersummaries
+  - clusterconfigurations
   verbs: {{ include "rbac.editorVerbs" . | nindent 4 }}
 - apiGroups:
   - k0rdent.mirantis.com

--- a/templates/provider/kcm/templates/rbac/controller/serviceset-verifier-role.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/serviceset-verifier-role.yaml
@@ -20,6 +20,7 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - deployments
   - statefulsets
   - daemonsets
   verbs:

--- a/templates/provider/kcm/templates/rbac/controller/serviceset-verifier-role.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/serviceset-verifier-role.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kcm.fullname" . }}-serviceset-verifier-role
+  labels:
+    k0rdent.mirantis.com/aggregate-to-manager: "true"
+  {{- include "kcm.labels" . | nindent 4 }}
+# Read-only access used by the sveltos adapter's on-cluster service state
+# verifier (internal/controller/adapters/sveltos/verify.go) to list resources
+# sveltos deployed via helm and evaluate their health against embedded rules.
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - persistentvolumes
+  - persistentvolumeclaims
+  verbs:
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  verbs:
+  - list


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the deployed services' state tracking. Instead if relying on the release/service name and namespace and/or version along with the state reported by the sveltos controllers, the serviceSet controller will compute the hash of the applied workload which is a sum of

- release hash (obtained from the ClusterConfiguration project, computed from release name, namespace, app version, chart version and the source)
- values hash (reported by sveltos)
- patches hash (reported by sveltos)

This allows accurate tracking of what is currently deployed and whether there are any changes that must be applied or rolled back.

Aside from that this PR introduces health checks for deployed workloads: when the sveltos reports that the services are deployed, serviceSet controller verifies that the deployed resources (deployments, statefulsets, daemonsets, pods, PVs and PVCs) are in proper state. If checks pass, then the serviceSet state will be changed to `Deployed` otherwise it won't change.

**Which issue(s) this PR fixes**:
#2612 
#2844 
