### PR TITLE
fix: do not add owner ref to profile when operating on regional clusters

### DIFF
--- a/internal/controller/adapters/sveltos/enqueue.go
+++ b/internal/controller/adapters/sveltos/enqueue.go
@@ -42,7 +42,7 @@ func enqueueClusterSummary(cl client.Client, systemNamespace string) pollerutil.
 		logger.V(1).Info("Listing ServiceSet objects", "service_set_count", len(serviceSetList.Items))
 
 		// cluster object key -> regional client, reused within a single tick
-		rgnClients := make(map[client.ObjectKey]client.Client)
+		rgnClients := make(map[client.ObjectKey]regionalClientEntry)
 
 		out := make([]*kcmv1.ServiceSet, 0, len(serviceSetList.Items))
 		for i := range serviceSetList.Items {
@@ -52,7 +52,7 @@ func enqueueClusterSummary(cl client.Client, systemNamespace string) pollerutil.
 				continue
 			}
 
-			rgnClient, err := resolveRegionalClient(ctx, cl, serviceSet, systemNamespace, rgnClients)
+			rgnClient, _, err := resolveRegionalClient(ctx, cl, serviceSet, systemNamespace, rgnClients)
 			if err != nil {
 				logger.V(1).Error(err, "failed to get regional client", "service_set", client.ObjectKeyFromObject(serviceSet))
 				continue

--- a/internal/controller/adapters/sveltos/enqueue.go
+++ b/internal/controller/adapters/sveltos/enqueue.go
@@ -42,7 +42,7 @@ func enqueueClusterSummary(cl client.Client, systemNamespace string) pollerutil.
 		logger.V(1).Info("Listing ServiceSet objects", "service_set_count", len(serviceSetList.Items))
 
 		// cluster object key -> regional client, reused within a single tick
-		rgnClients := make(map[client.ObjectKey]regionalClientEntry)
+		rgnClients := make(map[client.ObjectKey]client.Client)
 
 		out := make([]*kcmv1.ServiceSet, 0, len(serviceSetList.Items))
 		for i := range serviceSetList.Items {
@@ -52,7 +52,7 @@ func enqueueClusterSummary(cl client.Client, systemNamespace string) pollerutil.
 				continue
 			}
 
-			rgnClient, _, err := resolveRegionalClient(ctx, cl, serviceSet, systemNamespace, rgnClients)
+			rgnClient, err := resolveRegionalClient(ctx, cl, serviceSet, systemNamespace, rgnClients)
 			if err != nil {
 				logger.V(1).Error(err, "failed to get regional client", "service_set", client.ObjectKeyFromObject(serviceSet))
 				continue

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -128,7 +128,7 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	rgnClient, regionName, err := getRegionalClient(ctx, r.Client, serviceSet, r.SystemNamespace)
+	rgnClient, err := getRegionalClient(ctx, r.Client, serviceSet, r.SystemNamespace)
 	if err != nil {
 		l.Error(err, "failed to get regional client")
 		return ctrl.Result{}, err
@@ -204,7 +204,7 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// first we'll ensure the profile exists and up-to-date
-	if err = r.ensureProfile(ctx, rgnClient, regionName, serviceSet); err != nil {
+	if err = r.ensureProfile(ctx, rgnClient, serviceSet); err != nil {
 		conditionOldState := apimeta.FindStatusCondition(clone.Status.Conditions, kcmv1.ServiceSetProfileCondition)
 		conditionNewState := apimeta.FindStatusCondition(serviceSet.Status.Conditions, kcmv1.ServiceSetProfileCondition)
 		// we'll emit ServiceSetEnsureProfileFailedEvent warning
@@ -398,7 +398,7 @@ func (r *ServiceSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // ensureProfile ensures that a [github.com/projectsveltos/addon-controller/api/v1beta1.Profile]
 // object exists for a given [github.com/K0rdent/kcm/api/v1beta1.ServiceSet].
-func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient client.Client, regionName string, serviceSet *kcmv1.ServiceSet) error {
+func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) error {
 	start := time.Now()
 	l := ctrl.LoggerFrom(ctx)
 	l.Info("Ensuring ProjectSveltos Profile")
@@ -447,7 +447,7 @@ func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient clie
 			return fmt.Errorf("failed to create or update ClusterProfile: %w", err)
 		}
 	} else {
-		if err = r.createOrUpdateProfile(ctx, rgnClient, regionName, serviceSet, spec); err != nil {
+		if err = r.createOrUpdateProfile(ctx, rgnClient, serviceSet, spec); err != nil {
 			return fmt.Errorf("failed to create or update Profile: %w", err)
 		}
 	}
@@ -458,8 +458,12 @@ func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient clie
 	return nil
 }
 
-func (*ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, rgnClient client.Client, regionName string, serviceSet *kcmv1.ServiceSet, spec *addoncontrollerv1beta1.Spec) error {
+func (r *ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet, spec *addoncontrollerv1beta1.Spec) error {
 	ownerReference := metav1.NewControllerRef(serviceSet, kcmv1.GroupVersion.WithKind(kcmv1.ServiceSetKind))
+	// the same ref in mem means the Profile lives in the mgmt cluster next to
+	// the owning ServiceSet; on a regional cluster the reference would point
+	// to a nonexistent object
+	inMgmtCluster := rgnClient == r.Client
 
 	profile := new(addoncontrollerv1beta1.Profile)
 	key := client.ObjectKeyFromObject(serviceSet)
@@ -481,7 +485,7 @@ func (*ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, rgnClien
 		profile.Labels = map[string]string{
 			kcmv1.KCMManagedLabelKey: kcmv1.KCMManagedLabelValue,
 		}
-		if regionName == "" {
+		if inMgmtCluster {
 			profile.OwnerReferences = []metav1.OwnerReference{*ownerReference}
 		}
 		profile.Spec = *spec
@@ -492,7 +496,7 @@ func (*ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, rgnClien
 	// we need to update it. Make sure that the empty values in `spec`
 	// are defaulted otherwise comparison will always return false.
 	case annotationsUpdated || !equality.Semantic.DeepEqual(profile.Spec, *spec):
-		if regionName == "" {
+		if inMgmtCluster {
 			profile.OwnerReferences = []metav1.OwnerReference{*ownerReference}
 		}
 		profile.Spec = *spec
@@ -1554,17 +1558,9 @@ func conditionReasonChanged(conditionOldState, conditionNewState *metav1.Conditi
 
 // getRegionalClient returns the kubernetes client for the cluster where
 // serviceSet's workload runs: the local client cl for self-managed (empty
-// .spec.cluster) ServiceSets, or the regional client otherwise. The returned
-// region name is empty when the client targets the management cluster.
-func getRegionalClient(ctx context.Context, cl client.Client, serviceSet *kcmv1.ServiceSet, systemNamespace string) (client.Client, string, error) {
+// .spec.cluster) ServiceSets, or the regional client otherwise.
+func getRegionalClient(ctx context.Context, cl client.Client, serviceSet *kcmv1.ServiceSet, systemNamespace string) (client.Client, error) {
 	return resolveRegionalClient(ctx, cl, serviceSet, systemNamespace, nil)
-}
-
-// regionalClientEntry pairs a resolved client with the name of the region it
-// targets ("" for the management cluster).
-type regionalClientEntry struct {
-	client     client.Client
-	regionName string
 }
 
 // resolveRegionalClient is the cache-aware variant of [getRegionalClient].
@@ -1576,30 +1572,30 @@ func resolveRegionalClient(
 	cl client.Client,
 	serviceSet *kcmv1.ServiceSet,
 	systemNamespace string,
-	cache map[client.ObjectKey]regionalClientEntry,
-) (client.Client, string, error) {
+	cache map[client.ObjectKey]client.Client,
+) (client.Client, error) {
 	if serviceSet.Spec.Cluster == "" {
 		// ServiceSet that self-manages the management cluster has no
 		// matching ClusterDeployment, so the local client is the answer
-		return cl, "", nil
+		return cl, nil
 	}
 
 	clusterKey := client.ObjectKey{Namespace: serviceSet.Namespace, Name: serviceSet.Spec.Cluster}
 	if cache != nil {
-		if e, ok := cache[clusterKey]; ok {
-			return e.client, e.regionName, nil
+		if c, ok := cache[clusterKey]; ok {
+			return c, nil
 		}
 	}
 
 	cd := new(kcmv1.ClusterDeployment)
 	if err := cl.Get(ctx, clusterKey, cd); err != nil {
-		return nil, "", fmt.Errorf("failed to get ClusterDeployment %s: %w", clusterKey, err)
+		return nil, fmt.Errorf("failed to get ClusterDeployment %s: %w", clusterKey, err)
 	}
 
 	cred := new(kcmv1.Credential)
 	credKey := client.ObjectKey{Namespace: cd.Namespace, Name: cd.Spec.Credential}
 	if err := cl.Get(ctx, credKey, cred); err != nil {
-		return nil, "", fmt.Errorf("failed to get Credential %s: %w", credKey, err)
+		return nil, fmt.Errorf("failed to get Credential %s: %w", credKey, err)
 	}
 
 	rgn := cl
@@ -1607,15 +1603,15 @@ func resolveRegionalClient(
 		var err error
 		rgn, err = kubeutil.GetRegionalClientByRegionName(ctx, cl, systemNamespace, cred.Spec.Region, schemeutil.GetRegionalSchemeWithSveltos)
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to get regional client for region %s: %w", cred.Spec.Region, err)
+			return nil, fmt.Errorf("failed to get regional client for region %s: %w", cred.Spec.Region, err)
 		}
 	}
 
 	if cache != nil {
-		cache[clusterKey] = regionalClientEntry{client: rgn, regionName: cred.Spec.Region}
+		cache[clusterKey] = rgn
 	}
 
-	return rgn, cred.Spec.Region, nil
+	return rgn, nil
 }
 
 func clusterReference(serviceSet *kcmv1.ServiceSet) *corev1.ObjectReference {

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -128,7 +128,7 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	rgnClient, err := getRegionalClient(ctx, r.Client, serviceSet, r.SystemNamespace)
+	rgnClient, regionName, err := getRegionalClient(ctx, r.Client, serviceSet, r.SystemNamespace)
 	if err != nil {
 		l.Error(err, "failed to get regional client")
 		return ctrl.Result{}, err
@@ -204,7 +204,7 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// first we'll ensure the profile exists and up-to-date
-	if err = r.ensureProfile(ctx, rgnClient, serviceSet); err != nil {
+	if err = r.ensureProfile(ctx, rgnClient, regionName, serviceSet); err != nil {
 		conditionOldState := apimeta.FindStatusCondition(clone.Status.Conditions, kcmv1.ServiceSetProfileCondition)
 		conditionNewState := apimeta.FindStatusCondition(serviceSet.Status.Conditions, kcmv1.ServiceSetProfileCondition)
 		// we'll emit ServiceSetEnsureProfileFailedEvent warning
@@ -398,7 +398,7 @@ func (r *ServiceSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // ensureProfile ensures that a [github.com/projectsveltos/addon-controller/api/v1beta1.Profile]
 // object exists for a given [github.com/K0rdent/kcm/api/v1beta1.ServiceSet].
-func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet) error {
+func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient client.Client, regionName string, serviceSet *kcmv1.ServiceSet) error {
 	start := time.Now()
 	l := ctrl.LoggerFrom(ctx)
 	l.Info("Ensuring ProjectSveltos Profile")
@@ -447,7 +447,7 @@ func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient clie
 			return fmt.Errorf("failed to create or update ClusterProfile: %w", err)
 		}
 	} else {
-		if err = r.createOrUpdateProfile(ctx, rgnClient, serviceSet, spec); err != nil {
+		if err = r.createOrUpdateProfile(ctx, rgnClient, regionName, serviceSet, spec); err != nil {
 			return fmt.Errorf("failed to create or update Profile: %w", err)
 		}
 	}
@@ -458,7 +458,7 @@ func (r *ServiceSetReconciler) ensureProfile(ctx context.Context, rgnClient clie
 	return nil
 }
 
-func (*ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, rgnClient client.Client, serviceSet *kcmv1.ServiceSet, spec *addoncontrollerv1beta1.Spec) error {
+func (*ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, rgnClient client.Client, regionName string, serviceSet *kcmv1.ServiceSet, spec *addoncontrollerv1beta1.Spec) error {
 	ownerReference := metav1.NewControllerRef(serviceSet, kcmv1.GroupVersion.WithKind(kcmv1.ServiceSetKind))
 
 	profile := new(addoncontrollerv1beta1.Profile)
@@ -481,7 +481,9 @@ func (*ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, rgnClien
 		profile.Labels = map[string]string{
 			kcmv1.KCMManagedLabelKey: kcmv1.KCMManagedLabelValue,
 		}
-		profile.OwnerReferences = []metav1.OwnerReference{*ownerReference}
+		if regionName == "" {
+			profile.OwnerReferences = []metav1.OwnerReference{*ownerReference}
+		}
 		profile.Spec = *spec
 		if err = rgnClient.Create(ctx, profile); err != nil {
 			return fmt.Errorf("failed to create Profile for ServiceSet %s: %w", serviceSet.Name, err)
@@ -490,7 +492,9 @@ func (*ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, rgnClien
 	// we need to update it. Make sure that the empty values in `spec`
 	// are defaulted otherwise comparison will always return false.
 	case annotationsUpdated || !equality.Semantic.DeepEqual(profile.Spec, *spec):
-		profile.OwnerReferences = []metav1.OwnerReference{*ownerReference}
+		if regionName == "" {
+			profile.OwnerReferences = []metav1.OwnerReference{*ownerReference}
+		}
 		profile.Spec = *spec
 		if err = rgnClient.Update(ctx, profile); err != nil {
 			return fmt.Errorf("failed to update Profile for ServiceSet %s: %w", serviceSet.Name, err)
@@ -1550,9 +1554,17 @@ func conditionReasonChanged(conditionOldState, conditionNewState *metav1.Conditi
 
 // getRegionalClient returns the kubernetes client for the cluster where
 // serviceSet's workload runs: the local client cl for self-managed (empty
-// .spec.cluster) ServiceSets, or the regional client otherwise.
-func getRegionalClient(ctx context.Context, cl client.Client, serviceSet *kcmv1.ServiceSet, systemNamespace string) (client.Client, error) {
+// .spec.cluster) ServiceSets, or the regional client otherwise. The returned
+// region name is empty when the client targets the management cluster.
+func getRegionalClient(ctx context.Context, cl client.Client, serviceSet *kcmv1.ServiceSet, systemNamespace string) (client.Client, string, error) {
 	return resolveRegionalClient(ctx, cl, serviceSet, systemNamespace, nil)
+}
+
+// regionalClientEntry pairs a resolved client with the name of the region it
+// targets ("" for the management cluster).
+type regionalClientEntry struct {
+	client     client.Client
+	regionName string
 }
 
 // resolveRegionalClient is the cache-aware variant of [getRegionalClient].
@@ -1564,30 +1576,30 @@ func resolveRegionalClient(
 	cl client.Client,
 	serviceSet *kcmv1.ServiceSet,
 	systemNamespace string,
-	cache map[client.ObjectKey]client.Client,
-) (client.Client, error) {
+	cache map[client.ObjectKey]regionalClientEntry,
+) (client.Client, string, error) {
 	if serviceSet.Spec.Cluster == "" {
 		// ServiceSet that self-manages the management cluster has no
 		// matching ClusterDeployment, so the local client is the answer
-		return cl, nil
+		return cl, "", nil
 	}
 
 	clusterKey := client.ObjectKey{Namespace: serviceSet.Namespace, Name: serviceSet.Spec.Cluster}
 	if cache != nil {
-		if c, ok := cache[clusterKey]; ok {
-			return c, nil
+		if e, ok := cache[clusterKey]; ok {
+			return e.client, e.regionName, nil
 		}
 	}
 
 	cd := new(kcmv1.ClusterDeployment)
 	if err := cl.Get(ctx, clusterKey, cd); err != nil {
-		return nil, fmt.Errorf("failed to get ClusterDeployment %s: %w", clusterKey, err)
+		return nil, "", fmt.Errorf("failed to get ClusterDeployment %s: %w", clusterKey, err)
 	}
 
 	cred := new(kcmv1.Credential)
 	credKey := client.ObjectKey{Namespace: cd.Namespace, Name: cd.Spec.Credential}
 	if err := cl.Get(ctx, credKey, cred); err != nil {
-		return nil, fmt.Errorf("failed to get Credential %s: %w", credKey, err)
+		return nil, "", fmt.Errorf("failed to get Credential %s: %w", credKey, err)
 	}
 
 	rgn := cl
@@ -1595,15 +1607,15 @@ func resolveRegionalClient(
 		var err error
 		rgn, err = kubeutil.GetRegionalClientByRegionName(ctx, cl, systemNamespace, cred.Spec.Region, schemeutil.GetRegionalSchemeWithSveltos)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get regional client for region %s: %w", cred.Spec.Region, err)
+			return nil, "", fmt.Errorf("failed to get regional client for region %s: %w", cred.Spec.Region, err)
 		}
 	}
 
 	if cache != nil {
-		cache[clusterKey] = rgn
+		cache[clusterKey] = regionalClientEntry{client: rgn, regionName: cred.Spec.Region}
 	}
 
-	return rgn, nil
+	return rgn, cred.Spec.Region, nil
 }
 
 func clusterReference(serviceSet *kcmv1.ServiceSet) *corev1.ObjectReference {

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -475,6 +475,7 @@ func (r *ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, rgnCli
 	}
 
 	annotationsUpdated := handlePauseAnnotations(&profile.ObjectMeta, serviceSet)
+	staleOwnerRefs := !inMgmtCluster && len(profile.OwnerReferences) > 0
 
 	switch {
 	// we already excluded all errors except NotFound
@@ -495,9 +496,11 @@ func (r *ServiceSetReconciler) createOrUpdateProfile(ctx context.Context, rgnCli
 	// If profile spec is not equal to the spec we just created so
 	// we need to update it. Make sure that the empty values in `spec`
 	// are defaulted otherwise comparison will always return false.
-	case annotationsUpdated || !equality.Semantic.DeepEqual(profile.Spec, *spec):
+	case annotationsUpdated || staleOwnerRefs || !equality.Semantic.DeepEqual(profile.Spec, *spec):
 		if inMgmtCluster {
 			profile.OwnerReferences = []metav1.OwnerReference{*ownerReference}
+		} else {
+			profile.OwnerReferences = nil
 		}
 		profile.Spec = *spec
 		if err = rgnClient.Update(ctx, profile); err != nil {

--- a/internal/controller/adapters/sveltos/serviceset_controller_test.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller_test.go
@@ -993,6 +993,66 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 			})
 		})
 	})
+
+	Context("Profile owner references", func() {
+		var profileSpec addoncontrollerv1beta1.Spec
+
+		BeforeEach(func() {
+			profileSpec = addoncontrollerv1beta1.Spec{
+				SyncMode: addoncontrollerv1beta1.SyncModeContinuous,
+			}
+		})
+
+		It("should set the controller owner reference on the Profile when no region is in play", func() {
+			By("creating the Profile", func() {
+				Expect(reconciler.createOrUpdateProfile(ctx, cl, emptyString, &serviceSet, &profileSpec)).To(Succeed())
+				profile = addoncontrollerv1beta1.Profile{}
+				Expect(cl.Get(ctx, client.ObjectKeyFromObject(&serviceSet), &profile)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(client.IgnoreNotFound(cl.Delete(ctx, &profile))).To(Succeed())
+				})
+				Expect(profile.OwnerReferences).To(HaveLen(1))
+				Expect(profile.OwnerReferences[0]).To(SatisfyAll(
+					HaveField("Kind", kcmv1.ServiceSetKind),
+					HaveField("Name", serviceSet.Name),
+					HaveField("UID", serviceSet.UID),
+					HaveField("Controller", HaveValue(BeTrue())),
+				))
+			})
+
+			By("updating the Profile", func() {
+				updatedSpec := profileSpec
+				updatedSpec.StopMatchingBehavior = addoncontrollerv1beta1.LeavePolicies
+				Expect(reconciler.createOrUpdateProfile(ctx, cl, emptyString, &serviceSet, &updatedSpec)).To(Succeed())
+				Expect(cl.Get(ctx, client.ObjectKeyFromObject(&serviceSet), &profile)).To(Succeed())
+				Expect(profile.Spec.StopMatchingBehavior).To(Equal(addoncontrollerv1beta1.LeavePolicies))
+				Expect(profile.OwnerReferences).To(HaveLen(1))
+			})
+		})
+
+		It("should not set owner references on the Profile when the ServiceSet targets a region", func() {
+			const regionName = "test-region"
+
+			By("creating the Profile", func() {
+				Expect(reconciler.createOrUpdateProfile(ctx, cl, regionName, &serviceSet, &profileSpec)).To(Succeed())
+				profile = addoncontrollerv1beta1.Profile{}
+				Expect(cl.Get(ctx, client.ObjectKeyFromObject(&serviceSet), &profile)).To(Succeed())
+				DeferCleanup(func() {
+					Expect(client.IgnoreNotFound(cl.Delete(ctx, &profile))).To(Succeed())
+				})
+				Expect(profile.OwnerReferences).To(BeEmpty())
+			})
+
+			By("updating the Profile", func() {
+				updatedSpec := profileSpec
+				updatedSpec.StopMatchingBehavior = addoncontrollerv1beta1.LeavePolicies
+				Expect(reconciler.createOrUpdateProfile(ctx, cl, regionName, &serviceSet, &updatedSpec)).To(Succeed())
+				Expect(cl.Get(ctx, client.ObjectKeyFromObject(&serviceSet), &profile)).To(Succeed())
+				Expect(profile.Spec.StopMatchingBehavior).To(Equal(addoncontrollerv1beta1.LeavePolicies))
+				Expect(profile.OwnerReferences).To(BeEmpty())
+			})
+		})
+	})
 })
 
 func prepareStateManagementProvider() kcmv1.StateManagementProvider {

--- a/internal/controller/adapters/sveltos/serviceset_controller_test.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller_test.go
@@ -28,6 +28,7 @@ import (
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	clusterapiv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
@@ -1005,7 +1006,7 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 
 		It("should set the controller owner reference on the Profile when no region is in play", func() {
 			By("creating the Profile", func() {
-				Expect(reconciler.createOrUpdateProfile(ctx, cl, emptyString, &serviceSet, &profileSpec)).To(Succeed())
+				Expect(reconciler.createOrUpdateProfile(ctx, cl, &serviceSet, &profileSpec)).To(Succeed())
 				profile = addoncontrollerv1beta1.Profile{}
 				Expect(cl.Get(ctx, client.ObjectKeyFromObject(&serviceSet), &profile)).To(Succeed())
 				DeferCleanup(func() {
@@ -1023,7 +1024,7 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 			By("updating the Profile", func() {
 				updatedSpec := profileSpec
 				updatedSpec.StopMatchingBehavior = addoncontrollerv1beta1.LeavePolicies
-				Expect(reconciler.createOrUpdateProfile(ctx, cl, emptyString, &serviceSet, &updatedSpec)).To(Succeed())
+				Expect(reconciler.createOrUpdateProfile(ctx, cl, &serviceSet, &updatedSpec)).To(Succeed())
 				Expect(cl.Get(ctx, client.ObjectKeyFromObject(&serviceSet), &profile)).To(Succeed())
 				Expect(profile.Spec.StopMatchingBehavior).To(Equal(addoncontrollerv1beta1.LeavePolicies))
 				Expect(profile.OwnerReferences).To(HaveLen(1))
@@ -1031,10 +1032,14 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 		})
 
 		It("should not set owner references on the Profile when the ServiceSet targets a region", func() {
-			const regionName = "test-region"
+			// a regional client is a separate instance, even when it points
+			// at the same cluster; owner references are gated on the client
+			// being the very same object as the reconciler's
+			rgnCl, err := client.New(config, client.Options{Scheme: scheme.Scheme})
+			Expect(err).NotTo(HaveOccurred())
 
 			By("creating the Profile", func() {
-				Expect(reconciler.createOrUpdateProfile(ctx, cl, regionName, &serviceSet, &profileSpec)).To(Succeed())
+				Expect(reconciler.createOrUpdateProfile(ctx, rgnCl, &serviceSet, &profileSpec)).To(Succeed())
 				profile = addoncontrollerv1beta1.Profile{}
 				Expect(cl.Get(ctx, client.ObjectKeyFromObject(&serviceSet), &profile)).To(Succeed())
 				DeferCleanup(func() {
@@ -1046,7 +1051,7 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 			By("updating the Profile", func() {
 				updatedSpec := profileSpec
 				updatedSpec.StopMatchingBehavior = addoncontrollerv1beta1.LeavePolicies
-				Expect(reconciler.createOrUpdateProfile(ctx, cl, regionName, &serviceSet, &updatedSpec)).To(Succeed())
+				Expect(reconciler.createOrUpdateProfile(ctx, rgnCl, &serviceSet, &updatedSpec)).To(Succeed())
 				Expect(cl.Get(ctx, client.ObjectKeyFromObject(&serviceSet), &profile)).To(Succeed())
 				Expect(profile.Spec.StopMatchingBehavior).To(Equal(addoncontrollerv1beta1.LeavePolicies))
 				Expect(profile.OwnerReferences).To(BeEmpty())

--- a/internal/controller/adapters/sveltos/serviceset_controller_test.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller_test.go
@@ -1031,10 +1031,10 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 			})
 		})
 
-		It("should not set owner references on the Profile when the ServiceSet targets a region", func() {
-			// a regional client is a separate instance, even when it points
-			// at the same cluster; owner references are gated on the client
-			// being the very same object as the reconciler's
+		It("should not set owner references on the Profile when using a regional (non-management) client", func() {
+			// Simulate a regional client by creating a separate client instance (even if it points
+			// at the same API server); owner references are gated on the client being the exact
+			// same object as the reconciler's client.
 			rgnCl, err := client.New(config, client.Options{Scheme: scheme.Scheme})
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This change skips adding the owner ref to the sveltos profile when operating against a regional cluster.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2820 