### PR TITLE
fix: gcp and kubevirt rendering issues

### DIFF
--- a/config/dev/gcp-clusterdeployment.yaml
+++ b/config/dev/gcp-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gcp-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: gcp-standalone-cp-1-0-38
+  template: gcp-standalone-cp-1-0-39
   credential: gcp-credential
   config:
     clusterLabels: {}

--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-17
+  template: kubevirt-standalone-cp-1-0-18
   credential: kubevirt-cred
   propagateCredentials: false
   config:

--- a/templates/cluster/gcp-hosted-cp/Chart.yaml
+++ b/templates/cluster/gcp-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.40
+version: 1.0.41
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-hosted-cp/templates/gcpmachinetemplate.yaml
+++ b/templates/cluster/gcp-hosted-cp/templates/gcpmachinetemplate.yaml
@@ -7,10 +7,18 @@ spec:
     spec:
       {{- with .Values.worker }}
       instanceType: {{ .instanceType }}
+      {{- if .subnet }}
       subnet: {{ .subnet }}
+      {{- end }}
+      {{- if .providerID }}
       providerID: {{ .providerID }}
+      {{- end }}
+      {{- if .imageFamily }}
       imageFamily: {{ .imageFamily }}
+      {{- end }}
+      {{- if .image }}
       image: {{ .image }}
+      {{- end }}
       {{- if .additionalLabels }}
       additionalLabels: {{- toYaml .additionalLabels | nindent 8 }}
       {{- end }}

--- a/templates/cluster/gcp-standalone-cp/Chart.yaml
+++ b/templates/cluster/gcp-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.38
+version: 1.0.39
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/gcp-standalone-cp/templates/gcpmachinetemplate-controlplane.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/gcpmachinetemplate-controlplane.yaml
@@ -7,10 +7,18 @@ spec:
     spec:
       {{- with .Values.controlPlane }}
       instanceType: {{ .instanceType }}
+      {{- if .subnet }}
       subnet: {{ .subnet }}
+      {{- end }}
+      {{- if .providerID }}
       providerID: {{ .providerID }}
+      {{- end }}
+      {{- if .imageFamily }}
       imageFamily: {{ .imageFamily }}
+      {{- end }}
+      {{- if .image }}
       image: {{ .image }}
+      {{- end }}
       {{- if .additionalLabels }}
       additionalLabels: {{- toYaml .additionalLabels | nindent 8 }}
       {{- end }}

--- a/templates/cluster/gcp-standalone-cp/templates/gcpmachinetemplate-worker.yaml
+++ b/templates/cluster/gcp-standalone-cp/templates/gcpmachinetemplate-worker.yaml
@@ -8,10 +8,18 @@ spec:
     spec:
       {{- with .Values.worker }}
       instanceType: {{ .instanceType }}
+      {{- if .subnet }}
       subnet: {{ .subnet }}
+      {{- end }}
+      {{- if .providerID }}
       providerID: {{ .providerID }}
+      {{- end }}
+      {{- if .imageFamily }}
       imageFamily: {{ .imageFamily }}
+      {{- end }}
+      {{- if .image }}
       image: {{ .image }}
+      {{- end }}
       {{- if .additionalLabels }}
       additionalLabels: {{- toYaml .additionalLabels | nindent 8 }}
       {{- end }}

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.15
+version: 1.0.16
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-hosted-cp/templates/kubevirtmachinetemplate.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/kubevirtmachinetemplate.yaml
@@ -24,7 +24,9 @@ spec:
                   cores: {{ .Values.worker.cpus }}
                   model: {{ .Values.worker.cpu.model  | quote }}
                   numa: {{- toYaml .Values.worker.cpu.numa | nindent 20 }}
+                {{- if .Values.worker.ioThreadsPolicy }}
                 ioThreadsPolicy: {{ .Values.worker.ioThreadsPolicy }}
+                {{- end }}
                 devices:
                   interfaces: {{ toYaml .Values.worker.devices.interfaces | nindent 20 }}
                   disks: {{- include "devices.disks" .Values.worker | nindent 20 }}

--- a/templates/cluster/kubevirt-hosted-cp/values.schema.json
+++ b/templates/cluster/kubevirt-hosted-cp/values.schema.json
@@ -494,6 +494,16 @@
             "Never"
           ]
         },
