### PR TITLE
fix: properly handle k0smotron service annotations for vsphere hosted

### DIFF
--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.39
+version: 1.0.40
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -6,26 +6,21 @@ metadata:
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
   version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
-  {{- with (omit (.Values.k0smotron.service | default dict) "annotations") }}
+  {{- if .Values.k0smotron.service }}
   service:
-    {{- toYaml . | nindent 4 }}
+    {{- if .Values.k0smotron.service.type }}
+    type: {{ .Values.k0smotron.service.type }}
+    {{- end }}
+    {{- if .Values.k0smotron.service.apiPort }}
+    apiPort: {{ .Values.k0smotron.service.apiPort }}
+    {{- end }}
+    {{- if .Values.k0smotron.service.konnectivityPort }}
+    konnectivityPort: {{ .Values.k0smotron.service.konnectivityPort }}
+    {{- end }}
   {{- end }}
-  {{- if or .Values.k0smotron.service.annotations .Values.k0smotron.patches }}
+  {{- with .Values.k0smotron.patches }}
   patches:
-    {{- with .Values.k0smotron.service.annotations }}
-    - target:
-        kind: Service
-        component: control-plane
-      patch:
-        type: merge
-        content: |
-          metadata:
-            annotations:
-              {{- toYaml . | nindent 14 }}
-    {{- end }}
-    {{- with .Values.k0smotron.patches }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -6,17 +6,9 @@ metadata:
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
   version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
-  {{- if .Values.k0smotron.service }}
+  {{- with (omit (.Values.k0smotron.service | default dict) "annotations") }}
   service:
-  {{- if .Values.k0smotron.service.type }}
-    type: {{ .Values.k0smotron.service.type }}
-  {{- end }}
-  {{- if .Values.k0smotron.service.apiPort }}
-    apiPort: {{ .Values.k0smotron.service.apiPort }}
-  {{- end }}
-  {{- if .Values.k0smotron.service.konnectivityPort }}
-    konnectivityPort: {{ .Values.k0smotron.service.konnectivityPort }}
-  {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- if or .Values.k0smotron.service.annotations .Values.k0smotron.patches }}
   patches:

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -6,9 +6,34 @@ metadata:
 spec:
   replicas: {{ .Values.controlPlaneNumber }}
   version: {{ .Values.k0s.version | replace "+" "-"  | quote }}
-  {{- with .Values.k0smotron.service }}
+  {{- if .Values.k0smotron.service }}
   service:
+  {{- if .Values.k0smotron.service.type }}
+    type: {{ .Values.k0smotron.service.type }}
+  {{- end }}
+  {{- if .Values.k0smotron.service.apiPort }}
+    apiPort: {{ .Values.k0smotron.service.apiPort }}
+  {{- end }}
+  {{- if .Values.k0smotron.service.konnectivityPort }}
+    konnectivityPort: {{ .Values.k0smotron.service.konnectivityPort }}
+  {{- end }}
+  {{- end }}
+  {{- if or .Values.k0smotron.service.annotations .Values.k0smotron.patches }}
+  patches:
+    {{- with .Values.k0smotron.service.annotations }}
+    - target:
+        kind: Service
+        component: control-plane
+      patch:
+        type: merge
+        content: |
+          metadata:
+            annotations:
+              {{- toYaml . | nindent 14 }}
+    {{- end }}
+    {{- with .Values.k0smotron.patches }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
   {{- if $global.registry }}
   image: {{ $global.registry }}/k0sproject/k0s

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -249,11 +249,6 @@
           "description": "The API service configuration",
           "type": "object",
           "properties": {
-            "annotations": {
-              "description": "Annotations to add to the service (converted to spec.patches for v1beta2 compatibility)",
-              "type": "object",
-              "additionalProperties": true
-            },
             "apiPort": {
               "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
               "type": "number",
@@ -276,7 +271,8 @@
                 "LoadBalancer"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       }
     },

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -238,10 +238,19 @@
             "type": "string"
           }
         },
