### PR TITLE
feat: show creation of ServiceSet by MCS blocked by another MCS in status

### DIFF
--- a/api/v1beta1/multiclusterservice_types.go
+++ b/api/v1beta1/multiclusterservice_types.go
@@ -59,6 +59,11 @@ const (
 
 	// MultiClusterServiceDependencyValidationCondition defines the condition of MultiClusterService dependencies.
 	MultiClusterServiceDependencyValidationCondition = "MultiClusterServiceDependencyValidation"
+
+	// MultiClusterServiceDependencyReadyCondition defines the condition of whether every
+	// MultiClusterService this one depends on has finished deploying its services to
+	// every cluster this MultiClusterService matches.
+	MultiClusterServiceDependencyReadyCondition = "MultiClusterServiceDependencyReady"
 )
 
 // Reasons are provided as utility, and not part of the declarative API.
@@ -79,6 +84,9 @@ const (
 	SveltosFeatureReadyReason = "SveltosFeatureReady"
 	// SveltosFeatureNotReadyReason signals that the feature managed by Sveltos on target cluster is not yet ready.
 	SveltosFeatureNotReadyReason = "SveltosFeatureNotReady"
+	// MultiClusterServiceDependencyNotReadyReason signals that this MultiClusterService is waiting for
+	// a MultiClusterService it depends on to deploy its services to one or more matching clusters.
+	MultiClusterServiceDependencyNotReadyReason = "MultiClusterServiceDependencyNotReady"
 )
 
 // Service represents a Service to be deployed.
@@ -375,6 +383,15 @@ type MatchingCluster struct {
 
 	// LastTransitionTime reflects when Deployed state was changed last time.
 	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
+
+	// Reason is a brief machine-readable explanation for why services are not yet
+	// Deployed on this cluster, e.g. MultiClusterServiceDependencyNotReady when this
+	// MultiClusterService is waiting for a MultiClusterService it depends on to finish
+	// deploying its services here.
+	Reason string `json:"reason,omitempty"`
+
+	// Message is a human-readable explanation of Reason.
+	Message string `json:"message,omitempty"`
 
 	// +kubebuilder:default=false
 

--- a/api/v1beta1/multiclusterservice_types.go
+++ b/api/v1beta1/multiclusterservice_types.go
@@ -87,6 +87,10 @@ const (
 	// MultiClusterServiceDependencyNotReadyReason signals that this MultiClusterService is waiting for
 	// a MultiClusterService it depends on to deploy its services to one or more matching clusters.
 	MultiClusterServiceDependencyNotReadyReason = "MultiClusterServiceDependencyNotReady"
+	// MultiClusterServiceDependencyCheckFailedReason signals that an unexpected error prevented this
+	// MultiClusterService from determining whether its MultiClusterService dependencies are ready
+	// on one or more matching clusters.
+	MultiClusterServiceDependencyCheckFailedReason = "MultiClusterServiceDependencyCheckFailed"
 )
 
 // Service represents a Service to be deployed.

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -49,6 +49,7 @@ import (
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	"github.com/K0rdent/kcm/internal/record"
+	"github.com/K0rdent/kcm/internal/serviceset"
 	helmutil "github.com/K0rdent/kcm/internal/util/helm"
 	kubeutil "github.com/K0rdent/kcm/internal/util/kube"
 	pointerutil "github.com/K0rdent/kcm/internal/util/pointer"
@@ -1619,12 +1620,7 @@ func resolveRegionalClient(
 
 func clusterReference(serviceSet *kcmv1.ServiceSet) *corev1.ObjectReference {
 	if serviceSet.Spec.Provider.SelfManagement {
-		return &corev1.ObjectReference{
-			Kind:       libsveltosv1beta1.SveltosClusterKind,
-			Name:       "mgmt",
-			Namespace:  "mgmt",
-			APIVersion: libsveltosv1beta1.GroupVersion.WithKind(libsveltosv1beta1.SveltosClusterKind).GroupVersion().String(),
-		}
+		return serviceset.SelfManagementClusterReference()
 	}
 	return &corev1.ObjectReference{
 		Kind:       kcmv1.ClusterDeploymentKind,

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -176,12 +177,33 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	// counted in the denominator of the ClusterInReadyState condition.
 	totalMatchingClusters := 0
 
+	// blocked collects, for each matching cluster whose ServiceSet could not be created
+	// or updated because a MultiClusterService this one depends on hasn't finished
+	// deploying its services there yet, a reference to that cluster and a message
+	// describing what it's waiting on. Unlike other errors, this is an expected,
+	// self-resolving state rather than a failure, so it's surfaced on mcs.Status
+	// instead of being returned as a reconcile error.
+	var blocked []blockedCluster
+
 	// if selfManagement flag is set, then we'll need to create serviceSet which does not refer
 	// any clusterDeployment, but also has selfManagement flag set to true.
 	if mcs.Spec.ServiceSpec.Provider.SelfManagement {
-		l.V(1).Info("Ensuring ServiceSet for the management cluster")
-		errs = r.createOrUpdateServiceSet(ctx, mcs, nil)
 		totalMatchingClusters++
+
+		l.V(1).Info("Checking if creation of ServiceSet for the management cluster is blocked by another MultiClusterService")
+		blockedErr, err := r.okToReconcileServiceSet(ctx, mcs, nil)
+		if blockedErr == nil && err == nil {
+			l.V(1).Info("Ensuring ServiceSet for the management cluster")
+			errs = errors.Join(errs, r.createOrUpdateServiceSet(ctx, mcs, nil))
+		}
+		if blockedErr != nil {
+			blocked = append(blocked, blockedCluster{ref: serviceset.SelfManagementClusterReference(), msg: blockedErr.Error()})
+		}
+		if err != nil {
+			// Unexpected failure - propagate it as a real reconcile error instead of
+			// masking it as the MCS merely waiting on a dependency.
+			errs = errors.Join(errs, err)
+		}
 	}
 
 	clusters := new(kcmv1.ClusterDeploymentList)
@@ -194,12 +216,35 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	l.V(1).Info("Matching ClusterDeployments found", "count", len(clusters.Items))
 	matchingClusterKeys := make(map[client.ObjectKey]struct{}, len(clusters.Items))
 	for _, cluster := range clusters.Items {
+		clusterKey := client.ObjectKeyFromObject(&cluster)
 		if !cluster.DeletionTimestamp.IsZero() {
 			continue
 		}
 		totalMatchingClusters++
-		matchingClusterKeys[client.ObjectKeyFromObject(&cluster)] = struct{}{}
-		errs = errors.Join(errs, r.createOrUpdateServiceSet(ctx, mcs, &cluster))
+		matchingClusterKeys[clusterKey] = struct{}{}
+
+		l.V(1).Info("Checking if creation of ServiceSet for matching ClusterDeployment is blocked by another MultiClusterService", "CD", clusterKey)
+		blockedErr, err := r.okToReconcileServiceSet(ctx, mcs, &cluster)
+		if blockedErr == nil && err == nil {
+			l.V(1).Info("Ensuring ServiceSet for the matching ClusterDeployment", "CD", clusterKey)
+			errs = errors.Join(errs, r.createOrUpdateServiceSet(ctx, mcs, &cluster))
+		}
+		if blockedErr != nil {
+			blocked = append(blocked, blockedCluster{
+				ref: &corev1.ObjectReference{
+					Kind:       kcmv1.ClusterDeploymentKind,
+					Name:       cluster.Name,
+					Namespace:  cluster.Namespace,
+					APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
+				},
+				msg: blockedErr.Error(),
+			})
+		}
+		if err != nil {
+			// Unexpected failure - propagate it as a real reconcile error instead of
+			// masking it as the MCS merely waiting on a dependency.
+			errs = errors.Join(errs, err)
+		}
 	}
 
 	serviceSetList := new(kcmv1.ServiceSetList)
@@ -231,6 +276,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 
 	r.setClustersCondition(ctx, mcs, totalMatchingClusters, currentlyMatchingServiceSets)
+	r.setDependencyReadyCondition(mcs, blocked)
 	if errs != nil {
 		return ctrl.Result{}, errs
 	}
@@ -242,7 +288,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	upgradePaths, servicesErr = serviceset.ServicesUpgradePaths(ctx, r.Client, mcs.Spec.ServiceSpec.Services, r.SystemNamespace)
 	mcs.Status.ServicesUpgradePaths = upgradePaths
 
-	clustersErr := r.setMatchingClusters(ctx, mcs, currentlyMatchingServiceSets)
+	clustersErr := r.setMatchingClusters(ctx, mcs, currentlyMatchingServiceSets, blocked)
 
 	return result, errors.Join(servicesErr, clustersErr)
 }
@@ -291,13 +337,45 @@ func (*MultiClusterServiceReconciler) setClustersCondition(ctx context.Context, 
 	apimeta.SetStatusCondition(&mcs.Status.Conditions, c)
 }
 
+// blockedCluster describes a matching cluster whose ServiceSet could not be created or
+// updated because a MultiClusterService this one depends on has not yet deployed all of
+// its services there.
+type blockedCluster struct {
+	ref *corev1.ObjectReference
+	msg string
+}
+
+// setDependencyReadyCondition updates the MultiClusterServiceDependencyReady condition, which
+// reflects whether every MultiClusterService this one depends on has finished deploying its
+// services to all clusters this MultiClusterService matches.
+func (*MultiClusterServiceReconciler) setDependencyReadyCondition(mcs *kcmv1.MultiClusterService, blocked []blockedCluster) {
+	c := metav1.Condition{
+		Type:   kcmv1.MultiClusterServiceDependencyReadyCondition,
+		Status: metav1.ConditionTrue,
+		Reason: kcmv1.SucceededReason,
+	}
+	if len(blocked) > 0 {
+		c.Status = metav1.ConditionFalse
+		c.Reason = kcmv1.MultiClusterServiceDependencyNotReadyReason
+		c.Message = fmt.Sprintf("waiting for MultiClusterService dependencies to be ready on %d matching cluster(s)", len(blocked))
+	}
+	apimeta.SetStatusCondition(&mcs.Status.Conditions, c)
+}
+
 // setMatchingClusters collects service deployments status on matching clusters from ServiceSet objects and
-// updates MultiClusterService object's status.
-func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context, mcs *kcmv1.MultiClusterService, serviceSets []kcmv1.ServiceSet) error {
+// updates MultiClusterService object's status. blocked provides an entry for each matching cluster whose
+// ServiceSet does not exist yet because it is waiting on a MultiClusterService dependency, so that such
+// clusters are still surfaced in the status instead of silently missing from it.
+func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context, mcs *kcmv1.MultiClusterService, serviceSets []kcmv1.ServiceSet, blocked []blockedCluster) error {
 	l := ctrl.LoggerFrom(ctx)
 	l.V(1).Info("Reconciling MultiClusterService matching clusters")
 	now := metav1.NewTime(r.timeFunc())
-	matchingClusters := make([]kcmv1.MatchingCluster, 0, len(serviceSets))
+	// clusterEntries is keyed by cluster (namespace/name) rather than appended to a plain slice, because
+	// a cluster can appear in both serviceSets and blocked at the same time: its ServiceSet may have been
+	// created during an earlier, unblocked reconcile and is still around (we don't delete the services
+	// already deployed before dependency changed), while the current reconcile now finds it blocked again.
+	// Keying by cluster ensures exactly one entry per cluster instead of one from each source.
+	clusterEntries := make(map[client.ObjectKey]kcmv1.MatchingCluster, len(serviceSets)+len(blocked))
 
 	var errs error
 	for _, serviceSet := range serviceSets {
@@ -334,6 +412,25 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 			}
 			cluster.Regional = cred.Spec.Region != ""
 		}
+		clusterEntries[client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}] = cluster
+	}
+
+	// blocked is applied after serviceSets and overwrites any entry for the same cluster - it
+	// reflects this reconcile's up-to-date view of whether the dependency is satisfied, whereas a
+	// pre-existing ServiceSet-derived entry may be stale (e.g. still Deployed from before the
+	// dependency became unsatisfied again, even though it is no longer being kept in sync).
+	for _, b := range blocked {
+		clusterEntries[client.ObjectKey{Namespace: b.ref.Namespace, Name: b.ref.Name}] = kcmv1.MatchingCluster{
+			ObjectReference:    b.ref,
+			LastTransitionTime: &now,
+			Deployed:           false,
+			Reason:             kcmv1.MultiClusterServiceDependencyNotReadyReason,
+			Message:            b.msg,
+		}
+	}
+
+	matchingClusters := make([]kcmv1.MatchingCluster, 0, len(clusterEntries))
+	for _, cluster := range clusterEntries {
 		matchingClusters = append(matchingClusters, cluster)
 	}
 
@@ -353,6 +450,8 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 			observedCluster.Deployed = cluster.Deployed
 			observedCluster.LastTransitionTime = cluster.LastTransitionTime.DeepCopy()
 		}
+		observedCluster.Reason = cluster.Reason
+		observedCluster.Message = cluster.Message
 		resultingClusters = append(resultingClusters, observedCluster)
 	}
 
@@ -523,19 +622,13 @@ func (r *MultiClusterServiceReconciler) SetupWithManager(mgr ctrl.Manager) error
 	return managedController.Complete(r)
 }
 