+        "ioThreadsPolicy": {
+          "description": "Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads",
+          "type": "string",
+          "enum": [
+            "shared",
+            "auto",
+            "supplementalPool",
+            ""
+          ]
+        },
         "memory": {
           "description": "Memory allocated to worker nodes",
           "type": "string",

--- a/templates/cluster/kubevirt-hosted-cp/values.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/values.yaml
@@ -69,6 +69,8 @@ worker: # @schema description: Worker parameters; type: object
     model: "" # @schema description: CPU model (e.g., host-passthrough); type: string
     numa: {} # @schema description: NUMA configuration; type: object; additionalProperties: true
 
+  ioThreadsPolicy: "" # @schema description: Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads; type: string; enum: [shared, auto, supplementalPool, ""]
+
   devices: # @schema description: Device configuration; type: object
     interfaces: # @schema description: Network interfaces which are added to the vmi; type: array; item: object
     - name: default # @schema description: Name of the network interface; type: string

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.17
+version: 1.0.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
@@ -22,9 +22,13 @@ spec:
               domain:
                 cpu:
                   cores: {{ .Values.controlPlane.cpus }}
+                  {{- if .Values.controlPlane.cpu.model }}
                   model: {{ .Values.controlPlane.cpu.model  | quote }}
+                  {{- end }}
                   numa: {{- toYaml .Values.controlPlane.cpu.numa | nindent 20 }}
+                {{- if .Values.controlPlane.ioThreadsPolicy }}
                 ioThreadsPolicy: {{ .Values.controlPlane.ioThreadsPolicy }}
+                {{- end }}
                 devices:
                   interfaces: {{ toYaml .Values.controlPlane.devices.interfaces | nindent 20 }}
                   disks: {{- include "devices.disks" .Values.controlPlane | nindent 20 }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
@@ -23,9 +23,13 @@ spec:
               domain:
                 cpu:
                   cores: {{ .Values.worker.cpus }}
+                  {{- if .Values.worker.cpu.model }}
                   model: {{ .Values.worker.cpu.model  | quote }}
+                  {{- end }}
                   numa: {{- toYaml .Values.worker.cpu.numa | nindent 20 }}
+                {{- if .Values.worker.ioThreadsPolicy }}
                 ioThreadsPolicy: {{ .Values.worker.ioThreadsPolicy }}
+                {{- end }}
                 devices:
                   interfaces: {{ toYaml .Values.worker.devices.interfaces | nindent 20 }}
                   disks: {{- include "devices.disks" .Values.worker | nindent 20 }}

--- a/templates/cluster/kubevirt-standalone-cp/values.schema.json
+++ b/templates/cluster/kubevirt-standalone-cp/values.schema.json
@@ -266,6 +266,16 @@
             "Never"
           ]
         },
+        "ioThreadsPolicy": {
+          "description": "Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads",
+          "type": "string",
+          "enum": [
+            "shared",
+            "auto",
+            "supplementalPool",
+            ""
+          ]
+        },
         "memory": {
           "description": "Memory allocated to worker nodes",
           "type": "string",
@@ -583,6 +593,16 @@
             "Always",
             "IfNotPresent",
             "Never"
+          ]
+        },
+        "ioThreadsPolicy": {
+          "description": "Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads",
+          "type": "string",
+          "enum": [
+            "shared",
+            "auto",
+            "supplementalPool",
+            ""
           ]
         },
         "memory": {

--- a/templates/cluster/kubevirt-standalone-cp/values.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/values.yaml
@@ -66,6 +66,8 @@ controlPlane: # @schema description: Configuration of the control plane machines
     model: "" # @schema description: CPU model (e.g., host-passthrough); type: string
     numa: {} # @schema description: NUMA configuration; type: object; additionalProperties: true
 
+  ioThreadsPolicy: "" # @schema description: Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads; type: string; enum: [shared, auto, supplementalPool, ""]
+
   devices: # @schema description: Device configuration; type: object
     interfaces: # @schema description: Network interfaces which are added to the vmi; type: array; item: object
     - name: default # @schema description: Name of the network interface; type: string
@@ -100,6 +102,8 @@ worker: # @schema description: Worker parameters; type: object
   cpu: # @schema description: CPU configuration; type: object
     model: "" # @schema description: CPU model (e.g., host-passthrough); type: string
     numa: {} # @schema description: NUMA configuration; type: object; additionalProperties: true
+
+  ioThreadsPolicy: "" # @schema description: Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads; type: string; enum: [shared, auto, supplementalPool, ""]
 
   devices: # @schema description: Device configuration; type: object
     interfaces: # @schema description: Network interfaces which are added to the vmi; type: array; item: object

--- a/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-41.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-hosted-cp-1-0-41.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-hosted-cp-1-0-40
+  name: gcp-hosted-cp-1-0-41
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-hosted-cp
-      version: 1.0.40
+      version: 1.0.41
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-39.yaml
+++ b/templates/provider/kcm-templates/files/templates/gcp-standalone-cp-1-0-39.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: gcp-standalone-cp-1-0-38
+  name: gcp-standalone-cp-1-0-39
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: gcp-standalone-cp
-      version: 1.0.38
+      version: 1.0.39
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-16.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-16.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-hosted-cp-1-0-15
+  name: kubevirt-hosted-cp-1-0-16
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kubevirt-hosted-cp
-      version: 1.0.15
+      version: 1.0.16
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-18.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-18.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-17
+  name: kubevirt-standalone-cp-1-0-18
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kubevirt-standalone-cp
-      version: 1.0.17
+      version: 1.0.18
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes rendering issues for kubevirt and gcp cluster templates.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2946
Fixes #2947