### PR TITLE
fix: show failure if invalid kubeconfig is used for adopted cluster

### DIFF
--- a/api/v1beta1/clusterdeployment_types.go
+++ b/api/v1beta1/clusterdeployment_types.go
@@ -94,6 +94,17 @@ const (
 	// CAPIClusterMissingReason indicates the underlying CAPI Cluster object is unexpectedly
 	// absent while the [ClusterDeployment] is still alive (e.g., it was deleted out-of-band).
 	CAPIClusterMissingReason = "CAPIClusterMissing"
+	// SveltosClusterMissingReason indicates the underlying SveltosCluster object is unexpectedly
+	// absent while the [ClusterDeployment] is still alive (e.g., it was deleted out-of-band).
+	SveltosClusterMissingReason = "SveltosClusterMissing"
+	// ConnectionDownReason indicates the connection from the management cluster to the managed
+	// cluster is down, i.e. the health check has failed at least
+	// [github.com/projectsveltos/libsveltos/api/v1beta1.SveltosClusterSpec.ConsecutiveFailureThreshold]
+	// times in a row.
+	ConnectionDownReason = "ConnectionDown"
+	// ConnectionProbePendingReason indicates the connection from the management cluster to the
+	// managed cluster has not been probed yet, so its health is not yet known.
+	ConnectionProbePendingReason = "ConnectionProbePending"
 )
 
 // ClusterDeploymentSpec defines the desired state of ClusterDeployment

--- a/internal/controller/clusterdeployment_capi_poller.go
+++ b/internal/controller/clusterdeployment_capi_poller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	clusterapiv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,11 +31,17 @@ import (
 )
 
 // capiClusterPollEnqueue is the [pollerutil.EnqueueFunc] driving the
-// periodic CAPI Cluster status check. For each non-deleted, non-dry-run
-// ClusterDeployment it fetches the CAPI Cluster from the cluster where it
-// lives (management or regional) and only emits the ClusterDeployment when
-// the computed CAPIClusterSummary condition would differ from the one
-// already set.
+// periodic cluster status check. For each non-deleted, non-dry-run
+// ClusterDeployment it fetches the CAPI Cluster and the SveltosCluster from
+// the cluster where they live (management or regional) and only emits the
+// ClusterDeployment when the computed CAPIClusterSummary or
+// SveltosClusterReady condition would differ from the one already set.
+//
+// The SveltosCluster is polled here rather than watched because, like the
+// CAPI Cluster, it may live in a regional cluster the manager has no cache
+// for. Its health is refreshed out-of-band by sveltoscluster-manager, so
+// without this the ClusterDeployment would keep reporting a stale Ready
+// state after an adopted cluster becomes unreachable.
 //
 // Regional clients are cached per region for the duration of a single tick.
 func (r *ClusterDeploymentReconciler) capiClusterPollEnqueue(ctx context.Context) ([]*kcmv1.ClusterDeployment, error) {
@@ -71,6 +78,14 @@ func (r *ClusterDeploymentReconciler) capiClusterPollEnqueue(ctx context.Context
 			continue
 		}
 
+		if !changed {
+			changed, err = r.sveltosClusterConditionDrifted(ctx, cl, cd)
+			if err != nil {
+				l.V(1).Error(err, "skipping SveltosCluster check in CAPI poll: cannot evaluate condition", "clusterdeployment", client.ObjectKeyFromObject(cd))
+				continue
+			}
+		}
+
 		if changed {
 			enqueue = append(enqueue, cd)
 		}
@@ -97,7 +112,8 @@ func (r *ClusterDeploymentReconciler) resolveCAPIClusterClient(ctx context.Conte
 		return cl, nil
 	}
 
-	cl, err := kubeutil.GetRegionalClientByRegionName(ctx, r.MgmtClient, r.SystemNamespace, cred.Spec.Region, schemeutil.GetRegionalScheme)
+	// the Sveltos types are required to read the health of adopted clusters living in this region
+	cl, err := kubeutil.GetRegionalClientByRegionName(ctx, r.MgmtClient, r.SystemNamespace, cred.Spec.Region, schemeutil.GetRegionalSchemeWithSveltos)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get regional client for region %s: %w", cred.Spec.Region, err)
 	}