-// createOrUpdateServiceSet creates or updates the ServiceSet for the given ClusterDeployment.
+// createOrUpdateServiceSet creates or updates the ServiceSet for the provided mcs and cd (cd is
+// nil for the self-management ServiceSet).
 func (r *MultiClusterServiceReconciler) createOrUpdateServiceSet(
 	ctx context.Context,
 	mcs *kcmv1.MultiClusterService,
 	cd *kcmv1.ClusterDeployment,
 ) error {
-	// We won't create or update the ServiceSet until all MultiClusterServices
-	// which this one depends on successfully deploy all of their services to
-	// the cluster represented by the provided ClusterDeployment.
-	if err := r.okToReconcileServiceSet(ctx, mcs, cd); err != nil {
-		return err
-	}
-
 	serviceSetObjectKey := serviceset.ObjectKey(r.SystemNamespace, cd, mcs)
 	opRequisites := serviceset.OperationRequisites{
 		ObjectKey:       serviceSetObjectKey,
@@ -635,19 +728,32 @@ func (*MultiClusterServiceReconciler) setCondition(mcs *kcmv1.MultiClusterServic
 
 // okToReconcileServiceSet verifies if it is ok to reconcile a serviceset for the provided
 // mcs and cd by verifying if all of the services defined in the multiclusterservices that
-// mcs depends on have been successfully deployed on the cluster represented by cd.
-func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Context, mcs *kcmv1.MultiClusterService, cd *kcmv1.ClusterDeployment) (errs error) {
+// mcs depends on have been successfully deployed on the cluster represented by cd (cd is
+// nil for the self-management ServiceSet).
+//
+// blocked is non-nil when the ServiceSet must not be created/updated yet because a
+// MultiClusterService this one depends on hasn't finished deploying its services to this
+// cluster - an expected, self-resolving state that the caller should surface on mcs.Status
+// rather than treat as a failure. err is non-nil for any other, unexpected failure (e.g. a
+// Get or label-selector error) that the caller should instead propagate as a real reconcile
+// error, so controller-runtime retries it with backoff and it's logged as an actual failure
+// rather than being silently folded into the "waiting on dependency" status.
+func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Context, mcs *kcmv1.MultiClusterService, cd *kcmv1.ClusterDeployment) (blocked, err error) {
 	clusterRef := client.ObjectKey{Namespace: "mgmt", Name: "mgmt"}
 	clusterLabels := make(map[string]string)
-	if !mcs.Spec.ServiceSpec.Provider.SelfManagement {
-		// cd should never be nil here because selfManagement=false.
+	// cd is nil only for the self-management (mothership) ServiceSet. A MultiClusterService
+	// can both self-manage and match a ClusterSelector at the same time, in which case this
+	// function is called once with cd == nil (mgmt) and once per matching cd - so cd's
+	// presence, not mcs's own SelfManagement flag, is what tells us which target this call
+	// is checking.
+	if cd != nil {
 		clusterRef = client.ObjectKeyFromObject(cd)
 		clusterLabels = cd.Labels
 	}
 
 	defer func() {
-		if errs != nil {
-			errs = errors.Join(errs, fmt.Errorf("skipping create/update of ServiceSet for matching cluster %s", clusterRef))
+		if blocked != nil {
+			blocked = errors.Join(blocked, fmt.Errorf("skipping create/update of ServiceSet for matching cluster %s", clusterRef))
 		}
 	}()
 
@@ -655,35 +761,50 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 		// Get the MCS this one depends on.
 		depMCSKey := client.ObjectKey{Name: dep}
 		depMCS := new(kcmv1.MultiClusterService)
-		if err := r.Client.Get(ctx, depMCSKey, depMCS); err != nil {
-			errs = errors.Join(errs, fmt.Errorf("failed to get MultiClusterService %s which this depends on: %w", depMCSKey, err))
+		if getErr := r.Client.Get(ctx, depMCSKey, depMCS); getErr != nil {
+			// Unexpected: ValidateMCSDependencyOverall already confirmed depMCS exists earlier
+			// in this same reconcile, so a Get failure here is a real (likely transient) error,
+			// not a normal "waiting on dependency" state.
+			err = errors.Join(err, fmt.Errorf("failed to get MultiClusterService %s which this depends on: %w", depMCSKey, getErr))
 			continue
 		}
 
-		// Check if depMCS matches the provided CD.
-		sel, err := metav1.LabelSelectorAsSelector(&depMCS.Spec.ClusterSelector)
-		if err != nil {
-			errs = errors.Join(errs, fmt.Errorf("failed to determine if MultiClusterService %s which this depends on matches cluster %s: %w", depMCSKey, clusterRef, err))
-			continue
-		}
-
-		selfMgmtDependency := mcs.Spec.ServiceSpec.Provider.SelfManagement && depMCS.Spec.ServiceSpec.Provider.SelfManagement
-		if !selfMgmtDependency && !sel.Matches(labels.Set(clusterLabels)) {
-			// depMCS does not match the provided CD via labels but before continuing
-			// we still have to see whether both mcs and depMCS manage the mothership.
-			// If they do then we will have to consider the status of depMCS's services.
-			// Being here in the execution means that there is no dependency between mcs
-			// and depMCS w.r.t to self-management of the mothership cluster, so we continue.
-			continue
+		// Check if depMCS applies to the cluster represented by clusterRef. Self-management and
+		// ClusterSelector are independent, mutually exclusive-in-relevance mechanisms: whether depMCS
+		// targets the mgmt pseudo-cluster depends solely on depMCS's own SelfManagement flag (a
+		// ClusterSelector never applies to the mothership itself), while whether depMCS targets a real
+		// ClusterDeployment depends solely on whether its ClusterSelector matches that cluster's labels
+		// - depMCS's SelfManagement flag has no bearing on that (a MultiClusterService can self-manage
+		// and independently match other ClusterDeployments via ClusterSelector at the same time).
+		if cd == nil {
+			if !depMCS.Spec.ServiceSpec.Provider.SelfManagement {
+				// depMCS does not target the mgmt cluster, so there is no dependency here.
+				continue
+			}
+		} else {
+			sel, selErr := metav1.LabelSelectorAsSelector(&depMCS.Spec.ClusterSelector)
+			if selErr != nil {
+				// Unexpected: a malformed ClusterSelector is a configuration/validation
+				// problem, not the dependency simply not being ready yet.
+				err = errors.Join(err, fmt.Errorf("failed to determine if MultiClusterService %s which this depends on matches cluster %s: %w", depMCSKey, clusterRef, selErr))
+				continue
+			}
+			// An empty ClusterSelector converts to labels.Everything(), which Matches() treats as
+			// matching every cluster. reconcileUpdate instead treats an empty selector as matching no
+			// ClusterDeployment (it only lists matching ClusterDeployments when !selector.Empty()), so
+			// mirror that here - otherwise a depMCS with a blank ClusterSelector would appear to depend
+			// against every ClusterDeployment, even ones its own reconcile never targets.
+			if sel.Empty() || !sel.Matches(labels.Set(clusterLabels)) {
+				continue
+			}
 		}
 
 		// Get the ServiceSet associated with provided CD and depMCS.
 		sset := new(kcmv1.ServiceSet)
 		ssetKey := serviceset.ObjectKey(r.SystemNamespace, cd, depMCS)
-		err = r.Client.Get(ctx, ssetKey, sset)
-		if apierrors.IsNotFound(err) {
-			// If the ServiceSet for depMCS is not yet created, we will
-			// consider that an error so that the reconcile loop is retriggered.
+		getErr := r.Client.Get(ctx, ssetKey, sset)
+		if apierrors.IsNotFound(getErr) {
+			// Expected: depMCS simply hasn't created its ServiceSet for this cluster yet.
 			//
 			// NOTE: We can safely retrigger here by adding error to return value because
 			// we already return earlier if depMCS does not match either the cluster
@@ -693,11 +814,12 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 			// don't match either the cluster represented by CD or the mgmt cluster.
 			// In such a scenario, the execution will always add error and continue because
 			// it is trying to fetch the ServiceSet for depMCS and cluster which will never exist.
-			errs = errors.Join(errs, fmt.Errorf("serviceSet %s (owned by MultiClusterService %s) which this depends on not yet created: %w", ssetKey, depMCSKey, err))
+			blocked = errors.Join(blocked, fmt.Errorf("serviceSet %s (owned by MultiClusterService %s) which this depends on not yet created: %w", ssetKey, depMCSKey, getErr))
 			continue
 		}
-		if err != nil {
-			errs = errors.Join(errs, fmt.Errorf("failed to get serviceSet %s (owned by MultiClusterService %s) which this depends on: %w", ssetKey, depMCSKey, err))
+		if getErr != nil {
+			// Unexpected: any error other than NotFound is a real (likely transient) failure.
+			err = errors.Join(err, fmt.Errorf("failed to get serviceSet %s (owned by MultiClusterService %s): %w", ssetKey, depMCSKey, getErr))
 			continue
 		}
 
@@ -719,10 +841,11 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 		}
 
 		if deployed != len(depMCS.Spec.ServiceSpec.Services) {
-			errs = errors.Join(errs, fmt.Errorf("not all services in ServiceSet %s (owned by MultiClusterService %s) are deployed (%d/%d deployed)", ssetKey, client.ObjectKeyFromObject(depMCS), deployed, len(depMCS.Spec.ServiceSpec.Services)))
+			// Expected: depMCS's ServiceSet exists but hasn't finished deploying yet.
+			blocked = errors.Join(blocked, fmt.Errorf("not all services in ServiceSet %s (owned by MultiClusterService %s) are deployed (%d/%d deployed)", ssetKey, client.ObjectKeyFromObject(depMCS), deployed, len(depMCS.Spec.ServiceSpec.Services)))
 			continue
 		}
 	}
 
-	return errs
+	return blocked, err
 }

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -191,18 +191,15 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 		totalMatchingClusters++
 
 		l.V(1).Info("Checking if creation of ServiceSet for the management cluster is blocked by another MultiClusterService")
-		blockedErr, err := r.okToReconcileServiceSet(ctx, mcs, nil)
-		if blockedErr == nil && err == nil {
+		ok, err := r.okToReconcileServiceSet(ctx, mcs, nil, &blocked)
+		if err != nil {
+			// Real, unexpected failures only. A blocked (waiting-on-dependency) state
+			// is surfaced via `blocked`/status, not propagated as a reconcile error.
+			errs = errors.Join(errs, err)
+		}
+		if ok {
 			l.V(1).Info("Ensuring ServiceSet for the management cluster")
 			errs = errors.Join(errs, r.createOrUpdateServiceSet(ctx, mcs, nil))
-		}
-		if blockedErr != nil {
-			blocked = append(blocked, blockedCluster{ref: serviceset.SelfManagementClusterReference(), msg: blockedErr.Error()})
-		}
-		if err != nil {
-			// Unexpected failure - propagate it as a real reconcile error instead of
-			// masking it as the MCS merely waiting on a dependency.
-			errs = errors.Join(errs, err)
 		}
 	}
 
@@ -224,26 +221,15 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 		matchingClusterKeys[clusterKey] = struct{}{}
 
 		l.V(1).Info("Checking if creation of ServiceSet for matching ClusterDeployment is blocked by another MultiClusterService", "CD", clusterKey)
-		blockedErr, err := r.okToReconcileServiceSet(ctx, mcs, &cluster)
-		if blockedErr == nil && err == nil {
+		ok, err := r.okToReconcileServiceSet(ctx, mcs, &cluster, &blocked)
+		if err != nil {
+			// Real, unexpected failures only. A blocked (waiting-on-dependency) state
+			// is surfaced via `blocked`/status, not propagated as a reconcile error.
+			errs = errors.Join(errs, err)
+		}
+		if ok {
 			l.V(1).Info("Ensuring ServiceSet for the matching ClusterDeployment", "CD", clusterKey)
 			errs = errors.Join(errs, r.createOrUpdateServiceSet(ctx, mcs, &cluster))
-		}
-		if blockedErr != nil {
-			blocked = append(blocked, blockedCluster{
-				ref: &corev1.ObjectReference{
-					Kind:       kcmv1.ClusterDeploymentKind,
-					Name:       cluster.Name,
-					Namespace:  cluster.Namespace,
-					APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
-				},
-				msg: blockedErr.Error(),
-			})
-		}
-		if err != nil {
-			// Unexpected failure - propagate it as a real reconcile error instead of
-			// masking it as the MCS merely waiting on a dependency.
-			errs = errors.Join(errs, err)
 		}
 	}
 
@@ -731,14 +717,24 @@ func (*MultiClusterServiceReconciler) setCondition(mcs *kcmv1.MultiClusterServic
 // mcs depends on have been successfully deployed on the cluster represented by cd (cd is
 // nil for the self-management ServiceSet).
 //
-// blocked is non-nil when the ServiceSet must not be created/updated yet because a
-// MultiClusterService this one depends on hasn't finished deploying its services to this
-// cluster - an expected, self-resolving state that the caller should surface on mcs.Status
-// rather than treat as a failure. err is non-nil for any other, unexpected failure (e.g. a
-// Get or label-selector error) that the caller should instead propagate as a real reconcile
-// error, so controller-runtime retries it with backoff and it's logged as an actual failure
-// rather than being silently folded into the "waiting on dependency" status.
-func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Context, mcs *kcmv1.MultiClusterService, cd *kcmv1.ClusterDeployment) (blocked, err error) {
+// It reports its result through three channels, kept deliberately separate so the caller can
+// treat an expected "waiting on dependency" state differently from a real failure:
+//
+//   - ok is true only when the ServiceSet may be created/updated, i.e. there is neither a real
+//     error nor a blocked state. The caller should create/update the ServiceSet only when ok.
+//   - err is non-nil only for unexpected failures (e.g. a Get or label-selector error). The
+//     caller should propagate it as a real reconcile error so controller-runtime retries it with
+//     backoff and it's logged as an actual failure. It never carries the blocked state.
+//   - blocked is appended to (one entry for cd, or the mgmt pseudo-cluster when cd is nil) when
+//     the ServiceSet must not be created/updated yet because a MultiClusterService this one
+//     depends on hasn't finished deploying its services to this cluster - an expected,
+//     self-resolving state the caller should surface on mcs.Status rather than treat as a
+//     failure. A blocked state leaves err nil (and ok false).
+//
+// A single call may both hit a real error on one dependency and be blocked on another: err is
+// then non-nil and blocked has an entry, so the failure is propagated while the blocked cluster
+// is still surfaced on status.
+func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Context, mcs *kcmv1.MultiClusterService, cd *kcmv1.ClusterDeployment, blocked *[]blockedCluster) (ok bool, err error) {
 	clusterRef := client.ObjectKey{Namespace: "mgmt", Name: "mgmt"}
 	clusterLabels := make(map[string]string)
 	// cd is nil only for the self-management (mothership) ServiceSet. A MultiClusterService
@@ -751,10 +747,33 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 		clusterLabels = cd.Labels
 	}
 
+	var blockedErr error
+
 	defer func() {
-		if blocked != nil {
-			blocked = errors.Join(blocked, fmt.Errorf("skipping create/update of ServiceSet for matching cluster %s", clusterRef))
+		if blockedErr != nil && blocked != nil { // To avoid panic by dereferencing a nil pointer
+			blockedErr = errors.Join(blockedErr, fmt.Errorf("skipping create/update of ServiceSet for matching cluster %s", clusterRef))
+			if cd != nil {
+				*blocked = append(*blocked, blockedCluster{
+					ref: &corev1.ObjectReference{
+						Kind:       kcmv1.ClusterDeploymentKind,
+						Name:       cd.Name,
+						Namespace:  cd.Namespace,
+						APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
+					},
+					msg: blockedErr.Error(),
+				})
+			} else {
+				*blocked = append(*blocked, blockedCluster{
+					ref: serviceset.SelfManagementClusterReference(),
+					msg: blockedErr.Error(),
+				})
+			}
 		}
+		// ok to create/update the ServiceSet only when there is neither a real,
+		// unexpected error nor an expected blocked state. blockedErr is surfaced via
+		// *blocked (status) rather than folded into err, so a blocked-but-not-errored
+		// call returns err == nil and is not propagated as a reconcile error.
+		ok = err == nil && blockedErr == nil
 	}()
 
 	for _, dep := range mcs.Spec.DependsOn {
@@ -814,7 +833,7 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 			// don't match either the cluster represented by CD or the mgmt cluster.
 			// In such a scenario, the execution will always add error and continue because
 			// it is trying to fetch the ServiceSet for depMCS and cluster which will never exist.
-			blocked = errors.Join(blocked, fmt.Errorf("serviceSet %s (owned by MultiClusterService %s) which this depends on not yet created: %w", ssetKey, depMCSKey, getErr))
+			blockedErr = errors.Join(blockedErr, fmt.Errorf("serviceSet %s (owned by MultiClusterService %s) which this depends on not yet created: %w", ssetKey, depMCSKey, getErr))
 			continue
 		}
 		if getErr != nil {
@@ -833,7 +852,7 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 
 		deployed := 0
 		for _, svc := range sset.Status.Services {
-			if _, ok := svcToCheck[serviceset.ServiceKey(svc.Namespace, svc.Name)]; ok {
+			if _, found := svcToCheck[serviceset.ServiceKey(svc.Namespace, svc.Name)]; found {
 				if svc.State == kcmv1.ServiceStateDeployed {
 					deployed++
 				}
@@ -842,10 +861,10 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 
 		if deployed != len(depMCS.Spec.ServiceSpec.Services) {
 			// Expected: depMCS's ServiceSet exists but hasn't finished deploying yet.
-			blocked = errors.Join(blocked, fmt.Errorf("not all services in ServiceSet %s (owned by MultiClusterService %s) are deployed (%d/%d deployed)", ssetKey, client.ObjectKeyFromObject(depMCS), deployed, len(depMCS.Spec.ServiceSpec.Services)))
+			blockedErr = errors.Join(blockedErr, fmt.Errorf("not all services in ServiceSet %s (owned by MultiClusterService %s) are deployed (%d/%d deployed)", ssetKey, client.ObjectKeyFromObject(depMCS), deployed, len(depMCS.Spec.ServiceSpec.Services)))
 			continue
 		}
 	}
 
-	return blocked, err
+	return ok, err
 }

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -324,9 +324,14 @@ func (*MultiClusterServiceReconciler) setClustersCondition(ctx context.Context, 
 		Reason: kcmv1.SucceededReason,
 	}
 
-	blockedKeys := make(map[client.ObjectKey]struct{}, len(blocked))
+	// Keyed by clusterTargetKey (Kind/APIVersion/namespace/name), not namespace/name alone: the
+	// self-management pseudo-target is a SveltosCluster always named mgmt/mgmt, and a real,
+	// unrelated ClusterDeployment coincidentally also named mgmt in namespace mgmt may exist at
+	// the same time - a namespace/name-only key would let a blocked self-management entry wrongly
+	// exclude that ClusterDeployment's own, unrelated ServiceSet below.
+	blockedKeys := make(map[clusterTargetKey]struct{}, len(blocked))
 	for _, b := range blocked {
-		blockedKeys[client.ObjectKey{Namespace: b.ref.Namespace, Name: b.ref.Name}] = struct{}{}
+		blockedKeys[clusterTargetKeyFromRef(b.ref)] = struct{}{}
 	}
 
 	for _, serviceSet := range serviceSets {
@@ -344,7 +349,7 @@ func (*MultiClusterServiceReconciler) setClustersCondition(ctx context.Context, 
 		// it is no longer being kept in sync with the spec, its Deployed flag is stale: counting
 		// it here would let this condition claim e.g. 1/1 ready for a cluster that
 		// setMatchingClusters simultaneously reports as not deployed and dependency-blocked.
-		if _, isBlocked := blockedKeys[serviceset.ClusterKey(&serviceSet)]; isBlocked {
+		if _, isBlocked := blockedKeys[clusterTargetKeyFromRef(serviceset.ClusterReference(&serviceSet))]; isBlocked {
 			continue
 		}
 		if serviceSet.Status.Deployed {

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -365,6 +365,19 @@ type blockedCluster struct {
 	msg string
 }
 
+// clusterTargetKey uniquely identifies a matching-cluster target for .status.matchingClusters
+// bookkeeping. Namespace/name alone is not sufficient: the self-management pseudo-target is a
+// SveltosCluster named mgmt/mgmt, and a real, unrelated ClusterDeployment coincidentally also
+// named mgmt in namespace mgmt may exist at the same time - both count toward the readiness
+// denominator, so they must not collide into a single map entry.
+type clusterTargetKey struct {
+	kind, apiVersion, namespace, name string
+}
+
+func clusterTargetKeyFromRef(ref *corev1.ObjectReference) clusterTargetKey {
+	return clusterTargetKey{kind: ref.Kind, apiVersion: ref.APIVersion, namespace: ref.Namespace, name: ref.Name}
+}
+
 // setDependencyReadyCondition updates the MultiClusterServiceDependencyReady condition, which
 // reflects whether every MultiClusterService this one depends on has finished deploying its
 // services to all clusters this MultiClusterService matches.
@@ -404,12 +417,12 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 	l := ctrl.LoggerFrom(ctx)
 	l.V(1).Info("Reconciling MultiClusterService matching clusters")
 	now := metav1.NewTime(r.timeFunc())
-	// clusterEntries is keyed by cluster (namespace/name) rather than appended to a plain slice, because
+	// clusterEntries is keyed by clusterTargetKey rather than appended to a plain slice, because
 	// a cluster can appear in both serviceSets and blocked at the same time: its ServiceSet may have been
 	// created during an earlier, unblocked reconcile and is still around (we don't delete the services
 	// already deployed before dependency changed), while the current reconcile now finds it blocked again.
 	// Keying by cluster ensures exactly one entry per cluster instead of one from each source.
-	clusterEntries := make(map[client.ObjectKey]kcmv1.MatchingCluster, len(serviceSets)+len(blocked))
+	clusterEntries := make(map[clusterTargetKey]kcmv1.MatchingCluster, len(serviceSets)+len(blocked))
 
 	var errs error
 	for _, serviceSet := range serviceSets {
@@ -433,7 +446,7 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 			continue
 		}
 		cluster.Regional = regional
-		clusterEntries[client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}] = cluster
+		clusterEntries[clusterTargetKeyFromRef(cluster.ObjectReference)] = cluster
 	}
 
 	// blocked is applied after serviceSets and overwrites any entry for the same cluster - it
@@ -449,7 +462,7 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 		// Regional here just means it's best-effort reported as false for this reconcile; it self-
 		// corrects once the Credential is resolvable, via the merge below.
 		regional, _ := r.clusterRegional(ctx, b.ref)
-		clusterEntries[client.ObjectKey{Namespace: b.ref.Namespace, Name: b.ref.Name}] = kcmv1.MatchingCluster{
+		clusterEntries[clusterTargetKeyFromRef(b.ref)] = kcmv1.MatchingCluster{
 			ObjectReference:    b.ref,
 			LastTransitionTime: &now,
 			Regional:           regional,
@@ -464,14 +477,14 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 		matchingClusters = append(matchingClusters, cluster)
 	}
 
-	observedClustersMap := make(map[client.ObjectKey]kcmv1.MatchingCluster)
+	observedClustersMap := make(map[clusterTargetKey]kcmv1.MatchingCluster)
 	for _, cluster := range mcs.Status.MatchingClusters {
-		observedClustersMap[client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}] = cluster
+		observedClustersMap[clusterTargetKeyFromRef(cluster.ObjectReference)] = cluster
 	}
 
 	resultingClusters := make([]kcmv1.MatchingCluster, 0)
 	for _, cluster := range matchingClusters {
-		observedCluster, ok := observedClustersMap[client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}]
+		observedCluster, ok := observedClustersMap[clusterTargetKeyFromRef(cluster.ObjectReference)]
 		if !ok {
 			resultingClusters = append(resultingClusters, cluster)
 			continue

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -261,7 +261,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 		}
 	}
 
-	r.setClustersCondition(ctx, mcs, totalMatchingClusters, currentlyMatchingServiceSets)
+	r.setClustersCondition(ctx, mcs, totalMatchingClusters, currentlyMatchingServiceSets, blocked)
 	r.setDependencyReadyCondition(mcs, blocked)
 	if errs != nil {
 		return ctrl.Result{}, errs
@@ -288,7 +288,11 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 // the ServiceSets list, otherwise clusters whose ServiceSet was not created yet
 // (e.g. due to unsatisfied dependencies or transient errors) would be silently
 // dropped from the denominator and the condition would misrepresent reality.
-func (*MultiClusterServiceReconciler) setClustersCondition(ctx context.Context, mcs *kcmv1.MultiClusterService, totalClusters int, serviceSets []kcmv1.ServiceSet) {
+//
+// blocked lists the clusters this reconcile found waiting on a MultiClusterService dependency;
+// they are excluded from the numerator so that this condition agrees with the same clusters'
+// entries in .status.matchingClusters, which setMatchingClusters reports as not deployed.
+func (*MultiClusterServiceReconciler) setClustersCondition(ctx context.Context, mcs *kcmv1.MultiClusterService, totalClusters int, serviceSets []kcmv1.ServiceSet, blocked []blockedCluster) {
 	l := ctrl.LoggerFrom(ctx)
 	l.V(1).Info("Reconciling MultiClusterService conditions")
 
@@ -300,6 +304,11 @@ func (*MultiClusterServiceReconciler) setClustersCondition(ctx context.Context, 
 		Reason: kcmv1.SucceededReason,
 	}
 
+	blockedKeys := make(map[client.ObjectKey]struct{}, len(blocked))
+	for _, b := range blocked {
+		blockedKeys[client.ObjectKey{Namespace: b.ref.Namespace, Name: b.ref.Name}] = struct{}{}
+	}
+
 	for _, serviceSet := range serviceSets {
 		// We won't count serviceSets being deleted in the ready deployments count.
 		// If the serviceSet is being deleted, this means that either corresponding
@@ -307,6 +316,15 @@ func (*MultiClusterServiceReconciler) setClustersCondition(ctx context.Context, 
 		// match selector anymore. Hence all services defined in the service set
 		// will be removed from cluster and there is no reason to count them anyhow.
 		if !serviceSet.DeletionTimestamp.IsZero() {
+			continue
+		}
+		// A ServiceSet created during an earlier, unblocked reconcile is not deleted when the
+		// dependency becomes unsatisfied again (already deployed services are never torn down),
+		// so it can still report Deployed while this reconcile finds its cluster blocked. Since
+		// it is no longer being kept in sync with the spec, its Deployed flag is stale: counting
+		// it here would let this condition claim e.g. 1/1 ready for a cluster that
+		// setMatchingClusters simultaneously reports as not deployed and dependency-blocked.
+		if _, isBlocked := blockedKeys[serviceset.ClusterKey(&serviceSet)]; isBlocked {
 			continue
 		}
 		if serviceSet.Status.Deployed {

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -409,13 +409,54 @@ func (*MultiClusterServiceReconciler) setDependencyReadyCondition(mcs *kcmv1.Mul
 	case checkErr != nil:
 		c.Status = metav1.ConditionUnknown
 		c.Reason = kcmv1.MultiClusterServiceDependencyCheckFailedReason
-		c.Message = "failed to determine MultiClusterService dependency readiness: " + checkErr.Error()
+		// checkErr itself is not bounded here - the caller still returns and thus logs it in full
+		// (controller-runtime logs any non-nil error returned from Reconcile) - only what gets
+		// persisted onto mcs.Status is capped. See dependencyCheckMessage.
+		c.Message = dependencyCheckMessage(checkErr)
 	case len(blocked) > 0:
 		c.Status = metav1.ConditionFalse
 		c.Reason = kcmv1.MultiClusterServiceDependencyNotReadyReason
 		c.Message = fmt.Sprintf("waiting for MultiClusterService dependencies to be ready on %d matching cluster(s)", len(blocked))
 	}
 	apimeta.SetStatusCondition(&mcs.Status.Conditions, c)
+}
+
+// maxDependencyCheckMessageBytes bounds the DependencyReady condition's Message when reporting
+// checkErr. checkErr accumulates one wrapped error per (target, dependency) pair across the whole
+// reconcile - proportional to matching-cluster count x len(DependsOn), neither of which is
+// bounded - and this message is persisted on mcs.Status, unlike checkErr itself, which the caller
+// still returns (and controller-runtime thus logs) in full. Without this cap, a persistent
+// failure on a large deployment could grow the condition message toward API object size limits.
+const maxDependencyCheckMessageBytes = 1024
+
+// dependencyCheckMessage renders checkErr into a message bounded to maxDependencyCheckMessageBytes,
+// noting the total number of underlying errors and, when truncated, how much detail was omitted.
+func dependencyCheckMessage(checkErr error) string {
+	msg := fmt.Sprintf("failed to determine MultiClusterService dependency readiness (%d error(s)): %s",
+		countJoinedErrors(checkErr), checkErr.Error())
+	if len(msg) <= maxDependencyCheckMessageBytes {
+		return msg
+	}
+	omittedBytes := len(msg) - maxDependencyCheckMessageBytes
+	truncated := strings.ToValidUTF8(msg[:maxDependencyCheckMessageBytes], "")
+	return fmt.Sprintf("%s... (%d bytes omitted, see reconcile logs for the full error)", truncated, omittedBytes)
+}
+
+// countJoinedErrors returns the number of leaf errors joined into err via errors.Join (recursively,
+// since errors.Join trees can nest), 1 for a non-joined error, or 0 for nil.
+func countJoinedErrors(err error) int {
+	if err == nil {
+		return 0
+	}
+	joined, ok := err.(interface{ Unwrap() []error })
+	if !ok {
+		return 1
+	}
+	n := 0
+	for _, e := range joined.Unwrap() {
+		n += countJoinedErrors(e)
+	}
+	return n
 }
 
 // setMatchingClusters collects service deployments status on matching clusters from ServiceSet objects and

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -185,6 +185,13 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	// instead of being returned as a reconcile error.
 	var blocked []blockedCluster
 
+	// dependencyCheckErrs collects only the errors okToReconcileServiceSet returns via its own
+	// err return value (real, unexpected failures - never the blocked state). It is kept separate
+	// from errs, which also accumulates createOrUpdateServiceSet failures unrelated to dependency
+	// readiness, so that setDependencyReadyCondition below reports Unknown precisely when this
+	// MCS's dependency readiness could not be established - not whenever any error occurred.
+	var dependencyCheckErrs error
+
 	// if selfManagement flag is set, then we'll need to create serviceSet which does not refer
 	// any clusterDeployment, but also has selfManagement flag set to true.
 	if mcs.Spec.ServiceSpec.Provider.SelfManagement {
@@ -196,6 +203,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 			// Real, unexpected failures only. A blocked (waiting-on-dependency) state
 			// is surfaced via `blocked`/status, not propagated as a reconcile error.
 			errs = errors.Join(errs, err)
+			dependencyCheckErrs = errors.Join(dependencyCheckErrs, err)
 		}
 		if ok {
 			l.V(1).Info("Ensuring ServiceSet for the management cluster")
@@ -226,6 +234,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 			// Real, unexpected failures only. A blocked (waiting-on-dependency) state
 			// is surfaced via `blocked`/status, not propagated as a reconcile error.
 			errs = errors.Join(errs, err)
+			dependencyCheckErrs = errors.Join(dependencyCheckErrs, err)
 		}
 		if ok {
 			l.V(1).Info("Ensuring ServiceSet for the matching ClusterDeployment", "CD", clusterKey)
@@ -262,7 +271,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	}
 
 	r.setClustersCondition(ctx, mcs, totalMatchingClusters, currentlyMatchingServiceSets, blocked)
-	r.setDependencyReadyCondition(mcs, blocked)
+	r.setDependencyReadyCondition(mcs, blocked, dependencyCheckErrs)
 
 	// setMatchingClusters must run even when errs is non-nil. A single reconcile can both hit a
 	// real error on one cluster/dependency and find another cluster blocked (see
@@ -359,13 +368,27 @@ type blockedCluster struct {
 // setDependencyReadyCondition updates the MultiClusterServiceDependencyReady condition, which
 // reflects whether every MultiClusterService this one depends on has finished deploying its
 // services to all clusters this MultiClusterService matches.
-func (*MultiClusterServiceReconciler) setDependencyReadyCondition(mcs *kcmv1.MultiClusterService, blocked []blockedCluster) {
+//
+// checkErr is the joined set of real, unexpected errors okToReconcileServiceSet returned while
+// checking dependencies (e.g. failing to Get a dependency MultiClusterService/ServiceSet, a
+// malformed ClusterSelector) - never the expected blocked state, which is carried by blocked
+// instead. When checkErr is non-nil, dependency readiness could not be established for at least
+// one matching cluster: that cluster is neither confirmed ready nor confirmed blocked, so
+// reporting True or False would assert something we don't actually know, even if other clusters
+// were genuinely found blocked in the same reconcile.
+func (*MultiClusterServiceReconciler) setDependencyReadyCondition(mcs *kcmv1.MultiClusterService, blocked []blockedCluster, checkErr error) {
 	c := metav1.Condition{
-		Type:   kcmv1.MultiClusterServiceDependencyReadyCondition,
-		Status: metav1.ConditionTrue,
-		Reason: kcmv1.SucceededReason,
+		Type:               kcmv1.MultiClusterServiceDependencyReadyCondition,
+		Status:             metav1.ConditionTrue,
+		Reason:             kcmv1.SucceededReason,
+		ObservedGeneration: mcs.Generation,
 	}
-	if len(blocked) > 0 {
+	switch {
+	case checkErr != nil:
+		c.Status = metav1.ConditionUnknown
+		c.Reason = kcmv1.MultiClusterServiceDependencyCheckFailedReason
+		c.Message = "failed to determine MultiClusterService dependency readiness: " + checkErr.Error()
+	case len(blocked) > 0:
 		c.Status = metav1.ConditionFalse
 		c.Reason = kcmv1.MultiClusterServiceDependencyNotReadyReason
 		c.Message = fmt.Sprintf("waiting for MultiClusterService dependencies to be ready on %d matching cluster(s)", len(blocked))

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -193,13 +193,16 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	// MCS's dependency readiness could not be established - not whenever any error occurred.
 	var dependencyCheckErrs error
 
+	// deps resolves mcs.Spec.DependsOn once for all targets checked below - see resolveDependencies.
+	deps := r.resolveDependencies(ctx, mcs)
+
 	// if selfManagement flag is set, then we'll need to create serviceSet which does not refer
 	// any clusterDeployment, but also has selfManagement flag set to true.
 	if mcs.Spec.ServiceSpec.Provider.SelfManagement {
 		totalMatchingClusters++
 
 		l.V(1).Info("Checking if creation of ServiceSet for the management cluster is blocked by another MultiClusterService")
-		ok, err := r.okToReconcileServiceSet(ctx, mcs, nil, &blocked)
+		ok, err := r.okToReconcileServiceSet(ctx, nil, deps, &blocked)
 		if err != nil {
 			// Real, unexpected failures only. A blocked (waiting-on-dependency) state
 			// is surfaced via `blocked`/status, not propagated as a reconcile error.
@@ -230,7 +233,7 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 		matchingClusterKeys[clusterKey] = struct{}{}
 
 		l.V(1).Info("Checking if creation of ServiceSet for matching ClusterDeployment is blocked by another MultiClusterService", "CD", clusterKey)
-		ok, err := r.okToReconcileServiceSet(ctx, mcs, &cluster, &blocked)
+		ok, err := r.okToReconcileServiceSet(ctx, &cluster, deps, &blocked)
 		if err != nil {
 			// Real, unexpected failures only. A blocked (waiting-on-dependency) state
 			// is surfaced via `blocked`/status, not propagated as a reconcile error.
@@ -792,10 +795,62 @@ func (*MultiClusterServiceReconciler) setCondition(mcs *kcmv1.MultiClusterServic
 	})
 }
 
+// resolvedDependency is one entry of mcs.Spec.DependsOn, resolved once per reconcile: the
+// dependency MultiClusterService fetched, its ClusterSelector compiled, and its desired-service
+// key set built. None of that depends on which target (self-management or a specific matching
+// ClusterDeployment) is being checked, so resolveDependencies computes it once up front instead
+// of okToReconcileServiceSet repeating it for every target.
+type resolvedDependency struct {
+	key client.ObjectKey
+
+	// getErr is set instead of mcs when the dependency MultiClusterService itself could not be
+	// fetched; every other field is unset in that case.
+	getErr error
+
+	// selectorErr is set instead of selector when mcs.Spec.ClusterSelector fails to compile.
+	selectorErr error
+	selector    labels.Selector
+
+	// svcToCheck is the set of service keys from mcs.Spec.ServiceSpec.Services, used to check
+	// which of a target ServiceSet's reported services belong to this dependency.
+	svcToCheck map[client.ObjectKey]struct{}
+	mcs        *kcmv1.MultiClusterService
+
+	name string
+}
+
+// resolveDependencies resolves every entry of mcs.Spec.DependsOn once - see resolvedDependency's
+// doc comment for why this must happen only once per reconcile rather than once per target.
+func (r *MultiClusterServiceReconciler) resolveDependencies(ctx context.Context, mcs *kcmv1.MultiClusterService) []resolvedDependency {
+	deps := make([]resolvedDependency, 0, len(mcs.Spec.DependsOn))
+	for _, dep := range mcs.Spec.DependsOn {
+		rd := resolvedDependency{name: dep, key: client.ObjectKey{Name: dep}}
+
+		depMCS := new(kcmv1.MultiClusterService)
+		if getErr := r.Client.Get(ctx, rd.key, depMCS); getErr != nil {
+			rd.getErr = getErr
+			deps = append(deps, rd)
+			continue
+		}
+		rd.mcs = depMCS
+
+		rd.selector, rd.selectorErr = metav1.LabelSelectorAsSelector(&depMCS.Spec.ClusterSelector)
+
+		svcToCheck := make(map[client.ObjectKey]struct{}, len(depMCS.Spec.ServiceSpec.Services))
+		for _, svc := range depMCS.Spec.ServiceSpec.Services {
+			svcToCheck[serviceset.ServiceKey(svc.Namespace, svc.Name)] = struct{}{}
+		}
+		rd.svcToCheck = svcToCheck
+
+		deps = append(deps, rd)
+	}
+	return deps
+}
+
 // okToReconcileServiceSet verifies if it is ok to reconcile a serviceset for the provided
-// mcs and cd by verifying if all of the services defined in the multiclusterservices that
-// mcs depends on have been successfully deployed on the cluster represented by cd (cd is
-// nil for the self-management ServiceSet).
+// cd by verifying, for each of deps, that all of that dependency's services have been
+// successfully deployed on the cluster represented by cd (cd is nil for the self-management
+// ServiceSet).
 //
 // It reports its result through three channels, kept deliberately separate so the caller can
 // treat an expected "waiting on dependency" state differently from a real failure:
@@ -814,7 +869,10 @@ func (*MultiClusterServiceReconciler) setCondition(mcs *kcmv1.MultiClusterServic
 // A single call may both hit a real error on one dependency and be blocked on another: err is
 // then non-nil and blocked has an entry, so the failure is propagated while the blocked cluster
 // is still surfaced on status.
-func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Context, mcs *kcmv1.MultiClusterService, cd *kcmv1.ClusterDeployment, blocked *[]blockedCluster) (ok bool, err error) {
+//
+// deps is mcs.Spec.DependsOn already resolved once per reconcile by resolveDependencies - see its
+// doc comment for why that must not be redone per target.
+func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Context, cd *kcmv1.ClusterDeployment, deps []resolvedDependency, blocked *[]blockedCluster) (ok bool, err error) {
 	clusterRef := client.ObjectKey{Namespace: "mgmt", Name: "mgmt"}
 	clusterLabels := make(map[string]string)
 	// cd is nil only for the self-management (mothership) ServiceSet. A MultiClusterService
@@ -860,17 +918,15 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 		ok = err == nil && len(blockingDeps) == 0
 	}()
 
-	for _, dep := range mcs.Spec.DependsOn {
-		// Get the MCS this one depends on.
-		depMCSKey := client.ObjectKey{Name: dep}
-		depMCS := new(kcmv1.MultiClusterService)
-		if getErr := r.Client.Get(ctx, depMCSKey, depMCS); getErr != nil {
+	for _, rd := range deps {
+		if rd.getErr != nil {
 			// Unexpected: ValidateMCSDependencyOverall already confirmed depMCS exists earlier
 			// in this same reconcile, so a Get failure here is a real (likely transient) error,
 			// not a normal "waiting on dependency" state.
-			err = errors.Join(err, fmt.Errorf("failed to get MultiClusterService %s which this depends on: %w", depMCSKey, getErr))
+			err = errors.Join(err, fmt.Errorf("failed to get MultiClusterService %s which this depends on: %w", rd.key, rd.getErr))
 			continue
 		}
+		depMCS := rd.mcs
 
 		// Check if depMCS applies to the cluster represented by clusterRef. Self-management and
 		// ClusterSelector are independent, mutually exclusive-in-relevance mechanisms: whether depMCS
@@ -885,11 +941,10 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 				continue
 			}
 		} else {
-			sel, selErr := metav1.LabelSelectorAsSelector(&depMCS.Spec.ClusterSelector)
-			if selErr != nil {
+			if rd.selectorErr != nil {
 				// Unexpected: a malformed ClusterSelector is a configuration/validation
 				// problem, not the dependency simply not being ready yet.
-				err = errors.Join(err, fmt.Errorf("failed to determine if MultiClusterService %s which this depends on matches cluster %s: %w", depMCSKey, clusterRef, selErr))
+				err = errors.Join(err, fmt.Errorf("failed to determine if MultiClusterService %s which this depends on matches cluster %s: %w", rd.key, clusterRef, rd.selectorErr))
 				continue
 			}
 			// An empty ClusterSelector converts to labels.Everything(), which Matches() treats as
@@ -897,7 +952,7 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 			// ClusterDeployment (it only lists matching ClusterDeployments when !selector.Empty()), so
 			// mirror that here - otherwise a depMCS with a blank ClusterSelector would appear to depend
 			// against every ClusterDeployment, even ones its own reconcile never targets.
-			if sel.Empty() || !sel.Matches(labels.Set(clusterLabels)) {
+			if rd.selector.Empty() || !rd.selector.Matches(labels.Set(clusterLabels)) {
 				continue
 			}
 		}
@@ -920,26 +975,21 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 			// getErr (a NotFound error) is deliberately not embedded here - it adds nothing
 			// actionable beyond "not yet created" and would make this entry's size depend on the
 			// underlying API error's formatting.
-			blockingDeps = append(blockingDeps, dep+" (ServiceSet not yet created)")
+			blockingDeps = append(blockingDeps, rd.name+" (ServiceSet not yet created)")
 			continue
 		}
 		if getErr != nil {
 			// Unexpected: any error other than NotFound is a real (likely transient) failure.
-			err = errors.Join(err, fmt.Errorf("failed to get serviceSet %s (owned by MultiClusterService %s): %w", ssetKey, depMCSKey, getErr))
+			err = errors.Join(err, fmt.Errorf("failed to get serviceSet %s (owned by MultiClusterService %s): %w", ssetKey, rd.key, getErr))
 			continue
 		}
 
-		// To check if all services for depMCS have been deployed, we have
-		// to use depMCS's spec because the ServiceSet may not have the full
-		// list of services in it's spec or status due to inter-service dependencies.
-		svcToCheck := make(map[client.ObjectKey]struct{}, len(depMCS.Spec.ServiceSpec.Services))
-		for _, svc := range depMCS.Spec.ServiceSpec.Services {
-			svcToCheck[serviceset.ServiceKey(svc.Namespace, svc.Name)] = struct{}{}
-		}
-
+		// To check if all services for depMCS have been deployed, we use rd.svcToCheck (built
+		// once from depMCS's spec, not the ServiceSet's) because the ServiceSet may not have the
+		// full list of services in its spec or status due to inter-service dependencies.
 		deployed := 0
 		for _, svc := range sset.Status.Services {
-			if _, found := svcToCheck[serviceset.ServiceKey(svc.Namespace, svc.Name)]; found {
+			if _, found := rd.svcToCheck[serviceset.ServiceKey(svc.Namespace, svc.Name)]; found {
 				if svc.State == kcmv1.ServiceStateDeployed {
 					deployed++
 				}
@@ -948,7 +998,7 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 
 		if deployed != len(depMCS.Spec.ServiceSpec.Services) {
 			// Expected: depMCS's ServiceSet exists but hasn't finished deploying yet.
-			blockingDeps = append(blockingDeps, fmt.Sprintf("%s (%d/%d services deployed)", dep, deployed, len(depMCS.Spec.ServiceSpec.Services)))
+			blockingDeps = append(blockingDeps, fmt.Sprintf("%s (%d/%d services deployed)", rd.name, deployed, len(depMCS.Spec.ServiceSpec.Services)))
 			continue
 		}
 	}

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -425,27 +425,14 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 		cluster := kcmv1.MatchingCluster{
 			ObjectReference:    serviceSet.Status.Cluster.DeepCopy(),
 			LastTransitionTime: &now,
-			Regional:           false,
 			Deployed:           serviceSet.Status.Deployed,
 		}
-		if cluster.Kind == kcmv1.ClusterDeploymentKind {
-			cd := new(kcmv1.ClusterDeployment)
-			key := client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}
-			if err := r.Client.Get(ctx, key, cd); err != nil {
-				errs = errors.Join(errs, fmt.Errorf("failed to get ClusterDeployment %s: %w", key, err))
-				continue
-			}
-			cred := new(kcmv1.Credential)
-			key = client.ObjectKey{
-				Namespace: cd.Namespace,
-				Name:      cd.Spec.Credential,
-			}
-			if err := r.Client.Get(ctx, key, cred); err != nil {
-				errs = errors.Join(errs, fmt.Errorf("failed to get Credential %s: %w", key, err))
-				continue
-			}
-			cluster.Regional = cred.Spec.Region != ""
+		regional, err := r.clusterRegional(ctx, cluster.ObjectReference)
+		if err != nil {
+			errs = errors.Join(errs, err)
+			continue
 		}
+		cluster.Regional = regional
 		clusterEntries[client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name}] = cluster
 	}
 
@@ -454,9 +441,18 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 	// pre-existing ServiceSet-derived entry may be stale (e.g. still Deployed from before the
 	// dependency became unsatisfied again, even though it is no longer being kept in sync).
 	for _, b := range blocked {
+		// Unlike the serviceSets loop above, a failure here is not joined into errs and does not
+		// skip the entry: we already know for certain that this cluster is blocked on a dependency,
+		// and that is the important fact to surface - it must not depend on the Credential a
+		// blocked cluster's ClusterDeployment references already existing (dependency-blocked and
+		// Credential-not-yet-created are independent, unrelated states). A failure to compute
+		// Regional here just means it's best-effort reported as false for this reconcile; it self-
+		// corrects once the Credential is resolvable, via the merge below.
+		regional, _ := r.clusterRegional(ctx, b.ref)
 		clusterEntries[client.ObjectKey{Namespace: b.ref.Namespace, Name: b.ref.Name}] = kcmv1.MatchingCluster{
 			ObjectReference:    b.ref,
 			LastTransitionTime: &now,
+			Regional:           regional,
 			Deployed:           false,
 			Reason:             kcmv1.MultiClusterServiceDependencyNotReadyReason,
 			Message:            b.msg,
@@ -486,6 +482,13 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 		}
 		observedCluster.Reason = cluster.Reason
 		observedCluster.Message = cluster.Message
+		// Regional and the object reference are recomputed every reconcile (unlike Deployed, which
+		// intentionally preserves its prior LastTransitionTime unless it actually changed), so they
+		// must always be copied onto the observed entry - otherwise a cluster first observed while
+		// blocked (Regional defaulted false, since it isn't known yet) would keep that stale false
+		// forever, even once it unblocks and its true Regional value has been computed.
+		observedCluster.Regional = cluster.Regional
+		observedCluster.ObjectReference = cluster.ObjectReference.DeepCopy()
 		resultingClusters = append(resultingClusters, observedCluster)
 	}
 
@@ -503,6 +506,26 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 	mcs.Status.MatchingClusters = resultingClusters
 
 	return errs
+}
+
+// clusterRegional determines whether ref - a ClusterDeployment or the self-management mgmt
+// pseudo-cluster - is regional. Only a ClusterDeployment reference carries region information
+// (via its Credential); the mgmt pseudo-cluster is never regional.
+func (r *MultiClusterServiceReconciler) clusterRegional(ctx context.Context, ref *corev1.ObjectReference) (bool, error) {
+	if ref.Kind != kcmv1.ClusterDeploymentKind {
+		return false, nil
+	}
+	cd := new(kcmv1.ClusterDeployment)
+	key := client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}
+	if err := r.Client.Get(ctx, key, cd); err != nil {
+		return false, fmt.Errorf("failed to get ClusterDeployment %s: %w", key, err)
+	}
+	cred := new(kcmv1.Credential)
+	key = client.ObjectKey{Namespace: cd.Namespace, Name: cd.Spec.Credential}
+	if err := r.Client.Get(ctx, key, cred); err != nil {
+		return false, fmt.Errorf("failed to get Credential %s: %w", key, err)
+	}
+	return cred.Spec.Region != "", nil
 }
 
 // updateStatus check whether status needs to be updated, if so updates the status for the MultiClusterService object

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -263,8 +263,17 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 
 	r.setClustersCondition(ctx, mcs, totalMatchingClusters, currentlyMatchingServiceSets, blocked)
 	r.setDependencyReadyCondition(mcs, blocked)
+
+	// setMatchingClusters must run even when errs is non-nil. A single reconcile can both hit a
+	// real error on one cluster/dependency and find another cluster blocked (see
+	// okToReconcileServiceSet), and the conditions set above already reflect `blocked` - while
+	// Reconcile's deferred updateStatus persists the status regardless of the error returned here.
+	// Returning before this ran would therefore persist conditions announcing that N clusters are
+	// waiting on a dependency alongside a .status.matchingClusters that is stale (or empty on a
+	// first reconcile), and it would stay that way for as long as the error keeps recurring.
+	clustersErr := r.setMatchingClusters(ctx, mcs, currentlyMatchingServiceSets, blocked)
 	if errs != nil {
-		return ctrl.Result{}, errs
+		return ctrl.Result{}, errors.Join(errs, clustersErr)
 	}
 
 	var (
@@ -273,8 +282,6 @@ func (r *MultiClusterServiceReconciler) reconcileUpdate(ctx context.Context, mcs
 	)
 	upgradePaths, servicesErr = serviceset.ServicesUpgradePaths(ctx, r.Client, mcs.Spec.ServiceSpec.Services, r.SystemNamespace)
 	mcs.Status.ServicesUpgradePaths = upgradePaths
-
-	clustersErr := r.setMatchingClusters(ctx, mcs, currentlyMatchingServiceSets, blocked)
 
 	return result, errors.Join(servicesErr, clustersErr)
 }

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -472,18 +472,13 @@ func (r *MultiClusterServiceReconciler) setMatchingClusters(ctx context.Context,
 		}
 	}
 
-	matchingClusters := make([]kcmv1.MatchingCluster, 0, len(clusterEntries))
-	for _, cluster := range clusterEntries {
-		matchingClusters = append(matchingClusters, cluster)
-	}
-
-	observedClustersMap := make(map[clusterTargetKey]kcmv1.MatchingCluster)
+	observedClustersMap := make(map[clusterTargetKey]kcmv1.MatchingCluster, len(mcs.Status.MatchingClusters))
 	for _, cluster := range mcs.Status.MatchingClusters {
 		observedClustersMap[clusterTargetKeyFromRef(cluster.ObjectReference)] = cluster
 	}
 
-	resultingClusters := make([]kcmv1.MatchingCluster, 0)
-	for _, cluster := range matchingClusters {
+	resultingClusters := make([]kcmv1.MatchingCluster, 0, len(clusterEntries))
+	for _, cluster := range clusterEntries {
 		observedCluster, ok := observedClustersMap[clusterTargetKeyFromRef(cluster.ObjectReference)]
 		if !ok {
 			resultingClusters = append(resultingClusters, cluster)

--- a/internal/controller/multiclusterservice_controller.go
+++ b/internal/controller/multiclusterservice_controller.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -826,11 +827,15 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 		clusterLabels = cd.Labels
 	}
 
-	var blockedErr error
+	// blockingDeps collects one short, bounded entry per DependsOn entry found blocking (never a
+	// full wrapped error) - DependsOn is not meaningfully bounded, and this ends up stored on
+	// mcs.Status once per matching cluster, so an unbounded per-dependency message here would let
+	// status size grow as O(cluster count x DependsOn length) instead of O(cluster count).
+	var blockingDeps []string
 
 	defer func() {
-		if blockedErr != nil && blocked != nil { // To avoid panic by dereferencing a nil pointer
-			blockedErr = errors.Join(blockedErr, fmt.Errorf("skipping create/update of ServiceSet for matching cluster %s", clusterRef))
+		if len(blockingDeps) > 0 && blocked != nil { // To avoid panic by dereferencing a nil pointer
+			msg := blockedMessage(clusterRef, blockingDeps)
 			if cd != nil {
 				*blocked = append(*blocked, blockedCluster{
 					ref: &corev1.ObjectReference{
@@ -839,20 +844,20 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 						Namespace:  cd.Namespace,
 						APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
 					},
-					msg: blockedErr.Error(),
+					msg: msg,
 				})
 			} else {
 				*blocked = append(*blocked, blockedCluster{
 					ref: serviceset.SelfManagementClusterReference(),
-					msg: blockedErr.Error(),
+					msg: msg,
 				})
 			}
 		}
 		// ok to create/update the ServiceSet only when there is neither a real,
-		// unexpected error nor an expected blocked state. blockedErr is surfaced via
+		// unexpected error nor an expected blocked state. blockingDeps is surfaced via
 		// *blocked (status) rather than folded into err, so a blocked-but-not-errored
 		// call returns err == nil and is not propagated as a reconcile error.
-		ok = err == nil && blockedErr == nil
+		ok = err == nil && len(blockingDeps) == 0
 	}()
 
 	for _, dep := range mcs.Spec.DependsOn {
@@ -912,7 +917,10 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 			// don't match either the cluster represented by CD or the mgmt cluster.
 			// In such a scenario, the execution will always add error and continue because
 			// it is trying to fetch the ServiceSet for depMCS and cluster which will never exist.
-			blockedErr = errors.Join(blockedErr, fmt.Errorf("serviceSet %s (owned by MultiClusterService %s) which this depends on not yet created: %w", ssetKey, depMCSKey, getErr))
+			// getErr (a NotFound error) is deliberately not embedded here - it adds nothing
+			// actionable beyond "not yet created" and would make this entry's size depend on the
+			// underlying API error's formatting.
+			blockingDeps = append(blockingDeps, dep+" (ServiceSet not yet created)")
 			continue
 		}
 		if getErr != nil {
@@ -940,10 +948,32 @@ func (r *MultiClusterServiceReconciler) okToReconcileServiceSet(ctx context.Cont
 
 		if deployed != len(depMCS.Spec.ServiceSpec.Services) {
 			// Expected: depMCS's ServiceSet exists but hasn't finished deploying yet.
-			blockedErr = errors.Join(blockedErr, fmt.Errorf("not all services in ServiceSet %s (owned by MultiClusterService %s) are deployed (%d/%d deployed)", ssetKey, client.ObjectKeyFromObject(depMCS), deployed, len(depMCS.Spec.ServiceSpec.Services)))
+			blockingDeps = append(blockingDeps, fmt.Sprintf("%s (%d/%d services deployed)", dep, deployed, len(depMCS.Spec.ServiceSpec.Services)))
 			continue
 		}
 	}
 
 	return ok, err
+}
+
+// maxBlockingDependenciesInMessage caps how many blocking dependencies are named individually in
+// a blocked cluster's status message; DependsOn is not meaningfully bounded, so beyond this the
+// remainder is summarized by count instead, keeping the message (and thus mcs.Status) a bounded
+// size regardless of how many dependencies are actually blocking.
+const maxBlockingDependenciesInMessage = 3
+
+// blockedMessage renders a bounded summary of blockingDeps (see maxBlockingDependenciesInMessage)
+// explaining why clusterRef's ServiceSet is being skipped this reconcile.
+func blockedMessage(clusterRef client.ObjectKey, blockingDeps []string) string {
+	shown := blockingDeps
+	var omitted int
+	if len(shown) > maxBlockingDependenciesInMessage {
+		omitted = len(shown) - maxBlockingDependenciesInMessage
+		shown = shown[:maxBlockingDependenciesInMessage]
+	}
+	msg := fmt.Sprintf("skipping create/update of ServiceSet for matching cluster %s: waiting on %s", clusterRef, strings.Join(shown, ", "))
+	if omitted > 0 {
+		msg += fmt.Sprintf(" and %d more", omitted)
+	}
+	return msg
 }

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -17,7 +17,9 @@ package controller
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
+	"testing"
 	"time"
 
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -32,11 +34,66 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+	"github.com/K0rdent/kcm/internal/serviceset"
 	kubeutil "github.com/K0rdent/kcm/internal/util/kube"
+	testscheme "github.com/K0rdent/kcm/test/scheme"
 )
+
+// createFailingSelfManagingDependency creates and reconciles a MultiClusterService named name
+// that self-manages, matches a CD via ClusterSelector "test": "true", and references a
+// nonexistent ServiceTemplate so it never produces any ServiceSet. Used as a dependency MCS in
+// tests exercising okToReconcileServiceSet's blocking behavior.
+func createFailingSelfManagingDependency(name string, reconciler *MultiClusterServiceReconciler) *kcmv1.MultiClusterService {
+	failingMCS := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{kcmv1.GenericComponentNameLabel: kcmv1.GenericComponentLabelValueKCM},
+		},
+		Spec: kcmv1.MultiClusterServiceSpec{
+			ClusterSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"test": "true"},
+			},
+			ServiceSpec: kcmv1.ServiceSpec{
+				Provider: kcmv1.StateManagementProviderConfig{
+					Name:           kubeutil.DefaultStateManagementProvider,
+					SelfManagement: true,
+				},
+				Services: []kcmv1.Service{
+					{Template: "nonexistent-service-template", Name: "bad-rel", Namespace: "ns-bad"},
+				},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, failingMCS)).To(Succeed())
+	DeferCleanup(func() {
+		got := &kcmv1.MultiClusterService{}
+		if err := k8sClient.Get(ctx, client.ObjectKey{Name: name}, got); err == nil {
+			Expect(k8sClient.Delete(ctx, got)).To(Succeed())
+		}
+	})
+
+	Eventually(func(g Gomega) {
+		g.Expect(mgrClient.Get(ctx, client.ObjectKey{Name: name}, &kcmv1.MultiClusterService{})).To(Succeed())
+	}).Should(Succeed())
+
+	Eventually(func(g Gomega) {
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKey{Name: name}})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: name}, failingMCS)).To(Succeed())
+		g.Expect(failingMCS.Status.Conditions).To(ContainElement(SatisfyAll(
+			HaveField("Type", kcmv1.ServicesReferencesValidationCondition),
+			HaveField("Status", metav1.ConditionFalse),
+		)))
+	}).Should(Succeed())
+
+	return failingMCS
+}
 
 var _ = Describe("MultiClusterService Controller", func() {
 	Context("When reconciling a resource", func() {
@@ -537,12 +594,17 @@ var _ = Describe("MultiClusterService Controller", func() {
 
 			By("reconciling and asserting the denominator counts the matching CD even with no ServiceSet", func() {
 				Eventually(func(g Gomega) {
-					_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					// Waiting on an MCS dependency is an expected, self-resolving state,
+					// not a reconcile failure, so it must not be returned as an error
+					// (which would otherwise put the object into backoff-rate-limited
+					// requeues instead of the steady default requeue interval).
+					g.Expect(err).NotTo(HaveOccurred())
 
 					// ServiceSet for the matching CD must not exist - creation was
 					// blocked because the sibling's ServiceSet for this CD is missing.
-					err := k8sClient.Get(ctx, serviceSetKey, &kcmv1.ServiceSet{})
-					g.Expect(apierrors.IsNotFound(err)).To(BeTrue(),
+					ssErr := k8sClient.Get(ctx, serviceSetKey, &kcmv1.ServiceSet{})
+					g.Expect(apierrors.IsNotFound(ssErr)).To(BeTrue(),
 						"ServiceSet should not be created when DependsOn is unsatisfied")
 
 					// The matching CD must still appear in the denominator: "0/1",
@@ -554,6 +616,382 @@ var _ = Describe("MultiClusterService Controller", func() {
 						HaveField("Reason", kcmv1.FailedReason),
 						HaveField("Message", "0/1"),
 					)))
+
+					// The MultiClusterServiceDependencyReady condition must explicitly call
+					// out that this MCS is waiting on its dependency, instead of leaving the
+					// user to infer that from the bare ClusterInReadyState ratio.
+					g.Expect(multiClusterService.Status.Conditions).To(ContainElement(SatisfyAll(
+						HaveField("Type", kcmv1.MultiClusterServiceDependencyReadyCondition),
+						HaveField("Status", metav1.ConditionFalse),
+						HaveField("Reason", kcmv1.MultiClusterServiceDependencyNotReadyReason),
+						HaveField("Message", "waiting for MultiClusterService dependencies to be ready on 1 matching cluster(s)"),
+					)))
+
+					// The blocked cluster must be surfaced per-cluster in matchingClusters,
+					// even though it has no ServiceSet yet, with a message identifying the
+					// sibling MultiClusterService it's waiting on.
+					g.Expect(multiClusterService.Status.MatchingClusters).To(ContainElement(SatisfyAll(
+						HaveField("Name", clusterDeployment.Name),
+						HaveField("Namespace", clusterDeployment.Namespace),
+						HaveField("Deployed", false),
+						HaveField("Reason", kcmv1.MultiClusterServiceDependencyNotReadyReason),
+						HaveField("Message", ContainSubstring(siblingMCSName)),
+					)))
+				}).Should(Succeed())
+			})
+		})
+
+		// Regression test: okToReconcileServiceSet used to decide whether it was checking the
+		// self-management (mgmt) target or a real matching ClusterDeployment based on the
+		// reconciled MCS's own SelfManagement flag, instead of on whether a cd was actually
+		// passed in. That breaks down for an MCS that both self-manages AND matches a
+		// ClusterSelector, since okToReconcileServiceSet is then called twice for it: once with
+		// cd == nil (mgmt) and once with the real cd. With the bug, the CD-based call still used
+		// the mgmt cluster's (empty) labels instead of the real cd's labels to decide whether a
+		// dependency applied, so once the dependency MCS stopped self-managing, its still-matching
+		// ClusterSelector was wrongly ignored and the CD ServiceSet was created despite the
+		// dependency's services never having been deployed there.
+		It("should keep the CD blocked on a dependency that still matches it via ClusterSelector, even after that dependency stops self-managing", func() {
+			const failingMCSName = "test-multiclusterservice-failing-dependency"
+
+			reconciler := &MultiClusterServiceReconciler{
+				Client:          mgrClient,
+				timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+				SystemNamespace: testSystemNamespace,
+			}
+
+			failingMCS := createFailingSelfManagingDependency(failingMCSName, reconciler)
+
+			By("configuring mcs2 to self-manage, match the CD, and depend on mcs1", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					multiClusterService.Spec.DependsOn = []string{failingMCSName}
+					multiClusterService.Spec.ServiceSpec.Provider.SelfManagement = true
+					g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+				}).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					fresh := &kcmv1.MultiClusterService{}
+					g.Expect(mgrClient.Get(ctx, multiClusterServiceRef, fresh)).To(Succeed())
+					g.Expect(fresh.Spec.DependsOn).To(ContainElement(failingMCSName))
+					g.Expect(fresh.Spec.ServiceSpec.Provider.SelfManagement).To(BeTrue())
+				}).Should(Succeed())
+			})
+
+			By("reconciling mcs2 and asserting it is blocked on both the CD and the mgmt cluster", func() {
+				Eventually(func(g Gomega) {
+					_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					g.Expect(err).NotTo(HaveOccurred())
+
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, serviceSetKey, &kcmv1.ServiceSet{}))).To(BeTrue(),
+						"CD ServiceSet should not be created while mcs1 is blocking it")
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, mgmtServiceSetKey, &kcmv1.ServiceSet{}))).To(BeTrue(),
+						"mgmt ServiceSet should not be created while mcs1 is blocking it")
+
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					g.Expect(multiClusterService.Status.Conditions).To(ContainElement(SatisfyAll(
+						HaveField("Type", kcmv1.ClusterInReadyStateCondition),
+						HaveField("Message", "0/2"),
+					)))
+				}).Should(Succeed())
+			})
+
+			By("mcs1 stops self-managing but still matches the CD via ClusterSelector", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: failingMCSName}, failingMCS)).To(Succeed())
+					failingMCS.Spec.ServiceSpec.Provider.SelfManagement = false
+					g.Expect(k8sClient.Update(ctx, failingMCS)).To(Succeed())
+				}).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					fresh := &kcmv1.MultiClusterService{}
+					g.Expect(mgrClient.Get(ctx, client.ObjectKey{Name: failingMCSName}, fresh)).To(Succeed())
+					g.Expect(fresh.Spec.ServiceSpec.Provider.SelfManagement).To(BeFalse())
+				}).Should(Succeed())
+			})
+
+			By("reconciling mcs2 again and asserting the mgmt ServiceSet is created while the CD one remains blocked", func() {
+				Eventually(func(g Gomega) {
+					_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					g.Expect(err).NotTo(HaveOccurred())
+
+					// mcs1 no longer targets the mgmt cluster, so mcs2's mgmt ServiceSet must
+					// now be created.
+					g.Expect(k8sClient.Get(ctx, mgmtServiceSetKey, &kcmv1.ServiceSet{})).To(Succeed())
+
+					// mcs1 still matches the CD via ClusterSelector and has never produced a
+					// ServiceSet there (its ServiceTemplate is still invalid), so mcs2's CD
+					// ServiceSet must remain blocked.
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, serviceSetKey, &kcmv1.ServiceSet{}))).To(BeTrue(),
+						"CD ServiceSet must remain blocked since mcs1 still matches the CD and has not deployed there")
+
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					g.Expect(multiClusterService.Status.MatchingClusters).To(ContainElement(SatisfyAll(
+						HaveField("Name", clusterDeployment.Name),
+						HaveField("Namespace", clusterDeployment.Namespace),
+						HaveField("Deployed", false),
+						HaveField("Reason", kcmv1.MultiClusterServiceDependencyNotReadyReason),
+					)))
+				}).Should(Succeed())
+			})
+		})
+
+		// Regression test: okToReconcileServiceSet's selfMgmtDependency shortcut (both mcs and
+		// depMCS self-manage) used to bypass the ClusterSelector match check for BOTH the mgmt
+		// pseudo-target AND any real matching ClusterDeployment. But self-management only pertains
+		// to the mothership - it says nothing about whether depMCS targets some other, unrelated CD.
+		// So once depMCS's ClusterSelector no longer matched the CD, it should have unblocked that
+		// CD's ServiceSet regardless of both MCS's self-management status; instead the shortcut kept
+		// it blocked because both objects still self-managed the mothership.
+		It("should unblock the CD once a dependency's ClusterSelector stops matching it, even while both still self-manage", func() {
+			const failingMCSName = "test-multiclusterservice-failing-dependency-2"
+
+			reconciler := &MultiClusterServiceReconciler{
+				Client:          mgrClient,
+				timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+				SystemNamespace: testSystemNamespace,
+			}
+
+			failingMCS := createFailingSelfManagingDependency(failingMCSName, reconciler)
+
+			By("configuring mcs2 to self-manage, match the CD, and depend on mcs1", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					multiClusterService.Spec.DependsOn = []string{failingMCSName}
+					multiClusterService.Spec.ServiceSpec.Provider.SelfManagement = true
+					g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+				}).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					fresh := &kcmv1.MultiClusterService{}
+					g.Expect(mgrClient.Get(ctx, multiClusterServiceRef, fresh)).To(Succeed())
+					g.Expect(fresh.Spec.DependsOn).To(ContainElement(failingMCSName))
+					g.Expect(fresh.Spec.ServiceSpec.Provider.SelfManagement).To(BeTrue())
+				}).Should(Succeed())
+			})
+
+			By("reconciling mcs2 and asserting it is blocked on both the CD and the mgmt cluster", func() {
+				Eventually(func(g Gomega) {
+					_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					g.Expect(err).NotTo(HaveOccurred())
+
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, serviceSetKey, &kcmv1.ServiceSet{}))).To(BeTrue(),
+						"CD ServiceSet should not be created while mcs1 is blocking it")
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, mgmtServiceSetKey, &kcmv1.ServiceSet{}))).To(BeTrue(),
+						"mgmt ServiceSet should not be created while mcs1 is blocking it")
+
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					g.Expect(multiClusterService.Status.Conditions).To(ContainElement(SatisfyAll(
+						HaveField("Type", kcmv1.ClusterInReadyStateCondition),
+						HaveField("Message", "0/2"),
+					)))
+				}).Should(Succeed())
+			})
+
+			By("mcs1 stops matching the CD (ClusterSelector cleared) but keeps self-managing", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: failingMCSName}, failingMCS)).To(Succeed())
+					failingMCS.Spec.ClusterSelector = metav1.LabelSelector{}
+					g.Expect(k8sClient.Update(ctx, failingMCS)).To(Succeed())
+				}).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					fresh := &kcmv1.MultiClusterService{}
+					g.Expect(mgrClient.Get(ctx, client.ObjectKey{Name: failingMCSName}, fresh)).To(Succeed())
+					g.Expect(fresh.Spec.ClusterSelector.MatchLabels).To(BeEmpty())
+					g.Expect(fresh.Spec.ServiceSpec.Provider.SelfManagement).To(BeTrue())
+				}).Should(Succeed())
+			})
+
+			By("reconciling mcs2 again and asserting the CD ServiceSet is created while the mgmt one remains blocked", func() {
+				Eventually(func(g Gomega) {
+					_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					g.Expect(err).NotTo(HaveOccurred())
+
+					// mcs1 no longer matches the CD via ClusterSelector, so mcs2's CD
+					// ServiceSet must now be created.
+					g.Expect(k8sClient.Get(ctx, serviceSetKey, &kcmv1.ServiceSet{})).To(Succeed())
+
+					// mcs1 still self-manages the mothership and has never produced a
+					// ServiceSet there (its ServiceTemplate is still invalid), so mcs2's
+					// mgmt ServiceSet must remain blocked.
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, mgmtServiceSetKey, &kcmv1.ServiceSet{}))).To(BeTrue(),
+						"mgmt ServiceSet must remain blocked since mcs1 still self-manages and has not deployed there")
+
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					g.Expect(multiClusterService.Status.MatchingClusters).To(ContainElement(SatisfyAll(
+						HaveField("Kind", "SveltosCluster"),
+						HaveField("Name", "mgmt"),
+						HaveField("Namespace", "mgmt"),
+						HaveField("Deployed", false),
+						HaveField("Reason", kcmv1.MultiClusterServiceDependencyNotReadyReason),
+					)))
+				}).Should(Succeed())
+			})
+		})
+
+		// Regression test: setMatchingClusters used to build the ServiceSet-derived entries and the
+		// blocked entries as two separate slices and simply concatenate them. If a cluster's
+		// ServiceSet was created during an earlier, unblocked reconcile (and is deliberately never
+		// deleted, since already-deployed services should keep running) and the dependency later
+		// becomes unsatisfied again, that same cluster ends up in both slices - once from the
+		// still-existing ServiceSet and once from the newly-computed blocked list - producing two
+		// entries for the same cluster in .status.matchingClusters instead of one.
+		It("should keep exactly one matchingClusters entry per cluster after a ServiceSet is created, blocked again, but not deleted", func() {
+			const failingMCSName = "test-multiclusterservice-failing-dependency-3"
+
+			reconciler := &MultiClusterServiceReconciler{
+				Client:          mgrClient,
+				timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+				SystemNamespace: testSystemNamespace,
+			}
+
+			failingMCS := createFailingSelfManagingDependency(failingMCSName, reconciler)
+
+			By("creating the Credential referenced by the CD, so setMatchingClusters can resolve it once a real matchingClusters entry exists", func() {
+				cred := &kcmv1.Credential{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      clusterDeployment.Spec.Credential,
+						Namespace: clusterDeployment.Namespace,
+					},
+					Spec: kcmv1.CredentialSpec{
+						IdentityRef: &corev1.ObjectReference{
+							Kind:       "Secret",
+							Name:       "sample-identity",
+							Namespace:  clusterDeployment.Namespace,
+							APIVersion: "v1",
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, cred)).To(Succeed())
+				DeferCleanup(func() {
+					got := &kcmv1.Credential{}
+					if err := k8sClient.Get(ctx, client.ObjectKey{Name: cred.Name, Namespace: cred.Namespace}, got); err == nil {
+						Expect(k8sClient.Delete(ctx, got)).To(Succeed())
+					}
+				})
+			})
+
+			By("configuring mcs2 to self-manage, match the CD, and depend on mcs1", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					multiClusterService.Spec.DependsOn = []string{failingMCSName}
+					multiClusterService.Spec.ServiceSpec.Provider.SelfManagement = true
+					g.Expect(k8sClient.Update(ctx, multiClusterService)).To(Succeed())
+				}).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					fresh := &kcmv1.MultiClusterService{}
+					g.Expect(mgrClient.Get(ctx, multiClusterServiceRef, fresh)).To(Succeed())
+					g.Expect(fresh.Spec.DependsOn).To(ContainElement(failingMCSName))
+					g.Expect(fresh.Spec.ServiceSpec.Provider.SelfManagement).To(BeTrue())
+				}).Should(Succeed())
+			})
+
+			By("reconciling mcs2 and asserting it is blocked on both the CD and the mgmt cluster", func() {
+				Eventually(func(g Gomega) {
+					_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					g.Expect(err).NotTo(HaveOccurred())
+
+					g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, serviceSetKey, &kcmv1.ServiceSet{}))).To(BeTrue(),
+						"CD ServiceSet should not be created while mcs1 is blocking it")
+				}).Should(Succeed())
+			})
+
+			By("mcs1 stops matching the CD (ClusterSelector cleared), unblocking the CD ServiceSet", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: failingMCSName}, failingMCS)).To(Succeed())
+					failingMCS.Spec.ClusterSelector = metav1.LabelSelector{}
+					g.Expect(k8sClient.Update(ctx, failingMCS)).To(Succeed())
+				}).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					fresh := &kcmv1.MultiClusterService{}
+					g.Expect(mgrClient.Get(ctx, client.ObjectKey{Name: failingMCSName}, fresh)).To(Succeed())
+					g.Expect(fresh.Spec.ClusterSelector.MatchLabels).To(BeEmpty())
+				}).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					g.Expect(err).NotTo(HaveOccurred())
+
+					g.Expect(k8sClient.Get(ctx, serviceSetKey, &kcmv1.ServiceSet{})).To(Succeed())
+				}).Should(Succeed())
+
+				// The MCS reconciler only creates the ServiceSet; a separate ServiceSet
+				// controller (not running in this suite) is what normally populates
+				// .status.cluster once the underlying Sveltos objects exist. Set it
+				// manually here to simulate that and let setMatchingClusters pick up
+				// this cluster as a real (non-blocked) matchingClusters entry.
+				Eventually(func(g Gomega) {
+					ss := &kcmv1.ServiceSet{}
+					g.Expect(k8sClient.Get(ctx, serviceSetKey, ss)).To(Succeed())
+					ss.Status.Cluster = &corev1.ObjectReference{
+						Kind:       kcmv1.ClusterDeploymentKind,
+						Name:       clusterDeployment.Name,
+						Namespace:  clusterDeployment.Namespace,
+						APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
+					}
+					ss.Status.Deployed = true
+					g.Expect(k8sClient.Status().Update(ctx, ss)).To(Succeed())
+				}).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					g.Expect(err).NotTo(HaveOccurred())
+
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					matching := make([]kcmv1.MatchingCluster, 0)
+					for _, c := range multiClusterService.Status.MatchingClusters {
+						if c.Kind == kcmv1.ClusterDeploymentKind {
+							matching = append(matching, c)
+						}
+					}
+					g.Expect(matching).To(HaveLen(1))
+					g.Expect(matching[0].Deployed).To(BeTrue())
+				}).Should(Succeed())
+			})
+
+			By("mcs1 matches the CD again, blocking its ServiceSet, without deleting the already-created ServiceSet", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: failingMCSName}, failingMCS)).To(Succeed())
+					failingMCS.Spec.ClusterSelector = metav1.LabelSelector{
+						MatchLabels: map[string]string{"test": "true"},
+					}
+					g.Expect(k8sClient.Update(ctx, failingMCS)).To(Succeed())
+				}).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					fresh := &kcmv1.MultiClusterService{}
+					g.Expect(mgrClient.Get(ctx, client.ObjectKey{Name: failingMCSName}, fresh)).To(Succeed())
+					g.Expect(fresh.Spec.ClusterSelector.MatchLabels).To(HaveKeyWithValue("test", "true"))
+				}).Should(Succeed())
+			})
+
+			By("reconciling mcs2 again and asserting exactly one matchingClusters entry remains for the CD, reflecting the blocked state", func() {
+				Eventually(func(g Gomega) {
+					_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: multiClusterServiceRef})
+					g.Expect(err).NotTo(HaveOccurred())
+
+					// The ServiceSet created earlier must still exist - already-deployed
+					// services are never torn down just because a dependency becomes
+					// unsatisfied again.
+					g.Expect(k8sClient.Get(ctx, serviceSetKey, &kcmv1.ServiceSet{})).To(Succeed())
+
+					g.Expect(k8sClient.Get(ctx, multiClusterServiceRef, multiClusterService)).To(Succeed())
+					matching := make([]kcmv1.MatchingCluster, 0)
+					for _, c := range multiClusterService.Status.MatchingClusters {
+						if c.Kind == kcmv1.ClusterDeploymentKind {
+							matching = append(matching, c)
+						}
+					}
+					g.Expect(matching).To(HaveLen(1), "expected exactly one matchingClusters entry for the CD, got %d", len(matching))
+					g.Expect(matching[0]).To(SatisfyAll(
+						HaveField("Name", clusterDeployment.Name),
+						HaveField("Namespace", clusterDeployment.Namespace),
+						HaveField("Deployed", false),
+						HaveField("Reason", kcmv1.MultiClusterServiceDependencyNotReadyReason),
+					))
 				}).Should(Succeed())
 			})
 		})
