### PR TITLE
chore(deps): bump CAPA provider from 2.12.1 to 2.13.0

### DIFF
--- a/templates/provider/cluster-api-provider-aws/Chart.yaml
+++ b/templates/provider/cluster-api-provider-aws/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.25
+version: 1.0.26
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.12.1"
+appVersion: "v2.13.0"
 annotations:
   cluster.x-k8s.io/provider: infrastructure-aws
   cluster.x-k8s.io/v1beta1: v1beta1_v1beta2

--- a/templates/provider/kcm-templates/files/release.yaml
+++ b/templates/provider/kcm-templates/files/release.yaml
@@ -20,7 +20,7 @@ spec:
     - name: cluster-api-provider-vsphere
       template: cluster-api-provider-vsphere-1-0-21
     - name: cluster-api-provider-aws
-      template: cluster-api-provider-aws-1-0-25
+      template: cluster-api-provider-aws-1-0-26
     - name: cluster-api-provider-openstack
       template: cluster-api-provider-openstack-1-0-28
     - name: cluster-api-provider-docker

--- a/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
+++ b/templates/provider/kcm-templates/files/templates/cluster-api-provider-aws.yaml
@@ -1,14 +1,14 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ProviderTemplate
 metadata:
-  name: cluster-api-provider-aws-1-0-25
+  name: cluster-api-provider-aws-1-0-26
   annotations:
     helm.sh/resource-policy: keep
 spec:
   helm:
     chartSpec:
       chart: cluster-api-provider-aws
-      version: 1.0.25
+      version: 1.0.26
       interval: 10m0s
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Closes #2984