### PR TITLE
ci: update release branch naming pattern

### DIFF
--- a/.github/workflows/build-staging.yaml
+++ b/.github/workflows/build-staging.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - '*-release'
+      - 'release-*'
     tags:
       - "v*.*.*" # only v-prefixed tags
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - reopened
     branches:
       - main
-      - '*-release'
+      - 'release-*'
     paths-ignore:
       - 'config/**'
       - '**.md'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ on:
       - reopened
     branches:
       - main
-      - '*-release'
+      - 'release-*'
     paths-ignore:
       - 'config/**'
       - '**.md'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the release branch naming pattern in CI according to new rules (release branch name `release-v1.*.*` instead of `v1.*.*-release`).