@@ -940,3 +1378,180 @@ var _ = Describe("MultiClusterService Controller", func() {
 		)
 	})
 })
+
+// Test_okToReconcileServiceSet verifies that okToReconcileServiceSet distinguishes expected
+// "dependency not ready" states (missing dependency ServiceSet, dependency not fully deployed)
+// - returned via the blocked value and meant to be surfaced only in status - from unexpected
+// operational errors (failing to Get the dependency MultiClusterService/ServiceSet, an
+// unparsable ClusterSelector) - returned via err and meant to propagate as a real reconcile
+// error so controller-runtime retries it with backoff instead of it being silently folded into
+// the "waiting on dependency" status.
+func Test_okToReconcileServiceSet(t *testing.T) {
+	const (
+		mcsName     = "mcs2"
+		depMCSName  = "mcs1"
+		cdName      = "test-cd"
+		cdNamespace = "test-ns"
+		sysNS       = "kcm-system"
+	)
+
+	depService := kcmv1.Service{Template: "tmpl", Name: "svc", Namespace: "ns"}
+	matchingSelector := metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}}
+
+	newDepMCS := func(selfManagement bool, clusterSelector metav1.LabelSelector) *kcmv1.MultiClusterService {
+		return &kcmv1.MultiClusterService{
+			ObjectMeta: metav1.ObjectMeta{Name: depMCSName},
+			Spec: kcmv1.MultiClusterServiceSpec{
+				ClusterSelector: clusterSelector,
+				ServiceSpec: kcmv1.ServiceSpec{
+					Provider: kcmv1.StateManagementProviderConfig{SelfManagement: selfManagement},
+					Services: []kcmv1.Service{depService},
+				},
+			},
+		}
+	}
+
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cdName,
+			Namespace: cdNamespace,
+			Labels:    map[string]string{"test": "true"},
+		},
+	}
+
+	tests := []struct {
+		name              string
+		mcsSelfManagement bool
+		cd                *kcmv1.ClusterDeployment // nil to exercise the self-management (mgmt) path
+		depMCS            *kcmv1.MultiClusterService
+		serviceSet        *kcmv1.ServiceSet
+		clientInterceptor *interceptor.Funcs
+		wantBlocked       bool
+		wantErr           bool
+	}{
+		{
+			name:   "transient error getting dependency MultiClusterService is a real error, not blocked",
+			cd:     cd,
+			depMCS: newDepMCS(false, matchingSelector),
+			clientInterceptor: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*kcmv1.MultiClusterService); ok && key.Name == depMCSName {
+						return errors.New("transient API server error")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed ClusterSelector on the dependency is a real error, not blocked",
+			cd:   cd,
+			depMCS: newDepMCS(false, metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "owner", Operator: "NotAnOperator", Values: []string{"dev-team"}},
+				},
+			}),
+			wantErr: true,
+		},
+		{
+			name:        "dependency ServiceSet not yet created is an expected blocked state",
+			cd:          cd,
+			depMCS:      newDepMCS(false, matchingSelector),
+			wantBlocked: true,
+		},
+		{
+			name:   "transient error getting dependency ServiceSet is a real error, not blocked",
+			cd:     cd,
+			depMCS: newDepMCS(false, matchingSelector),
+			clientInterceptor: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*kcmv1.ServiceSet); ok {
+						return errors.New("transient API server error")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "dependency ServiceSet exists but not all services deployed is an expected blocked state",
+			cd:     cd,
+			depMCS: newDepMCS(false, matchingSelector),
+			serviceSet: &kcmv1.ServiceSet{
+				Status: kcmv1.ServiceSetStatus{},
+			},
+			wantBlocked: true,
+		},
+		{
+			name:   "dependency fully deployed: neither blocked nor error",
+			cd:     cd,
+			depMCS: newDepMCS(false, matchingSelector),
+			serviceSet: &kcmv1.ServiceSet{
+				Status: kcmv1.ServiceSetStatus{
+					Services: []kcmv1.ServiceState{
+						{Name: depService.Name, Namespace: depService.Namespace, State: kcmv1.ServiceStateDeployed},
+					},
+				},
+			},
+		},
+		{
+			name:              "mgmt path: dependency ServiceSet not yet created is an expected blocked state",
+			mcsSelfManagement: true,
+			cd:                nil,
+			depMCS:            newDepMCS(true, metav1.LabelSelector{}),
+			wantBlocked:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []client.Object{tt.depMCS}
+			if tt.cd != nil {
+				objs = append(objs, tt.cd)
+			}
+			if tt.serviceSet != nil {
+				ssKey := serviceset.ObjectKey(sysNS, tt.cd, tt.depMCS)
+				tt.serviceSet.Name = ssKey.Name
+				tt.serviceSet.Namespace = ssKey.Namespace
+				objs = append(objs, tt.serviceSet)
+			}
+
+			builder := fake.NewClientBuilder().WithScheme(testscheme.Scheme).WithObjects(objs...)
+			if tt.clientInterceptor != nil {
+				builder = builder.WithInterceptorFuncs(*tt.clientInterceptor)
+			}
+
+			mcs := &kcmv1.MultiClusterService{
+				ObjectMeta: metav1.ObjectMeta{Name: mcsName},
+				Spec: kcmv1.MultiClusterServiceSpec{
+					DependsOn: []string{depMCSName},
+					ServiceSpec: kcmv1.ServiceSpec{
+						Provider: kcmv1.StateManagementProviderConfig{SelfManagement: tt.mcsSelfManagement},
+					},
+				},
+			}
+
+			r := &MultiClusterServiceReconciler{
+				Client:          builder.Build(),
+				SystemNamespace: sysNS,
+			}
+
+			blocked, err := r.okToReconcileServiceSet(t.Context(), mcs, tt.cd)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected err, got nil")
+				}
+			} else if err != nil {
+				t.Fatalf("expected no err, got: %v", err)
+			}
+
+			if tt.wantBlocked {
+				if blocked == nil {
+					t.Fatal("expected blocked, got nil")
+				}
+			} else if blocked != nil {
+				t.Fatalf("expected no blocked, got: %v", blocked)
+			}
+		})
+	}
+}

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -1501,6 +1501,28 @@ func Test_okToReconcileServiceSet(t *testing.T) {
 			depMCS:            newDepMCS(true, metav1.LabelSelector{}),
 			wantBlocked:       true,
 		},
