### PR TITLE
feat: remote-cluster: expose prestart configuration

### DIFF
--- a/config/dev/remote-clusterdeployment.yaml
+++ b/config/dev/remote-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: remote-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: remote-cluster-1-0-33
+  template: remote-cluster-1-0-34
   credential: remote-cred
   propagateCredentials: false
   config:

--- a/templates/cluster/remote-cluster/Chart.yaml
+++ b/templates/cluster/remote-cluster/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.33
+version: 1.0.34
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -33,14 +33,12 @@ spec:
   downloadURL: "{{ $global.k0sURL }}/k0s-{{ $.Values.k0s.version }}-{{ $.Values.k0s.arch }}"
   {{- end }}
   preInstalledK0s: {{ $machine.preInstalledK0s | default false }}
-  {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
+  {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret $machine.files }}
   {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
        Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
        and the k0s binary (both Go). curl for the k0s binary is handled
        separately via preK0sCommands below */}}
   {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
-  {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret $machine.files }}
-  {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
   files:
     {{- range $name, $secret := $certs }}
     {{- if $secret }}
@@ -62,23 +60,19 @@ spec:
     {{- end }}
     {{- if $machine.files }}
     {{- range $machine.files }}
-    - path: {{ .path | quote }}
-      content: {{ .content | quote }}
-      {{- if .permissions }}
-      permissions: {{ .permissions | quote }}
-      {{- end }}
+    - {{ toYaml . | trim | nindent 6 }}
     {{- end }}
     {{- end }}
   {{- end }}
   {{- if or $global.k0sURLCertSecret $machine.preK0sCommands }}
-  {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
   preK0sCommands:
     {{- if $global.k0sURLCertSecret }}
+    {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
     - {{ printf "%ssh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true" (ternary "sudo " "" $machine.useSudo) | quote }}
     {{- end }}
     {{- if $machine.preK0sCommands }}
     {{- range $machine.preK0sCommands }}
-      - {{ . | quote }}
+    - {{ . | quote }}
     {{- end }}
     {{- end }}
   {{- end }}

--- a/templates/cluster/remote-cluster/templates/machines.yaml
+++ b/templates/cluster/remote-cluster/templates/machines.yaml
@@ -32,12 +32,15 @@ spec:
   {{- if $global.k0sURL }}
   downloadURL: "{{ $global.k0sURL }}/k0s-{{ $.Values.k0s.version }}-{{ $.Values.k0s.arch }}"
   {{- end }}
+  preInstalledK0s: {{ $machine.preInstalledK0s | default false }}
   {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret }}
   {{/* Drop CAs into a dir Go's crypto/x509 always scans (https://github.com/golang/go/blob/d468ad3648be469ffc4090e4586c29709182d6b6/src/crypto/x509/root_linux.go#L20).
        Works on Debian/RHEL/SUSE/Alpine/Flatcar without update-ca-*; covers containerd
        and the k0s binary (both Go). curl for the k0s binary is handled
        separately via preK0sCommands below */}}
   {{- $certs := dict "kcm-registry.pem" $global.registryCertSecret "kcm-k0s-url.pem" $global.k0sURLCertSecret }}
+  {{- if or $global.registryCertSecret $global.k0sURLCertSecret $global.registryCredentialSecret $machine.files }}
+  {{- $certs := dict "registry.crt" $global.registryCertSecret "k0s-url.crt" $global.k0sURLCertSecret }}
   files:
     {{- range $name, $secret := $certs }}
     {{- if $secret }}
@@ -57,11 +60,27 @@ spec:
       permissions: "0664"
       path: /etc/k0s/containerd.d/registry-auth.toml
     {{- end }}
+    {{- if $machine.files }}
+    {{- range $machine.files }}
+    - path: {{ .path | quote }}
+      content: {{ .content | quote }}
+      {{- if .permissions }}
+      permissions: {{ .permissions | quote }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
   {{- end }}
-  {{- if $global.k0sURLCertSecret }}
+  {{- if or $global.k0sURLCertSecret $machine.preK0sCommands }}
   {{/* curl (used to fetch the k0s binary) reads the OS-generated bundle; install the CA into the anchor dir so update-ca-* rebuilds preserve it */}}
   preK0sCommands:
+    {{- if $global.k0sURLCertSecret }}
     - {{ printf "%ssh -c 'src=/etc/ssl/certs/kcm-k0s-url.pem; if [ -d /usr/local/share/ca-certificates ]; then install -m 0644 \"$src\" /usr/local/share/ca-certificates/kcm-k0s-url.crt && update-ca-certificates; elif [ -d /etc/pki/ca-trust/source/anchors ]; then install -m 0644 \"$src\" /etc/pki/ca-trust/source/anchors/kcm-k0s-url.pem && update-ca-trust extract; elif [ -d /etc/pki/trust/anchors ]; then install -m 0644 \"$src\" /etc/pki/trust/anchors/kcm-k0s-url.pem && update-ca-certificates; fi' || true" (ternary "sudo " "" $machine.useSudo) | quote }}
+    {{- end }}
+    {{- if $machine.preK0sCommands }}
+    {{- range $machine.preK0sCommands }}
+      - {{ . | quote }}
+    {{- end }}
+    {{- end }}
   {{- end }}
   {{- if and $machine.k0s $machine.k0s.args }}
   args:

--- a/templates/cluster/remote-cluster/values.schema.json
+++ b/templates/cluster/remote-cluster/values.schema.json
@@ -295,7 +295,7 @@
             "type": "string"
           },
           "files": {
-            "description": "Files to create on the node before k0s starts. Each entry requires path and content. Use for repo files, certificates, or config that must exist before preStartCommands run.",
+            "description": "Files to create on the node before k0s starts. Each entry requires path and content. Use for repo files, certificates, or config that must exist before preK0sCommands run",
             "type": "array",
             "items": {
               "type": "object"
@@ -333,7 +333,7 @@
             "type": "boolean"
           },
           "preK0sCommands": {
-            "description": "Shell commands executed on the node before k0s worker starts.",
+            "description": "Shell commands executed on the node before k0s worker starts",
             "type": "array",
             "items": {
               "type": "string"

--- a/templates/cluster/remote-cluster/values.schema.json
+++ b/templates/cluster/remote-cluster/values.schema.json
@@ -294,6 +294,13 @@
             ],
             "type": "string"
           },
+          "files": {
+            "description": "Files to create on the node before k0s starts. Each entry requires path and content. Use for repo files, certificates, or config that must exist before preStartCommands run.",
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
           "k0s": {
             "description": "k0s worker configuration options",
             "type": "object",
@@ -319,6 +326,18 @@
             "type": "number",
             "maximum": 65535,
             "minimum": 1
+          },
+          "preInstalledK0s": {
+            "description": "When true, k0smotron skips downloading and installing k0s — the binary must already be present on the node",
+            "default": false,
+            "type": "boolean"
+          },
+          "preK0sCommands": {
+            "description": "Shell commands executed on the node before k0s worker starts.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "provisionJob": {
             "description": "The kubernetes Job to use to provision the machine",

--- a/templates/cluster/remote-cluster/values.yaml
+++ b/templates/cluster/remote-cluster/values.yaml
@@ -48,6 +48,9 @@ machines: # @schema description: The list of remote machines configurations; typ
     name: "" # @schema description: Unique machine name. If empty, it will be auto-generated from the cluster name with a SHA-based postfix derived from the address and port; type: string; maxLength: 253
     user: "root" # @schema description: The user to use when connecting to the remote machine; type: string; default: root
     useSudo: false # @schema description: Determines whether to use sudo for k0s cluster bootstrap commands; type: boolean; default: false
+    preInstalledK0s: false # @schema description: When true, k0smotron skips downloading and installing k0s — the binary must already be present on the node; type: boolean; default: false
+    preK0sCommands: [] # @schema description: Shell commands executed on the node before k0s worker starts.; type: array; item: string
+    files: [] # @schema description: Files to create on the node before k0s starts. Each entry requires path and content. Use for repo files, certificates, or config that must exist before preStartCommands run.; type: array; item: object
     provisionJob: # @schema description: The kubernetes Job to use to provision the machine; type: object
       scpCommand: scp # @schema description: The scp command; type: string; default: scp
       sshCommand: ssh # @schema description: The ssh command; type: string; default: ssh

--- a/templates/cluster/remote-cluster/values.yaml
+++ b/templates/cluster/remote-cluster/values.yaml
@@ -49,8 +49,8 @@ machines: # @schema description: The list of remote machines configurations; typ
     user: "root" # @schema description: The user to use when connecting to the remote machine; type: string; default: root
     useSudo: false # @schema description: Determines whether to use sudo for k0s cluster bootstrap commands; type: boolean; default: false
     preInstalledK0s: false # @schema description: When true, k0smotron skips downloading and installing k0s — the binary must already be present on the node; type: boolean; default: false
-    preK0sCommands: [] # @schema description: Shell commands executed on the node before k0s worker starts.; type: array; item: string
-    files: [] # @schema description: Files to create on the node before k0s starts. Each entry requires path and content. Use for repo files, certificates, or config that must exist before preStartCommands run.; type: array; item: object
+    preK0sCommands: [] # @schema description: Shell commands executed on the node before k0s worker starts; type: array; item: string
+    files: [] # @schema description: Files to create on the node before k0s starts. Each entry requires path and content. Use for repo files, certificates, or config that must exist before preK0sCommands run; type: array; item: object
     provisionJob: # @schema description: The kubernetes Job to use to provision the machine; type: object
       scpCommand: scp # @schema description: The scp command; type: string; default: scp
       sshCommand: ssh # @schema description: The ssh command; type: string; default: ssh

--- a/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-34.yaml
+++ b/templates/provider/kcm-templates/files/templates/remote-cluster-1-0-34.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: remote-cluster-1-0-33
+  name: remote-cluster-1-0-34
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: remote-cluster
-      version: 1.0.33
+      version: 1.0.34
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:

Expose prek0scommands to allow for custom k0s installation procedures
