### PR TITLE
chore(bump): gcp provider to v1.13.0

### DIFF
--- a/templates/provider/cluster-api-provider-gcp/Chart.yaml
+++ b/templates/provider/cluster-api-provider-gcp/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.23
+version: 1.0.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.12.0"
+appVersion: "v1.13.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-gcp
   cluster.x-k8s.io/v1beta1: v1beta1

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -26,7 +26,7 @@ spec:
     - name: cluster-api-provider-docker
       template: cluster-api-provider-docker-1-0-24
     - name: cluster-api-provider-gcp
-      template: cluster-api-provider-gcp-1-0-23
+      template: cluster-api-provider-gcp-1-0-24
     - name: cluster-api-provider-ipam
       template: cluster-api-provider-ipam-1-0-13
     - name: cluster-api-provider-infoblox

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-gcp.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-gcp-1-0-23
+  name: cluster-api-provider-gcp-1-0-24
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-gcp
-      version: 1.0.23
+      version: 1.0.24
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates gcp provider to v1.13.0.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2985