+		{
+			// mgmt path, but depMCS does not self-manage, so it never targets the mgmt
+			// pseudo-cluster - there is no dependency here and reconcile may proceed.
+			name:              "mgmt path: dependency that does not target the mgmt cluster is not a dependency",
+			mcsSelfManagement: true,
+			cd:                nil,
+			depMCS:            newDepMCS(false, matchingSelector),
+		},
+		{
+			// An empty ClusterSelector matches no ClusterDeployment (mirroring reconcileUpdate),
+			// so depMCS does not target this cluster and there is no dependency.
+			name:   "dependency with empty ClusterSelector is not a dependency",
+			cd:     cd,
+			depMCS: newDepMCS(false, metav1.LabelSelector{}),
+		},
+		{
+			// depMCS's ClusterSelector does not match the cluster's labels, so it does not
+			// target this cluster and there is no dependency.
+			name:   "dependency whose ClusterSelector does not match the cluster is not a dependency",
+			cd:     cd,
+			depMCS: newDepMCS(false, metav1.LabelSelector{MatchLabels: map[string]string{"test": "false"}}),
+		},
 	}
 
 	for _, tt := range tests {
@@ -1536,7 +1558,11 @@ func Test_okToReconcileServiceSet(t *testing.T) {
 				SystemNamespace: sysNS,
 			}
 
-			blocked, err := r.okToReconcileServiceSet(t.Context(), mcs, tt.cd)
+			var blocked []blockedCluster
+			ok, err := r.okToReconcileServiceSet(t.Context(), mcs, tt.cd, &blocked)
+
+			// A real, unexpected error is returned via err; an expected blocked state is
+			// surfaced only by appending to the blocked slice (err stays nil for it).
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected err, got nil")
@@ -1545,13 +1571,123 @@ func Test_okToReconcileServiceSet(t *testing.T) {
 				t.Fatalf("expected no err, got: %v", err)
 			}
 
-			if tt.wantBlocked {
-				if blocked == nil {
-					t.Fatal("expected blocked, got nil")
-				}
-			} else if blocked != nil {
-				t.Fatalf("expected no blocked, got: %v", blocked)
+			gotBlocked := len(blocked) > 0
+			if gotBlocked != tt.wantBlocked {
+				t.Fatalf("expected blocked=%v, got %v (%v)", tt.wantBlocked, gotBlocked, blocked)
+			}
+
+			// ok gates create/update: true only when neither errored nor blocked.
+			if wantOk := !tt.wantErr && !tt.wantBlocked; ok != wantOk {
+				t.Fatalf("expected ok=%v, got %v", wantOk, ok)
 			}
 		})
