### PR TITLE
chore: fix unquoted linter template issues

### DIFF
--- a/config/dev/kubevirt-clusterdeployment.yaml
+++ b/config/dev/kubevirt-clusterdeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubevirt-${CLUSTER_NAME_SUFFIX}
   namespace: ${NAMESPACE}
 spec:
-  template: kubevirt-standalone-cp-1-0-20
+  template: kubevirt-standalone-cp-1-0-21
   credential: kubevirt-cred
   propagateCredentials: false
   config:

--- a/templates/cluster/kubevirt-hosted-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.18
+version: 1.0.19
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-hosted-cp/templates/kubevirtmachinetemplate.yaml
+++ b/templates/cluster/kubevirt-hosted-cp/templates/kubevirtmachinetemplate.yaml
@@ -25,7 +25,7 @@ spec:
                   model: {{ .Values.worker.cpu.model  | quote }}
                   numa: {{- toYaml .Values.worker.cpu.numa | nindent 20 }}
                 {{- if .Values.worker.ioThreadsPolicy }}
-                ioThreadsPolicy: {{ .Values.worker.ioThreadsPolicy }}
+                ioThreadsPolicy: {{ .Values.worker.ioThreadsPolicy | quote }}
                 {{- end }}
                 devices:
                   interfaces: {{ toYaml .Values.worker.devices.interfaces | nindent 20 }}

--- a/templates/cluster/kubevirt-standalone-cp/Chart.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.20
+version: 1.0.21
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml
@@ -27,7 +27,7 @@ spec:
                   {{- end }}
                   numa: {{- toYaml .Values.controlPlane.cpu.numa | nindent 20 }}
                 {{- if .Values.controlPlane.ioThreadsPolicy }}
-                ioThreadsPolicy: {{ .Values.controlPlane.ioThreadsPolicy }}
+                ioThreadsPolicy: {{ .Values.controlPlane.ioThreadsPolicy | quote }}
                 {{- end }}
                 devices:
                   interfaces: {{ toYaml .Values.controlPlane.devices.interfaces | nindent 20 }}

--- a/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
+++ b/templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml
@@ -28,7 +28,7 @@ spec:
                   {{- end }}
                   numa: {{- toYaml .Values.worker.cpu.numa | nindent 20 }}
                 {{- if .Values.worker.ioThreadsPolicy }}
-                ioThreadsPolicy: {{ .Values.worker.ioThreadsPolicy }}
+                ioThreadsPolicy: {{ .Values.worker.ioThreadsPolicy | quote }}
                 {{- end }}
                 devices:
                   interfaces: {{ toYaml .Values.worker.devices.interfaces | nindent 20 }}

--- a/templates/cluster/vsphere-hosted-cp/Chart.yaml
+++ b/templates/cluster/vsphere-hosted-cp/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.41
+version: 1.0.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
+++ b/templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml
@@ -9,7 +9,7 @@ spec:
   {{- if .Values.k0smotron.service }}
   service:
     {{- if .Values.k0smotron.service.type }}
-    type: {{ .Values.k0smotron.service.type }}
+    type: {{ .Values.k0smotron.service.type | quote }}
     {{- end }}
     {{- if .Values.k0smotron.service.apiPort }}
     apiPort: {{ .Values.k0smotron.service.apiPort }}

--- a/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-19.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-hosted-cp-1-0-19.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: vsphere-hosted-cp-1-0-41
+  name: kubevirt-hosted-cp-1-0-19
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: vsphere-hosted-cp
-      version: 1.0.41
+      chart: kubevirt-hosted-cp
+      version: 1.0.19
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-21.yaml
+++ b/templates/provider/kcm-templates/files/templates/kubevirt-standalone-cp-1-0-21.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-standalone-cp-1-0-20
+  name: kubevirt-standalone-cp-1-0-21
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: kubevirt-standalone-cp
-      version: 1.0.20
+      version: 1.0.21
       interval: 10m0s
       sourceRef:
         kind: HelmRepository

--- a/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-42.yaml
+++ b/templates/provider/kcm-templates/files/templates/vsphere-hosted-cp-1-0-42.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ClusterTemplate
 metadata:
-  name: kubevirt-hosted-cp-1-0-18
+  name: vsphere-hosted-cp-1-0-42
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
-      chart: kubevirt-hosted-cp
-      version: 1.0.18
+      chart: vsphere-hosted-cp
+      version: 1.0.42
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the unquoted linter is failing with:
```
  Found unquoted string .Values interpolations in YAML value positions:
  templates/cluster/kubevirt-hosted-cp/templates/kubevirtmachinetemplate.yaml:28:                ioThreadsPolicy: {{ .Values.worker.ioThreadsPolicy }}
  templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-controlplane.yaml:30:                ioThreadsPolicy: {{ .Values.controlPlane.ioThreadsPolicy }}
  templates/cluster/kubevirt-standalone-cp/templates/kubevirtmachinetemplate-worker.yaml:31:                ioThreadsPolicy: {{ .Values.worker.ioThreadsPolicy }}
  templates/cluster/vsphere-hosted-cp/templates/k0smotroncontrolplane.yaml:12:    type: {{ .Values.k0smotron.service.type }}
  make[2]: *** [Makefile:250: lint-quoted-values] Error 1
```
