### PR TITLE
fix: unintended release deletion on failed upgrade

### DIFF
--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -82,7 +82,7 @@ type profileConfig struct {
 	Priority *int32 `json:"priority,omitempty"`
 
 	// MaxConsecutiveFailures defines how many install/upgrade attempts
-	// sveltos will take beforce giving up. After this many consecutive failures,
+	// sveltos will take before giving up. After this many consecutive failures,
 	// the deployment will be considered failed, and Sveltos will stop retrying.
 	MaxConsecutiveFailures *uint `json:"maxConsecutiveFailures,omitempty"`
 

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -1469,7 +1469,12 @@ func convertValuesFrom(src []kcmv1.ValuesFrom, namespace string) []addoncontroll
 
 func convertHelmOptions(options *kcmv1.ServiceHelmOptions) *addoncontrollerv1beta1.HelmOptions {
 	if options == nil {
-		return nil
+		// we'll set atomic to true in case no helm options were
+		// defined to protect the deployment from unintended deletion
+		// in case of failed upgrade on the sveltos side.
+		return new(addoncontrollerv1beta1.HelmOptions{
+			Atomic: true,
+		})
 	}
 	toReturn := addoncontrollerv1beta1.HelmOptions{
 		Timeout: options.Timeout,
@@ -1509,6 +1514,11 @@ func convertHelmOptions(options *kcmv1.ServiceHelmOptions) *addoncontrollerv1bet
 
 	if options.Atomic != nil {
 		toReturn.Atomic = *options.Atomic
+	} else {
+		// we'll set atomic to true in case it's not defined
+		// to protect the deployment from unintended deletion
+		// in case of failed upgrade on the sveltos side.
+		toReturn.Atomic = true
 	}
 
 	if options.DependencyUpdate != nil {

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -80,6 +80,12 @@ type profileConfig struct {
 	// KSM specific configuration
 	// Priority is the priority of the Profile.
 	Priority *int32 `json:"priority,omitempty"`
+
+	// MaxConsecutiveFailures defines how many install/upgrade attempts
+	// sveltos will take beforce giving up. After this many consecutive failures,
+	// the deployment will be considered failed, and Sveltos will stop retrying.
+	MaxConsecutiveFailures *uint `json:"maxConsecutiveFailures,omitempty"`
+
 	// DriftIgnore is a list of [github.com/projectsveltos/libsveltos/api/v1beta1.PatchSelector] to ignore
 	// when checking for drift.
 	DriftIgnore []libsveltosv1beta1.PatchSelector `json:"driftIgnore,omitempty"`
@@ -1575,6 +1581,7 @@ func buildProfileSpec(config *apiextv1.JSON) (*addoncontrollerv1beta1.Spec, erro
 	spec.PolicyRefs = params.PolicyRefs
 	spec.Patches = params.Patches
 	spec.DriftExclusions = params.DriftExclusions
+	spec.MaxConsecutiveFailures = params.MaxConsecutiveFailures
 
 	for _, target := range params.DriftIgnore {
 		spec.Patches = append(spec.Patches, libsveltosv1beta1.Patch{

--- a/internal/controller/adapters/sveltos/serviceset_controller_test.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller_test.go
@@ -274,6 +274,32 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 		),
 	)
 
+	DescribeTable("helm options conversion",
+		func(options *kcmv1.ServiceHelmOptions, want *addoncontrollerv1beta1.HelmOptions) {
+			Expect(convertHelmOptions(options)).To(Equal(want))
+		},
+		Entry("options=nil → atomic defaults to true",
+			nil,
+			&addoncontrollerv1beta1.HelmOptions{Atomic: true},
+		),
+		Entry("empty options → atomic defaults to true",
+			&kcmv1.ServiceHelmOptions{},
+			&addoncontrollerv1beta1.HelmOptions{Atomic: true},
+		),
+		Entry("atomic unset alongside other options → atomic defaults to true",
+			&kcmv1.ServiceHelmOptions{Timeout: testTimeout, Wait: new(true)},
+			&addoncontrollerv1beta1.HelmOptions{Timeout: testTimeout, Wait: true, Atomic: true},
+		),
+		Entry("atomic explicitly disabled → kept as is",
+			&kcmv1.ServiceHelmOptions{Atomic: new(false)},
+			&addoncontrollerv1beta1.HelmOptions{Atomic: false},
+		),
+		Entry("atomic explicitly enabled → kept as is",
+			&kcmv1.ServiceHelmOptions{Atomic: new(true)},
+			&addoncontrollerv1beta1.HelmOptions{Atomic: true},
+		),
+	)
+
 	Context("When StateManagementProvider is not ready", func() {
 		It("should only update the status of the ServiceSet", func() {
 			By("checking the StateManagementProvider is not ready", func() {
@@ -388,7 +414,8 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 				providerConfig := `
 {
 	"stopMatchingBehavior": "LeavePolicies",
-	"syncMode": "OneTime"
+	"syncMode": "OneTime",
+	"maxConsecutiveFailures": 3
 }
 `
 				serviceSet.Spec.Provider.Config = &apiextv1.JSON{
@@ -421,6 +448,7 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 				Expect(Object(&profile)()).Should(SatisfyAll(
 					HaveField("Spec.StopMatchingBehavior", Equal(addoncontrollerv1beta1.LeavePolicies)),
 					HaveField("Spec.SyncMode", Equal(addoncontrollerv1beta1.SyncModeOneTime)),
+					HaveField("Spec.MaxConsecutiveFailures", HaveValue(Equal(uint(3)))),
 				))
 			})
 		})
@@ -490,7 +518,8 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 				providerConfig := `
 {
 	"stopMatchingBehavior": "LeavePolicies",
-	"syncMode": "OneTime"
+	"syncMode": "OneTime",
+	"maxConsecutiveFailures": 3
 }
 `
 				serviceSet.Spec.Provider.Config = &apiextv1.JSON{
@@ -523,6 +552,7 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 				Expect(Object(&profile)()).Should(SatisfyAll(
 					HaveField("Spec.StopMatchingBehavior", Equal(addoncontrollerv1beta1.LeavePolicies)),
 					HaveField("Spec.SyncMode", Equal(addoncontrollerv1beta1.SyncModeOneTime)),
+					HaveField("Spec.MaxConsecutiveFailures", HaveValue(Equal(uint(3)))),
 				))
 			})
 
@@ -530,7 +560,8 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 				providerConfig := `
 {
 	"stopMatchingBehavior": "WithdrawPolicies",
-	"continueOnError": true
+	"continueOnError": true,
+	"maxConsecutiveFailures": 5
 }
 `
 				serviceSet.Spec.Provider.Config = &apiextv1.JSON{
@@ -564,6 +595,7 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 					HaveField("Spec.StopMatchingBehavior", Equal(addoncontrollerv1beta1.WithdrawPolicies)),
 					HaveField("Spec.SyncMode", Equal(addoncontrollerv1beta1.SyncModeContinuous)),
 					HaveField("Spec.ContinueOnError", BeTrue()),
+					HaveField("Spec.MaxConsecutiveFailures", HaveValue(Equal(uint(5)))),
 				))
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

When sveltos fails to upgrade the deployed Helm chart it may delete already deployed release and re-install it.
In handlers_helm.go (https://github.com/projectsveltos/addon-controller/blob/9401ba30a020f8f9a8786ff820f0ffd30c8d0ea6/controllers/handlers_helm.go#L1586-L1624):
```go
func handleInstall(ctx context.Context, dCtx *deploymentContext,
	currentChart *configv1beta1.HelmChart, kubeconfig string,
	registryOptions *registryClientOptions, isPullMode, templateOnly bool, logger logr.Logger,
) (*releasev1.Release, *configv1beta1.ReleaseReport, error) {

	logger.V(logs.LogDebug).Info("install helm release")

	maxHistory := uint(getMaxHistoryValue(currentChart.Options))

	if !isPullMode {
		if fs := getFeatureSummaryForFeatureID(dCtx.clusterSummary, libsveltosv1beta1.FeatureHelm); fs != nil {
			if fs.ConsecutiveFailures%maxHistory == 0 && fs.FailureMessage != nil {
				err := doUninstallRelease(ctx, dCtx.clusterSummary, currentChart, kubeconfig, registryOptions, logger)
				if err != nil {
					// Ignore release not found error
					if errors.Is(err, driver.ErrReleaseNotFound) || strings.Contains(err.Error(), "release: not found") {
						logger.V(logs.LogInfo).Info("Release not found, ignoring error")
					} else {
						logger.V(logs.LogInfo).Info(fmt.Sprintf("handleInstall failed %v", err))
						return nil, nil, err
					}
				}
			}
		}
	}

	var report *configv1beta1.ReleaseReport

	helmRelease, err := doInstallRelease(ctx, dCtx, currentChart, kubeconfig, registryOptions, templateOnly, logger)
	if err != nil {
		logger.V(logs.LogInfo).Info(fmt.Sprintf("doInstallRelease error %v", err))
		return nil, nil, err
	}
	report = &configv1beta1.ReleaseReport{
		ReleaseNamespace: currentChart.ReleaseNamespace, ReleaseName: currentChart.ReleaseName,
		ChartVersion: currentChart.ChartVersion, Action: string(configv1beta1.InstallHelmAction),
	}
	return helmRelease, report, nil
}
```

we can see the if `!isPullMode` branch where the `doUninstallRelease` is called in case the `fs.ConsecutiveFailures%maxHistory == 0 && fs.FailureMessage != nil` is true. On failure it's obviously true -> sveltos uninstalls the release.

The solution is to set the `helmOptions.atomic: true`. This value will be passed to `RollbackOnFailure` helm client field (https://github.com/projectsveltos/addon-controller/blob/9401ba30a020f8f9a8786ff820f0ffd30c8d0ea6/controllers/handlers_helm.go#L4380-L4442):

```go
func getHelmInstallClient(ctx context.Context, requestedChart *configv1beta1.HelmChart, kubeconfig string,
	registryOptions *registryClientOptions, patches []libsveltosv1beta1.Patch, templateOnly bool, logger logr.Logger,
) (*action.Install, error) {
	...
	installClient.RollbackOnFailure = getAtomicHelmValue(requestedChart.Options)
	...
}
```

this will affect how the helm SDK will handle failed upgrade. Then since the upgrade failed and no changes were recorded. Here (https://github.com/projectsveltos/addon-controller/blob/9401ba30a020f8f9a8786ff820f0ffd30c8d0ea6/controllers/handlers_helm.go#L2807-L2831):

```go
func shouldInstall(currentRelease *releaseInfo, requestedChart *configv1beta1.HelmChart) bool {
	...
	if currentRelease != nil &&
		currentRelease.ChartVersion != requestedChart.ChartVersion {

		return false
	}
	...
}
```

sveltos will get false and will never call the `handleInstall` function.

This PR also adds the option to pass the `MaxConsecutiveFailures` to profile config, otherwise sveltos will re-try to upgrade indefinitely. With this field set it will end up with the message `FailedNonRetryable`.

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