+	}
+}
+
+// Test_okToReconcileServiceSet_errorAndBlocked verifies the mixed case a single-dependency
+// table cannot express: when one dependency fails with a real, unexpected error while another
+// is merely not-ready-yet, okToReconcileServiceSet must both return a non-nil err (so the
+// failure is propagated and retried with backoff) and append the not-ready cluster to blocked
+// (so it is still surfaced on mcs.Status). ok must be false.
+func Test_okToReconcileServiceSet_errorAndBlocked(t *testing.T) {
+	const (
+		mcsName     = "mcs3"
+		errDepName  = "dep-err" // dependency whose ServiceSet Get fails with a real error
+		blkDepName  = "dep-blk" // dependency that is blocked (its ServiceSet does not exist yet)
+		cdName      = "test-cd"
+		cdNamespace = "test-ns"
+		sysNS       = "kcm-system"
+	)
+
+	matchingSelector := metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}}
+	depService := kcmv1.Service{Template: "tmpl", Name: "svc", Namespace: "ns"}
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: cdName, Namespace: cdNamespace, Labels: map[string]string{"test": "true"}},
+	}
+
+	newDep := func(name string) *kcmv1.MultiClusterService {
+		return &kcmv1.MultiClusterService{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: kcmv1.MultiClusterServiceSpec{
+				ClusterSelector: matchingSelector,
+				ServiceSpec:     kcmv1.ServiceSpec{Services: []kcmv1.Service{depService}},
+			},
+		}
+	}
+	errDep := newDep(errDepName)
+	blkDep := newDep(blkDepName)
+
+	// Fail the Get only for errDep's ServiceSet; blkDep's ServiceSet is simply absent (NotFound).
+	errDepSSetKey := serviceset.ObjectKey(sysNS, cd, errDep)
+	builder := fake.NewClientBuilder().WithScheme(testscheme.Scheme).
+		WithObjects(cd, errDep, blkDep).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*kcmv1.ServiceSet); ok && key == errDepSSetKey {
+					return errors.New("transient API server error")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		})
+
+	mcs := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{Name: mcsName},
+		Spec:       kcmv1.MultiClusterServiceSpec{DependsOn: []string{errDepName, blkDepName}},
+	}
+	r := &MultiClusterServiceReconciler{Client: builder.Build(), SystemNamespace: sysNS}
+
+	var blocked []blockedCluster
+	ok, err := r.okToReconcileServiceSet(t.Context(), mcs, cd, &blocked)
+
+	if err == nil {
+		t.Fatal("expected a real error from the failing dependency, got nil")
+	}
+	if len(blocked) != 1 {
+		t.Fatalf("expected exactly one blocked cluster, got %d (%v)", len(blocked), blocked)
+	}
+	if ok {
+		t.Fatal("expected ok=false when both errored and blocked")
+	}
+}
+
+// Test_okToReconcileServiceSet_nilBlocked verifies the defensive nil-pointer guard: a blocked
+// state with a nil blocked slice pointer must not panic. ok is still false so the caller skips
+// create/update, and err stays nil since the blocked state is never folded into err.
+func Test_okToReconcileServiceSet_nilBlocked(t *testing.T) {
+	const (
+		mcsName     = "mcs4"
+		depMCSName  = "dep"
+		cdName      = "test-cd"
+		cdNamespace = "test-ns"
+		sysNS       = "kcm-system"
+	)
+
+	depMCS := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{Name: depMCSName},
+		Spec: kcmv1.MultiClusterServiceSpec{
+			ClusterSelector: metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}},
+			ServiceSpec:     kcmv1.ServiceSpec{Services: []kcmv1.Service{{Template: "tmpl", Name: "svc", Namespace: "ns"}}},
+		},
+	}
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: cdName, Namespace: cdNamespace, Labels: map[string]string{"test": "true"}},
+	}
+	mcs := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{Name: mcsName},
+		Spec:       kcmv1.MultiClusterServiceSpec{DependsOn: []string{depMCSName}},
+	}
+
+	r := &MultiClusterServiceReconciler{
+		Client:          fake.NewClientBuilder().WithScheme(testscheme.Scheme).WithObjects(cd, depMCS).Build(),
+		SystemNamespace: sysNS,
+	}
+
+	// depMCS's ServiceSet does not exist -> blocked state, but blocked pointer is nil.
+	ok, err := r.okToReconcileServiceSet(t.Context(), mcs, cd, nil)
+	if err != nil {
+		t.Fatalf("expected no err, got: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false for a blocked state")
 	}
 }

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -1600,6 +1600,145 @@ func Test_Reconcile_dependencyCheckErrorReportsUnknown(t *testing.T) {
 	}
 }
 
