### PR TITLE
refactor: drop PI lookup on CD delete path

### DIFF
--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -38,11 +38,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 	clusterapiv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/controllers/external"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
@@ -58,7 +58,6 @@ import (
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	"github.com/K0rdent/kcm/internal/helm"
 	"github.com/K0rdent/kcm/internal/metrics"
-	"github.com/K0rdent/kcm/internal/providerinterface"
 	"github.com/K0rdent/kcm/internal/record"
 	"github.com/K0rdent/kcm/internal/serviceset"
 	authutil "github.com/K0rdent/kcm/internal/util/auth"
@@ -72,9 +71,6 @@ import (
 )
 
 var (
-	errClusterNotFound         = errors.New("cluster is not found")
-	errClusterTemplateNotFound = errors.New("cluster template is not found")
-
 	errClusterDeploymentSpecUpdated = errors.New("cluster deployment spec updated")
 	errIPAMNotReady                 = errors.New("IPAM not ready")
 	errInvalidIPAMClaimRef          = errors.New("invalid IPAM claim ref")
@@ -177,7 +173,7 @@ func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if !clusterDeployment.DeletionTimestamp.IsZero() {
 		l.Info("Deleting ClusterDeployment")
-		return r.reconcileDelete(ctx, management, scope)
+		return r.reconcileDelete(ctx, scope)
 	}
 
 	if !management.DeletionTimestamp.IsZero() {
@@ -1579,7 +1575,7 @@ func (r *ClusterDeploymentReconciler) getSourceArtifact(ctx context.Context, ref
 	return hc.GetArtifact(), nil
 }
 
-func (r *ClusterDeploymentReconciler) reconcileDelete(ctx context.Context, mgmt *kcmv1.Management, scope *clusterScope) (result ctrl.Result, err error) {
+func (r *ClusterDeploymentReconciler) reconcileDelete(ctx context.Context, scope *clusterScope) (result ctrl.Result, err error) {
 	l := ctrl.LoggerFrom(ctx)
 
 	cd := scope.cd
@@ -1605,6 +1601,10 @@ func (r *ClusterDeploymentReconciler) reconcileDelete(ctx context.Context, mgmt 
 		if controllerutil.ContainsFinalizer(cd, kcmv1.ClusterDeploymentFinalizer) {
 			err = errors.Join(err, r.updateStatus(ctx, oldCD, cd, nil))
 		}
+
+		if err != nil {
+			l.Error(err, "Deleting ClusterDeployment")
+		}
 	}()
 
 	if r.IsDisabledValidationWH {
@@ -1618,13 +1618,7 @@ func (r *ClusterDeploymentReconciler) reconcileDelete(ctx context.Context, mgmt 
 		return ctrl.Result{}, fmt.Errorf("failed to aggregate conditions from CAPI Cluster for ClusterDeployment %s: %w", client.ObjectKeyFromObject(cd), err)
 	}
 
-	if err := r.releaseProviderCluster(ctx, mgmt, scope); err != nil {
-		if r.IsDisabledValidationWH && errors.Is(err, errClusterTemplateNotFound) {
-			l.Error(err, "failed to release provider cluster object due to absent ClusterTemplate, will not retrigger")
-			// there is not much to do, we cannot release the clusterdeployment without the clustertemplate
-			return ctrl.Result{}, nil
-		}
-
+	if err := r.releaseProviderCluster(ctx, scope); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -1857,124 +1851,68 @@ func (*ClusterDeploymentReconciler) deleteChildResources(ctx context.Context, sc
 	return false, nil
 }
 
-func (*ClusterDeploymentReconciler) getProviderGVKs(providerInterface *kcmv1.ProviderInterface) []schema.GroupVersionKind {
-	if providerInterface == nil {
-		return nil
-	}
-	gvks := make([]schema.GroupVersionKind, 0, len(providerInterface.Spec.ClusterGVKs))
-
-	for _, el := range providerInterface.Spec.ClusterGVKs {
-		gvks = append(gvks, schema.GroupVersionKind{
-			Group:   el.Group,
-			Version: el.Version,
-			Kind:    el.Kind,
-		})
-	}
-
-	return gvks
-}
-
-func (r *ClusterDeploymentReconciler) releaseProviderCluster(ctx context.Context, mgmt *kcmv1.Management, scope *clusterScope) error {
+// releaseProviderCluster removes the blocking finalizer from the infrastructure Cluster object owned
+// by the given ClusterDeployment, if the infrastructure Cluster has no remaining CAPI Machines.
+// The infra Cluster is resolved via the CAPI Cluster's spec.infrastructureRef (contract-versioned),
+// so no ProviderInterface lookup or label-matched GVK guessing is needed on the deletion path
+func (r *ClusterDeploymentReconciler) releaseProviderCluster(ctx context.Context, scope *clusterScope) error {
 	cd := scope.cd
-	infraProviders, err := r.getInfraProvidersNames(ctx, cd.Namespace, cd.Spec.Template)
-	if err != nil {
-		return err
-	}
 
-	var parent validationutil.ClusterParent = mgmt
-	if scope.region != nil {
-		parent = scope.region
-	}
-
-	providerInterfaces := make([]*kcmv1.ProviderInterface, 0, len(infraProviders))
-	for _, infraProvider := range infraProviders {
-		if pi := providerinterface.FindProviderInterfaceForInfra(ctx, scope.rgnClient, parent, infraProvider); pi != nil {
-			providerInterfaces = append(providerInterfaces, pi)
-		}
-	}
-
-	// Associate the provider with it's GVK
-	for _, pi := range providerInterfaces {
-		gvks := r.getProviderGVKs(pi)
-		if len(gvks) == 0 {
-			continue
-		}
-
-		cluster, err := r.getProviderCluster(ctx, scope.rgnClient, cd.Namespace, cd.Name, gvks...)
-		if err != nil {
-			if !errors.Is(err, errClusterNotFound) {
-				return err
-			}
+	capiCluster := new(clusterapiv1.Cluster)
+	if err := scope.rgnClient.Get(ctx, client.ObjectKeyFromObject(cd), capiCluster); err != nil {
+		if apierrors.IsNotFound(err) {
 			return nil
 		}
 
-		found, err := r.clusterCAPIMachinesExist(ctx, scope.rgnClient, cd.Namespace, cluster.Name)
-		if err != nil {
-			continue
+		return fmt.Errorf("failed to get CAPI Cluster %s: %w", client.ObjectKeyFromObject(cd), err)
+	}
+
+	if !capiCluster.Spec.InfrastructureRef.IsDefined() {
+		return nil
+	}
+
+	infraRef, err := external.GetObjectFromContractVersionedRef(ctx, scope.rgnClient, capiCluster.Spec.InfrastructureRef, capiCluster.Namespace)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
 		}
 
-		if !found {
-			finalizersUpdated, err := r.removeClusterFinalizer(ctx, scope.rgnClient, cluster)
-			if finalizersUpdated {
-				r.eventf(cd, "ClusterDeleted", "Cluster %s has been deleted", client.ObjectKeyFromObject(cd))
-			}
-			if err != nil {
-				return fmt.Errorf("failed to remove finalizer from %s %s: %w", cluster.Kind, client.ObjectKeyFromObject(cluster), err)
-			}
-		}
+		return fmt.Errorf("failed to get infrastructure Cluster %s/%s (%s) for ClusterDeployment %s: %w",
+			capiCluster.Namespace, capiCluster.Spec.InfrastructureRef.Name, capiCluster.Spec.InfrastructureRef.Kind,
+			client.ObjectKeyFromObject(cd), err)
+	}
+
+	found, err := r.clusterCAPIMachinesExist(ctx, scope.rgnClient, cd.Namespace, capiCluster.Name)
+	if err != nil {
+		return fmt.Errorf("checking if Machines still exist: %w", err)
+	}
+
+	if found {
+		return nil
+	}
+
+	finalizersUpdated, err := r.removeInfraRefFinalizer(ctx, scope.rgnClient, infraRef)
+	if finalizersUpdated {
+		r.eventf(cd, "ClusterDeleted", "Cluster %s has been deleted", client.ObjectKeyFromObject(cd))
+	}
+	if err != nil {
+		return fmt.Errorf("failed to remove finalizer from %s (%s): %w", client.ObjectKeyFromObject(infraRef), infraRef.GetKind(), err)
 	}
 
 	return nil
 }
 
-// getInfraProvidersNames returns the list of exposed infrastructure providers with the `infrastructure-` prefix for provided template
-func (r *ClusterDeploymentReconciler) getInfraProvidersNames(ctx context.Context, templateNamespace, templateName string) ([]string, error) {
-	template := &kcmv1.ClusterTemplate{}
-	templateRef := client.ObjectKey{Name: templateName, Namespace: templateNamespace}
-	if err := r.MgmtClient.Get(ctx, templateRef, template); err != nil {
-		ctrl.LoggerFrom(ctx).Error(err, "Failed to get ClusterTemplate", "template namespace", templateNamespace, "template name", templateName)
-		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("failed to get ClusterTemplate %s: %w", templateRef, errClusterTemplateNotFound)
-		}
-		return nil, err
+func (*ClusterDeploymentReconciler) removeInfraRefFinalizer(ctx context.Context, rgnClient client.Client, infraRef client.Object) (finalizersUpdated bool, err error) {
+	originalCluster, ok := infraRef.DeepCopyObject().(client.Object)
+	if !ok {
+		return false, fmt.Errorf("failed to deep copy %T as client.Object", infraRef)
 	}
 
-	ips := make([]string, 0, len(template.Status.Providers))
-	for _, v := range template.Status.Providers {
-		if strings.HasPrefix(v, kcmv1.InfrastructureProviderPrefix) {
-			ips = append(ips, v)
-		}
-	}
-
-	return ips, nil
-}
-
-// getProviderCluster fetches a first provider Cluster from the given list of GVKs.
-func (*ClusterDeploymentReconciler) getProviderCluster(ctx context.Context, rgnClient client.Client, namespace, name string, gvks ...schema.GroupVersionKind) (*metav1.PartialObjectMetadata, error) {
-	for _, gvk := range gvks {
-		itemsList := &metav1.PartialObjectMetadataList{}
-		itemsList.SetGroupVersionKind(gvk)
-		if err := rgnClient.List(ctx, itemsList, client.InNamespace(namespace), client.MatchingLabels{kcmv1.FluxHelmChartNameKey: name}); err != nil {
-			if apimeta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
-				continue
-			}
-			return nil, fmt.Errorf("failed to list %s in namespace %s: %w", gvk.Kind, namespace, err)
-		}
-
-		if len(itemsList.Items) > 0 {
-			return &itemsList.Items[0], nil
-		}
-	}
-
-	return nil, errClusterNotFound
-}
-
-func (*ClusterDeploymentReconciler) removeClusterFinalizer(ctx context.Context, rgnClient client.Client, cluster *metav1.PartialObjectMetadata) (finalizersUpdated bool, err error) {
-	originalCluster := *cluster
-	if finalizersUpdated = controllerutil.RemoveFinalizer(cluster, kcmv1.BlockingFinalizer); finalizersUpdated {
-		ctrl.LoggerFrom(ctx).Info("Allow to stop cluster", "finalizer", kcmv1.BlockingFinalizer)
-		if err := rgnClient.Patch(ctx, cluster, client.MergeFrom(&originalCluster)); err != nil {
-			return false, fmt.Errorf("failed to patch cluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
+	if finalizersUpdated = controllerutil.RemoveFinalizer(infraRef, kcmv1.BlockingFinalizer); finalizersUpdated {
+		refKind, refKey := infraRef.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(infraRef)
+		ctrl.LoggerFrom(ctx).Info("Allowed to delete infrastructure reference", "finalizer", kcmv1.BlockingFinalizer, "ref kind", refKind, "ref key", refKey)
+		if err := rgnClient.Patch(ctx, infraRef, client.MergeFrom(originalCluster)); err != nil {
+			return false, fmt.Errorf("failed to patch infrastructure reference %s (%s): %w", refKey, refKind, err)
 		}
 	}
 
@@ -1984,9 +1922,15 @@ func (*ClusterDeploymentReconciler) removeClusterFinalizer(ctx context.Context, 
 func (*ClusterDeploymentReconciler) clusterCAPIMachinesExist(ctx context.Context, rgnClient client.Client, namespace, clusterName string) (bool, error) {
 	itemsList := &metav1.PartialObjectMetadataList{}
 	itemsList.SetGroupVersionKind(clusterapiv1.GroupVersion.WithKind("Machine"))
-	if err := rgnClient.List(ctx, itemsList, client.InNamespace(namespace), client.Limit(1), client.MatchingLabels{clusterapiv1.ClusterNameLabel: clusterName}); err != nil {
+	if err := rgnClient.List(
+		ctx, itemsList,
+		client.InNamespace(namespace),
+		client.Limit(1),
+		client.MatchingLabels{clusterapiv1.ClusterNameLabel: clusterName},
+	); err != nil {
 		return false, err
 	}
+
 	return len(itemsList.Items) != 0, nil
 }
 

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -1873,7 +1873,7 @@ func (r *ClusterDeploymentReconciler) releaseProviderCluster(ctx context.Context
 
 	infraRef, err := external.GetObjectFromContractVersionedRef(ctx, scope.rgnClient, capiCluster.Spec.InfrastructureRef, capiCluster.Namespace)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) {
 			return nil
 		}
 
@@ -1903,7 +1903,7 @@ func (r *ClusterDeploymentReconciler) releaseProviderCluster(ctx context.Context
 }
 
 func (*ClusterDeploymentReconciler) removeInfraRefFinalizer(ctx context.Context, rgnClient client.Client, infraRef client.Object) (finalizersUpdated bool, err error) {
-	originalCluster, ok := infraRef.DeepCopyObject().(client.Object)
+	originalInfraRef, ok := infraRef.DeepCopyObject().(client.Object)
 	if !ok {
 		return false, fmt.Errorf("failed to deep copy %T as client.Object", infraRef)
 	}
@@ -1911,7 +1911,7 @@ func (*ClusterDeploymentReconciler) removeInfraRefFinalizer(ctx context.Context,
 	if finalizersUpdated = controllerutil.RemoveFinalizer(infraRef, kcmv1.BlockingFinalizer); finalizersUpdated {
 		refKind, refKey := infraRef.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(infraRef)
 		ctrl.LoggerFrom(ctx).Info("Allowed to delete infrastructure reference", "finalizer", kcmv1.BlockingFinalizer, "ref kind", refKind, "ref key", refKey)
-		if err := rgnClient.Patch(ctx, infraRef, client.MergeFrom(originalCluster)); err != nil {
+		if err := rgnClient.Patch(ctx, infraRef, client.MergeFrom(originalInfraRef)); err != nil {
 			return false, fmt.Errorf("failed to patch infrastructure reference %s (%s): %w", refKey, refKind, err)
 		}
 	}

--- a/internal/controller/clusterdeployment_controller_test.go
+++ b/internal/controller/clusterdeployment_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -36,10 +37,13 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
@@ -404,7 +408,8 @@ func (tc *cldTestCase) testClusterDeploymentReconciliation(reconciler *ClusterDe
 						HaveField("Status", metav1.ConditionTrue),
 						HaveField("Reason", kcmv1.PausedReason),
 						HaveField("Message", Equal(fmt.Sprintf("Related Region %s is paused", tc.region))),
-					))))
+					))),
+				)
 			}).Should(Succeed())
 		})
 
@@ -436,7 +441,8 @@ func (tc *cldTestCase) testClusterDeploymentReconciliation(reconciler *ClusterDe
 						HaveField("Type", kcmv1.PausedCondition),
 						HaveField("Status", metav1.ConditionFalse),
 						HaveField("Reason", kcmv1.NotPausedReason),
-					))))
+					))),
+				)
 			}).Should(Succeed())
 		})
 	}