+        "patches": {
+          "description": "Additional patches to apply to k0smotron generated resources (StatefulSet, Service, ConfigMap, etc.). Patches are applied after generation and before apply. Target resources are matched by Kind and app.kubernetes.io/component label. Each patch should follow the k0smotron v1beta2 patch format",
+          "type": "array"
+        },
         "service": {
           "description": "The API service configuration",
           "type": "object",
           "properties": {
+            "annotations": {
+              "description": "Annotations to add to the service (converted to spec.patches for v1beta2 compatibility)",
+              "type": "object",
+              "additionalProperties": true
+            },
             "apiPort": {
               "description": "The kubernetes API port. If empty k0smotron will pick it automatically",
               "type": "number",

--- a/templates/cluster/vsphere-hosted-cp/values.schema.json
+++ b/templates/cluster/vsphere-hosted-cp/values.schema.json
@@ -240,7 +240,10 @@
         },
         "patches": {
           "description": "Additional patches to apply to k0smotron generated resources (StatefulSet, Service, ConfigMap, etc.). Patches are applied after generation and before apply. Target resources are matched by Kind and app.kubernetes.io/component label. Each patch should follow the k0smotron v1beta2 patch format",
-          "type": "array"
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
         },
         "service": {
           "description": "The API service configuration",

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -65,11 +65,10 @@ network: ""
 k0smotron: # @schema description: K0smotron parameters; type: object
   controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
   patches: [] # @schema description: Additional patches to apply to k0smotron generated resources (StatefulSet, Service, ConfigMap, etc.). Patches are applied after generation and before apply. Target resources are matched by Kind and app.kubernetes.io/component label. Each patch should follow the k0smotron v1beta2 patch format; type: array; item: object
-  service: # @schema description: The API service configuration; type: object
+  service: # @schema description: The API service configuration; type: object; additionalProperties: false
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
     konnectivityPort: 8132 # @schema description: The konnectivity port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
-    annotations: {} # @schema description: Annotations to add to the service (converted to spec.patches for v1beta2 compatibility); type: object; additionalProperties: true
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -64,7 +64,7 @@ network: ""
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
   controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
-  patches: [] # @schema description: Additional patches to apply to k0smotron generated resources (StatefulSet, Service, ConfigMap, etc.). Patches are applied after generation and before apply. Target resources are matched by Kind and app.kubernetes.io/component label. Each patch should follow the k0smotron v1beta2 patch format; type: array
+  patches: [] # @schema description: Additional patches to apply to k0smotron generated resources (StatefulSet, Service, ConfigMap, etc.). Patches are applied after generation and before apply. Target resources are matched by Kind and app.kubernetes.io/component label. Each patch should follow the k0smotron v1beta2 patch format; type: array; item: object
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535

--- a/templates/cluster/vsphere-hosted-cp/values.yaml
+++ b/templates/cluster/vsphere-hosted-cp/values.yaml
@@ -64,10 +64,12 @@ network: ""
 # K0smotron parameters
 k0smotron: # @schema description: K0smotron parameters; type: object
   controlPlaneFlags: [] # @schema description: ControlPlaneFlags allows to configure additional flags for k0s control plane and to override existing ones. The default flags are kept unless they are overridden explicitly. Flags with arguments must be specified as a single string, e.g. --some-flag=argument; type: array; item: string; uniqueItems: true
+  patches: [] # @schema description: Additional patches to apply to k0smotron generated resources (StatefulSet, Service, ConfigMap, etc.). Patches are applied after generation and before apply. Target resources are matched by Kind and app.kubernetes.io/component label. Each patch should follow the k0smotron v1beta2 patch format; type: array
   service: # @schema description: The API service configuration; type: object
     type: LoadBalancer # @schema description: An ingress methods for a service; type: string; enum: ClusterIP, NodePort, LoadBalancer; default: LoadBalancer
     apiPort: 6443 # @schema description: The kubernetes API port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
     konnectivityPort: 8132 # @schema description: The konnectivity port. If empty k0smotron will pick it automatically; type: number; minimum: 1; maximum: 65535
+    annotations: {} # @schema description: Annotations to add to the service (converted to spec.patches for v1beta2 compatibility); type: object; additionalProperties: true
 
 # K0s parameters
 k0s: # @schema description: K0s parameters; type: object

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-40.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-40.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-39
+  name: vsphere-hosted-cp-1-0-40
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: vsphere-hosted-cp
-      version: 1.0.39
+      version: 1.0.40
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/test/e2e/clusterdeployment/resources/vsphere-hosted-cp.yaml.tpl
+++ b/test/e2e/clusterdeployment/resources/vsphere-hosted-cp.yaml.tpl
@@ -31,6 +31,13 @@ spec:
     network: "${VSPHERE_NETWORK}"
 
     k0smotron:
-      service:
-        annotations:
-          kube-vip.io/loadbalancerIPs: "${VSPHERE_HOSTED_CONTROL_PLANE_ENDPOINT}"
+      patches:
+        - patch:
+            content: |
+              metadata:
+                annotations:
+                  kube-vip.io/loadbalancerIPs: "${VSPHERE_HOSTED_CONTROL_PLANE_ENDPOINT}"
+            type: merge
+          target:
+            component: control-plane
+            kind: Service


### PR DESCRIPTION
**What this PR does / why we need it**:

The k0smotron v1beta2 API deprecated the `spec.service.annotations` field in K0smotronControlPlane. Previously, the `vsphere-hosted-cp` Helm chart allowed users to pass service annotations directly (e.g., `kube-vip.io/loadbalancerIPs`) via `k0smotron.service.annotations`, which were rendered inline under `spec.service`. After the migration to v1beta2, this field is no longer supported. Annotations must now be applied through `spec.patches` using a patch targeting the Service resource.

To maintain backward compatibility, the chart was updated to:
* Keep `spec.service` for non-deprecated fields (type, apiPort, konnectivityPort).
* Support user-provided arbitrary patches via a new `k0smotron.patches` field.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2953
