### PR TITLE
fix(templates): trust registry CA regardless of OS

### DIFF
--- a/config/dev/aws-clusterdeployment.yaml
+++ b/config/dev/aws-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: aws-standalone-cp-1-0-38
+  template: aws-standalone-cp-1-0-39
   credential: aws-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/azure-clusterdeployment.yaml
+++ b/config/dev/azure-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: azure-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: azure-standalone-cp-1-0-40
+  template: azure-standalone-cp-1-0-41
   credential: azure-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-36
+  template: gcp-standalone-cp-1-0-37
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-16
+  template: kubevirt-standalone-cp-1-0-17
   credential: kubevirt-cred
   propagateCredentials: false
   config:

--- a/config/dev/openstack-clusterdeployment.yaml
+++ b/config/dev/openstack-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openstack-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: openstack-standalone-cp-1-0-41
+  template: openstack-standalone-cp-1-0-42
   credential: openstack-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-32
+  template: remote-cluster-1-0-33
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/config/dev/vsphere-clusterdeployment.yaml
+++ b/config/dev/vsphere-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vsphere-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: vsphere-standalone-cp-1-0-37
+  template: vsphere-standalone-cp-1-0-38
   credential: vsphere-cluster-identity-cred
   config:
     clusterLabels: {}

--- a/templates/cluster/aws-hosted-cp/Chart.yaml
+++ b/templates/cluster/aws-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.40
+version: 1.0.41
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -10,16 +10,20 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+           and the k0s worker binary (both Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
       files:
-        {{- range $path, $secret := $certs }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- if $global.registryCredentialSecret }}
@@ -31,9 +35,12 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if $global.k0sURLCertSecret }}
+      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+           the k0s binary download in k0smotron v2 */}}
       preK0sCommands:
-      - "sudo update-ca-certificates"
+      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -36,11 +36,9 @@ spec:
         {{- end }}
       {{- end }}
       {{- if $global.k0sURLCertSecret }}
-      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-           the k0s binary download in k0smotron v2 */}}
+      {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
       preK0sCommands:
-      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+      - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/aws-standalone-cp/Chart.yaml
+++ b/templates/cluster/aws-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.38
+version: 1.0.39
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -59,15 +59,19 @@ spec:
     - {{ toYaml $file | trim | nindent 6 }}
     {{- end }}
     {{- end }}
-    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
-    {{- range $path, $secret := $certs }}
+    {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+         Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd,
+         k0s controller and HelmController (all Go). curl for the k0s binary is handled
+         separately via preK0sCommands below */}}
+    {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
+    {{- range $name, $secret := $certs }}
     {{- if $secret }}
     - contentFrom:
         secretRef:
           name: {{ $secret }}
           key: ca.crt
-      permissions: "0664"
-      path: /usr/local/share/ca-certificates/{{ $path }}
+      permissions: "0644"
+      path: /etc/ssl/certs/{{ $name }}
     {{- end }}
     {{- end }}
     {{- if $global.registryCredentialSecret }}
@@ -183,9 +187,12 @@ spec:
               enabled: true
             node:
               kubeletPath: /var/lib/k0s/kubelet
-    {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    {{- if $global.k0sURLCertSecret }}
+    {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+         Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+         the k0s binary download in k0smotron v2 */}}
     preK0sCommands:
-    - "sudo update-ca-certificates"
+    - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0scontrolplane.yaml
@@ -188,11 +188,9 @@ spec:
             node:
               kubeletPath: /var/lib/k0s/kubelet
     {{- if $global.k0sURLCertSecret }}
-    {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-         Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-         the k0s binary download in k0smotron v2 */}}
+    {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
     preK0sCommands:
-    - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+    - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -37,11 +37,9 @@ spec:
         {{- end }}
       {{- end }}
       {{- if $global.k0sURLCertSecret }}
-      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-           the k0s binary download in k0smotron v2 */}}
+      {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
       preK0sCommands:
-      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+      - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/aws-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -11,16 +11,20 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+           and the k0s worker binary (both Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
       files:
-        {{- range $path, $secret := $certs }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- if $global.registryCredentialSecret }}
@@ -32,9 +36,12 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if $global.k0sURLCertSecret }}
+      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+           the k0s binary download in k0smotron v2 */}}
       preK0sCommands:
-      - "sudo update-ca-certificates"
+      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/azure-hosted-cp/Chart.yaml
+++ b/templates/cluster/azure-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.43
+version: 1.0.44
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -10,16 +10,20 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+           and the k0s worker binary (both Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
       files:
-        {{- range $path, $secret := $certs }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- if $global.registryCredentialSecret }}
@@ -31,9 +35,12 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if $global.k0sURLCertSecret }}
+      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+           the k0s binary download in k0smotron v2 */}}
       preK0sCommands:
-      - "sudo update-ca-certificates"
+      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -36,11 +36,9 @@ spec:
         {{- end }}
       {{- end }}
       {{- if $global.k0sURLCertSecret }}
-      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-           the k0s binary download in k0smotron v2 */}}
+      {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
       preK0sCommands:
-      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+      - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/azure-standalone-cp/Chart.yaml
+++ b/templates/cluster/azure-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.40
+version: 1.0.41
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -168,11 +168,9 @@ spec:
               windows:
                 enabled: false
     {{- if $global.k0sURLCertSecret }}
-    {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-         Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-         the k0s binary download in k0smotron v2 */}}
+    {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
     preK0sCommands:
-    - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+    - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0scontrolplane.yaml
@@ -11,15 +11,19 @@ spec:
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
     {{- end }}
     files:
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
-      {{- range $path, $secret := $certs }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd,
+           k0s controller and HelmController (all Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
+      {{- range $name, $secret := $certs }}
       {{- if $secret }}
       - contentFrom:
           secretRef:
             name: {{ $secret }}
             key: ca.crt
-        permissions: "0664"
-        path: /usr/local/share/ca-certificates/{{ $path }}
+        permissions: "0644"
+        path: /etc/ssl/certs/{{ $name }}
       {{- end }}
       {{- end }}
       {{- if .Values.auth.configSecret.name }}
@@ -163,9 +167,12 @@ spec:
                 kubelet: "/var/lib/k0s/kubelet"
               windows:
                 enabled: false
-    {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    {{- if $global.k0sURLCertSecret }}
+    {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+         Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+         the k0s binary download in k0smotron v2 */}}
     preK0sCommands:
-    - "sudo update-ca-certificates"
+    - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -37,11 +37,9 @@ spec:
         {{- end }}
       {{- end }}
       {{- if $global.k0sURLCertSecret }}
-      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-           the k0s binary download in k0smotron v2 */}}
+      {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
       preK0sCommands:
-      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+      - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/azure-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -11,16 +11,20 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+           and the k0s worker binary (both Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
       files:
-        {{- range $path, $secret := $certs }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- if $global.registryCredentialSecret }}
@@ -32,9 +36,12 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if $global.k0sURLCertSecret }}
+      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+           the k0s binary download in k0smotron v2 */}}
       preK0sCommands:
-      - "sudo update-ca-certificates"
+      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.38
+version: 1.0.39
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -10,16 +10,20 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+           and the k0s worker binary (both Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
       files:
-        {{- range $path, $secret := $certs }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- if $global.registryCredentialSecret }}
@@ -31,9 +35,12 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if $global.k0sURLCertSecret }}
+      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+           the k0s binary download in k0smotron v2 */}}
       preK0sCommands:
-      - "sudo update-ca-certificates"
+      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -36,11 +36,9 @@ spec:
         {{- end }}
       {{- end }}
       {{- if $global.k0sURLCertSecret }}