+// Test_setMatchingClusters_regionalPropagatesAfterUnblock verifies that a cluster first observed
+// while blocked - Regional defaults to false then, since it isn't computed for blocked entries -
+// picks up its real Regional value once it unblocks and a ServiceSet reports it deployed. The
+// merge in setMatchingClusters preserves most fields of a previously observed entry (e.g.
+// LastTransitionTime unless Deployed actually changed), but Regional and the object reference
+// must always be refreshed from the freshly computed value, or a cluster observed as
+// non-regional while blocked would incorrectly stay non-regional forever.
+func Test_setMatchingClusters_regionalPropagatesAfterUnblock(t *testing.T) {
+	const (
+		cdName      = "test-cd"
+		cdNamespace = "test-ns"
+		credName    = "test-cred"
+		sysNS       = "kcm-system"
+	)
+
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: cdName, Namespace: cdNamespace},
+		Spec:       kcmv1.ClusterDeploymentSpec{Credential: credName},
+	}
+	cred := &kcmv1.Credential{
+		ObjectMeta: metav1.ObjectMeta{Name: credName, Namespace: cdNamespace},
+		Spec:       kcmv1.CredentialSpec{Region: "us-east-1"},
+	}
+
+	r := &MultiClusterServiceReconciler{
+		Client:          fake.NewClientBuilder().WithScheme(testscheme.Scheme).WithObjects(cd, cred).Build(),
+		SystemNamespace: sysNS,
+		timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+	}
+
+	// Simulate a prior reconcile that observed this cluster while blocked: Regional was never
+	// computed for blocked entries before this fix, so it defaulted to false.
+	mcs := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{Name: "mcs"},
+		Status: kcmv1.MultiClusterServiceStatus{
+			MatchingClusters: []kcmv1.MatchingCluster{
+				{
+					ObjectReference: &corev1.ObjectReference{
+						Kind:       kcmv1.ClusterDeploymentKind,
+						Name:       cdName,
+						Namespace:  cdNamespace,
+						APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
+					},
+					Regional: false,
+					Deployed: false,
+					Reason:   kcmv1.MultiClusterServiceDependencyNotReadyReason,
+					Message:  "waiting on dependency",
+				},
+			},
+		},
+	}
+
+	serviceSets := []kcmv1.ServiceSet{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "cd-sset", Namespace: cdNamespace},
+			Spec:       kcmv1.ServiceSetSpec{Cluster: cdName},
+			Status: kcmv1.ServiceSetStatus{
+				Deployed: true,
+				Cluster: &corev1.ObjectReference{
+					Kind:       kcmv1.ClusterDeploymentKind,
+					Name:       cdName,
+					Namespace:  cdNamespace,
+					APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
+				},
+			},
+		},
+	}
+
+	if err := r.setMatchingClusters(t.Context(), mcs, serviceSets, nil); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(mcs.Status.MatchingClusters) != 1 {
+		t.Fatalf("expected exactly one matchingClusters entry, got %d: %+v", len(mcs.Status.MatchingClusters), mcs.Status.MatchingClusters)
+	}
+	got := mcs.Status.MatchingClusters[0]
+	if !got.Deployed {
+		t.Error("expected the cluster to be reported as deployed")
+	}
+	if !got.Regional {
+		t.Error("expected Regional to be true now that the cluster has unblocked and its Credential region was resolved")
+	}
+}
+
+// Test_setMatchingClusters_regionalPopulatedWhileBlocked verifies that a blocked ClusterDeployment
+// gets its Regional value computed immediately, on first observation, rather than only ever
+// defaulting to false because Regional is never looked up for blocked entries.
+func Test_setMatchingClusters_regionalPopulatedWhileBlocked(t *testing.T) {
+	const (
+		cdName      = "test-cd"
+		cdNamespace = "test-ns"
+		credName    = "test-cred"
+		sysNS       = "kcm-system"
+	)
+
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: cdName, Namespace: cdNamespace},
+		Spec:       kcmv1.ClusterDeploymentSpec{Credential: credName},
+	}
+	cred := &kcmv1.Credential{
+		ObjectMeta: metav1.ObjectMeta{Name: credName, Namespace: cdNamespace},
+		Spec:       kcmv1.CredentialSpec{Region: "us-east-1"},
+	}
+
+	r := &MultiClusterServiceReconciler{
+		Client:          fake.NewClientBuilder().WithScheme(testscheme.Scheme).WithObjects(cd, cred).Build(),
+		SystemNamespace: sysNS,
+		timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+	}
+
+	mcs := &kcmv1.MultiClusterService{ObjectMeta: metav1.ObjectMeta{Name: "mcs"}}
+	blocked := []blockedCluster{
+		{
+			ref: &corev1.ObjectReference{
+				Kind:       kcmv1.ClusterDeploymentKind,
+				Name:       cdName,
+				Namespace:  cdNamespace,
+				APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
+			},
+			msg: "waiting on dependency",
+		},
+	}
+
+	if err := r.setMatchingClusters(t.Context(), mcs, nil, blocked); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(mcs.Status.MatchingClusters) != 1 {
+		t.Fatalf("expected exactly one matchingClusters entry, got %d: %+v", len(mcs.Status.MatchingClusters), mcs.Status.MatchingClusters)
+	}
+	got := mcs.Status.MatchingClusters[0]
+	if got.Deployed {
+		t.Error("expected the blocked cluster to be reported as not deployed")
+	}
+	if !got.Regional {
+		t.Error("expected Regional to be true even while the cluster is blocked, since its Credential region is resolvable")
+	}
+}
+
 // setMatchingClusters reports as not deployed with a MultiClusterServiceDependencyNotReady
 // reason.
 func Test_setClustersCondition(t *testing.T) {

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -2100,6 +2100,69 @@ func Test_setDependencyReadyCondition(t *testing.T) {
 	}
 }
 
+// Test_dependencyCheckMessage verifies that the DependencyReady condition's Message stays bounded
+// regardless of how many (target, dependency) pairs contributed a real error this reconcile -
+// checkErr accumulates one wrapped error per pair, proportional to matching-cluster count x
+// len(DependsOn), and unlike checkErr itself (still returned/logged in full by the caller), this
+// message is persisted on mcs.Status and must not grow toward API object size limits.
+func Test_dependencyCheckMessage(t *testing.T) {
+	t.Run("short error is not truncated and reports its count", func(t *testing.T) {
+		checkErr := errors.New("failed to get MultiClusterService dep: transient API server error")
+		msg := dependencyCheckMessage(checkErr)
+
+		if !strings.Contains(msg, "(1 error(s))") {
+			t.Errorf("expected the message to report exactly 1 error, got: %s", msg)
+		}
+		if !strings.Contains(msg, checkErr.Error()) {
+			t.Errorf("expected the full untruncated error text to be present, got: %s", msg)
+		}
+		if len(msg) > maxDependencyCheckMessageBytes {
+			t.Errorf("expected message within %d bytes, got %d", maxDependencyCheckMessageBytes, len(msg))
+		}
+	})
+
+	t.Run("many joined errors are truncated with a bounded size and an omitted-bytes note", func(t *testing.T) {
+		const numErrs = 500
+		var checkErr error
+		for i := range numErrs {
+			checkErr = errors.Join(checkErr, fmt.Errorf("failed to get serviceSet ns/cluster-%04d-sset (owned by MultiClusterService dep-%04d): ServiceSet.k0rdent.mirantis.com \"cluster-%04d-sset\" not found", i, i, i))
+		}
+
+		msg := dependencyCheckMessage(checkErr)
+
+		if len(msg) > maxDependencyCheckMessageBytes+200 {
+			// +200 slack for the "... (N bytes omitted, ...)" suffix itself.
+			t.Errorf("expected a bounded message, got %d bytes", len(msg))
+		}
+		if !strings.Contains(msg, fmt.Sprintf("(%d error(s))", numErrs)) {
+			t.Errorf("expected the message to report the full count of %d errors even though truncated, got: %s", numErrs, msg)
+		}
+		if !strings.Contains(msg, "bytes omitted") {
+			t.Errorf("expected a note about omitted content, got: %s", msg)
+		}
+		if strings.Contains(msg, fmt.Sprintf("cluster-%04d-sset", numErrs-1)) {
+			t.Errorf("expected the last joined error's detail to have been cut by truncation, got: %s", msg)
+		}
+	})
+
+	t.Run("countJoinedErrors counts leaves of a nested errors.Join tree", func(t *testing.T) {
+		leaf1 := errors.New("a")
+		leaf2 := errors.New("b")
+		leaf3 := errors.New("c")
+		nested := errors.Join(errors.Join(leaf1, leaf2), leaf3)
+
+		if got := countJoinedErrors(nested); got != 3 {
+			t.Errorf("expected 3 leaf errors, got %d", got)
+		}
+		if got := countJoinedErrors(nil); got != 0 {
+			t.Errorf("expected 0 for nil, got %d", got)
+		}
+		if got := countJoinedErrors(leaf1); got != 1 {
+			t.Errorf("expected 1 for a non-joined error, got %d", got)
+		}
+	})
+}
+
 // Test_okToReconcileServiceSet verifies that okToReconcileServiceSet distinguishes expected
 // "dependency not ready" states (missing dependency ServiceSet, dependency not fully deployed)
 // - returned via the blocked value and meant to be surfaced only in status - from unexpected

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -1392,11 +1392,6 @@ var _ = Describe("MultiClusterService Controller", func() {
 	})
 })
 
-// Test_setClustersCondition verifies the numerator of the ClusterInReadyState condition. In
-// particular, a ServiceSet left over from an earlier unblocked reconcile keeps reporting
-// Deployed after its cluster becomes dependency-blocked again (it is deliberately not deleted),
-// but it is no longer kept in sync, so it must not be counted as ready - otherwise this
-// condition would contradict the same cluster's .status.matchingClusters entry, which
 // Test_Reconcile_mixedErrorAndBlockedPersistsMatchingClusters verifies that a reconcile which
 // both hits a real, unexpected error on one matching cluster and finds another matching cluster
 // blocked on a MultiClusterService dependency still persists the blocked cluster in
@@ -1898,6 +1893,11 @@ func Test_setMatchingClusters_selfManagementAndClusterDeploymentNameCollision(t 
 	}
 }
 
+// Test_setClustersCondition verifies the numerator of the ClusterInReadyState condition. In
+// particular, a ServiceSet left over from an earlier unblocked reconcile keeps reporting
+// Deployed after its cluster becomes dependency-blocked again (it is deliberately not deleted),
+// but it is no longer kept in sync, so it must not be counted as ready - otherwise this
+// condition would contradict the same cluster's .status.matchingClusters entry, which
 // setMatchingClusters reports as not deployed with a MultiClusterServiceDependencyNotReady
 // reason.
 func Test_setClustersCondition(t *testing.T) {
@@ -1940,11 +1940,11 @@ func Test_setClustersCondition(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		totalCount  int
-		serviceSets []kcmv1.ServiceSet
-		blocked     []blockedCluster
 		wantMessage string
 		wantStatus  metav1.ConditionStatus
+		serviceSets []kcmv1.ServiceSet
+		blocked     []blockedCluster
+		totalCount  int
 	}{
 		{
 			name:        "deployed ServiceSet on a cluster that is not blocked is ready",

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -992,6 +993,16 @@ var _ = Describe("MultiClusterService Controller", func() {
 						HaveField("Deployed", false),
 						HaveField("Reason", kcmv1.MultiClusterServiceDependencyNotReadyReason),
 					))
+
+					// ClusterInReadyState must agree with the matchingClusters entry above: the
+					// preserved ServiceSet still reports Deployed, but it is no longer kept in
+					// sync while the CD is blocked, so neither the CD nor the (never created)
+					// mgmt ServiceSet counts as ready.
+					g.Expect(multiClusterService.Status.Conditions).To(ContainElement(SatisfyAll(
+						HaveField("Type", kcmv1.ClusterInReadyStateCondition),
+						HaveField("Status", metav1.ConditionFalse),
+						HaveField("Message", "0/2"),
+					)))
 				}).Should(Succeed())
 			})
 		})
@@ -1378,6 +1389,119 @@ var _ = Describe("MultiClusterService Controller", func() {
 		)
 	})
 })
+
+// Test_setClustersCondition verifies the numerator of the ClusterInReadyState condition. In
+// particular, a ServiceSet left over from an earlier unblocked reconcile keeps reporting
+// Deployed after its cluster becomes dependency-blocked again (it is deliberately not deleted),
+// but it is no longer kept in sync, so it must not be counted as ready - otherwise this
+// condition would contradict the same cluster's .status.matchingClusters entry, which
+// setMatchingClusters reports as not deployed with a MultiClusterServiceDependencyNotReady
+// reason.
+func Test_setClustersCondition(t *testing.T) {
+	const (
+		cdName      = "test-cd"
+		cdNamespace = "test-ns"
+		sysNS       = "kcm-system"
+	)
+
+	cdServiceSet := func(deployed, deleting bool) kcmv1.ServiceSet {
+		ss := kcmv1.ServiceSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "cd-sset", Namespace: cdNamespace},
+			Spec:       kcmv1.ServiceSetSpec{Cluster: cdName},
+			Status:     kcmv1.ServiceSetStatus{Deployed: deployed},
+		}
+		if deleting {
+			now := metav1.Now()
+			ss.DeletionTimestamp = &now
+			ss.Finalizers = []string{kcmv1.ServiceSetFinalizer}
+		}
+		return ss
+	}
+
+	// The self-management ServiceSet has no .spec.cluster and targets the mgmt pseudo-cluster.
+	mgmtServiceSet := kcmv1.ServiceSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "management-sset", Namespace: sysNS},
+		Status:     kcmv1.ServiceSetStatus{Deployed: true},
+	}
+
+	blockedCD := blockedCluster{
+		ref: &corev1.ObjectReference{
+			Kind:       kcmv1.ClusterDeploymentKind,
+			Name:       cdName,
+			Namespace:  cdNamespace,
+			APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
+		},
+		msg: "waiting on dependency",
+	}
+	blockedMgmt := blockedCluster{ref: serviceset.SelfManagementClusterReference(), msg: "waiting on dependency"}
+
+	tests := []struct {
+		name        string
+		totalCount  int
+		serviceSets []kcmv1.ServiceSet
+		blocked     []blockedCluster
+		wantMessage string
+		wantStatus  metav1.ConditionStatus
+	}{
+		{
+			name:        "deployed ServiceSet on a cluster that is not blocked is ready",
+			totalCount:  1,
+			serviceSets: []kcmv1.ServiceSet{cdServiceSet(true, false)},
+			wantMessage: "1/1",
+			wantStatus:  metav1.ConditionTrue,
+		},
+		{
+			name:        "stale deployed ServiceSet on a re-blocked cluster is not ready",
+			totalCount:  1,
+			serviceSets: []kcmv1.ServiceSet{cdServiceSet(true, false)},
+			blocked:     []blockedCluster{blockedCD},
+			wantMessage: "0/1",
+			wantStatus:  metav1.ConditionFalse,
+		},
+		{
+			name:        "stale deployed self-management ServiceSet on a re-blocked mgmt cluster is not ready",
+			totalCount:  1,
+			serviceSets: []kcmv1.ServiceSet{mgmtServiceSet},
+			blocked:     []blockedCluster{blockedMgmt},
+			wantMessage: "0/1",
+			wantStatus:  metav1.ConditionFalse,
+		},
+		{
+			name:        "only the blocked cluster is excluded, the other still counts",
+			totalCount:  2,
+			serviceSets: []kcmv1.ServiceSet{cdServiceSet(true, false), mgmtServiceSet},
+			blocked:     []blockedCluster{blockedCD},
+			wantMessage: "1/2",
+			wantStatus:  metav1.ConditionFalse,
+		},
+		{
+			name:        "ServiceSet being deleted is not counted",
+			totalCount:  1,
+			serviceSets: []kcmv1.ServiceSet{cdServiceSet(true, true)},
+			wantMessage: "0/1",
+			wantStatus:  metav1.ConditionFalse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcs := &kcmv1.MultiClusterService{ObjectMeta: metav1.ObjectMeta{Name: "mcs"}}
+			r := &MultiClusterServiceReconciler{SystemNamespace: sysNS}
+			r.setClustersCondition(t.Context(), mcs, tt.totalCount, tt.serviceSets, tt.blocked)
+
+			cond := apimeta.FindStatusCondition(mcs.Status.Conditions, kcmv1.ClusterInReadyStateCondition)
+			if cond == nil {
+				t.Fatalf("expected the %s condition to be set", kcmv1.ClusterInReadyStateCondition)
+			}
+			if cond.Message != tt.wantMessage {
+				t.Errorf("expected message %q, got %q", tt.wantMessage, cond.Message)
+			}
+			if cond.Status != tt.wantStatus {
+				t.Errorf("expected status %q, got %q", tt.wantStatus, cond.Status)
+			}
+		})
+	}
+}
 
 // Test_okToReconcileServiceSet verifies that okToReconcileServiceSet distinguishes expected
 // "dependency not ready" states (missing dependency ServiceSet, dependency not fully deployed)

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -27,6 +27,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"helm.sh/helm/v3/pkg/chart"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -1736,6 +1737,82 @@ func Test_setMatchingClusters_regionalPopulatedWhileBlocked(t *testing.T) {
 	}
 	if !got.Regional {
 		t.Error("expected Regional to be true even while the cluster is blocked, since its Credential region is resolvable")
+	}
+}
+
+// Test_setMatchingClusters_selfManagementAndClusterDeploymentNameCollision verifies that the
+// self-management pseudo-target (a SveltosCluster always named mgmt/mgmt) does not collide with
+// an unrelated real ClusterDeployment that happens to also be named "mgmt" in namespace "mgmt".
+// Both are legitimate, independent matching-cluster targets counted in the readiness denominator;
+// keying clusterEntries/observedClustersMap by namespace/name alone would make the blocked
+// self-management entry silently overwrite (or be overwritten by) the ClusterDeployment's real,
+// deployed status, since blocked is applied after serviceSets and both would land under the same
+// map key without Kind in the key.
+func Test_setMatchingClusters_selfManagementAndClusterDeploymentNameCollision(t *testing.T) {
+	const sysNS = "kcm-system"
+
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "mgmt", Namespace: "mgmt"},
+		Spec:       kcmv1.ClusterDeploymentSpec{Credential: "cred1"},
+	}
+	cred := &kcmv1.Credential{
+		ObjectMeta: metav1.ObjectMeta{Name: "cred1", Namespace: "mgmt"},
+	}
+
+	r := &MultiClusterServiceReconciler{
+		Client:          fake.NewClientBuilder().WithScheme(testscheme.Scheme).WithObjects(cd, cred).Build(),
+		SystemNamespace: sysNS,
+		timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+	}
+
+	mcs := &kcmv1.MultiClusterService{ObjectMeta: metav1.ObjectMeta{Name: "mcs"}}
+	serviceSets := []kcmv1.ServiceSet{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "cd-sset", Namespace: "mgmt"},
+			Spec:       kcmv1.ServiceSetSpec{Cluster: "mgmt"},
+			Status: kcmv1.ServiceSetStatus{
+				Deployed: true,
+				Cluster: &corev1.ObjectReference{
+					Kind:       kcmv1.ClusterDeploymentKind,
+					Name:       "mgmt",
+					Namespace:  "mgmt",
+					APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
+				},
+			},
+		},
+	}
+	blocked := []blockedCluster{
+		{ref: serviceset.SelfManagementClusterReference(), msg: "waiting on dependency"},
+	}
+
+	if err := r.setMatchingClusters(t.Context(), mcs, serviceSets, blocked); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(mcs.Status.MatchingClusters) != 2 {
+		t.Fatalf("expected two distinct matchingClusters entries (ClusterDeployment mgmt/mgmt and SveltosCluster mgmt/mgmt), got %d: %+v",
+			len(mcs.Status.MatchingClusters), mcs.Status.MatchingClusters)
+	}
+
+	var cdEntry, selfMgmtEntry *kcmv1.MatchingCluster
+	for i := range mcs.Status.MatchingClusters {
+		e := &mcs.Status.MatchingClusters[i]
+		switch e.Kind {
+		case kcmv1.ClusterDeploymentKind:
+			cdEntry = e
+		case libsveltosv1beta1.SveltosClusterKind:
+			selfMgmtEntry = e
+		}
+	}
+	if cdEntry == nil {
+		t.Fatal("expected a ClusterDeployment-kind entry for mgmt/mgmt")
+	} else if !cdEntry.Deployed {
+		t.Error("expected the ClusterDeployment entry to be reported as deployed")
+	}
+	if selfMgmtEntry == nil {
+		t.Fatal("expected a SveltosCluster-kind entry for the self-management mgmt/mgmt pseudo-target")
+	} else if selfMgmtEntry.Deployed {
+		t.Error("expected the self-management entry to be reported as not deployed (it's blocked)")
 	}
 }
 

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -2200,6 +2201,76 @@ func Test_okToReconcileServiceSet(t *testing.T) {
 				t.Fatalf("expected ok=%v, got %v", wantOk, ok)
 			}
 		})