@@ -484,10 +490,13 @@ func (tc *cldTestCase) testClusterDeploymentReconciliation(reconciler *ClusterDe
 					HaveField("Status", metav1.ConditionFalse),
 					HaveField("Reason", kcmv1.FailedReason),
 					HaveField("Message", Equal(
-						fmt.Sprintf("ClusterTemplate %s/%s is not marked as valid: some cluster template error",
+						fmt.Sprintf(
+							"ClusterTemplate %s/%s is not marked as valid: some cluster template error",
 							clusterTemplate.Namespace, clusterTemplate.Name,
-						))),
-				))))
+						),
+					)),
+				))),
+			)
 		}).Should(Succeed())
 
 		setClusterTemplateValidationStatus(clusterTemplate, "", true)
@@ -510,7 +519,8 @@ func (tc *cldTestCase) testClusterDeploymentReconciliation(reconciler *ClusterDe
 							HaveField("Type", kcmv1.CredentialReadyCondition),
 							HaveField("Status", metav1.ConditionFalse),
 							HaveField("Reason", kcmv1.FailedReason),
-						))))
+						))),
+					)
 				}).Should(Succeed())
 			})
 		}
@@ -530,7 +540,8 @@ func (tc *cldTestCase) testClusterDeploymentReconciliation(reconciler *ClusterDe
 					HaveField("Type", kcmv1.TemplateReadyCondition),
 					HaveField("Status", metav1.ConditionTrue),
 					HaveField("Reason", kcmv1.SucceededReason),
-				))))
+				))),
+			)
 			if !tc.isDisabledValidationWH {
 				g.Expect(cld).Should(
 					HaveField("Status.Conditions", ContainElement(SatisfyAll(
@@ -602,7 +613,8 @@ func (tc *cldTestCase) testClusterDeploymentReconciliation(reconciler *ClusterDe
 						HaveField("Type", kcmv1.ClusterAuditPolicyReadyCondition),
 						HaveField("Status", metav1.ConditionTrue),
 						HaveField("Reason", kcmv1.SucceededReason),
-					))))
+					))),
+				)
 			}).Should(Succeed())
 		})
 	} else {
@@ -638,7 +650,8 @@ func (tc *cldTestCase) testClusterDeploymentReconciliation(reconciler *ClusterDe
 						HaveField("Status", metav1.ConditionFalse),
 						HaveField("Reason", kcmv1.ProgressingReason),
 						HaveField("Message", fmt.Sprintf("cross-referenced ClusterDataSource %s/%s is not yet ready", cld.Namespace, cld.Name)),
-					))))
+					))),
+				)
 			}).To(Succeed())
 		})
 		By("Expect the reconcile to requeue until the cluster data source is ready", func() {
@@ -730,8 +743,10 @@ func (tc *cldTestCase) testClusterDeploymentReconciliation(reconciler *ClusterDe
 		By("Expect ClusterDeployment to not to have CAPI Cluster summary condition when CAPI cluster is not yet created", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(mgrClient.Get(ctx, cldName, cld)).To(Succeed())
-				g.Expect(cld).Should(Not(HaveField("Status.Conditions", ContainElement(
-					HaveField("Type", kcmv1.CAPIClusterSummaryCondition))),
+				g.Expect(cld).Should(Not(
+					HaveField("Status.Conditions", ContainElement(
+						HaveField("Type", kcmv1.CAPIClusterSummaryCondition),
+					)),
 				))
 			}).Should(Succeed())
 		})
@@ -1318,7 +1333,8 @@ var _ = Describe("ClusterDeployment Controller", Ordered, func() {
 		})
 	})
 
