### PR TITLE
fix: drop dead drift-detection ensure workaround

### DIFF
--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -28,7 +28,6 @@ import (
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
-	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -197,15 +196,6 @@ func (r *ManagementReconciler) update(ctx context.Context, management *kcmv1.Man
 		management.Status.Release = management.Spec.Release
 	}
 	management.Status.ObservedGeneration = management.Generation
-
-	driftRequeue, driftErr := r.ensureDriftDetectionManager(ctx, management)
-	if driftErr != nil {
-		l.Error(driftErr, "failed to ensure drift-detection-manager is deployed")
-		requeue = true
-	}
-	if driftRequeue {
-		requeue = true
-	}
 
 	if err := r.ensureCldRegistryCredSecret(ctx, management); err != nil {
 		var statusErr error
@@ -497,70 +487,6 @@ self.status.availableReplicas == self.status.readyReplicas`,
 	l.Info("Successfully created StateManagementProvider object")
 	r.eventf(mgmt, "StateManagementProviderCreated", "Created %s StateManagementProvider object", stateManagementProvider.GetName())
 	return nil
-}
-
-// ensureDriftDetectionManager ensures the drift-detection-manager Deployment is present in the
-// projectsveltos namespace.
-func (r *ManagementReconciler) ensureDriftDetectionManager(ctx context.Context, management *kcmv1.Management) (requeue bool, _ error) {
-	if !management.Status.Components[kcmv1.ProviderSveltosName].Success {
-		return false, nil
-	}
-
-	l := ctrl.LoggerFrom(ctx)
-
-	const (
-		sveltosNS           = "projectsveltos"
-		addonControllerName = "addon-controller"
-		driftDetectionName  = "drift-detection-manager"
-		restartAnnotation   = "k0rdent.mirantis.com/drift-detection-ensure-restart"
-	)
-
-	// we'll list deployments in projectsveltos namespace
-	deployList := &appsv1.DeploymentList{}
-	if err := r.Client.List(ctx, deployList, client.InNamespace(sveltosNS)); err != nil {
-		return false, fmt.Errorf("listing deployments in %s: %w", sveltosNS, err)
-	}
-
-	// we'll iterate over the deployments list and check for addon-controller and drift-detection-manager
-	// if the drift-detection-manager is present, we'll exit. This mean that all required components are
-	// already deployed.
-	var addonDeploy *appsv1.Deployment
-	for i := range deployList.Items {
-		switch deployList.Items[i].Name {
-		case driftDetectionName:
-			return false, nil // already present, nothing to do
-		case addonControllerName:
-			addonDeploy = &deployList.Items[i]
-		}
-	}
-
-	mgmtCluster := &libsveltosv1beta1.SveltosCluster{}
-	if err := r.Client.Get(ctx, client.ObjectKey{Name: "mgmt", Namespace: "mgmt"}, mgmtCluster); err != nil {
-		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
-			return true, nil // SveltosCluster not yet created; requeue
-		}
-		return false, fmt.Errorf("checking for mgmt/mgmt SveltosCluster: %w", err)
-	}
-
-	if addonDeploy == nil {
-		return true, nil // addon-controller not yet present; requeue
-	}
-
-	if annotations := addonDeploy.Spec.Template.Annotations; annotations != nil && annotations[restartAnnotation] != "" {
-		return true, nil // restart already triggered; wait for drift-detection-manager to appear
-	}
-
-	l.Info("Triggering addon-controller restart so upgradeDriftDetection goroutine runs with mgmt/mgmt present")
-	patch := client.MergeFrom(addonDeploy.DeepCopy())
-	if addonDeploy.Spec.Template.Annotations == nil {
-		addonDeploy.Spec.Template.Annotations = make(map[string]string)
-	}
-	addonDeploy.Spec.Template.Annotations[restartAnnotation] = time.Now().UTC().Format(time.RFC3339)
-	if err := r.Client.Patch(ctx, addonDeploy, patch); err != nil {
-		return false, fmt.Errorf("patching %s to trigger restart: %w", addonControllerName, err)
-	}
-
-	return true, nil
 }
 
 func (r *ManagementReconciler) delete(ctx context.Context, management *kcmv1.Management) (ctrl.Result, error) {

--- a/internal/controller/management_controller_test.go
+++ b/internal/controller/management_controller_test.go
@@ -26,8 +26,6 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -495,110 +493,6 @@ var _ = Describe("Management Controller", func() {
 		})
 	})
 
-	Context("ensureDriftDetectionManager", func() {
-		const (
-			sveltosNS            = "projectsveltos"
-			mgmtClusterName      = "mgmt"
-			mgmtClusterNamespace = "mgmt"
-			addonControllerName  = "addon-controller"
-			driftDetectionName   = "drift-detection-manager"
-			restartAnnotation    = "k0rdent.mirantis.com/drift-detection-ensure-restart"
-		)
-
-		var mgmt *kcmv1.Management
-
-		BeforeEach(func() {
-			By("ensuring the projectsveltos and mgmt namespaces exist")
-			for _, ns := range []string{sveltosNS, mgmtClusterNamespace} {
-				Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{Name: ns},
-				}))).To(Succeed())
-			}
-
-			mgmt = &kcmv1.Management{
-				Status: kcmv1.ManagementStatus{
-					ComponentsCommonStatus: kcmv1.ComponentsCommonStatus{
-						Components: map[string]kcmv1.ComponentStatus{
-							kcmv1.ProviderSveltosName: {Success: true},
-						},
-					},
-				},
-			}
-		})
-
-		AfterEach(func() {
-			By("cleaning up test deployments and SveltosCluster")
-			for _, name := range []string{driftDetectionName, addonControllerName} {
-				_ = k8sClient.Delete(ctx, &appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: sveltosNS},
-				})
-			}
-			_ = k8sClient.Delete(ctx, &libsveltosv1beta1.SveltosCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "mgmt", Namespace: mgmtClusterNamespace},
-			})
-		})
-
-		It("skips when drift-detection-manager already exists", func() {
-			driftDetector := newSveltosDeployment(driftDetectionName)
-			Expect(k8sClient.Create(ctx, driftDetector)).To(Succeed())
-
-			addonController := newSveltosDeployment(addonControllerName)
-			Expect(k8sClient.Create(ctx, addonController)).To(Succeed())
-
-			r := &ManagementReconciler{Client: k8sClient}
-			requeue, err := r.ensureDriftDetectionManager(ctx, mgmt)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(requeue).To(BeFalse())
-
-			got := &appsv1.Deployment{}
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(addonController), got)).To(Succeed())
-			Expect(got.Spec.Template.Annotations).NotTo(HaveKey(restartAnnotation))
-		})
-
-		It("requeues without patching when mgmt/mgmt SveltosCluster is missing", func() {
-			addonController := newSveltosDeployment(addonControllerName)
-			Expect(k8sClient.Create(ctx, addonController)).To(Succeed())
-
-			r := &ManagementReconciler{Client: k8sClient}
-			requeue, err := r.ensureDriftDetectionManager(ctx, mgmt)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(requeue).To(BeTrue())
-
-			got := &appsv1.Deployment{}
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(addonController), got)).To(Succeed())
-			Expect(got.Spec.Template.Annotations).NotTo(HaveKey(restartAnnotation))
-		})
-
-		It("patches addon-controller with restart annotation when SveltosCluster exists", func() {
-			addonController := newSveltosDeployment(addonControllerName)
-			Expect(k8sClient.Create(ctx, addonController)).To(Succeed())
-
-			Expect(k8sClient.Create(ctx, &libsveltosv1beta1.SveltosCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: mgmtClusterName, Namespace: mgmtClusterNamespace},
-			})).To(Succeed())
-
-			r := &ManagementReconciler{Client: k8sClient}
-			requeue, err := r.ensureDriftDetectionManager(ctx, mgmt)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(requeue).To(BeTrue())
-
-			got := &appsv1.Deployment{}
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(addonController), got)).To(Succeed())
-			Expect(got.Spec.Template.Annotations).To(HaveKey(restartAnnotation))
-			firstTS := got.Spec.Template.Annotations[restartAnnotation]
-			Expect(firstTS).NotTo(BeEmpty())
-
-			By("a subsequent call should short-circuit on the existing annotation and keep it intact")
-			requeue, err = r.ensureDriftDetectionManager(ctx, mgmt)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(requeue).To(BeTrue())
-
-			again := &appsv1.Deployment{}
-			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(addonController), again)).To(Succeed())
-			Expect(again.Spec.Template.Annotations[restartAnnotation]).To(Equal(firstTS))
-		})
-	})
-
 	Context("ensureCldRegistryCredSecret", func() {
 		const (
 			systemNamespace    = "kcm-system-cld-test"
@@ -861,28 +755,3 @@ var _ = Describe("Management Controller", func() {
 		})
 	})
 })
-
-func newSveltosDeployment(name string) *appsv1.Deployment {
-	const sveltosNS = "projectsveltos"
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: sveltosNS,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": name},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": name},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{Name: "app", Image: "podinfo"},
-					},
-				},
-			},
-		},
-	}
-}

--- a/internal/controller/statemanagementprovider/statemanagementprovider_controller.go
+++ b/internal/controller/statemanagementprovider/statemanagementprovider_controller.go
@@ -54,8 +54,6 @@ const (
 	clusterRoleSuffix        = "-cr"
 	clusterRoleBindingSuffix = "-crb"
 
-	apiExtensionsGroup    = "apiextensions.k8s.io"
-	apiExtensionsVersion  = "v1"
 	apiExtensionsResource = "customresourcedefinitions"
 
 	emptyConditionMessage = ""
@@ -566,7 +564,7 @@ func buildRBACRules(gvrList []schema.GroupVersionResource) []rbacv1.PolicyRule {
 		})
 	}
 	rules = append(rules, rbacv1.PolicyRule{
-		APIGroups: []string{apiExtensionsGroup},
+		APIGroups: []string{apiextv1.SchemeGroupVersion.Group},
 		Resources: []string{apiExtensionsResource},
 		Verbs:     []string{"get", "list", "watch"},
 	})
@@ -635,8 +633,8 @@ func validateProvisionerCRDs(ctx context.Context, config *rest.Config, group, ve
 		return fmt.Errorf("failed to create dynamic client: %w", err)
 	}
 	dyn := c.Resource(schema.GroupVersionResource{
-		Group:    apiExtensionsGroup,
-		Version:  apiExtensionsVersion,
+		Group:    apiextv1.SchemeGroupVersion.Group,
+		Version:  apiextv1.SchemeGroupVersion.Version,
 		Resource: apiExtensionsResource,
 	})
 	for _, resource := range resources {

--- a/internal/controller/statemanagementprovider/statemanagementprovider_controller_test.go
+++ b/internal/controller/statemanagementprovider/statemanagementprovider_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -163,7 +164,7 @@ func TestReconciler_buildRBACRules(t *testing.T) {
 					Resources: []string{"deployments", "statefulsets"},
 				},
 				{
-					APIGroups: []string{apiExtensionsGroup},
+					APIGroups: []string{apiextv1.SchemeGroupVersion.Group},
 					Resources: []string{apiExtensionsResource},
 					Verbs:     []string{"get", "list", "watch"},
 				},
@@ -273,7 +274,7 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 				},
 				Rules: []rbacv1.PolicyRule{
 					{
-						APIGroups: []string{apiExtensionsGroup},
+						APIGroups: []string{apiextv1.SchemeGroupVersion.Group},
 						Resources: []string{apiExtensionsResource},
 						Verbs:     []string{"get", "list", "watch"},
 					},
@@ -350,7 +351,7 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 				},
 				Rules: []rbacv1.PolicyRule{
 					{
-						APIGroups: []string{apiExtensionsGroup},
+						APIGroups: []string{apiextv1.SchemeGroupVersion.Group},
 						Resources: []string{apiExtensionsResource},
 						Verbs:     []string{"get", "list", "watch"},
 					},
@@ -413,7 +414,7 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							APIGroups: []string{apiExtensionsGroup},
+							APIGroups: []string{apiextv1.SchemeGroupVersion.Group},
 							Resources: []string{apiExtensionsResource},
 							Verbs:     []string{"get", "list", "watch"},
 						},
@@ -437,7 +438,7 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 				},
 				Rules: []rbacv1.PolicyRule{
 					{
-						APIGroups: []string{apiExtensionsGroup},
+						APIGroups: []string{apiextv1.SchemeGroupVersion.Group},
 						Resources: []string{apiExtensionsResource},
 						Verbs:     []string{"get", "list", "watch"},
 					},
@@ -524,7 +525,7 @@ func TestReconciler_ensureRBAC(t *testing.T) {
 				},
 				Rules: []rbacv1.PolicyRule{
 					{
-						APIGroups: []string{apiExtensionsGroup},
+						APIGroups: []string{apiextv1.SchemeGroupVersion.Group},
 						Resources: []string{apiExtensionsResource},
 						Verbs:     []string{"get", "list", "watch"},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:
- workaround from #2668 relied on Sveltos redeploying drift-detection-manager on addon-controller restart
- projectsveltos/addon-controller#1743 (v1.9.0) gates upgrades on presence, so restart no longer creates the deployment
- workaround now just infinite-requeues; KCM ships Sveltos 1.9.0
- remove function, call site, tests, and libsveltos import

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2911 