+	}
+}
+
+// Test_okToReconcileServiceSet_boundedBlockedMessage verifies that a blocked cluster's status
+// message stays a bounded size regardless of how many DependsOn entries are blocking: it must
+// name only the first maxBlockingDependenciesInMessage dependencies and summarize the rest by
+// count, never growing linearly with DependsOn (which is not meaningfully bounded, and this
+// message is stored on mcs.Status once per matching cluster).
+func Test_okToReconcileServiceSet_boundedBlockedMessage(t *testing.T) {
+	const (
+		mcsName     = "mcs-many-deps"
+		cdName      = "test-cd"
+		cdNamespace = "test-ns"
+		sysNS       = "kcm-system"
+	)
+
+	matchingSelector := metav1.LabelSelector{MatchLabels: map[string]string{"test": "true"}}
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: cdName, Namespace: cdNamespace, Labels: map[string]string{"test": "true"}},
+	}
+
+	// 5 dependencies, all matching the CD and all missing their ServiceSet for it (so all 5
+	// block), well beyond maxBlockingDependenciesInMessage.
+	depNames := []string{"dep1", "dep2", "dep3", "dep4", "dep5"}
+	objs := []client.Object{cd}
+	for _, name := range depNames {
+		objs = append(objs, &kcmv1.MultiClusterService{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: kcmv1.MultiClusterServiceSpec{
+				ClusterSelector: matchingSelector,
+				ServiceSpec:     kcmv1.ServiceSpec{Services: []kcmv1.Service{{Template: "tmpl", Name: "svc", Namespace: "ns"}}},
+			},
+		})
+	}
+
+	mcs := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{Name: mcsName},
+		Spec:       kcmv1.MultiClusterServiceSpec{DependsOn: depNames},
+	}
+	r := &MultiClusterServiceReconciler{
+		Client:          fake.NewClientBuilder().WithScheme(testscheme.Scheme).WithObjects(objs...).Build(),
+		SystemNamespace: sysNS,
+	}
+
+	var blocked []blockedCluster
+	ok, err := r.okToReconcileServiceSet(t.Context(), mcs, cd, &blocked)
+	if err != nil {
+		t.Fatalf("expected no err (all 5 dependencies are merely not-ready, not a real failure), got: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false: the cluster is blocked")
+	}
+	if len(blocked) != 1 {
+		t.Fatalf("expected exactly one blocked cluster, got %d", len(blocked))
+	}
+
+	msg := blocked[0].msg
+	for _, name := range depNames[:maxBlockingDependenciesInMessage] {
+		if !strings.Contains(msg, name) {
+			t.Errorf("expected message to name blocking dependency %q, got: %s", name, msg)
+		}
+	}
+	for _, name := range depNames[maxBlockingDependenciesInMessage:] {
+		if strings.Contains(msg, name) {
+			t.Errorf("expected message to omit dependency %q beyond the cap, got: %s", name, msg)
+		}
+	}
+	omitted := len(depNames) - maxBlockingDependenciesInMessage
+	if !strings.Contains(msg, fmt.Sprintf("%d more", omitted)) {
+		t.Errorf("expected message to summarize the %d omitted dependencies by count, got: %s", omitted, msg)
 	}
 }
 

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -1602,6 +1602,87 @@ func Test_Reconcile_dependencyCheckErrorReportsUnknown(t *testing.T) {
 	}
 }
 
+// Test_Reconcile_resolvesDependenciesOncePerReconcile verifies that a dependency MultiClusterService
+// is fetched exactly once per reconcile, not once per matching target. okToReconcileServiceSet is
+// called once for every matching ClusterDeployment (and once more for self-management, if set);
+// before resolveDependencies, each of those calls independently re-fetched every entry in
+// DependsOn, so the same dependency MCS was Get'd (and deep-copied by the cached client) once per
+// target instead of once total - O(targets x len(DependsOn)) work every 10-second reconcile.
+func Test_Reconcile_resolvesDependenciesOncePerReconcile(t *testing.T) {
+	const (
+		mcsName     = "mcs-many-targets"
+		depMCSName  = "dep-mcs"
+		cdNamespace = "test-ns"
+		sysNS       = "kcm-system"
+	)
+
+	matchingLabels := map[string]string{"test": "true"}
+	cd1 := &kcmv1.ClusterDeployment{ObjectMeta: metav1.ObjectMeta{Name: "cd1", Namespace: cdNamespace, Labels: matchingLabels}}
+	cd2 := &kcmv1.ClusterDeployment{ObjectMeta: metav1.ObjectMeta{Name: "cd2", Namespace: cdNamespace, Labels: matchingLabels}}
+	depMCS := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{Name: depMCSName},
+		Spec: kcmv1.MultiClusterServiceSpec{
+			ClusterSelector: metav1.LabelSelector{MatchLabels: matchingLabels},
+			ServiceSpec: kcmv1.ServiceSpec{
+				Services: []kcmv1.Service{{Template: "tmpl", Name: "svc", Namespace: "ns"}},
+			},
+		},
+	}
+	// depMCS never gets a ServiceSet for either cd in this test, so both cd1 and cd2 stay
+	// blocked on it - exercising okToReconcileServiceSet for both targets.
+	mcs := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       mcsName,
+			Finalizers: []string{kcmv1.MultiClusterServiceFinalizer},
+			Labels:     map[string]string{kcmv1.GenericComponentNameLabel: kcmv1.GenericComponentLabelValueKCM},
+		},
+		Spec: kcmv1.MultiClusterServiceSpec{
+			ClusterSelector: metav1.LabelSelector{MatchLabels: matchingLabels},
+			DependsOn:       []string{depMCSName},
+		},
+	}
+	mgmt := &kcmv1.Management{ObjectMeta: metav1.ObjectMeta{Name: kcmv1.ManagementName}}
+
+	var depMCSGets int
+	c := fake.NewClientBuilder().
+		WithScheme(testscheme.Scheme).
+		WithObjects(mcs, depMCS, cd1, cd2, mgmt).
+		WithStatusSubresource(&kcmv1.MultiClusterService{}).
+		WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetMultiClusterServiceIndexKey, kcmv1.ExtractServiceSetMultiClusterService).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*kcmv1.MultiClusterService); ok && key.Name == depMCSName {
+					depMCSGets++
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &MultiClusterServiceReconciler{
+		Client:          c,
+		SystemNamespace: sysNS,
+		timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+	}
+
+	if _, err := r.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKey{Name: mcsName}}); err != nil {
+		t.Fatalf("expected no error (both targets are merely blocked, not a real failure), got: %v", err)
+	}
+
+	if depMCSGets != 1 {
+		t.Errorf("expected the dependency MultiClusterService to be fetched exactly once for 2 matching targets, got %d fetches", depMCSGets)
+	}
+
+	got := &kcmv1.MultiClusterService{}
+	if err := c.Get(t.Context(), client.ObjectKey{Name: mcsName}, got); err != nil {
+		t.Fatalf("failed to get the reconciled MultiClusterService: %v", err)
+	}
+	if len(got.Status.MatchingClusters) != 2 {
+		t.Fatalf("expected both matching clusters to be processed and surfaced as blocked, got %d: %+v",
+			len(got.Status.MatchingClusters), got.Status.MatchingClusters)
+	}
+}
+
 // Test_setMatchingClusters_regionalPropagatesAfterUnblock verifies that a cluster first observed
 // while blocked - Regional defaults to false then, since it isn't computed for blocked entries -
 // picks up its real Regional value once it unblocks and a ServiceSet reports it deployed. The
@@ -2179,7 +2260,8 @@ func Test_okToReconcileServiceSet(t *testing.T) {
 			}
 
 			var blocked []blockedCluster
-			ok, err := r.okToReconcileServiceSet(t.Context(), mcs, tt.cd, &blocked)
+			deps := r.resolveDependencies(t.Context(), mcs)
+			ok, err := r.okToReconcileServiceSet(t.Context(), tt.cd, deps, &blocked)
 
 			// A real, unexpected error is returned via err; an expected blocked state is
 			// surfaced only by appending to the blocked slice (err stays nil for it).
@@ -2246,7 +2328,8 @@ func Test_okToReconcileServiceSet_boundedBlockedMessage(t *testing.T) {
 	}
 
 	var blocked []blockedCluster
-	ok, err := r.okToReconcileServiceSet(t.Context(), mcs, cd, &blocked)
+	deps := r.resolveDependencies(t.Context(), mcs)
+	ok, err := r.okToReconcileServiceSet(t.Context(), cd, deps, &blocked)
 	if err != nil {
 		t.Fatalf("expected no err (all 5 dependencies are merely not-ready, not a real failure), got: %v", err)
 	}
@@ -2327,7 +2410,8 @@ func Test_okToReconcileServiceSet_errorAndBlocked(t *testing.T) {
 	r := &MultiClusterServiceReconciler{Client: builder.Build(), SystemNamespace: sysNS}
 
 	var blocked []blockedCluster
-	ok, err := r.okToReconcileServiceSet(t.Context(), mcs, cd, &blocked)
+	deps := r.resolveDependencies(t.Context(), mcs)
+	ok, err := r.okToReconcileServiceSet(t.Context(), cd, deps, &blocked)
 
 	if err == nil {
 		t.Fatal("expected a real error from the failing dependency, got nil")
@@ -2373,7 +2457,8 @@ func Test_okToReconcileServiceSet_nilBlocked(t *testing.T) {
 	}
 
 	// depMCS's ServiceSet does not exist -> blocked state, but blocked pointer is nil.
-	ok, err := r.okToReconcileServiceSet(t.Context(), mcs, cd, nil)
+	deps := r.resolveDependencies(t.Context(), mcs)
+	ok, err := r.okToReconcileServiceSet(t.Context(), cd, deps, nil)
 	if err != nil {
 		t.Fatalf("expected no err, got: %v", err)
 	}

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -1400,9 +1400,10 @@ var _ = Describe("MultiClusterService Controller", func() {
 // blocked on a MultiClusterService dependency still persists the blocked cluster in
 // .status.matchingClusters. Reconcile's deferred updateStatus writes the status even when
 // reconcileUpdate returns an error, so bailing out before setMatchingClusters ran would persist
-// a MultiClusterServiceDependencyReady=False condition counting N waiting clusters next to a
-// matchingClusters list that never mentions them - and it would stay that way for as long as the
-// unrelated error keeps recurring.
+// a matchingClusters list that never mentions the blocked cluster - and it would stay that way
+// for as long as the unrelated error keeps recurring. It also verifies that, because dependency
+// readiness could not be established for cdErr, MultiClusterServiceDependencyReady is persisted
+// as Unknown (not False) even though cdBlocked was genuinely found waiting on a dependency.
 func Test_Reconcile_mixedErrorAndBlockedPersistsMatchingClusters(t *testing.T) {
 	const (
 		mcsName     = "mcs-mixed"
@@ -1481,11 +1482,14 @@ func Test_Reconcile_mixedErrorAndBlockedPersistsMatchingClusters(t *testing.T) {
 		t.Fatalf("failed to get the reconciled MultiClusterService: %v", getErr)
 	}
 
-	// The conditions and matchingClusters are persisted by the same status update, so they must
-	// tell the same story: one cluster waiting on a dependency.
+	// The conditions and matchingClusters are persisted by the same status update. cdErr's real
+	// error means dependency readiness as a whole could not be established, so the condition must
+	// report Unknown rather than False - False would assert that only cdBlocked is waiting, when
+	// cdErr's status is actually unknown, not confirmed ready.
 	depCond := apimeta.FindStatusCondition(got.Status.Conditions, kcmv1.MultiClusterServiceDependencyReadyCondition)
-	if depCond == nil || depCond.Status != metav1.ConditionFalse {
-		t.Fatalf("expected a False %s condition, got %+v", kcmv1.MultiClusterServiceDependencyReadyCondition, depCond)
+	if depCond == nil || depCond.Status != metav1.ConditionUnknown || depCond.Reason != kcmv1.MultiClusterServiceDependencyCheckFailedReason {
+		t.Fatalf("expected an Unknown %s condition with reason %s, got %+v",
+			kcmv1.MultiClusterServiceDependencyReadyCondition, kcmv1.MultiClusterServiceDependencyCheckFailedReason, depCond)
 	}
 
 	if len(got.Status.MatchingClusters) != 1 {
@@ -1504,6 +1508,95 @@ func Test_Reconcile_mixedErrorAndBlockedPersistsMatchingClusters(t *testing.T) {
 	}
 	if blockedEntry.Message == "" {
 		t.Error("expected a message describing what the blocked cluster is waiting on")
+	}
+}
+
+// Test_Reconcile_dependencyCheckErrorReportsUnknown verifies the pure error case: when
+// okToReconcileServiceSet fails with a real, unexpected error and nothing ends up in blocked
+// (no cluster was found waiting on a dependency), MultiClusterServiceDependencyReady must be
+// persisted as Unknown - not True. Before this was fixed, len(blocked) == 0 made
+// setDependencyReadyCondition report Ready=True/Succeeded despite dependency readiness never
+// having actually been established for this matching cluster, and the deferred updateStatus in
+// Reconcile persists that misleading status even though reconcileUpdate returns the real error.
+func Test_Reconcile_dependencyCheckErrorReportsUnknown(t *testing.T) {
+	const (
+		mcsName     = "mcs-checkerr"
+		depMCSName  = "dep-mcs"
+		cdName      = "cd-err"
+		cdNamespace = "test-ns"
+		sysNS       = "kcm-system"
+	)
+
+	matchingLabels := map[string]string{"test": "true"}
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: cdName, Namespace: cdNamespace, Labels: matchingLabels},
+	}
+	depMCS := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{Name: depMCSName},
+		Spec: kcmv1.MultiClusterServiceSpec{
+			ClusterSelector: metav1.LabelSelector{MatchLabels: matchingLabels},
+			ServiceSpec: kcmv1.ServiceSpec{
+				Services: []kcmv1.Service{{Template: "tmpl", Name: "svc", Namespace: "ns"}},
+			},
+		},
+	}
+	mcs := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       mcsName,
+			Finalizers: []string{kcmv1.MultiClusterServiceFinalizer},
+			Labels:     map[string]string{kcmv1.GenericComponentNameLabel: kcmv1.GenericComponentLabelValueKCM},
+		},
+		Spec: kcmv1.MultiClusterServiceSpec{
+			ClusterSelector:                metav1.LabelSelector{MatchLabels: matchingLabels},
+			DependsOn:                      []string{depMCSName},
+			KeepServicesOnSelectorMismatch: true,
+		},
+	}
+	mgmt := &kcmv1.Management{ObjectMeta: metav1.ObjectMeta{Name: kcmv1.ManagementName}}
+
+	// The only matching cluster's dependency ServiceSet Get fails with a real (non-NotFound)
+	// error, so it never lands in blocked - dependencyCheckErrs is the only signal.
+	errSSetKey := serviceset.ObjectKey(sysNS, cd, depMCS)
+	c := fake.NewClientBuilder().
+		WithScheme(testscheme.Scheme).
+		WithObjects(mcs, depMCS, cd, mgmt).
+		WithStatusSubresource(&kcmv1.MultiClusterService{}).
+		WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetMultiClusterServiceIndexKey, kcmv1.ExtractServiceSetMultiClusterService).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*kcmv1.ServiceSet); ok && key == errSSetKey {
+					return errors.New("transient API server error")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &MultiClusterServiceReconciler{
+		Client:          c,
+		SystemNamespace: sysNS,
+		timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+	}
+
+	_, err := r.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKey{Name: mcsName}})
+	if err == nil {
+		t.Fatal("expected the real dependency-check error to be propagated, got nil")
+	}
+
+	got := &kcmv1.MultiClusterService{}
+	if getErr := c.Get(t.Context(), client.ObjectKey{Name: mcsName}, got); getErr != nil {
+		t.Fatalf("failed to get the reconciled MultiClusterService: %v", getErr)
+	}
+
+	depCond := apimeta.FindStatusCondition(got.Status.Conditions, kcmv1.MultiClusterServiceDependencyReadyCondition)
+	if depCond == nil {
+		t.Fatalf("expected the %s condition to be set", kcmv1.MultiClusterServiceDependencyReadyCondition)
+	}
+	if depCond.Status == metav1.ConditionTrue {
+		t.Fatalf("dependency readiness could not be established, but the persisted condition claims True: %+v", depCond)
+	}
+	if depCond.Status != metav1.ConditionUnknown || depCond.Reason != kcmv1.MultiClusterServiceDependencyCheckFailedReason {
+		t.Errorf("expected Unknown/%s, got %s/%s", kcmv1.MultiClusterServiceDependencyCheckFailedReason, depCond.Status, depCond.Reason)
 	}
 }
 
@@ -1610,6 +1703,80 @@ func Test_setClustersCondition(t *testing.T) {
 			}
 			if cond.Status != tt.wantStatus {
 				t.Errorf("expected status %q, got %q", tt.wantStatus, cond.Status)
+			}
+		})
+	}
+}
+
+// Test_setDependencyReadyCondition verifies that a real, unexpected error checking dependencies
+// (checkErr) takes priority over the blocked state: dependency readiness could not be
+// established for at least one matching cluster in that case, so the condition must report
+// Unknown rather than claiming True (nothing waiting) or False (only these specific clusters
+// waiting) - both of which would assert more than is actually known, even when other clusters
+// were genuinely found blocked in the same reconcile.
+func Test_setDependencyReadyCondition(t *testing.T) {
+	blockedCD := blockedCluster{
+		ref: &corev1.ObjectReference{Kind: kcmv1.ClusterDeploymentKind, Name: "cd", Namespace: "ns"},
+		msg: "waiting on dependency",
+	}
+	checkErr := errors.New("failed to get MultiClusterService dep: transient API server error")
+
+	tests := []struct {
+		name        string
+		blocked     []blockedCluster
+		checkErr    error
+		wantStatus  metav1.ConditionStatus
+		wantReason  string
+		wantMessage string
+	}{
+		{
+			name:       "nothing blocked, no check error: ready",
+			wantStatus: metav1.ConditionTrue,
+			wantReason: kcmv1.SucceededReason,
+		},
+		{
+			name:        "blocked, no check error: not ready",
+			blocked:     []blockedCluster{blockedCD},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  kcmv1.MultiClusterServiceDependencyNotReadyReason,
+			wantMessage: "waiting for MultiClusterService dependencies to be ready on 1 matching cluster(s)",
+		},
+		{
+			name:       "check error, nothing blocked: unknown, not ready=true",
+			checkErr:   checkErr,
+			wantStatus: metav1.ConditionUnknown,
+			wantReason: kcmv1.MultiClusterServiceDependencyCheckFailedReason,
+		},
+		{
+			name:       "check error and blocked: unknown takes priority over blocked",
+			blocked:    []blockedCluster{blockedCD},
+			checkErr:   checkErr,
+			wantStatus: metav1.ConditionUnknown,
+			wantReason: kcmv1.MultiClusterServiceDependencyCheckFailedReason,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcs := &kcmv1.MultiClusterService{ObjectMeta: metav1.ObjectMeta{Name: "mcs", Generation: 3}}
+			r := &MultiClusterServiceReconciler{}
+			r.setDependencyReadyCondition(mcs, tt.blocked, tt.checkErr)
+
+			cond := apimeta.FindStatusCondition(mcs.Status.Conditions, kcmv1.MultiClusterServiceDependencyReadyCondition)
+			if cond == nil {
+				t.Fatalf("expected the %s condition to be set", kcmv1.MultiClusterServiceDependencyReadyCondition)
+			}
+			if cond.Status != tt.wantStatus {
+				t.Errorf("expected status %q, got %q", tt.wantStatus, cond.Status)
+			}
+			if cond.Reason != tt.wantReason {
+				t.Errorf("expected reason %q, got %q", tt.wantReason, cond.Reason)
+			}
+			if tt.wantMessage != "" && cond.Message != tt.wantMessage {
+				t.Errorf("expected message %q, got %q", tt.wantMessage, cond.Message)
+			}
+			if cond.ObservedGeneration != mcs.Generation {
+				t.Errorf("expected ObservedGeneration %d, got %d", mcs.Generation, cond.ObservedGeneration)
 			}
 		})
 	}

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -1938,6 +1938,15 @@ func Test_setClustersCondition(t *testing.T) {
 	}
 	blockedMgmt := blockedCluster{ref: serviceset.SelfManagementClusterReference(), msg: "waiting on dependency"}
 
+	// A ClusterDeployment-backed ServiceSet that happens to target a ClusterDeployment literally
+	// named "mgmt" in namespace "mgmt" - same namespace/name as the self-management pseudo-target,
+	// but a different Kind (ClusterDeployment vs SveltosCluster) and thus a wholly unrelated target.
+	mgmtNamedCDServiceSet := kcmv1.ServiceSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "mgmt-cd-sset", Namespace: "mgmt"},
+		Spec:       kcmv1.ServiceSetSpec{Cluster: "mgmt"},
+		Status:     kcmv1.ServiceSetStatus{Deployed: true},
+	}
+
 	tests := []struct {
 		name        string
 		wantMessage string
@@ -1983,6 +1992,17 @@ func Test_setClustersCondition(t *testing.T) {
 			serviceSets: []kcmv1.ServiceSet{cdServiceSet(true, true)},
 			wantMessage: "0/1",
 			wantStatus:  metav1.ConditionFalse,
+		},
+		{
+			// Regression: without Kind in blockedKeys, a blocked self-management pseudo-target
+			// (SveltosCluster mgmt/mgmt) would collide on namespace/name with this unrelated,
+			// deployed ClusterDeployment also named mgmt/mgmt and wrongly get excluded here too.
+			name:        "blocked self-management target does not collide with an unrelated ClusterDeployment named mgmt/mgmt",
+			totalCount:  1,
+			serviceSets: []kcmv1.ServiceSet{mgmtNamedCDServiceSet},
+			blocked:     []blockedCluster{blockedMgmt},
+			wantMessage: "1/1",
+			wantStatus:  metav1.ConditionTrue,
 		},
 	}
 