@@ -146,6 +162,46 @@ func (*ClusterDeploymentReconciler) capiClusterConditionDrifted(ctx context.Cont
 	if err != nil {
 		return false, fmt.Errorf("failed to compute CAPI summary condition: %w", err)
 	}
+
+	if curr == nil {
+		return true, nil
+	}
+
+	return curr.Status != next.Status || curr.Reason != next.Reason || curr.Message != next.Message, nil
+}
+
+// sveltosClusterConditionDrifted reports whether the SveltosClusterReady
+// condition computed from the SveltosCluster fetched via cl differs from the
+// one currently set on cd. As in [ClusterDeploymentReconciler.capiClusterConditionDrifted],
+// a CD that never had a SveltosClusterReady condition is treated as
+// legitimately SveltosCluster-less, since most templates never produce one.
+func (*ClusterDeploymentReconciler) sveltosClusterConditionDrifted(ctx context.Context, cl client.Client, cd *kcmv1.ClusterDeployment) (bool, error) {
+	sveltosClusters := new(libsveltosv1beta1.SveltosClusterList)
+	if err := cl.List(
+		ctx, sveltosClusters,
+		client.MatchingLabels{kcmv1.FluxHelmChartNameKey: cd.Name},
+		client.Limit(1),
+		client.InNamespace(cd.Namespace),
+	); err != nil {
+		if sveltosUnavailable(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to list SveltosClusters for %s: %w", client.ObjectKeyFromObject(cd), err)
+	}
+
+	curr := apimeta.FindStatusCondition(cd.Status.Conditions, kcmv1.SveltosClusterReadyCondition)
+
+	if len(sveltosClusters.Items) == 0 {
+		if curr == nil {
+			// never observed a SveltosCluster; nothing to surface
+			return false, nil
+		}
+		// the disappearance is either already reflected or still needs to be
+		return curr.Reason != kcmv1.SveltosClusterMissingReason, nil
+	}
+
+	next := conditionsutil.GetSveltosClusterReadyCondition(cd, &sveltosClusters.Items[0])
 
 	if curr == nil {
 		return true, nil

--- a/internal/controller/clusterdeployment_capi_poller_test.go
+++ b/internal/controller/clusterdeployment_capi_poller_test.go
@@ -20,9 +20,11 @@ import (
 	"strings"
 	"testing"
 
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	clusterapiv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -334,6 +336,143 @@ func Test_capiClusterPollEnqueue(t *testing.T) {
 				t.Fatalf("enqueued = %v, want %v", gotNames, tc.wantNames)
 			}
 		})
+	}
+}
+
+func Test_sveltosClusterConditionDrifted(t *testing.T) {
+	t.Parallel()
+
+	downStatus := libsveltosv1beta1.SveltosClusterStatus{
+		Ready:              true, // stale: left behind when the kubeconfig cannot be parsed
+		ConnectionStatus:   libsveltosv1beta1.ConnectionDown,
+		ConnectionFailures: 115,
+		FailureMessage:     new("BuildConfigFromFlags: couldn't get version/kind"),
+	}
+	healthyStatus := libsveltosv1beta1.SveltosClusterStatus{
+		Ready:            true,
+		ConnectionStatus: libsveltosv1beta1.ConnectionHealthy,
+	}
+
+	tests := map[string]struct {
+		cd             *kcmv1.ClusterDeployment
+		sveltosCluster *libsveltosv1beta1.SveltosCluster
+		listErr        error
+		wantChanged    bool
+		wantErrSub     string
+	}{
+		"no sveltos cluster, no current condition": {
+			cd: newClusterDeployment(t, "a"),
+		},
+		"no sveltos cluster, current healthy -> drift (cluster vanished)": {
+			cd: newClusterDeployment(t, "a", withCondition(metav1.Condition{
+				Type:   kcmv1.SveltosClusterReadyCondition,
+				Status: metav1.ConditionTrue,
+				Reason: kcmv1.SucceededReason,
+			})),
+			wantChanged: true,
+		},
+		"no sveltos cluster, current Missing -> no drift (already reflected)": {
+			cd: newClusterDeployment(t, "a", withCondition(metav1.Condition{
+				Type:   kcmv1.SveltosClusterReadyCondition,
+				Status: metav1.ConditionFalse,
+				Reason: kcmv1.SveltosClusterMissingReason,
+			})),
+		},
+		// this is the reported bug: the CD carries no SveltosClusterReady condition at all while its
+		// adopted cluster is unreachable, so the poller has to enqueue it
+		"sveltos cluster down, no current condition -> drift": {
+			cd:             newClusterDeployment(t, "a"),
+			sveltosCluster: newSveltosCluster(t, downStatus),
+			wantChanged:    true,
+		},
+		"sveltos cluster down, condition matches -> no drift": {
+			cd:             newClusterDeployment(t, "a", withMatchingSveltosCondition(t, newSveltosCluster(t, downStatus))),
+			sveltosCluster: newSveltosCluster(t, downStatus),
+		},
+		"sveltos cluster recovered, stale down condition -> drift": {
+			cd:             newClusterDeployment(t, "a", withMatchingSveltosCondition(t, newSveltosCluster(t, downStatus))),
+			sveltosCluster: newSveltosCluster(t, healthyStatus),
+			wantChanged:    true,
+		},
+		"sveltos cluster healthy, condition matches -> no drift": {
+			cd:             newClusterDeployment(t, "a", withMatchingSveltosCondition(t, newSveltosCluster(t, healthyStatus))),
+			sveltosCluster: newSveltosCluster(t, healthyStatus),
+		},
+		// Sveltos integration disabled or CRDs absent in a regional cluster: not an error
+		"unregistered type is not an error": {
+			cd:      newClusterDeployment(t, "a"),
+			listErr: runtime.NewNotRegisteredErrForKind("", libsveltosv1beta1.GroupVersion.WithKind("SveltosClusterList")),
+		},
+		"missing CRD is not an error": {
+			cd:      newClusterDeployment(t, "a"),
+			listErr: &apimeta.NoKindMatchError{GroupKind: libsveltosv1beta1.GroupVersion.WithKind("SveltosCluster").GroupKind()},
+		},
+		"list error propagates": {
+			cd:         newClusterDeployment(t, "a"),
+			listErr:    errors.New("boom"),
+			wantErrSub: "failed to list SveltosClusters",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			builder := fake.NewClientBuilder().WithScheme(testscheme.Scheme)
+			if tc.sveltosCluster != nil {
+				builder = builder.WithObjects(tc.sveltosCluster)
+			}
+			if tc.listErr != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+						return tc.listErr
+					},
+				})
+			}
+			cl := builder.Build()
+
+			r := &ClusterDeploymentReconciler{}
+			got, err := r.sveltosClusterConditionDrifted(t.Context(), cl, tc.cd)
+			if tc.wantErrSub != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("err = %v, want substring %q", err, tc.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantChanged {
+				t.Fatalf("changed = %v, want %v", got, tc.wantChanged)
+			}
+		})
+	}
+}
+
+// newSveltosCluster builds the SveltosCluster the adopted-cluster chart would render for the
+// ClusterDeployment "a" used throughout these cases, carrying the Flux label the lookup matches on.
+func newSveltosCluster(t *testing.T, status libsveltosv1beta1.SveltosClusterStatus) *libsveltosv1beta1.SveltosCluster {
+	t.Helper()
+
+	const cdName = "a"
+
+	return &libsveltosv1beta1.SveltosCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cdName,
+			Namespace: pollerTestNamespace,
+			Labels:    map[string]string{kcmv1.FluxHelmChartNameKey: cdName},
+		},
+		Status: status,
+	}
+}
+
+// withMatchingSveltosCondition seeds the CD with the exact SveltosClusterReady condition the poller
+// would compute for the given SveltosCluster, so the diff comparison reports no drift.
+func withMatchingSveltosCondition(t *testing.T, sveltosCluster *libsveltosv1beta1.SveltosCluster) func(*kcmv1.ClusterDeployment) {
+	t.Helper()
+
+	return func(cd *kcmv1.ClusterDeployment) {
+		apimeta.SetStatusCondition(&cd.Status.Conditions, *conditionsutil.GetSveltosClusterReadyCondition(cd, sveltosCluster))
 	}
 }
 