-	DescribeTable("ClusterDeployment Reconciliation",
+	DescribeTable(
+		"ClusterDeployment Reconciliation",
 		func(tc cldTestCase) {
 			awsCredential := tc.ensureCredential(namespace.Name)
 			DeferCleanup(k8sClient.Delete, awsCredential)
@@ -2896,6 +2912,194 @@ func Test_ensureAuditPolicyConfigMap(t *testing.T) {
 				if scope.audit.hash == "" {
 					t.Error("expected audit hash to be set on scope")
 				}
+			}
+		})
+	}
+}
+
+func Test_releaseProviderCluster(t *testing.T) {
+	const (
+		cdName    = "test-cd"
+		cdNs      = "default"
+		infraGrp  = "infrastructure.cluster.x-k8s.io"
+		infraKind = "AWSCluster"
+		infraCRD  = "awsclusters.infrastructure.cluster.x-k8s.io"
+		otherFin  = "kcm.test/other"
+	)
+
+	newCapiCluster := func(withRef bool) *clusterapiv1.Cluster {
+		c := &clusterapiv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: cdName, Namespace: cdNs},
+		}
+		if withRef {
+			c.Spec.InfrastructureRef = clusterapiv1.ContractVersionedObjectReference{
+				APIGroup: infraGrp,
+				Kind:     infraKind,
+				Name:     cdName,
+			}
+		}
+		return c
+	}
+
+	// newInfraCRD returns the CRD carrying the CAPI contract label so
+	// external.GetObjectFromContractVersionedRef resolves the API version to v1beta2
+	newInfraCRD := func() *apiextv1.CustomResourceDefinition {
+		return &apiextv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: infraCRD,
+				Labels: map[string]string{
+					clusterapiv1.GroupVersion.Group + "/v1beta2": "v1beta2",
+				},
+			},
+		}
+	}
+
+	newInfraCluster := func(finalizers ...string) *unstructured.Unstructured {
+		u := new(unstructured.Unstructured)
+		u.SetAPIVersion(infraGrp + "/v1beta2")
+		u.SetKind(infraKind)
+		u.SetName(cdName)
+		u.SetNamespace(cdNs)
+		if len(finalizers) > 0 {
+			u.SetFinalizers(finalizers)
+		}
+		return u
+	}
+
+	newMachine := func(name string) *clusterapiv1.Machine {
+		return &clusterapiv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: cdNs,
+				Labels:    map[string]string{clusterapiv1.ClusterNameLabel: cdName},
+			},
+		}
+	}
+
+	tests := []struct {
+		clientInterceptor *interceptor.Funcs
+		name              string
+		wantErrContains   string
+		objects           []crclient.Object
+		wantFinalizers    []string // nil = do not assert; non-nil = expect exact set on the infra Cluster
+		wantErr           bool
+	}{
+		{
+			name: "no CAPI Cluster - noop",
+		},
+		{
+			name:    "CAPI Cluster with empty infrastructureRef - noop",
+			objects: []crclient.Object{newCapiCluster(false)},
+		},
+		{
+			name: "infra Cluster not found - noop",
+			objects: []crclient.Object{
+				newCapiCluster(true),
+				newInfraCRD(),
+			},
+		},
+		{
+			name:    "infra provider CRD not discoverable - noop (NoMatch)",
+			objects: []crclient.Object{newCapiCluster(true)},
+			clientInterceptor: &interceptor.Funcs{
+				Get: func(ctx context.Context, c crclient.WithWatch, key crclient.ObjectKey, obj crclient.Object, opts ...crclient.GetOption) error {
+					if pm, ok := obj.(*metav1.PartialObjectMetadata); ok &&
+						pm.GetObjectKind().GroupVersionKind().Kind == "CustomResourceDefinition" {
+						return &meta.NoKindMatchError{
+							GroupKind: schema.GroupKind{Group: infraGrp, Kind: infraKind},
+						}
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+		},
+		{
+			name: "machines still exist - blocking finalizer preserved",
+			objects: []crclient.Object{
+				newCapiCluster(true),
+				newInfraCRD(),
+				newInfraCluster(kcmv1.BlockingFinalizer, otherFin),
+				newMachine("m1"),
+			},
+			wantFinalizers: []string{kcmv1.BlockingFinalizer, otherFin},
+		},
+		{
+			name: "no machines - blocking finalizer removed, others kept",
+			objects: []crclient.Object{
+				newCapiCluster(true),
+				newInfraCRD(),
+				newInfraCluster(kcmv1.BlockingFinalizer, otherFin),
+			},
+			wantFinalizers: []string{otherFin},
+		},
+		{
+			name: "no machines, no blocking finalizer - noop",
+			objects: []crclient.Object{
+				newCapiCluster(true),
+				newInfraCRD(),
+				newInfraCluster(otherFin),
+			},
+			wantFinalizers: []string{otherFin},
+		},
+		{
+			name: "transient error on CAPI Cluster Get returns error",
+			clientInterceptor: &interceptor.Funcs{
+				Get: func(_ context.Context, _ crclient.WithWatch, _ crclient.ObjectKey, obj crclient.Object, _ ...crclient.GetOption) error {
+					if _, ok := obj.(*clusterapiv1.Cluster); ok {
+						return errors.New("transient API server error")
+					}
+					return nil
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "failed to get CAPI Cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := fake.NewClientBuilder().WithScheme(testscheme.Scheme)
+			if len(tt.objects) > 0 {
+				b = b.WithObjects(tt.objects...)
+			}
+			if tt.clientInterceptor != nil {
+				b = b.WithInterceptorFuncs(*tt.clientInterceptor)
+			}
+			c := b.Build()
+
+			r := &ClusterDeploymentReconciler{MgmtClient: c}
+			scope := &clusterScope{
+				cd:        &kcmv1.ClusterDeployment{ObjectMeta: metav1.ObjectMeta{Name: cdName, Namespace: cdNs}},
+				rgnClient: c,
+			}
+
+			err := r.releaseProviderCluster(t.Context(), scope)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("expected error containing %q, got %v", tt.wantErrContains, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantFinalizers == nil {
+				return
+			}
+			got := newInfraCluster()
+			if err := c.Get(t.Context(), crclient.ObjectKeyFromObject(got), got); err != nil {
+				t.Fatalf("failed to Get infra Cluster: %v", err)
+			}
+
+			gotFin := slices.Sorted(slices.Values(got.GetFinalizers()))
+			wantFin := slices.Sorted(slices.Values(tt.wantFinalizers))
+			if !slices.Equal(gotFin, wantFin) {
+				t.Errorf("finalizers mismatch: got %v, want %v", got.GetFinalizers(), tt.wantFinalizers)
 			}
 		})
 	}

--- a/internal/providerinterface/util.go
+++ b/internal/providerinterface/util.go
@@ -71,21 +71,23 @@ func FindClusterIdentity(ctx context.Context, rgnClient client.Client, clusterId
 func FindProviderInterfaceForInfra(ctx context.Context, rgnClient client.Client, parent clusterParent, infra string) *kcmv1.ProviderInterface {
 	ll := ctrl.LoggerFrom(ctx).WithName("providerinterface").WithValues("infra provider", infra)
 
-	ll.Info("Finding ProviderInterface for the given infrastructure provider")
+	ll.V(1).Info("Finding ProviderInterface for the given infrastructure provider")
 
 	providerInterfaces := new(kcmv1.ProviderInterfaceList)
 	if err := rgnClient.List(
 		ctx, providerInterfaces,
 		client.MatchingLabels{clusterapiv1.ProviderNameLabel: infra},
 		client.Limit(1),
-	); err == nil && len(providerInterfaces.Items) > 0 {
+	); err != nil {
+		ll.Error(err, "Failed to list ProviderInterfaces by CAPI provider label, falling back")
+	} else if len(providerInterfaces.Items) > 0 {
 		pi := &providerInterfaces.Items[0]
-		ll.Info("Found ProviderInterface for the given infrastructure provider", "providerinterface", client.ObjectKeyFromObject(pi))
+		ll.V(1).Info("Found ProviderInterface for the given infrastructure provider", "providerinterface", client.ObjectKeyFromObject(pi))
 		return pi
 	}
 
 	// fallback: look up by the flux helm-chart-name label
-	ll.Info("Falling back to flux helm-chart name")
+	ll.V(1).Info("Falling back to flux helm-chart name")
 
 	componentName := findComponentForInfra(parent.GetComponentsStatus().Components, infra)
 	if componentName == "" {
@@ -98,13 +100,14 @@ func FindProviderInterfaceForInfra(ctx context.Context, rgnClient client.Client,
 		ctx, providerInterfaces,
 		client.MatchingLabels{kcmv1.FluxHelmChartNameKey: helm.ReleaseName(parent.HelmReleasePrefix(), componentName)},
 		client.Limit(1),
-	); err == nil && len(providerInterfaces.Items) > 0 {
+	); err != nil {
+		ll.Error(err, "Failed to list ProviderInterfaces by flux helm-chart name", "component name", componentName)
+	} else if len(providerInterfaces.Items) > 0 {
 		pi := &providerInterfaces.Items[0]
-		ll.Info("Found ProviderInterface for the given infrastructure provider from old flux helm-chart name", "component name", componentName, "providerinterface", client.ObjectKeyFromObject(pi))
+		ll.V(1).Info("Found ProviderInterface for the given infrastructure provider from old flux helm-chart name", "component name", componentName, "providerinterface", client.ObjectKeyFromObject(pi))
 		return pi
 	}
 
-	// NOTE: we specifically suppress any errors/zero-length lists
 	ll.Info("No ProviderInterface has been found")
 
 	return nil

--- a/internal/providerinterface/util.go
+++ b/internal/providerinterface/util.go
@@ -21,6 +21,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	clusterapiv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
@@ -61,23 +63,51 @@ func FindClusterIdentity(ctx context.Context, rgnClient client.Client, clusterId
 }
 
 // FindProviderInterfaceForInfra gets the first found ProviderInterface that is a part of the component exposing
-// given infrastructure provider
+// the given infrastructure provider.
+//
+// It first tries the standard CAPI provider label ("cluster.x-k8s.io/provider"); on miss it falls back
+// to the flux helm-chart-name label for backward compatibility with ProviderInterfaces installed via
+// their provider's own HelmRelease that don't yet carry the CAPI label
 func FindProviderInterfaceForInfra(ctx context.Context, rgnClient client.Client, parent clusterParent, infra string) *kcmv1.ProviderInterface {
+	ll := ctrl.LoggerFrom(ctx).WithName("providerinterface").WithValues("infra provider", infra)
+
+	ll.Info("Finding ProviderInterface for the given infrastructure provider")
+
+	providerInterfaces := new(kcmv1.ProviderInterfaceList)
+	if err := rgnClient.List(
+		ctx, providerInterfaces,
+		client.MatchingLabels{clusterapiv1.ProviderNameLabel: infra},
+		client.Limit(1),
+	); err == nil && len(providerInterfaces.Items) > 0 {
+		pi := &providerInterfaces.Items[0]
+		ll.Info("Found ProviderInterface for the given infrastructure provider", "providerinterface", client.ObjectKeyFromObject(pi))
+		return pi
+	}
+
+	// fallback: look up by the flux helm-chart-name label
+	ll.Info("Falling back to flux helm-chart name")
+
 	componentName := findComponentForInfra(parent.GetComponentsStatus().Components, infra)
 	if componentName == "" {
+		ll.Info("No component name found, skipping ProviderInterface search")
 		return nil
 	}
-	// Get the first found ProviderInterface from the <componentName> helm chart
-	providerInterfaces := &kcmv1.ProviderInterfaceList{}
-	if err := rgnClient.List(ctx, providerInterfaces,
+
+	providerInterfaces = &kcmv1.ProviderInterfaceList{}
+	if err := rgnClient.List(
+		ctx, providerInterfaces,
 		client.MatchingLabels{kcmv1.FluxHelmChartNameKey: helm.ReleaseName(parent.HelmReleasePrefix(), componentName)},
-		client.Limit(1)); err != nil {
-		return nil
+		client.Limit(1),
+	); err == nil && len(providerInterfaces.Items) > 0 {
+		pi := &providerInterfaces.Items[0]
+		ll.Info("Found ProviderInterface for the given infrastructure provider from old flux helm-chart name", "component name", componentName, "providerinterface", client.ObjectKeyFromObject(pi))
+		return pi
 	}
-	if len(providerInterfaces.Items) == 0 {
-		return nil
-	}
-	return &providerInterfaces.Items[0]
+
+	// NOTE: we specifically suppress any errors/zero-length lists
+	ll.Info("No ProviderInterface has been found")
+
+	return nil
 }
 
 func findComponentForInfra(exposedComponents map[string]kcmv1.ComponentStatus, infra string) string {

--- a/templates/provider/cluster-api-provider-aws/Chart.yaml
+++ b/templates/provider/cluster-api-provider-aws/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.22
+version: 1.0.23
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-aws/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-aws/templates/interface.yaml
@@ -2,6 +2,8 @@ apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderInterface
 metadata:
   name: cluster-api-provider-aws
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-aws
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/cluster-api-provider-azure/Chart.yaml
+++ b/templates/provider/cluster-api-provider-azure/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.28
+version: 1.0.29
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-azure/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-azure/templates/interface.yaml
@@ -2,6 +2,8 @@ apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderInterface
 metadata:
   name: cluster-api-provider-azure
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-azure
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/cluster-api-provider-docker/Chart.yaml
+++ b/templates/provider/cluster-api-provider-docker/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.21
+version: 1.0.22
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-docker/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-docker/templates/interface.yaml
@@ -2,6 +2,8 @@ apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderInterface
 metadata:
   name: cluster-api-provider-docker
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/cluster-api-provider-gcp/Chart.yaml
+++ b/templates/provider/cluster-api-provider-gcp/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.20
+version: 1.0.21
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-gcp/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-gcp/templates/interface.yaml
@@ -2,6 +2,8 @@ apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderInterface
 metadata:
   name: cluster-api-provider-gcp
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-gcp
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.29
+version: 1.0.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-k0sproject-k0smotron/templates/interface.yaml
@@ -2,6 +2,8 @@ apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderInterface
 metadata:
   name: cluster-api-provider-k0sproject-k0smotron
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-k0sproject-k0smotron
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/cluster-api-provider-kubevirt/Chart.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-kubevirt/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-kubevirt/templates/interface.yaml
@@ -2,6 +2,8 @@ apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderInterface
 metadata:
   name: cluster-api-provider-kubevirt
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-kubevirt
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/cluster-api-provider-openstack/Chart.yaml
+++ b/templates/provider/cluster-api-provider-openstack/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-openstack/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-openstack/templates/interface.yaml
@@ -2,6 +2,8 @@ apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderInterface
 metadata:
   name: cluster-api-provider-openstack
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-openstack
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/cluster-api-provider-vsphere/Chart.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.19
+version: 1.0.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/provider/cluster-api-provider-vsphere/templates/interface.yaml
+++ b/templates/provider/cluster-api-provider-vsphere/templates/interface.yaml
@@ -2,6 +2,8 @@ apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderInterface
 metadata:
   name: cluster-api-provider-vsphere
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-vsphere
   annotations:
     helm.sh/resource-policy: keep
 spec:

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -14,24 +14,24 @@ spec:
     template: cluster-api-1-1-14
   providers:
     - name: cluster-api-provider-k0sproject-k0smotron
-      template: cluster-api-provider-k0sproject-k0smotron-1-0-29
+      template: cluster-api-provider-k0sproject-k0smotron-1-0-30
     - name: cluster-api-provider-azure
-      template: cluster-api-provider-azure-1-0-28
+      template: cluster-api-provider-azure-1-0-29
     - name: cluster-api-provider-vsphere
-      template: cluster-api-provider-vsphere-1-0-19
+      template: cluster-api-provider-vsphere-1-0-20
     - name: cluster-api-provider-aws
-      template: cluster-api-provider-aws-1-0-22
+      template: cluster-api-provider-aws-1-0-23
     - name: cluster-api-provider-openstack
-      template: cluster-api-provider-openstack-1-0-26
+      template: cluster-api-provider-openstack-1-0-27
     - name: cluster-api-provider-docker
-      template: cluster-api-provider-docker-1-0-21
+      template: cluster-api-provider-docker-1-0-22
     - name: cluster-api-provider-gcp
-      template: cluster-api-provider-gcp-1-0-20
+      template: cluster-api-provider-gcp-1-0-21
     - name: cluster-api-provider-ipam
       template: cluster-api-provider-ipam-1-0-12
     - name: cluster-api-provider-infoblox
       template: cluster-api-provider-infoblox-1-0-11
     - name: cluster-api-provider-kubevirt
-      template: cluster-api-provider-kubevirt-1-0-8
+      template: cluster-api-provider-kubevirt-1-0-9
     - name: projectsveltos
       template: projectsveltos-1-9-0

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-aws-1-0-22
+  name: cluster-api-provider-aws-1-0-23
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-aws
-      version: 1.0.22
+      version: 1.0.23
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-azure.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-azure-1-0-28
+  name: cluster-api-provider-azure-1-0-29
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-azure
-      version: 1.0.28
+      version: 1.0.29
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-docker.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-docker-1-0-21
+  name: cluster-api-provider-docker-1-0-22
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-docker
-      version: 1.0.21
+      version: 1.0.22
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-gcp-1-0-20
+  name: cluster-api-provider-gcp-1-0-21
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-gcp
-      version: 1.0.20
+      version: 1.0.21
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-k0sproject-k0smotron.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-k0sproject-k0smotron-1-0-29
+  name: cluster-api-provider-k0sproject-k0smotron-1-0-30
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-k0sproject-k0smotron
-      version: 1.0.29
+      version: 1.0.30
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-kubevirt.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-kubevirt-1-0-8
+  name: cluster-api-provider-kubevirt-1-0-9
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-kubevirt
-      version: 1.0.8
+      version: 1.0.9
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-openstack.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-openstack-1-0-26
+  name: cluster-api-provider-openstack-1-0-27
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-openstack
-      version: 1.0.26
+      version: 1.0.27
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-vsphere.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-vsphere-1-0-19
+  name: cluster-api-provider-vsphere-1-0-20
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-vsphere
-      version: 1.0.19
+      version: 1.0.20
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/test/scheme/scheme.go
+++ b/test/scheme/scheme.go
@@ -19,6 +19,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,6 +43,7 @@ var (
 		addoncontrollerv1beta1.AddToScheme,
 		kubevirtv1.AddToScheme,
 		cdiv1.AddToScheme,
+		apiextv1.AddToScheme,
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Resolve the infra Cluster via CAPI Cluster.spec.infrastructureRef using external.GetObjectFromContractVersionedRef instead of listing by guessed GVKs.

Switch FindProviderInterfaceForInfra to the standard CAPI cluster.x-k8s.io/provider label with the flux helm-chart-name label kept as a fallback, and stamp the CAPI label on all in-tree ProviderInterface templates

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #2888 
Closes #2894 