--- a/internal/controller/multiclusterservice_controller_test.go
+++ b/internal/controller/multiclusterservice_controller_test.go
@@ -1395,6 +1395,118 @@ var _ = Describe("MultiClusterService Controller", func() {
 // Deployed after its cluster becomes dependency-blocked again (it is deliberately not deleted),
 // but it is no longer kept in sync, so it must not be counted as ready - otherwise this
 // condition would contradict the same cluster's .status.matchingClusters entry, which
+// Test_Reconcile_mixedErrorAndBlockedPersistsMatchingClusters verifies that a reconcile which
+// both hits a real, unexpected error on one matching cluster and finds another matching cluster
+// blocked on a MultiClusterService dependency still persists the blocked cluster in
+// .status.matchingClusters. Reconcile's deferred updateStatus writes the status even when
+// reconcileUpdate returns an error, so bailing out before setMatchingClusters ran would persist
+// a MultiClusterServiceDependencyReady=False condition counting N waiting clusters next to a
+// matchingClusters list that never mentions them - and it would stay that way for as long as the
+// unrelated error keeps recurring.
+func Test_Reconcile_mixedErrorAndBlockedPersistsMatchingClusters(t *testing.T) {
+	const (
+		mcsName     = "mcs-mixed"
+		depMCSName  = "dep-mcs"
+		cdErrName   = "cd-err"     // its dependency ServiceSet Get fails with a real error
+		cdBlockName = "cd-blocked" // its dependency ServiceSet is simply absent -> blocked
+		cdNamespace = "test-ns"
+		sysNS       = "kcm-system"
+	)
+
+	matchingLabels := map[string]string{"test": "true"}
+	newCD := func(name string) *kcmv1.ClusterDeployment {
+		return &kcmv1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cdNamespace, Labels: matchingLabels},
+		}
+	}
+	cdErr, cdBlocked := newCD(cdErrName), newCD(cdBlockName)
+
+	depMCS := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{Name: depMCSName},
+		Spec: kcmv1.MultiClusterServiceSpec{
+			ClusterSelector: metav1.LabelSelector{MatchLabels: matchingLabels},
+			ServiceSpec: kcmv1.ServiceSpec{
+				Services: []kcmv1.Service{{Template: "tmpl", Name: "svc", Namespace: "ns"}},
+			},
+		},
+	}
+
+	// The MCS under test declares no services of its own, so template/service-dependency
+	// validation passes trivially and the only thing gating its ServiceSets is depMCS.
+	// KeepServicesOnSelectorMismatch avoids the cleanup pass, which is irrelevant here.
+	mcs := &kcmv1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       mcsName,
+			Finalizers: []string{kcmv1.MultiClusterServiceFinalizer},
+			Labels:     map[string]string{kcmv1.GenericComponentNameLabel: kcmv1.GenericComponentLabelValueKCM},
+		},
+		Spec: kcmv1.MultiClusterServiceSpec{
+			ClusterSelector:                metav1.LabelSelector{MatchLabels: matchingLabels},
+			DependsOn:                      []string{depMCSName},
+			KeepServicesOnSelectorMismatch: true,
+		},
+	}
+	mgmt := &kcmv1.Management{ObjectMeta: metav1.ObjectMeta{Name: kcmv1.ManagementName}}
+
+	// Fail the Get only for cdErr's dependency ServiceSet; cdBlocked's is absent (NotFound).
+	errSSetKey := serviceset.ObjectKey(sysNS, cdErr, depMCS)
+	c := fake.NewClientBuilder().
+		WithScheme(testscheme.Scheme).
+		WithObjects(mcs, depMCS, cdErr, cdBlocked, mgmt).
+		WithStatusSubresource(&kcmv1.MultiClusterService{}).
+		WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetMultiClusterServiceIndexKey, kcmv1.ExtractServiceSetMultiClusterService).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*kcmv1.ServiceSet); ok && key == errSSetKey {
+					return errors.New("transient API server error")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &MultiClusterServiceReconciler{
+		Client:          c,
+		SystemNamespace: sysNS,
+		timeFunc:        func() time.Time { return time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) },
+	}
+
+	_, err := r.Reconcile(t.Context(), reconcile.Request{NamespacedName: client.ObjectKey{Name: mcsName}})
+	if err == nil {
+		t.Fatal("expected the real error from the failing cluster to be propagated, got nil")
+	}
+
+	got := &kcmv1.MultiClusterService{}
+	if getErr := c.Get(t.Context(), client.ObjectKey{Name: mcsName}, got); getErr != nil {
+		t.Fatalf("failed to get the reconciled MultiClusterService: %v", getErr)
+	}
+
+	// The conditions and matchingClusters are persisted by the same status update, so they must
+	// tell the same story: one cluster waiting on a dependency.
+	depCond := apimeta.FindStatusCondition(got.Status.Conditions, kcmv1.MultiClusterServiceDependencyReadyCondition)
+	if depCond == nil || depCond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected a False %s condition, got %+v", kcmv1.MultiClusterServiceDependencyReadyCondition, depCond)
+	}
+
+	if len(got.Status.MatchingClusters) != 1 {
+		t.Fatalf("expected the blocked cluster to be persisted in .status.matchingClusters, got %d entries: %+v",
+			len(got.Status.MatchingClusters), got.Status.MatchingClusters)
+	}
+	blockedEntry := got.Status.MatchingClusters[0]
+	if blockedEntry.Name != cdBlockName || blockedEntry.Namespace != cdNamespace {
+		t.Errorf("expected the entry to be for %s/%s, got %s/%s", cdNamespace, cdBlockName, blockedEntry.Namespace, blockedEntry.Name)
+	}
+	if blockedEntry.Deployed {
+		t.Error("expected the blocked cluster to be reported as not deployed")
+	}
+	if blockedEntry.Reason != kcmv1.MultiClusterServiceDependencyNotReadyReason {
+		t.Errorf("expected reason %q, got %q", kcmv1.MultiClusterServiceDependencyNotReadyReason, blockedEntry.Reason)
+	}
+	if blockedEntry.Message == "" {
+		t.Error("expected a message describing what the blocked cluster is waiting on")
+	}
+}
+
 // setMatchingClusters reports as not deployed with a MultiClusterServiceDependencyNotReady
 // reason.
 func Test_setClustersCondition(t *testing.T) {

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +38,17 @@ import (
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 	kubeutil "github.com/K0rdent/kcm/internal/util/kube"
 )
+
+// SelfManagementClusterReference returns the ObjectReference identifying the
+// management cluster pseudo-target used for self-managed ServiceSets.
+func SelfManagementClusterReference() *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Kind:       libsveltosv1beta1.SveltosClusterKind,
+		Name:       "mgmt",
+		Namespace:  "mgmt",
+		APIVersion: libsveltosv1beta1.GroupVersion.WithKind(libsveltosv1beta1.SveltosClusterKind).GroupVersion().String(),
+	}
+}
 
 // ObjectKey generates a unique key for a ServiceSet given the input and returns it.
 func ObjectKey(systemNamespace string, cd *kcmv1.ClusterDeployment, mcs *kcmv1.MultiClusterService) client.ObjectKey {

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -74,6 +74,21 @@ func ObjectKey(systemNamespace string, cd *kcmv1.ClusterDeployment, mcs *kcmv1.M
 	}
 }
 
+// ClusterKey returns the key identifying the cluster a ServiceSet targets. It is keyed
+// the same way blockedCluster refs and .status.matchingClusters entries are - by namespace and
+// name only - so the three views of a cluster can be cross-referenced. An empty .spec.cluster
+// identifies the self-management (mgmt) pseudo-cluster rather than a real ClusterDeployment.
+func ClusterKey(serviceSet *kcmv1.ServiceSet) client.ObjectKey {
+	if serviceSet == nil {
+		return client.ObjectKey{}
+	}
+	if serviceSet.Spec.Cluster == "" {
+		ref := SelfManagementClusterReference()
+		return client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
+	}
+	return client.ObjectKey{Namespace: serviceSet.Namespace, Name: serviceSet.Spec.Cluster}
+}
+
 func ResolveServiceVersions(ctx context.Context, c client.Client, namespace string, services any) error {
 	switch s := services.(type) {
 	case []kcmv1.Service:

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -74,19 +74,24 @@ func ObjectKey(systemNamespace string, cd *kcmv1.ClusterDeployment, mcs *kcmv1.M
 	}
 }
 
-// ClusterKey returns the key identifying the cluster a ServiceSet targets. It is keyed
-// the same way blockedCluster refs and .status.matchingClusters entries are - by namespace and
-// name only - so the three views of a cluster can be cross-referenced. An empty .spec.cluster
-// identifies the self-management (mgmt) pseudo-cluster rather than a real ClusterDeployment.
-func ClusterKey(serviceSet *kcmv1.ServiceSet) client.ObjectKey {
+// ClusterReference returns the reference identifying the cluster a ServiceSet targets, including
+// Kind/APIVersion - not just namespace/name - so that the self-management pseudo-target (always a
+// SveltosCluster named mgmt/mgmt) can never be mistaken for a real, unrelated ClusterDeployment
+// that happens to also be named mgmt in namespace mgmt. An empty .spec.cluster identifies the
+// self-management (mgmt) pseudo-cluster rather than a real ClusterDeployment.
+func ClusterReference(serviceSet *kcmv1.ServiceSet) *corev1.ObjectReference {
 	if serviceSet == nil {
-		return client.ObjectKey{}
+		return &corev1.ObjectReference{}
 	}
 	if serviceSet.Spec.Cluster == "" {
-		ref := SelfManagementClusterReference()
-		return client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
+		return SelfManagementClusterReference()
 	}
-	return client.ObjectKey{Namespace: serviceSet.Namespace, Name: serviceSet.Spec.Cluster}
+	return &corev1.ObjectReference{
+		Kind:       kcmv1.ClusterDeploymentKind,
+		Name:       serviceSet.Spec.Cluster,
+		Namespace:  serviceSet.Namespace,
+		APIVersion: kcmv1.GroupVersion.WithKind(kcmv1.ClusterDeploymentKind).GroupVersion().String(),
+	}
 }
 
 func ResolveServiceVersions(ctx context.Context, c client.Client, namespace string, services any) error {

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_multiclusterservices.yaml
@@ -881,6 +881,9 @@ spec:
                         description: LastTransitionTime reflects when Deployed state was changed last time.
                         format: date-time
                         type: string
+                      message:
+                        description: Message is a human-readable explanation of Reason.
+                        type: string
                       name:
                         description: |-
                           Name of the referent.
@@ -890,6 +893,13 @@ spec:
                         description: |-
                           Namespace of the referent.
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      reason:
+                        description: |-
+                          Reason is a brief machine-readable explanation for why services are not yet
+                          Deployed on this cluster, e.g. MultiClusterServiceDependencyNotReady when this
+                          MultiClusterService is waiting for a MultiClusterService it depends on to finish
+                          deploying its services here.
                         type: string
                       regional:
                         default: false


### PR DESCRIPTION
Implements https://github.com/k0rdent/kcm/issues/2412.

# Verification

- We have the following CD:
```
➜  ~ kkcm get clusterdeployment --show-labels
NAME         READY   SERVICES   TEMPLATE                   MESSAGES          AGE   LABELS
wali-dev-0   True    0/0        aws-standalone-cp-1-0-38   Object is ready   14m   k0rdent.mirantis.com/component=kcm,owner=dev-team
```
- Create `mcs1` deploying `postgres-operator-1-14-0` (which does not exist) to the CD and the Mothership Cluster (via `Spec.ServiceSpec.Provider.SelfManagement: true`). So that the `mcs1` fails with its status showing that the ServiceTemplate does not exist:
```yaml
status:
  conditions:
  - lastTransitionTime: "2026-07-10T17:06:19Z"
    message: |-
      some services have invalid templates
      failed to get ServiceTemplate kcm-system/postgres-operator-1-14-0: ServiceTemplate.k0rdent.mirantis.com "postgres-operator-1-14-0" not found
    observedGeneration: 2
    reason: Failed
    status: "False"
    type: ServicesReferencesValidation
```

- Create `mcs2` depending on `mcs1` and deploying `ingress-nginx-4-13-0` (which exists) to the CD and the Mothership Cluster.

- ✅ Observe that the `mcs2` status shows that it is waiting on `mcs1` to deploy its ServiceSet for both the matching clusters (i.e CD and Mothership Cluster):
```yaml
  - lastTransitionTime: "2026-07-13T17:28:09Z"
    message: waiting for MultiClusterService dependencies to be ready on 2 matching
      cluster(s)
    reason: MultiClusterServiceDependencyNotReady
    status: "False"
    type: MultiClusterServiceDependencyReady
  - lastTransitionTime: "2026-07-13T17:28:09Z"
    message: 0/2 Clusters are ready.. waiting for MultiClusterService dependencies
      to be ready on 2 matching cluster(s)
    observedGeneration: 1
    reason: Failed
    status: "False"
    type: Ready
  matchingClusters:
  - apiVersion: k0rdent.mirantis.com/v1beta1
    deployed: false
    kind: ClusterDeployment
    lastTransitionTime: "2026-07-13T17:28:09Z"
    message: |-
      serviceSet kcm-system/wali-dev-0-3556efa5 (owned by MultiClusterService /mcs1) which this depends on not yet created: ServiceSet.k0rdent.mirantis.com "wali-dev-0-3556efa5" not found
      skipping create/update of ServiceSet for matching cluster kcm-system/wali-dev-0
    name: wali-dev-0
    namespace: kcm-system
    reason: MultiClusterServiceDependencyNotReady
    regional: false
  - apiVersion: lib.projectsveltos.io/v1beta1
    deployed: false
    kind: SveltosCluster
    lastTransitionTime: "2026-07-13T17:28:09Z"
    message: |-
      serviceSet kcm-system/management-3556efa5 (owned by MultiClusterService /mcs1) which this depends on not yet created: ServiceSet.k0rdent.mirantis.com "management-3556efa5" not found
      skipping create/update of ServiceSet for matching cluster mgmt/mgmt
    name: mgmt
    namespace: mgmt
    reason: MultiClusterServiceDependencyNotReady
    regional: false
```

## For Mothership

- ✅  Now set `Spec.ServiceSpec.Provider.SelfManagement: false` in `mcs1` spec, so now the status of `mcs2` should show that it is waiting on `mcs1` to to deploy its ServiceSet on only 1 cluster (the CD cluster) whereas it should show that it deployed on the mothership cluster:
```yaml
  - lastTransitionTime: "2026-07-13T17:28:09Z"
    message: 1/2
    reason: Failed
    status: "False"
    type: ClusterInReadyState
  - lastTransitionTime: "2026-07-13T17:28:09Z"
    message: waiting for MultiClusterService dependencies to be ready on 1 matching
      cluster(s)
    reason: MultiClusterServiceDependencyNotReady
    status: "False"
    type: MultiClusterServiceDependencyReady
  - lastTransitionTime: "2026-07-13T17:28:09Z"
    message: 1/2 Clusters are ready.. waiting for MultiClusterService dependencies
      to be ready on 1 matching cluster(s)
    observedGeneration: 1
    reason: Failed
    status: "False"
    type: Ready
  matchingClusters:
  - apiVersion: k0rdent.mirantis.com/v1beta1
    deployed: false
    kind: ClusterDeployment
    lastTransitionTime: "2026-07-13T17:28:09Z"
    message: |-
      serviceSet kcm-system/wali-dev-0-3556efa5 (owned by MultiClusterService /mcs1) which this depends on not yet created: ServiceSet.k0rdent.mirantis.com "wali-dev-0-3556efa5" not found
      skipping create/update of ServiceSet for matching cluster kcm-system/wali-dev-0
    name: wali-dev-0
    namespace: kcm-system
    reason: MultiClusterServiceDependencyNotReady
    regional: false
  - apiVersion: lib.projectsveltos.io/v1beta1
    deployed: true
    kind: SveltosCluster
    lastTransitionTime: "2026-07-13T17:33:23Z"
    name: mgmt
    namespace: mgmt
    regional: false
```

- ✅ Checking that mcs2 created the ServiceSet for the mothership cluster:
```
➜  ~ kkcm get serviceset
NAME                  CLUSTER      MULTICLUSTERSERVER   SERVICES   PROVIDER             SELF-MANAGEMENT   AGE
management-fc79ea26                mcs2                 1/1        ksm-projectsveltos   true              3m5s
wali-dev-0            wali-dev-0                        0/0        ksm-projectsveltos                     18m
```

- ✅ Now add back `Spec.ServiceSpec.Provider.SelfManagement: true` to mcs1 spec. Now the status of mcs2 should again show that it is waiting on `mcs1` to deploy its ServiceSet for both the matching clusters (i.e CD and Mothership Cluster. However, the ServiceSet that it had already created for the mothership cluster should remain. **The reason it should remain is because it was created before mcs1 started matching the mothership cluster and we do not want to remove already deployed services that were deployed beforehand.** (TODO: Should we block removing of selfManagement from mcs1 because its dependent mcs2 also has selfManagement, just as we block mcs1 from being deleted because mcs2 depends on it?). ❌ This ends up creating 2 entries for SveltosCluster (mgmt): one with deployed and other with error. We should probably make it so that there is only 1:
```yaml
  matchingClusters:
  - apiVersion: k0rdent.mirantis.com/v1beta1
    deployed: false
    kind: ClusterDeployment
    lastTransitionTime: "2026-07-21T00:11:54Z"
    message: |-
      serviceSet kcm-system/wali-dev-0-3556efa5 (owned by MultiClusterService /mcs1) which this depends on not yet created: ServiceSet.k0rdent.mirantis.com "wali-dev-0-3556efa5" not found
      skipping create/update of ServiceSet for matching cluster kcm-system/wali-dev-0
    name: wali-dev-0
    namespace: kcm-system
    reason: MultiClusterServiceDependencyNotReady
    regional: false
  - apiVersion: lib.projectsveltos.io/v1beta1
    deployed: true
    kind: SveltosCluster
    lastTransitionTime: "2026-07-21T00:14:44Z"
    name: mgmt
    namespace: mgmt
    regional: false
  - apiVersion: lib.projectsveltos.io/v1beta1
    deployed: false
    kind: SveltosCluster
    lastTransitionTime: "2026-07-21T00:14:24Z"
    message: |-
      serviceSet kcm-system/management-3556efa5 (owned by MultiClusterService /mcs1) which this depends on not yet created: ServiceSet.k0rdent.mirantis.com "management-3556efa5" not found
      skipping create/update of ServiceSet for matching cluster mgmt/mgmt
    name: mgmt
    namespace: mgmt
    reason: MultiClusterServiceDependencyNotReady
    regional: false
```
**UPDATE:** Made it so the that `.status.matchingClusters` shows the latest reconcile state per cluster, which means in this case it will show the entry that has error even though a ServiceSet exists before the dependency changed.

- ✅  Now set `Spec.ServiceSpec.Provider.SelfManagement: false` to mcs2 spec. Now the status of mcs2 should only show that it is waiting on mcs1 to create its ServiceSet for CD for it to create its own. Also the ServiceSet mcs2 had created for the Mothership Cluster should now be deleted.

- ✅ Now add back `Spec.ServiceSpec.Provider.SelfManagement: true` to mcs2 spec. Now the status of mcs2 should again show that it is waiting on `mcs1` to to deploy its ServiceSet on both the clusters.

## For ClusterDeployment

- ✅  Remove `.spec.clusterSelector` from `mcs1` spec. The status of `mcs2` should show that it is only waiting on mcs1 to deploy its ServiceSet for the Mothership cluster.

- ✅ Now add back `.spec.clusterSelector` matching the CD to `mcs1` spec. As expected `mcs2` status now shows error for both clusters and the ServiceSet that it had already created previously for CD is retained. ❌ However, the same problem as in the case with For Mothership (above) that we have duplicate entries in the status for CD:
```yaml
  matchingClusters:
  - apiVersion: k0rdent.mirantis.com/v1beta1
    deployed: true
    kind: ClusterDeployment
    lastTransitionTime: "2026-07-21T04:42:09Z"
    name: wali-dev-0
    namespace: kcm-system
    regional: false
  - apiVersion: k0rdent.mirantis.com/v1beta1
    deployed: false
    kind: ClusterDeployment
    lastTransitionTime: "2026-07-21T04:40:38Z"
    message: |-
      serviceSet kcm-system/wali-dev-0-3556efa5 (owned by MultiClusterService /mcs1) which this depends on not yet created: ServiceSet.k0rdent.mirantis.com "wali-dev-0-3556efa5" not found
      skipping create/update of ServiceSet for matching cluster kcm-system/wali-dev-0
    name: wali-dev-0
    namespace: kcm-system
    reason: MultiClusterServiceDependencyNotReady
    regional: false
```
**UPDATE:** Made it so the that `.status.matchingClusters` shows the latest reconcile state per cluster, which means in this case it will show the entry that has error even though a ServiceSet exists before the dependency changed.

- ✅ Now remove `.spec.clusterSelector` from `mcs2` spec. The status of `mcs2` now shows that it is depending on mcs1 to deploy its ServiceSet for only 1 cluster, which is the management cluster. Also the ServiceSet that mcs2 created for CD has been deleted.

- ✅ Now add back `.spec.clusterSelector` matching the CD to `mcs2` spec. The status of `mcs2` shows its waiting on mcs1 to create ServiceSet for both clusters.