--- a/internal/controller/clusterdeployment_controller.go
+++ b/internal/controller/clusterdeployment_controller.go
@@ -29,6 +29,7 @@ import (
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	fluxconditions "github.com/fluxcd/pkg/runtime/conditions"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"golang.org/x/sync/errgroup"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -38,6 +39,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
@@ -283,7 +285,8 @@ func (r *ClusterDeploymentReconciler) getClusterScope(ctx context.Context, cd *k
 		if err := r.MgmtClient.Get(ctx, client.ObjectKey{Name: cred.Spec.Region}, rgn); err != nil {
 			return nil, fmt.Errorf("failed to get %s region: %w", cred.Spec.Region, err)
 		}
-		if scope.rgnClient, _, err = kubeutil.GetRegionalClient(ctx, r.MgmtClient, r.SystemNamespace, rgn, schemeutil.GetRegionalScheme); err != nil {
+		// the Sveltos types are required to read the health of adopted clusters living in this region
+		if scope.rgnClient, _, err = kubeutil.GetRegionalClient(ctx, r.MgmtClient, r.SystemNamespace, rgn, schemeutil.GetRegionalSchemeWithSveltos); err != nil {
 			return nil, fmt.Errorf("failed to get client for %s region: %w", cred.Spec.Region, err)
 		}
 		scope.region = rgn
@@ -583,6 +586,12 @@ func (r *ClusterDeploymentReconciler) reconcileHelmRelease(
 
 		return ctrl.Result{}, err
 	}
+
+	sveltosRequeue, err := r.aggregateSveltosClusterConditions(ctx, scope)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	requeue = requeue || sveltosRequeue
 
 	if requeue || !fluxconditions.IsReady(hr) {
 		return ctrl.Result{RequeueAfter: r.defaultRequeueTime}, nil
@@ -1381,6 +1390,78 @@ func (r *ClusterDeploymentReconciler) aggregateCapiConditions(ctx context.Contex
 	return capiCondition.Status != metav1.ConditionTrue, nil
 }
 
+// sveltosUnavailable reports whether err means the SveltosCluster type cannot be queried at all,
+// as opposed to the query having failed. That happens when the Sveltos integration is disabled
+// (--enable-sveltos-ctrl=false leaves the types out of the scheme) or when a regional cluster does
+// not have the Sveltos CRDs installed. Neither is an error: there simply is no adopted-cluster
+// health to report.
+func sveltosUnavailable(err error) bool {
+	return runtime.IsNotRegisteredError(err) || apimeta.IsNoMatchError(err)
+}
+
+// aggregateSveltosClusterConditions reflects the health of the SveltosCluster backing scope.cd on
+// the ClusterDeployment. Templates that adopt an already existing cluster render a SveltosCluster
+// rather than a CAPI Cluster, so without this the reachability of the adopted cluster is never
+// surfaced and the ClusterDeployment reports Ready even when its kubeconfig is unusable.
+func (r *ClusterDeploymentReconciler) aggregateSveltosClusterConditions(ctx context.Context, scope *clusterScope) (requeue bool, _ error) {
+	cd := scope.cd
+	conditions := cd.GetConditions()
+
+	sveltosClusters := new(libsveltosv1beta1.SveltosClusterList)
+	if err := scope.rgnClient.List(ctx, sveltosClusters, client.MatchingLabels{kcmv1.FluxHelmChartNameKey: cd.Name}, client.Limit(1), client.InNamespace(cd.Namespace)); err != nil {
+		if sveltosUnavailable(err) {
+			return false, nil
+		}
+
+		apimeta.SetStatusCondition(conditions, metav1.Condition{
+			Type:               kcmv1.SveltosClusterReadyCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             kcmv1.FailedReason,
+			ObservedGeneration: cd.Generation,
+			Message:            err.Error(),
+		})
+
+		return false, fmt.Errorf("failed to list SveltosClusters for ClusterDeployment %s: %w", client.ObjectKeyFromObject(cd), err)
+	}
+
+	if len(sveltosClusters.Items) == 0 {
+		// Most ClusterTemplates do not produce a SveltosCluster, so its absence is only worth
+		// reporting once we have actually observed one going away.
+		if cond := apimeta.FindStatusCondition(*conditions, kcmv1.SveltosClusterReadyCondition); cond != nil && cond.Reason != kcmv1.SveltosClusterMissingReason {
+			apimeta.SetStatusCondition(conditions, metav1.Condition{
+				Type:               kcmv1.SveltosClusterReadyCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             kcmv1.SveltosClusterMissingReason,
+				ObservedGeneration: cd.Generation,
+				Message:            "Underlying SveltosCluster object is missing",
+			})
+		}
+
+		return false, nil
+	}
+
+	sveltosCondition := conditionsutil.GetSveltosClusterReadyCondition(cd, &sveltosClusters.Items[0])
+
+	// Event only on a real transition. A provider failure message can carry per-probe noise, so
+	// keying off "the condition changed at all" would re-emit the same event indefinitely.
+	prev := apimeta.FindStatusCondition(*conditions, kcmv1.SveltosClusterReadyCondition)
+	transitioned := prev == nil || prev.Status != sveltosCondition.Status || prev.Reason != sveltosCondition.Reason
+
+	apimeta.SetStatusCondition(conditions, *sveltosCondition)
+
+	if transitioned {
+		switch sveltosCondition.Reason {
+		case kcmv1.SucceededReason:
+			r.eventf(cd, "SveltosClusterIsReady", "Connection to the cluster is healthy")
+		case kcmv1.ConnectionDownReason:
+			// the message embeds a provider error, so it must not be treated as a format string
+			r.warnf(cd, "SveltosClusterConnectionDown", "%s", sveltosCondition.Message)
+		}
+	}
+
+	return sveltosCondition.Status != metav1.ConditionTrue, nil
+}
+
 func (*ClusterDeploymentReconciler) setCondition(cd *kcmv1.ClusterDeployment, typ, reason string, status metav1.ConditionStatus, err error) (changed bool) {
 	var msg string
 	if err != nil {
@@ -1553,6 +1634,17 @@ func handleClusterDeploymentFailedConditions(cond metav1.Condition) (errMsg, war
 		}
 		// if the condition has been False and was not updated for more than 30 minutes, we consider it a failure
 		errMsg = "Cluster is not ready. Check the provider logs for more details.\n" + cond.Message
+
+	// The SveltosCluster health check debounces transient failures itself via
+	// spec.consecutiveFailureThreshold: connectionStatus only flips to Down once the probe has
+	// failed that many times in a row. Below the threshold the failure is still worth showing, but
+	// it must not flap the cluster out of Ready, so no additional grace period is needed here.
+	case kcmv1.SveltosClusterReadyCondition:
+		if cond.Reason == kcmv1.ProgressingReason {
+			warning = cond.Message
+			break
+		}
+		errMsg = cond.Message
 	case kcmv1.ServicesInReadyStateCondition:
 		warning = cond.Message + " Services are ready."
 	default:

--- a/internal/controller/clusterdeployment_controller_test.go
+++ b/internal/controller/clusterdeployment_controller_test.go
@@ -1931,6 +1931,84 @@ func Test_updateClusterDeploymentConditions(t *testing.T) {
 			},
 		},
 		{
+			name: "Adopted cluster connection is down, should be a hard failure in Ready condition.",
+			currentConditions: []metav1.Condition{
+				{
+					Type:    kcmv1.HelmReleaseReadyCondition,
+					Status:  metav1.ConditionTrue,
+					Reason:  kcmv1.SucceededReason,
+					Message: "Helm install succeeded",
+				},
+				{
+					Type:    kcmv1.SveltosClusterReadyCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  kcmv1.ConnectionDownReason,
+					Message: "Connection to the cluster is down. couldn't get version/kind",
+				},
+			},
+			expectedReadyCondition: metav1.Condition{
+				Type:               kcmv1.ReadyCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             kcmv1.FailedReason,
+				Message:            "Connection to the cluster is down. couldn't get version/kind",
+				ObservedGeneration: generation,
+			},
+		},
+		{
+			name: "Adopted cluster is failing below its threshold, should only warn in Ready condition.",
+			currentConditions: []metav1.Condition{
+				{
+					Type:    kcmv1.SveltosClusterReadyCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  kcmv1.ProgressingReason,
+					Message: "Connection to the cluster has failed 2 time(s) in a row, retrying: i/o timeout",
+				},
+			},
+			expectedReadyCondition: metav1.Condition{
+				Type:               kcmv1.ReadyCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             kcmv1.ProgressingReason,
+				Message:            "Connection to the cluster has failed 2 time(s) in a row, retrying: i/o timeout",
+				ObservedGeneration: generation,
+			},
+		},
+		{
+			name: "Adopted cluster has not been probed yet, Ready condition should be Unknown.",
+			currentConditions: []metav1.Condition{
+				{
+					Type:    kcmv1.SveltosClusterReadyCondition,
+					Status:  metav1.ConditionUnknown,
+					Reason:  kcmv1.ConnectionProbePendingReason,
+					Message: "Waiting for the connection to the cluster to be probed",
+				},
+			},
+			expectedReadyCondition: metav1.Condition{
+				Type:               kcmv1.ReadyCondition,
+				Status:             metav1.ConditionUnknown,
+				Reason:             kcmv1.ProgressingReason,
+				Message:            "Waiting for the connection to the cluster to be probed",
+				ObservedGeneration: generation,
+			},
+		},
+		{
+			name: "Adopted cluster is healthy, should reflect Succeeded reason in Ready condition.",
+			currentConditions: []metav1.Condition{
+				{
+					Type:    kcmv1.SveltosClusterReadyCondition,
+					Status:  metav1.ConditionTrue,
+					Reason:  kcmv1.SucceededReason,
+					Message: "Connection to the cluster is healthy",
+				},
+			},
+			expectedReadyCondition: metav1.Condition{
+				Type:               kcmv1.ReadyCondition,
+				Status:             metav1.ConditionTrue,
+				Reason:             kcmv1.SucceededReason,
+				Message:            "Object is ready",
+				ObservedGeneration: generation,
+			},
+		},
+		{
 			name: "Cluster is deleting, Ready condition should be equal to Deleting condition",
 			currentConditions: []metav1.Condition{
 				{

--- a/internal/util/conditions/sveltos.go
+++ b/internal/util/conditions/sveltos.go
@@ -1,0 +1,102 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conditions
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+)
+
+// sveltosTempKubeconfigRe matches the temporary file sveltoscluster-manager writes the kubeconfig to
+// before loading it. The numeric suffix is random per probe, so it has to be stripped: it is the only
+// varying part of an otherwise identical failure message, and leaving it in makes the condition
+// message differ on every probe, which in turn produces an endless stream of status writes,
+// ClusterDeployment reconciles and duplicate events for a cluster whose state never actually changed.
+var sveltosTempKubeconfigRe = regexp.MustCompile(`(/tmp/kubeconfig)\d+`)
+
+// stableFailureMessage strips the per-probe noise out of a SveltosCluster failure message so that an
+// unchanged failure yields an unchanged message.
+func stableFailureMessage(msg string) string {
+	return sveltosTempKubeconfigRe.ReplaceAllString(strings.TrimSpace(msg), "$1")
+}
+
+// GetSveltosClusterReadyCondition builds the [github.com/K0rdent/kcm/api/v1beta1.SveltosClusterReadyCondition]
+// for cd from the health of its underlying SveltosCluster.
+//
+// Templates that adopt an already existing cluster (e.g. adopted-cluster) produce a SveltosCluster
+// instead of a CAPI Cluster, so [GetCAPIClusterSummaryCondition] has nothing to summarize and the
+// reachability of the adopted cluster would otherwise never be reflected on the ClusterDeployment.
+//
+// The condition is derived from spec.connectionStatus and spec.failureMessage, which
+// sveltoscluster-manager refreshes on every health probe:
+//
+//   - ConnectionDown: the probe has failed at least spec.consecutiveFailureThreshold times in a row.
+//     Reported as a failure.
+//   - a failureMessage without ConnectionDown: the probe is failing but is still within the
+//     configured threshold. Reported as progressing so that a transient blip does not flap the
+//     ClusterDeployment out of its Ready state; spec.consecutiveFailureThreshold is what tunes
+//     how forgiving this is.
+//   - ConnectionHealthy: the cluster is reachable.
+//   - anything else: the cluster has not been probed yet, so its health is genuinely unknown.
+//
+// NOTE: status.ready is deliberately NOT consulted. When sveltoscluster-manager cannot even build
+// a client from the kubeconfig it returns before touching status.ready, which leaves the previously
+// observed (or default) value behind. An adopted cluster whose kubeconfig is malformed therefore
+// reports connectionStatus=Down alongside a stale ready=true.
+func GetSveltosClusterReadyCondition(cd *kcmv1.ClusterDeployment, sveltosCluster *libsveltosv1beta1.SveltosCluster) *metav1.Condition {
+	cond := &metav1.Condition{
+		Type:               kcmv1.SveltosClusterReadyCondition,
+		ObservedGeneration: cd.Generation,
+	}
+
+	failureMessage := ""
+	if sveltosCluster.Status.FailureMessage != nil {
+		failureMessage = stableFailureMessage(*sveltosCluster.Status.FailureMessage)
+	}
+
+	switch {
+	case sveltosCluster.Status.ConnectionStatus == libsveltosv1beta1.ConnectionDown:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = kcmv1.ConnectionDownReason
+		cond.Message = "Connection to the cluster is down."
+		if failureMessage != "" {
+			cond.Message += " " + failureMessage
+		}
+
+	case failureMessage != "":
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = kcmv1.ProgressingReason
+		cond.Message = fmt.Sprintf("Connection to the cluster has failed %d time(s) in a row, retrying: %s",
+			sveltosCluster.Status.ConnectionFailures, failureMessage)
+
+	case sveltosCluster.Status.ConnectionStatus == libsveltosv1beta1.ConnectionHealthy:
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = kcmv1.SucceededReason
+		cond.Message = "Connection to the cluster is healthy"
+
+	default:
+		cond.Status = metav1.ConditionUnknown
+		cond.Reason = kcmv1.ConnectionProbePendingReason
+		cond.Message = "Waiting for the connection to the cluster to be probed"
+	}
+
+	return cond
+}

--- a/internal/util/conditions/sveltos_test.go
+++ b/internal/util/conditions/sveltos_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conditions
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+)
+
+// the failure message sveltoscluster-manager reports for a Secret whose kubeconfig is not
+// parseable at all, e.g. one holding the literal "hello world"
+const unparseableKubeconfigFailure = `BuildConfigFromFlags: error loading config file "/tmp/kubeconfig1453503567": ` +
+	`couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct ` +
+	`{ APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }`
+
+func TestGetSveltosClusterReadyCondition(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		status         libsveltosv1beta1.SveltosClusterStatus
+		wantStatus     metav1.ConditionStatus
+		wantReason     string
+		wantMsgSubstrs []string
+	}{
+		// A malformed kubeconfig makes sveltoscluster-manager fail before it can build a client, so
+		// it returns without ever resetting status.ready: the stale ready=true here is exactly what
+		// used to let the ClusterDeployment report Ready.
+		"unparseable kubeconfig, stale ready=true": {
+			status: libsveltosv1beta1.SveltosClusterStatus{
+				Ready:              true,
+				Version:            "v1.36.1+k0s",
+				ConnectionStatus:   libsveltosv1beta1.ConnectionDown,
+				ConnectionFailures: 115,
+				FailureMessage:     new(unparseableKubeconfigFailure),
+			},
+			wantStatus:     metav1.ConditionFalse,
+			wantReason:     kcmv1.ConnectionDownReason,
+			wantMsgSubstrs: []string{"Connection to the cluster is down.", "couldn't get version/kind"},
+		},
+
+		// Valid kubeconfig, unreachable API server. The config builds fine, so the probe gets as far
+		// as GET /version and fails there.
+		"valid kubeconfig, connection refused past threshold": {
+			status: libsveltosv1beta1.SveltosClusterStatus{
+				ConnectionStatus:   libsveltosv1beta1.ConnectionDown,
+				ConnectionFailures: 3,
+				FailureMessage:     new(`Get "https://127.0.0.1:1/version?timeout=32s": dial tcp 127.0.0.1:1: connect: connection refused`),
+			},
+			wantStatus:     metav1.ConditionFalse,
+			wantReason:     kcmv1.ConnectionDownReason,
+			wantMsgSubstrs: []string{"Connection to the cluster is down.", "connection refused"},
+		},
+		"valid kubeconfig, network timeout past threshold": {
+			status: libsveltosv1beta1.SveltosClusterStatus{
+				ConnectionStatus:   libsveltosv1beta1.ConnectionDown,
+				ConnectionFailures: 3,
+				FailureMessage:     new(`Get "https://192.0.2.1:6443/version?timeout=32s": dial tcp 192.0.2.1:6443: i/o timeout`),
+			},
+			wantStatus:     metav1.ConditionFalse,
+			wantReason:     kcmv1.ConnectionDownReason,
+			wantMsgSubstrs: []string{"Connection to the cluster is down.", "i/o timeout"},
+		},
+
+		// Sveltos populates failureMessage on every failed probe but only flips connectionStatus to
+		// Down once spec.consecutiveFailureThreshold is crossed, so a failure without Down means the
+		// cluster is still within its allowance and must not hard-fail the ClusterDeployment.
+		"failing but below the consecutive failure threshold": {
+			status: libsveltosv1beta1.SveltosClusterStatus{
+				ConnectionFailures: 2,
+				FailureMessage:     new(`Get "https://192.0.2.1:6443/version?timeout=32s": dial tcp 192.0.2.1:6443: i/o timeout`),
+			},
+			wantStatus:     metav1.ConditionFalse,
+			wantReason:     kcmv1.ProgressingReason,
+			wantMsgSubstrs: []string{"failed 2 time(s) in a row", "i/o timeout"},
+		},
+
+		"healthy": {
+			status: libsveltosv1beta1.SveltosClusterStatus{
+				Ready:              true,
+				Version:            "v1.35.0",
+				ConnectionStatus:   libsveltosv1beta1.ConnectionHealthy,
+				ConnectionFailures: 0,
+			},
+			wantStatus: metav1.ConditionTrue,
+			wantReason: kcmv1.SucceededReason,
+		},
+
+		// Freshly created SveltosCluster: the health of the cluster is genuinely not known yet, so
+		// it must not be reported as ready.
+		"not probed yet": {
+			status:     libsveltosv1beta1.SveltosClusterStatus{},
+			wantStatus: metav1.ConditionUnknown,
+			wantReason: kcmv1.ConnectionProbePendingReason,
+		},
+		// ready=true with nothing else is still an unprobed cluster as far as we are concerned.
+		"ready=true is not trusted on its own": {
+			status: libsveltosv1beta1.SveltosClusterStatus{
+				Ready:   true,
+				Version: "v1.36.1+k0s",
+			},
+			wantStatus: metav1.ConditionUnknown,
+			wantReason: kcmv1.ConnectionProbePendingReason,
+		},
+		// an empty failure message must not be mistaken for a failure
+		"blank failure message is ignored": {
+			status: libsveltosv1beta1.SveltosClusterStatus{
+				ConnectionStatus: libsveltosv1beta1.ConnectionHealthy,
+				FailureMessage:   new("   "),
+			},
+			wantStatus: metav1.ConditionTrue,
+			wantReason: kcmv1.SucceededReason,
+		},
+	}
+
+	const generation = 7
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			cd := &kcmv1.ClusterDeployment{}
+			cd.Generation = generation
+			sc := &libsveltosv1beta1.SveltosCluster{Status: tc.status}
+
+			got := GetSveltosClusterReadyCondition(cd, sc)
+
+			if got.Type != kcmv1.SveltosClusterReadyCondition {
+				t.Errorf("Type = %q, want %q", got.Type, kcmv1.SveltosClusterReadyCondition)
+			}
+			if got.Status != tc.wantStatus {
+				t.Errorf("Status = %q, want %q", got.Status, tc.wantStatus)
+			}
+			if got.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", got.Reason, tc.wantReason)
+			}
+			if got.ObservedGeneration != generation {
+				t.Errorf("ObservedGeneration = %d, want %d", got.ObservedGeneration, generation)
+			}
+			for _, substr := range tc.wantMsgSubstrs {
+				if !strings.Contains(got.Message, substr) {
+					t.Errorf("Message = %q, want substring %q", got.Message, substr)
+				}
+			}
+		})
+	}
+}
+
+// Sveltos loads the kubeconfig through a randomly-named temp file and puts that name in the failure
+// message, so two probes of the same broken cluster report different strings. The condition message
+// has to come out identical anyway, otherwise every probe looks like a state change and drives an
+// endless loop of status updates, reconciles and duplicate events.
+func TestGetSveltosClusterReadyCondition_stableAcrossProbes(t *testing.T) {
+	t.Parallel()
+
+	const failure = `BuildConfigFromFlags: error loading config file %q: couldn't get version/kind; json parse error`
+
+	cd := &kcmv1.ClusterDeployment{}
+
+	first := GetSveltosClusterReadyCondition(cd, &libsveltosv1beta1.SveltosCluster{
+		Status: libsveltosv1beta1.SveltosClusterStatus{
+			ConnectionStatus:   libsveltosv1beta1.ConnectionDown,
+			ConnectionFailures: 3,
+			FailureMessage:     new(fmt.Sprintf(failure, "/tmp/kubeconfig2139820100")),
+		},
+	})
+	second := GetSveltosClusterReadyCondition(cd, &libsveltosv1beta1.SveltosCluster{
+		Status: libsveltosv1beta1.SveltosClusterStatus{
+			ConnectionStatus:   libsveltosv1beta1.ConnectionDown,
+			ConnectionFailures: 4, // the retry counter moves on; the reported problem does not
+			FailureMessage:     new(fmt.Sprintf(failure, "/tmp/kubeconfig1188603431")),
+		},
+	})
+
+	if first.Message != second.Message {
+		t.Errorf("message differs between probes of the same failure:\n first  = %q\n second = %q", first.Message, second.Message)
+	}
+	// the diagnostic itself must survive the scrubbing
+	if !strings.Contains(first.Message, "couldn't get version/kind") {
+		t.Errorf("Message = %q, want it to retain the underlying error", first.Message)
+	}
+}
+
+func TestStableFailureMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct{ in, want string }{
+		"temp kubeconfig suffix stripped": {
+			in:   `error loading config file "/tmp/kubeconfig2139820100": bad`,
+			want: `error loading config file "/tmp/kubeconfig": bad`,
+		},
+		"surrounding whitespace trimmed": {
+			in:   "  dial tcp 192.0.2.1:6443: i/o timeout\n",
+			want: "dial tcp 192.0.2.1:6443: i/o timeout",
+		},
+		"unrelated numbers preserved": {
+			in:   `Get "https://192.0.2.1:6443/version?timeout=32s": i/o timeout`,
+			want: `Get "https://192.0.2.1:6443/version?timeout=32s": i/o timeout`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := stableFailureMessage(tc.in); got != tc.want {
+				t.Errorf("stableFailureMessage(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/test/scheme/scheme.go
+++ b/test/scheme/scheme.go
@@ -18,6 +18,7 @@ import (
 	helmcontrollerv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,6 +42,7 @@ var (
 		sourcev1.AddToScheme,
 		helmcontrollerv2.AddToScheme,
 		addoncontrollerv1beta1.AddToScheme,
+		libsveltosv1beta1.AddToScheme,
 		kubevirtv1.AddToScheme,
 		cdiv1.AddToScheme,
 		apiextv1.AddToScheme,


### PR DESCRIPTION
Fixes https://github.com/k0rdent/kcm/issues/2196.