### PR TITLE
fix: allow controller to delete configmaps

### DIFF
--- a/templates/provider/kcm/templates/rbac/controller/roles.yaml
+++ b/templates/provider/kcm/templates/rbac/controller/roles.yaml
@@ -302,12 +302,7 @@ rules:
   - ""
   resources:
   - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - create
+  verbs: {{ include "rbac.editorVerbs" . | nindent 2 }}
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates controller RBAC rules to allow configmaps deletion.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Fixes #2988