-      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-           the k0s binary download in k0smotron v2 */}}
+      {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
       preK0sCommands:
-      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+      - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.36
+version: 1.0.37
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -182,11 +182,9 @@ spec:
                     repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
               {{- end }}
     {{- if $global.k0sURLCertSecret }}
-    {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-         Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-         the k0s binary download in k0smotron v2 */}}
+    {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
     preK0sCommands:
-    - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+    - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0scontrolplane.yaml
@@ -11,15 +11,19 @@ spec:
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
     {{- end }}
     files:
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
-      {{- range $path, $secret := $certs }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd,
+           k0s controller and HelmController (all Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
+      {{- range $name, $secret := $certs }}
       {{- if $secret }}
       - contentFrom:
           secretRef:
             name: {{ $secret }}
             key: ca.crt
-        permissions: "0664"
-        path: /usr/local/share/ca-certificates/{{ $path }}
+        permissions: "0644"
+        path: /etc/ssl/certs/{{ $name }}
       {{- end }}
       {{- end }}
       {{- if .Values.auth.configSecret.name }}
@@ -177,9 +181,12 @@ spec:
                   image:
                     repository: {{ $global.registry }}/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
               {{- end }}
-    {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    {{- if $global.k0sURLCertSecret }}
+    {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+         Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+         the k0s binary download in k0smotron v2 */}}
     preK0sCommands:
-    - "sudo update-ca-certificates"
+    - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -37,11 +37,9 @@ spec:
         {{- end }}
       {{- end }}
       {{- if $global.k0sURLCertSecret }}
-      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-           the k0s binary download in k0smotron v2 */}}
+      {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
       preK0sCommands:
-      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+      - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -11,16 +11,20 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+           and the k0s worker binary (both Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
       files:
-        {{- range $path, $secret := $certs }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- if $global.registryCredentialSecret }}
@@ -32,9 +36,12 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if $global.k0sURLCertSecret }}
+      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+           the k0s binary download in k0smotron v2 */}}
       preK0sCommands:
-      - "sudo update-ca-certificates"
+      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.14
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -10,16 +10,20 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+           and the k0s worker binary (both Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
       files:
-        {{- range $path, $secret := $certs }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- if $global.registryCredentialSecret }}
@@ -31,9 +35,12 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if $global.k0sURLCertSecret }}
+      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+           the k0s binary download in k0smotron v2 */}}
       preK0sCommands:
-      - "sudo update-ca-certificates"
+      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -36,11 +36,9 @@ spec:
         {{- end }}
       {{- end }}
       {{- if $global.k0sURLCertSecret }}
-      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-           the k0s binary download in k0smotron v2 */}}
+      {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
       preK0sCommands:
-      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+      - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.16
+version: 1.0.17
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
@@ -11,16 +11,20 @@ spec:
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
     {{- end }}
     {{- if or $global.registryCertSecret $global.k0sURLCertSecret .Values.auth.configSecret.name .Values.encryption.configSecret.name $global.registryCredentialSecret .Values.audit.policyRef.name }}
-    {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+    {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+         Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd,
+         k0s controller and HelmController (all Go). curl for the k0s binary is handled
+         separately via preK0sCommands below */}}
+    {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
     files:
-      {{- range $path, $secret := $certs }}
+      {{- range $name, $secret := $certs }}
       {{- if $secret }}
       - contentFrom:
           secretRef:
             name: {{ $secret }}
             key: ca.crt
-        permissions: "0664"
-        path: /usr/local/share/ca-certificates/{{ $path }}
+        permissions: "0644"
+        path: /etc/ssl/certs/{{ $name }}
       {{- end }}
       {{- end }}
       {{- if .Values.auth.configSecret.name }}
@@ -62,9 +66,12 @@ spec:
         path: /etc/k0s/containerd.d/registry-auth.toml
       {{- end }}
     {{- end }}
-    {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    {{- if $global.k0sURLCertSecret }}
+    {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+         Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+         the k0s binary download in k0smotron v2 */}}
     preK0sCommands:
-    - "sudo update-ca-certificates"
+    - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0scontrolplane.yaml
@@ -67,11 +67,9 @@ spec:
       {{- end }}
     {{- end }}
     {{- if $global.k0sURLCertSecret }}
-    {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-         Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-         the k0s binary download in k0smotron v2 */}}
+    {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
     preK0sCommands:
-    - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+    - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -37,11 +37,9 @@ spec:
         {{- end }}
       {{- end }}
       {{- if $global.k0sURLCertSecret }}
-      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-           the k0s binary download in k0smotron v2 */}}
+      {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
       preK0sCommands:
-      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+      - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -11,16 +11,20 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+           and the k0s worker binary (both Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
       files:
-        {{- range $path, $secret := $certs }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- if $global.registryCredentialSecret }}
@@ -32,9 +36,12 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if $global.k0sURLCertSecret }}
+      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+           the k0s binary download in k0smotron v2 */}}
       preK0sCommands:
-      - "sudo update-ca-certificates"
+      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/openstack-hosted-cp/Chart.yaml
+++ b/templates/cluster/openstack-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.35
+version: 1.0.36
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -10,16 +10,20 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+           and the k0s worker binary (both Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
       files:
-        {{- range $path, $secret := $certs }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- if $global.registryCredentialSecret }}
@@ -31,9 +35,12 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if $global.k0sURLCertSecret }}
+      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+           the k0s binary download in k0smotron v2 */}}
       preK0sCommands:
-      - "sudo update-ca-certificates"
+      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -36,11 +36,9 @@ spec:
         {{- end }}
       {{- end }}
       {{- if $global.k0sURLCertSecret }}
-      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-           the k0s binary download in k0smotron v2 */}}
+      {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
       preK0sCommands:
-      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+      - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/openstack-standalone-cp/Chart.yaml
+++ b/templates/cluster/openstack-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.41
+version: 1.0.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -223,11 +223,9 @@ spec:
                     mountPath: {{ .Values.identityRef.caCert.path  | quote }}
                  {{- end }}
     {{- if $global.k0sURLCertSecret }}
-    {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-         Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-         the k0s binary download in k0smotron v2 */}}
+    {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
     preK0sCommands:
-    - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+    - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0scontrolplane.yaml
@@ -11,15 +11,19 @@ spec:
     downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
     {{- end }}
     files:
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
-      {{- range $path, $secret := $certs }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd,
+           k0s controller and HelmController (all Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
+      {{- range $name, $secret := $certs }}
       {{- if $secret }}
       - contentFrom:
           secretRef:
             name: {{ $secret }}
             key: ca.crt
-        permissions: "0664"
-        path: /usr/local/share/ca-certificates/{{ $path }}
+        permissions: "0644"
+        path: /etc/ssl/certs/{{ $name }}
       {{- end }}
       {{- end }}
       {{- if .Values.auth.configSecret.name }}
@@ -218,9 +222,12 @@ spec:
                   - name: cloud-ca-cert
                     mountPath: {{ .Values.identityRef.caCert.path  | quote }}
                  {{- end }}
-    {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+    {{- if $global.k0sURLCertSecret }}
+    {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+         Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+         the k0s binary download in k0smotron v2 */}}
     preK0sCommands:
-    - "sudo update-ca-certificates"
+    - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
     {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -37,11 +37,9 @@ spec:
         {{- end }}
       {{- end }}
       {{- if $global.k0sURLCertSecret }}
-      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-           the k0s binary download in k0smotron v2 */}}
+      {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
       preK0sCommands:
-      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+      - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/openstack-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -11,16 +11,20 @@ spec:
       downloadURL: "{{ $global.k0sURL }}/k0s-{{ .Values.k0s.version }}-{{ .Values.k0s.arch }}"
       {{- end }}
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+           and the k0s worker binary (both Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
       files:
-        {{- range $path, $secret := $certs }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- if $global.registryCredentialSecret }}
@@ -32,9 +36,12 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
       {{- end }}
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+      {{- if $global.k0sURLCertSecret }}
+      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+           the k0s binary download in k0smotron v2 */}}
       preK0sCommands:
-      - "sudo update-ca-certificates"
+      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
       {{- end }}
       version: {{ .Values.k0s.version  | quote }}
       args:

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.32
+version: 1.0.33
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -33,16 +33,20 @@ spec:
   downloadURL: "{{ $global.k0sURL }}/k0s-{{ $.Values.k0s.version }}-{{ $.Values.k0s.arch }}"
   {{- end }}
   {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
-  {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
+  {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+       Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+       and the k0s binary (both Go). curl for the k0s binary is handled
+       separately via preK0sCommands below */}}
+  {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
   files:
-    {{- range $path, $secret := $certs }}
+    {{- range $name, $secret := $certs }}
     {{- if $secret }}
     - contentFrom:
         secretRef:
           name: {{ $secret }}
           key: ca.crt
-      permissions: "0664"
-      path: /usr/local/share/ca-certificates/{{ $path }}
+      permissions: "0644"
+      path: /etc/ssl/certs/{{ $name }}
     {{- end }}
     {{- end }}
     {{- if $global.registryCredentialSecret }}
@@ -54,9 +58,12 @@ spec:
       path: /etc/k0s/containerd.d/registry-auth.toml
     {{- end }}
   {{- end }}
-  {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
+  {{- if $global.k0sURLCertSecret }}
+  {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+       Go's cert dirs. Append the CA to whichever OS trust bundle exists. sh -c is
+       needed so the `for` keyword can run under sudo when required */}}
   preK0sCommands:
-    - {{ printf "%supdate-ca-certificates" (ternary "sudo " "" $machine.useSudo) | quote }}
+    - {{ printf "%ssh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'" (ternary "sudo " "" $machine.useSudo) | quote }}
   {{- end }}
   {{- if and $machine.k0s $machine.k0s.args }}
   args:

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -59,11 +59,9 @@ spec:
     {{- end }}
   {{- end }}
   {{- if $global.k0sURLCertSecret }}
-  {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-       Go's cert dirs. Append the CA to whichever OS trust bundle exists. sh -c is
-       needed so the `for` keyword can run under sudo when required */}}
+  {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
   preK0sCommands:
-    - {{ printf "%ssh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'" (ternary "sudo " "" $machine.useSudo) | quote }}
+    - {{ printf "%ssh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true" (ternary "sudo " "" $machine.useSudo) | quote }}
   {{- end }}
   {{- if and $machine.k0s $machine.k0s.args }}
   args:

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.38
+version: 1.0.39
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -28,21 +28,28 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
         {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-        {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
-        {{- range $path, $secret := $certs }}
+        {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+             Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+             and the k0s worker binary (both Go). curl for the k0s binary is handled
+             separately via preK0sCommands below */}}
+        {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- end }}
       preK0sCommands:
         - chown {{ .Values.ssh.user }} /home/{{ .Values.ssh.user }}/.ssh/authorized_keys
-        {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-        - "sudo update-ca-certificates"
+        {{- if $global.k0sURLCertSecret }}
+        {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+             Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+             the k0s binary download in k0smotron v2 */}}
+        - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
         {{- end }}
 

--- a/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0sworkerconfigtemplate.yaml
@@ -47,9 +47,7 @@ spec:
       preK0sCommands:
         - chown {{ .Values.ssh.user }} /home/{{ .Values.ssh.user }}/.ssh/authorized_keys
         {{- if $global.k0sURLCertSecret }}
-        {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-             Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-             the k0s binary download in k0smotron v2 */}}
-        - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+        {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
+        - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
         {{- end }}
 

--- a/templates/cluster/vsphere-standalone-cp/Chart.yaml
+++ b/templates/cluster/vsphere-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.37
+version: 1.0.38
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -15,15 +15,19 @@ spec:
         permissions: "0600"
         content: "{{ trim .Values.controlPlane.ssh.publicKey }}"
       {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
-      {{- range $path, $secret := $certs }}
+      {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+           Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd,
+           k0s controller and HelmController (all Go). curl for the k0s binary is handled
+           separately via preK0sCommands below */}}
+      {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
+      {{- range $name, $secret := $certs }}
       {{- if $secret }}
       - contentFrom:
           secretRef:
             name: {{ $secret }}
             key: ca.crt
-        permissions: "0664"
-        path: /usr/local/share/ca-certificates/{{ $path }}
+        permissions: "0644"
+        path: /etc/ssl/certs/{{ $name }}
       {{- end }}
       {{- end }}
       {{- end }}
@@ -230,8 +234,11 @@ spec:
     preK0sCommands:
       - chown {{ .Values.controlPlane.ssh.user }} /home/{{ .Values.controlPlane.ssh.user }}/.ssh/authorized_keys
       - sed -i 's/"externalAddress":"{{ .Values.controlPlaneEndpointIP }}",//' /etc/k0s.yaml
-      {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-      - "sudo update-ca-certificates"
+      {{- if $global.k0sURLCertSecret }}
+      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+           the k0s binary download in k0smotron v2 */}}
+      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
       {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0scontrolplane.yaml
@@ -235,10 +235,8 @@ spec:
       - chown {{ .Values.controlPlane.ssh.user }} /home/{{ .Values.controlPlane.ssh.user }}/.ssh/authorized_keys
       - sed -i 's/"externalAddress":"{{ .Values.controlPlaneEndpointIP }}",//' /etc/k0s.yaml
       {{- if $global.k0sURLCertSecret }}
-      {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-           Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-           the k0s binary download in k0smotron v2 */}}
-      - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+      {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
+      - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
       {{- end }}
     {{- if and .Values.audit.policyRef.name .Values.audit.logPath (ne .Values.audit.logPath "-") }}
     {{- $logPath := .Values.audit.logPath }}

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -29,21 +29,28 @@ spec:
           path: /etc/k0s/containerd.d/registry-auth.toml
         {{- end }}
         {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-        {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
-        {{- range $path, $secret := $certs }}
+        {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
+             Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
+             and the k0s worker binary (both Go). curl for the k0s binary is handled
+             separately via preK0sCommands below */}}
+        {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
+        {{- range $name, $secret := $certs }}
         {{- if $secret }}
         - contentFrom:
             secretRef:
               name: {{ $secret }}
               key: ca.crt
-          permissions: "0664"
-          path: /usr/local/share/ca-certificates/{{ $path }}
+          permissions: "0644"
+          path: /etc/ssl/certs/{{ $name }}
         {{- end }}
         {{- end }}
         {{- end }}
       preK0sCommands:
         - chown {{ .Values.worker.ssh.user }} /home/{{ .Values.worker.ssh.user }}/.ssh/authorized_keys
-        {{- if or $global.registryCertSecret $global.k0sURLCertSecret }}
-        - "sudo update-ca-certificates"
+        {{- if $global.k0sURLCertSecret }}
+        {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
+             Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
+             the k0s binary download in k0smotron v2 */}}
+        - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
         {{- end }}
 {{- end }}

--- a/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
+++ b/templates/cluster/vsphere-standalone-cp/templates/k0sworkerconfigtemplate.yaml
@@ -48,9 +48,7 @@ spec:
       preK0sCommands:
         - chown {{ .Values.worker.ssh.user }} /home/{{ .Values.worker.ssh.user }}/.ssh/authorized_keys
         {{- if $global.k0sURLCertSecret }}
-        {{/* curl (fetches the k0s binary from a self-signed HTTPS mirror) uses OpenSSL, not
-             Go's cert dirs. Append the CA to whichever OS trust bundle exists. Runs before
-             the k0s binary download in k0smotron v2 */}}
-        - "sudo sh -c 'for b in /etc/ssl/certs/ca-certificates.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem; do [ -w \"$b\" ] && printf \"\\n\" >> \"$b\" && cat /etc/ssl/certs/kcm-k0s-url.pem >> \"$b\" || true; done'"
+        {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
+        - "sudo sh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true"
         {{- end }}
 {{- end }}

--- a/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-41.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-hosted-cp-1-0-41.yaml
@@ -1,13 +1,13 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-standalone-cp-1-0-41
+  name: aws-hosted-cp-1-0-41
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-standalone-cp
+      chart: aws-hosted-cp
       version: 1.0.41
       interval: 10m0s
       sourceRef:

--- a/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-39.yaml
+++ b/templates/provider/kcm-templates/files/templates/aws-standalone-cp-1-0-39.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-standalone-cp-1-0-38
+  name: aws-standalone-cp-1-0-39
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: aws-standalone-cp
-      version: 1.0.38
+      version: 1.0.39
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-44.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-hosted-cp-1-0-44.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-16
+  name: azure-hosted-cp-1-0-44
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-standalone-cp
-      version: 1.0.16
+      chart: azure-hosted-cp
+      version: 1.0.44
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-41.yaml
+++ b/templates/provider/kcm-templates/files/templates/azure-standalone-cp-1-0-41.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-38
+  name: azure-standalone-cp-1-0-41
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: gcp-hosted-cp
-      version: 1.0.38
+      chart: azure-standalone-cp
+      version: 1.0.41
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-39.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-39.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: aws-hosted-cp-1-0-40
+  name: gcp-hosted-cp-1-0-39
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: aws-hosted-cp
-      version: 1.0.40
+      chart: gcp-hosted-cp
+      version: 1.0.39
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-37.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-37.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-36
+  name: gcp-standalone-cp-1-0-37
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-standalone-cp
-      version: 1.0.36
+      version: 1.0.37
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-15.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-15.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-hosted-cp-1-0-43
+  name: kubevirt-hosted-cp-1-0-15
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-hosted-cp
-      version: 1.0.43
+      chart: kubevirt-hosted-cp
+      version: 1.0.15
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-17.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-17.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: openstack-hosted-cp-1-0-35
+  name: kubevirt-standalone-cp-1-0-17
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: openstack-hosted-cp
-      version: 1.0.35
+      chart: kubevirt-standalone-cp
+      version: 1.0.17
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-36.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-hosted-cp-1-0-36.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-38
+  name: openstack-hosted-cp-1-0-36
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.38
+      chart: openstack-hosted-cp
+      version: 1.0.36
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-42.yaml
+++ b/templates/provider/kcm-templates/files/templates/openstack-standalone-cp-1-0-42.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-hosted-cp-1-0-14
+  name: openstack-standalone-cp-1-0-42
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-hosted-cp
-      version: 1.0.14
+      chart: openstack-standalone-cp
+      version: 1.0.42
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-33.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-33.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-standalone-cp-1-0-37
+  name: remote-cluster-1-0-33
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-standalone-cp
-      version: 1.0.37
+      chart: remote-cluster
+      version: 1.0.33
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-39.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-39.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-32
+  name: vsphere-hosted-cp-1-0-39
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: remote-cluster
-      version: 1.0.32
+      chart: vsphere-hosted-cp
+      version: 1.0.39
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-38.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-standalone-cp-1-0-38.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: azure-standalone-cp-1-0-40
+  name: vsphere-standalone-cp-1-0-38
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: azure-standalone-cp
-      version: 1.0.40
+      chart: vsphere-standalone-cp
+      version: 1.0.38
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop the registry and k0s download URL CAs into /etc/ssl/certs/, a directory Go's crypto/x509 always scans. Removes the reliance on update-ca-certificates, which silently no-ops on RHEL-based images.

When k0sURLCertSecret is set, also append the CA to whichever OS trust bundle exists in preK0sCommands so curl trusts it for the k0s binary download

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2858
