### PR TITLE
fix: share one RESTMapper per cluster instead of rebuilding per client

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -298,6 +298,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := mgr.Add(kubeutil.RESTMapperCacheSweeper()); err != nil {
+		setupLog.Error(err, "unable to add RESTMapper cache sweeper")
+		os.Exit(1)
+	}
+
 	if enableWebhook {
 		if err := setupWebhooks(mgr, systemNamespace, validateClusterUpgradePath); err != nil {
 			setupLog.Error(err, "failed to setup webhooks")

--- a/cmd/telemetry/main.go
+++ b/cmd/telemetry/main.go
@@ -31,6 +31,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/K0rdent/kcm/internal/telemetry"
+	kubeutil "github.com/K0rdent/kcm/internal/util/kube"
 	schemeutil "github.com/K0rdent/kcm/internal/util/scheme"
 )
 
@@ -113,6 +114,11 @@ func main() {
 		}
 	} else {
 		setupLog.Info("Telemetry collection is effectively disabled, will keep the instance without exiting")
+	}
+
+	if err := mgr.Add(kubeutil.RESTMapperCacheSweeper()); err != nil {
+		setupLog.Error(err, "unable to add RESTMapper cache sweeper")
+		os.Exit(1)
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/internal/util/kube/client.go
+++ b/internal/util/kube/client.go
@@ -56,20 +56,33 @@ func GetKubeconfigSecretKey(clusterKey client.ObjectKey) client.ObjectKey {
 	return client.ObjectKey{Name: clusterKey.Name + "-kubeconfig", Namespace: clusterKey.Namespace}
 }
 
+// newClientOptions assembles the rest config and client options for the given
+// kubeconfig bytes, wiring in the shared RESTMapper and the HTTP client it
+// discovers through, so every client for a cluster identity reuses one
+// discovery cache and one transport instead of rebuilding both.
+func newClientOptions(kubeconfig []byte, scheme *runtime.Scheme) (*rest.Config, client.Options, error) {
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return nil, client.Options{}, fmt.Errorf("failed to build rest config from the given kubeconfig data: %w", err)
+	}
+
+	mapper, httpClient, err := sharedRESTMapperCache.get(restCfg, kubeconfig)
+	if err != nil {
+		return nil, client.Options{}, fmt.Errorf("failed to get shared REST mapper: %w", err)
+	}
+
+	return restCfg, client.Options{Scheme: scheme, Mapper: mapper, HTTPClient: httpClient}, nil
+}
+
 // DefaultClientFactory constructs a [sigs.k8s.io/controller-runtime/pkg/client.Client] from the
 // given kubeconfig bytes and scheme.
 func DefaultClientFactory(kubeconfig []byte, scheme *runtime.Scheme) (client.Client, error) {
-	restCfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build rest config from the given kubeconfig data: %w", err)
-	}
-
-	mapper, err := sharedRESTMapperCache.get(restCfg, kubeconfig)
+	restCfg, opts, err := newClientOptions(kubeconfig, scheme)
 	if err != nil {
 		return nil, err
 	}
 
-	cl, err := client.New(restCfg, client.Options{Scheme: scheme, Mapper: mapper})
+	cl, err := client.New(restCfg, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
@@ -86,19 +99,14 @@ func DefaultClientFactory(kubeconfig []byte, scheme *runtime.Scheme) (client.Cli
 func DefaultClientFactoryWithRestConfig() (func([]byte, *runtime.Scheme) (client.Client, error), *rest.Config) {
 	restCfg := new(rest.Config)
 	return func(kubeconfig []byte, scheme *runtime.Scheme) (client.Client, error) {
-		cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build rest config from the given kubeconfig data: %w", err)
-		}
-
-		*restCfg = *cfg
-
-		mapper, err := sharedRESTMapperCache.get(cfg, kubeconfig)
+		cfg, opts, err := newClientOptions(kubeconfig, scheme)
 		if err != nil {
 			return nil, err
 		}
 
-		cl, err := client.New(cfg, client.Options{Scheme: scheme, Mapper: mapper})
+		*restCfg = *cfg
+
+		cl, err := client.New(cfg, opts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create client: %w", err)
 		}

--- a/internal/util/kube/client.go
+++ b/internal/util/kube/client.go
@@ -64,7 +64,12 @@ func DefaultClientFactory(kubeconfig []byte, scheme *runtime.Scheme) (client.Cli
 		return nil, fmt.Errorf("failed to build rest config from the given kubeconfig data: %w", err)
 	}
 
-	cl, err := client.New(restCfg, client.Options{Scheme: scheme})
+	mapper, err := sharedRESTMapperCache.get(restCfg, kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	cl, err := client.New(restCfg, client.Options{Scheme: scheme, Mapper: mapper})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
@@ -88,7 +93,12 @@ func DefaultClientFactoryWithRestConfig() (func([]byte, *runtime.Scheme) (client
 
 		*restCfg = *cfg
 
-		cl, err := client.New(cfg, client.Options{Scheme: scheme})
+		mapper, err := sharedRESTMapperCache.get(cfg, kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+
+		cl, err := client.New(cfg, client.Options{Scheme: scheme, Mapper: mapper})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create client: %w", err)
 		}

--- a/internal/util/kube/client_test.go
+++ b/internal/util/kube/client_test.go
@@ -120,3 +120,22 @@ current-context: default`
 		require.Equal(t, "value", retrieved.Data["field"])
 	})
 }
+
+func TestNewClientOptionsWiresSharedCache(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+
+	kubeconfig := kubeconfigForHost(t, "https://wiring.example:6443", "u")
+
+	cfg, opts, err := newClientOptions(kubeconfig, scheme)
+	require.NoError(t, err)
+	require.Same(t, scheme, opts.Scheme)
+
+	// Both factories hand these options to client.New verbatim, so pointer
+	// identity against a direct cache lookup proves the mapper and its
+	// transport actually reach the object client.
+	mapper, httpClient, err := sharedRESTMapperCache.get(cfg, kubeconfig)
+	require.NoError(t, err)
+	require.Same(t, mapper, opts.Mapper, "client.New must receive the cached RESTMapper")
+	require.Same(t, httpClient, opts.HTTPClient, "client.New must receive the cached HTTP client")
+}

--- a/internal/util/kube/restmapper_cache.go
+++ b/internal/util/kube/restmapper_cache.go
@@ -1,0 +1,88 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// restMapperCache holds one RESTMapper per remote cluster. A client.New that
+// leaves Options.Mapper unset gets a dynamic mapper of its own, and each fresh
+// mapper discovers the target apiserver's API surface on its first RESTMapping
+// — two requests, one of which carries every group on a server supporting
+// aggregated discovery.
+//
+// Keyed by apiserver URL: the API surface is a property of the cluster, not of
+// the credentials used to reach it, so this also bounds the map by cluster count
+// rather than growing on every credential rotation. The fingerprint is of the
+// kubeconfig the mapper was built from, because a mapper owns a discovery client with
+// those credentials baked in, so a rotation has to produce a new one.
+type restMapperCache struct {
+	entries map[string]restMapperEntry
+	mu      sync.RWMutex
+}
+
+type restMapperEntry struct {
+	mapper      meta.RESTMapper
+	fingerprint string
+}
+
+var sharedRESTMapperCache = &restMapperCache{entries: make(map[string]restMapperEntry)}
+
+func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMapper, error) {
+	sum := sha256.Sum256(kubeconfig)
+	fingerprint := hex.EncodeToString(sum[:])
+
+	c.mu.RLock()
+	entry, ok := c.entries[cfg.Host]
+	c.mu.RUnlock()
+	if ok && entry.fingerprint == fingerprint {
+		return entry.mapper, nil
+	}
+
+	httpClient, err := rest.HTTPClientFor(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+	}
+	mapper, err := apiutil.NewDynamicRESTMapper(cfg, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create REST mapper: %w", err)
+	}
+
+	// Re-check under the write lock and prefer whatever a racing caller stored:
+	// callers must converge on one mapper per cluster, or several would each run
+	// their own discovery.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cur, ok := c.entries[cfg.Host]; ok && cur.fingerprint == fingerprint {
+		return cur.mapper, nil
+	}
+	c.entries[cfg.Host] = restMapperEntry{mapper: mapper, fingerprint: fingerprint}
+
+	return mapper, nil
+}
+
+func (c *restMapperCache) len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}

--- a/internal/util/kube/restmapper_cache.go
+++ b/internal/util/kube/restmapper_cache.go
@@ -48,8 +48,9 @@ type restMapperCache struct {
 	// mu, so a test may swap it mid-flight without racing a concurrent get.
 	raceHook func()
 
-	ttl           time.Duration
-	sweepInterval time.Duration
+	ttl             time.Duration
+	refreshInterval time.Duration
+	sweepInterval   time.Duration
 
 	// generation increments on every store, so a build that started earlier can
 	// tell it is about to overwrite state a later caller installed.
@@ -59,25 +60,36 @@ type restMapperCache struct {
 	mu        sync.RWMutex
 }
 
-func newRESTMapperCache(ttl, sweepInterval time.Duration) *restMapperCache {
-	return newRESTMapperCacheWithClock(ttl, sweepInterval, time.Now)
+func newRESTMapperCache(ttl, refreshInterval, sweepInterval time.Duration) *restMapperCache {
+	return newRESTMapperCacheWithClock(ttl, refreshInterval, sweepInterval, time.Now)
 }
 
-func newRESTMapperCacheWithClock(ttl, sweepInterval time.Duration, nowFunc func() time.Time) *restMapperCache {
+func newRESTMapperCacheWithClock(ttl, refreshInterval, sweepInterval time.Duration, nowFunc func() time.Time) *restMapperCache {
 	return &restMapperCache{
-		entries:       make(map[string]*restMapperEntry),
-		nowFunc:       nowFunc,
-		ttl:           ttl,
-		sweepInterval: sweepInterval,
+		entries:         make(map[string]*restMapperEntry),
+		nowFunc:         nowFunc,
+		ttl:             ttl,
+		refreshInterval: refreshInterval,
+		sweepInterval:   sweepInterval,
 	}
 }
 
 type restMapperEntry struct {
-	mapper               meta.RESTMapper
+	mapper meta.RESTMapper
+	// createdAt is set once at store time and never refreshed by hits, unlike
+	// lastUsed, so an entry's absolute age keeps growing while it is in use.
+	createdAt            time.Time
 	fingerprint          string
 	canonicalFingerprint string
 	generation           uint64
 	lastUsed             atomic.Int64
+}
+
+// aged reports whether the entry has passed the absolute rebuild deadline. An
+// aged entry is treated as a miss even if recently used; lastUsed drives idle
+// eviction only.
+func (e *restMapperEntry) aged(now time.Time, refreshInterval time.Duration) bool {
+	return now.Sub(e.createdAt) >= refreshInterval
 }
 
 const (
@@ -85,13 +97,20 @@ const (
 	// clusters do not retain a discovery cache for the life of the process.
 	restMapperTTL = time.Hour
 
+	// restMapperRefreshInterval bounds a mapper's absolute age. The dynamic
+	// mapper re-discovers only on a NoMatch and serves a mapping it already
+	// knows from memory forever, so a cluster looked up more often than the TTL
+	// would otherwise keep a removed API version or a changed CRD scope alive
+	// until the process restarts. An aged entry is rebuilt on its next lookup.
+	restMapperRefreshInterval = 30 * time.Minute
+
 	// restMapperSweepInterval is how often eviction runs. It is driven by elapsed
 	// time rather than by cache misses: deleting a cluster produces no miss, so a
 	// miss-driven sweep would never reclaim a fleet that only shrinks.
 	restMapperSweepInterval = 10 * time.Minute
 )
 
-var sharedRESTMapperCache = newRESTMapperCache(restMapperTTL, restMapperSweepInterval)
+var sharedRESTMapperCache = newRESTMapperCache(restMapperTTL, restMapperRefreshInterval, restMapperSweepInterval)
 
 func normalizeHost(host string) string { return strings.TrimRight(host, "/") }
 
@@ -103,7 +122,7 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 
 	c.mu.RLock()
 	entry, ok := c.entries[host]
-	if ok && entry.fingerprint == fingerprint {
+	if ok && entry.fingerprint == fingerprint && !entry.aged(now, c.refreshInterval) {
 		entry.lastUsed.Store(now.UnixNano())
 		c.mu.RUnlock()
 		return entry.mapper, nil
@@ -125,7 +144,7 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 		entry, ok = c.entries[host]
 		if ok {
 			observedGeneration = entry.generation
-			if entry.canonicalFingerprint == canonicalFingerprint {
+			if entry.canonicalFingerprint == canonicalFingerprint && !entry.aged(now, c.refreshInterval) {
 				entry.lastUsed.Store(now.UnixNano())
 				c.mu.RUnlock()
 				return entry.mapper, nil
@@ -157,7 +176,7 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	cur, ok := c.entries[host]
-	if ok && (cur.fingerprint == fingerprint || cur.canonicalFingerprint == canonicalFingerprint) {
+	if ok && !cur.aged(now, c.refreshInterval) && (cur.fingerprint == fingerprint || cur.canonicalFingerprint == canonicalFingerprint) {
 		cur.lastUsed.Store(now.UnixNano())
 		return cur.mapper, nil
 	}
@@ -177,6 +196,7 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 		fingerprint:          fingerprint,
 		canonicalFingerprint: canonicalFingerprint,
 		generation:           c.generation,
+		createdAt:            now,
 	}
 	e.lastUsed.Store(now.UnixNano())
 	c.entries[host] = e

--- a/internal/util/kube/restmapper_cache.go
+++ b/internal/util/kube/restmapper_cache.go
@@ -29,32 +29,39 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-// restMapperCache holds one RESTMapper per remote cluster. A client.New that
-// leaves Options.Mapper unset gets a dynamic mapper of its own, and each fresh
-// mapper discovers the target apiserver's API surface on its first RESTMapping
-// — two requests, one of which carries every group on a server supporting
-// aggregated discovery.
+// restMapperCache holds one RESTMapper per remote cluster identity. A
+// client.New that leaves Options.Mapper unset gets a dynamic mapper of its
+// own, and each fresh mapper discovers the target apiserver's API surface on
+// its first RESTMapping — two requests, one of which carries every group on a
+// server supporting aggregated discovery.
 //
-// Keyed by apiserver URL: the API surface is a property of the cluster, not of
-// the credentials used to reach it, so a credential rotation replaces an entry
-// rather than adding one. The fingerprint is of the kubeconfig the mapper was
-// built from, because a mapper owns a discovery client with those credentials
-// baked in, so a rotation has to produce a new one.
+// Keyed by apiserver URL plus a canonical fingerprint of the kubeconfig: a
+// mapper owns a discovery client with its credentials baked in, and several
+// identities may legitimately address one apiserver (distinct service
+// accounts, impersonation), so a single slot per host would have them evict
+// each other on every alternation. A rotated credential therefore adds an
+// entry, and the superseded one is reclaimed by the idle TTL once nothing
+// looks it up anymore.
+//
+// aliases indexes each entry's current byte representation, so steady-state
+// lookups hash the bytes and skip parsing; an equivalent but byte-different
+// kubeconfig (e.g. a reordered Secret rewrite) is canonicalized once, promoted
+// into the index, and rides the fast path thereafter. Promotion swaps the
+// entry's single alias rather than accumulating every representation seen, so
+// len(aliases) == len(entries) always and the index cannot outgrow the cache.
 type restMapperCache struct {
 	entries map[string]*restMapperEntry
+	// aliases maps an entry's current raw kubeconfig fingerprint to its
+	// entries key.
+	aliases map[string]string
 	nowFunc func() time.Time
-	// raceHook runs between examining the cache and storing a new mapper. Nil
-	// outside tests, which use it to interleave a competing lookup. Read under
-	// mu, so a test may swap it mid-flight without racing a concurrent get.
-	raceHook func()
+	// canonicalize is canonicalKubeconfigFingerprint, injectable so tests can
+	// count how often lookups leave the fast path.
+	canonicalize func([]byte) (string, error)
 
 	ttl             time.Duration
 	refreshInterval time.Duration
 	sweepInterval   time.Duration
-
-	// generation increments on every store, so a build that started earlier can
-	// tell it is about to overwrite state a later caller installed.
-	generation uint64
 
 	lastSweep atomic.Int64
 	mu        sync.RWMutex
@@ -67,7 +74,9 @@ func newRESTMapperCache(ttl, refreshInterval, sweepInterval time.Duration) *rest
 func newRESTMapperCacheWithClock(ttl, refreshInterval, sweepInterval time.Duration, nowFunc func() time.Time) *restMapperCache {
 	return &restMapperCache{
 		entries:         make(map[string]*restMapperEntry),
+		aliases:         make(map[string]string),
 		nowFunc:         nowFunc,
+		canonicalize:    canonicalKubeconfigFingerprint,
 		ttl:             ttl,
 		refreshInterval: refreshInterval,
 		sweepInterval:   sweepInterval,
@@ -78,11 +87,12 @@ type restMapperEntry struct {
 	mapper meta.RESTMapper
 	// createdAt is set once at store time and never refreshed by hits, unlike
 	// lastUsed, so an entry's absolute age keeps growing while it is in use.
-	createdAt            time.Time
-	fingerprint          string
-	canonicalFingerprint string
-	generation           uint64
-	lastUsed             atomic.Int64
+	createdAt time.Time
+	// rawFingerprint is the entry's current byte representation — the one the
+	// aliases index resolves. Mutated only under the cache's write lock, when a
+	// promotion swaps it for a newer representation.
+	rawFingerprint string
+	lastUsed       atomic.Int64
 }
 
 // aged reports whether the entry has passed the absolute rebuild deadline. An
@@ -117,48 +127,33 @@ func normalizeHost(host string) string { return strings.TrimRight(host, "/") }
 func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMapper, error) {
 	now := c.nowFunc()
 	c.maybeSweep(now)
-	host := normalizeHost(cfg.Host)
-	fingerprint := fingerprint(kubeconfig)
+	rawFingerprint := fingerprint(kubeconfig)
 
 	c.mu.RLock()
-	entry, ok := c.entries[host]
-	if ok && entry.fingerprint == fingerprint && !entry.aged(now, c.refreshInterval) {
+	if key, ok := c.aliases[rawFingerprint]; ok {
+		if entry, ok := c.entries[key]; ok && !entry.aged(now, c.refreshInterval) {
+			entry.lastUsed.Store(now.UnixNano())
+			c.mu.RUnlock()
+			return entry.mapper, nil
+		}
+	}
+	c.mu.RUnlock()
+
+	host := normalizeHost(cfg.Host)
+	canonicalFingerprint, err := c.canonicalize(kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fingerprint kubeconfig for %s: %w", host, err)
+	}
+	key := host + "\x00" + canonicalFingerprint
+
+	c.mu.Lock()
+	if entry, ok := c.entries[key]; ok && !entry.aged(now, c.refreshInterval) {
 		entry.lastUsed.Store(now.UnixNano())
-		c.mu.RUnlock()
+		c.promote(entry, key, rawFingerprint)
+		c.mu.Unlock()
 		return entry.mapper, nil
 	}
-	c.mu.RUnlock()
-
-	var (
-		canonicalFingerprint string
-		observedGeneration   uint64
-		err                  error
-	)
-	if ok {
-		canonicalFingerprint, err = canonicalKubeconfigFingerprint(kubeconfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fingerprint kubeconfig for %s: %w", host, err)
-		}
-
-		c.mu.RLock()
-		entry, ok = c.entries[host]
-		if ok {
-			observedGeneration = entry.generation
-			if entry.canonicalFingerprint == canonicalFingerprint && !entry.aged(now, c.refreshInterval) {
-				entry.lastUsed.Store(now.UnixNano())
-				c.mu.RUnlock()
-				return entry.mapper, nil
-			}
-		}
-		c.mu.RUnlock()
-	}
-
-	c.mu.RLock()
-	raceHook := c.raceHook
-	c.mu.RUnlock()
-	if raceHook != nil {
-		raceHook()
-	}
+	c.mu.Unlock()
 
 	httpClient, err := rest.HTTPClientFor(cfg)
 	if err != nil {
@@ -175,33 +170,37 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 	// with older ones, so the loser keeps its own mapper and caches nothing.
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	cur, ok := c.entries[host]
-	if ok && !cur.aged(now, c.refreshInterval) && (cur.fingerprint == fingerprint || cur.canonicalFingerprint == canonicalFingerprint) {
-		cur.lastUsed.Store(now.UnixNano())
-		return cur.mapper, nil
-	}
-	if ok && cur.generation != observedGeneration {
-		return mapper, nil
+	if entry, ok := c.entries[key]; ok && !entry.aged(now, c.refreshInterval) {
+		entry.lastUsed.Store(now.UnixNano())
+		c.promote(entry, key, rawFingerprint)
+		return entry.mapper, nil
 	}
 
-	if canonicalFingerprint == "" {
-		if canonicalFingerprint, err = canonicalKubeconfigFingerprint(kubeconfig); err != nil {
-			return nil, fmt.Errorf("failed to fingerprint kubeconfig for %s: %w", host, err)
-		}
+	// An aged predecessor keeps its slot's key but not its alias: the new entry
+	// resolves from the bytes that built it.
+	if old, ok := c.entries[key]; ok {
+		delete(c.aliases, old.rawFingerprint)
 	}
-
-	c.generation++
-	e := &restMapperEntry{
-		mapper:               mapper,
-		fingerprint:          fingerprint,
-		canonicalFingerprint: canonicalFingerprint,
-		generation:           c.generation,
-		createdAt:            now,
-	}
+	e := &restMapperEntry{mapper: mapper, rawFingerprint: rawFingerprint, createdAt: now}
 	e.lastUsed.Store(now.UnixNano())
-	c.entries[host] = e
+	c.entries[key] = e
+	c.aliases[rawFingerprint] = key
 
 	return mapper, nil
+}
+
+// promote makes rawFingerprint the entry's current byte representation, so its
+// later lookups take the fast path instead of canonicalizing again. The
+// previous representation's alias is dropped rather than kept: retaining every
+// representation ever seen would grow the index without bound on repeated
+// Secret rewrites. Must be called under the write lock.
+func (c *restMapperCache) promote(entry *restMapperEntry, key, rawFingerprint string) {
+	if entry.rawFingerprint == rawFingerprint {
+		return
+	}
+	delete(c.aliases, entry.rawFingerprint)
+	entry.rawFingerprint = rawFingerprint
+	c.aliases[rawFingerprint] = key
 }
 
 func fingerprint(data []byte) string {
@@ -224,14 +223,6 @@ func canonicalKubeconfigFingerprint(kubeconfig []byte) (string, error) {
 	return fingerprint(canonical), nil
 }
 
-// setRaceHook installs the hook under mu, so tests can swap it without racing a
-// concurrent get.
-func (c *restMapperCache) setRaceHook(hook func()) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.raceHook = hook
-}
-
 func (c *restMapperCache) maybeSweep(now time.Time) {
 	last := c.lastSweep.Load()
 	if now.UnixNano()-last < int64(c.sweepInterval) {
@@ -249,9 +240,10 @@ func (c *restMapperCache) evictStale(now time.Time) {
 	cutoff := now.Add(-c.ttl).UnixNano()
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	for host, e := range c.entries {
+	for key, e := range c.entries {
 		if e.lastUsed.Load() < cutoff {
-			delete(c.entries, host)
+			delete(c.entries, key)
+			delete(c.aliases, e.rawFingerprint)
 		}
 	}
 }

--- a/internal/util/kube/restmapper_cache.go
+++ b/internal/util/kube/restmapper_cache.go
@@ -18,10 +18,14 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
@@ -32,53 +36,204 @@ import (
 // aggregated discovery.
 //
 // Keyed by apiserver URL: the API surface is a property of the cluster, not of
-// the credentials used to reach it, so this also bounds the map by cluster count
-// rather than growing on every credential rotation. The fingerprint is of the
-// kubeconfig the mapper was built from, because a mapper owns a discovery client with
-// those credentials baked in, so a rotation has to produce a new one.
+// the credentials used to reach it, so a credential rotation replaces an entry
+// rather than adding one. The fingerprint is of the kubeconfig the mapper was
+// built from, because a mapper owns a discovery client with those credentials
+// baked in, so a rotation has to produce a new one.
 type restMapperCache struct {
-	entries map[string]restMapperEntry
-	mu      sync.RWMutex
+	entries map[string]*restMapperEntry
+	nowFunc func() time.Time
+	// raceHook runs between examining the cache and storing a new mapper. Nil
+	// outside tests, which use it to interleave a competing lookup. Read under
+	// mu, so a test may swap it mid-flight without racing a concurrent get.
+	raceHook func()
+
+	ttl           time.Duration
+	sweepInterval time.Duration
+
+	// generation increments on every store, so a build that started earlier can
+	// tell it is about to overwrite state a later caller installed.
+	generation uint64
+
+	lastSweep atomic.Int64
+	mu        sync.RWMutex
+}
+
+func newRESTMapperCache(ttl, sweepInterval time.Duration) *restMapperCache {
+	return newRESTMapperCacheWithClock(ttl, sweepInterval, time.Now)
+}
+
+func newRESTMapperCacheWithClock(ttl, sweepInterval time.Duration, nowFunc func() time.Time) *restMapperCache {
+	return &restMapperCache{
+		entries:       make(map[string]*restMapperEntry),
+		nowFunc:       nowFunc,
+		ttl:           ttl,
+		sweepInterval: sweepInterval,
+	}
 }
 
 type restMapperEntry struct {
-	mapper      meta.RESTMapper
-	fingerprint string
+	mapper               meta.RESTMapper
+	fingerprint          string
+	canonicalFingerprint string
+	generation           uint64
+	lastUsed             atomic.Int64
 }
 
-var sharedRESTMapperCache = &restMapperCache{entries: make(map[string]restMapperEntry)}
+const (
+	// restMapperTTL is how long an unused mapper is kept, so that deleted
+	// clusters do not retain a discovery cache for the life of the process.
+	restMapperTTL = time.Hour
+
+	// restMapperSweepInterval is how often eviction runs. It is driven by elapsed
+	// time rather than by cache misses: deleting a cluster produces no miss, so a
+	// miss-driven sweep would never reclaim a fleet that only shrinks.
+	restMapperSweepInterval = 10 * time.Minute
+)
+
+var sharedRESTMapperCache = newRESTMapperCache(restMapperTTL, restMapperSweepInterval)
+
+func normalizeHost(host string) string { return strings.TrimRight(host, "/") }
 
 func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMapper, error) {
-	sum := sha256.Sum256(kubeconfig)
-	fingerprint := hex.EncodeToString(sum[:])
+	now := c.nowFunc()
+	c.maybeSweep(now)
+	host := normalizeHost(cfg.Host)
+	fingerprint := fingerprint(kubeconfig)
 
 	c.mu.RLock()
-	entry, ok := c.entries[cfg.Host]
-	c.mu.RUnlock()
+	entry, ok := c.entries[host]
 	if ok && entry.fingerprint == fingerprint {
+		entry.lastUsed.Store(now.UnixNano())
+		c.mu.RUnlock()
 		return entry.mapper, nil
+	}
+	c.mu.RUnlock()
+
+	var (
+		canonicalFingerprint string
+		observedGeneration   uint64
+		err                  error
+	)
+	if ok {
+		canonicalFingerprint, err = canonicalKubeconfigFingerprint(kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fingerprint kubeconfig for %s: %w", host, err)
+		}
+
+		c.mu.RLock()
+		entry, ok = c.entries[host]
+		if ok {
+			observedGeneration = entry.generation
+			if entry.canonicalFingerprint == canonicalFingerprint {
+				entry.lastUsed.Store(now.UnixNano())
+				c.mu.RUnlock()
+				return entry.mapper, nil
+			}
+		}
+		c.mu.RUnlock()
+	}
+
+	c.mu.RLock()
+	raceHook := c.raceHook
+	c.mu.RUnlock()
+	if raceHook != nil {
+		raceHook()
 	}
 
 	httpClient, err := rest.HTTPClientFor(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP client: %w", err)
+		return nil, fmt.Errorf("failed to create HTTP client for %s: %w", host, err)
 	}
 	mapper, err := apiutil.NewDynamicRESTMapper(cfg, httpClient)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create REST mapper: %w", err)
+		return nil, fmt.Errorf("failed to create REST mapper for %s: %w", host, err)
 	}
 
-	// Re-check under the write lock and prefer whatever a racing caller stored:
-	// callers must converge on one mapper per cluster, or several would each run
-	// their own discovery.
+	// Re-check under the write lock: callers must converge on one mapper per
+	// cluster, or several would each run their own discovery. If the entry moved
+	// on while this build was in flight, a store would clobber newer credentials
+	// with older ones, so the loser keeps its own mapper and caches nothing.
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if cur, ok := c.entries[cfg.Host]; ok && cur.fingerprint == fingerprint {
+	cur, ok := c.entries[host]
+	if ok && (cur.fingerprint == fingerprint || cur.canonicalFingerprint == canonicalFingerprint) {
+		cur.lastUsed.Store(now.UnixNano())
 		return cur.mapper, nil
 	}
-	c.entries[cfg.Host] = restMapperEntry{mapper: mapper, fingerprint: fingerprint}
+	if ok && cur.generation != observedGeneration {
+		return mapper, nil
+	}
+
+	if canonicalFingerprint == "" {
+		if canonicalFingerprint, err = canonicalKubeconfigFingerprint(kubeconfig); err != nil {
+			return nil, fmt.Errorf("failed to fingerprint kubeconfig for %s: %w", host, err)
+		}
+	}
+
+	c.generation++
+	e := &restMapperEntry{
+		mapper:               mapper,
+		fingerprint:          fingerprint,
+		canonicalFingerprint: canonicalFingerprint,
+		generation:           c.generation,
+	}
+	e.lastUsed.Store(now.UnixNano())
+	c.entries[host] = e
 
 	return mapper, nil
+}
+
+func fingerprint(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func canonicalKubeconfigFingerprint(kubeconfig []byte) (string, error) {
+	config, err := clientcmd.Load(kubeconfig)
+	if err != nil {
+		return "", err
+	}
+	for _, cluster := range config.Clusters {
+		cluster.Server = normalizeHost(cluster.Server)
+	}
+	canonical, err := clientcmd.Write(*config)
+	if err != nil {
+		return "", err
+	}
+	return fingerprint(canonical), nil
+}
+
+// setRaceHook installs the hook under mu, so tests can swap it without racing a
+// concurrent get.
+func (c *restMapperCache) setRaceHook(hook func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.raceHook = hook
+}
+
+func (c *restMapperCache) maybeSweep(now time.Time) {
+	last := c.lastSweep.Load()
+	if now.UnixNano()-last < int64(c.sweepInterval) {
+		return
+	}
+	// One sweeper at a time; a loser simply skips this round.
+	if !c.lastSweep.CompareAndSwap(last, now.UnixNano()) {
+		return
+	}
+
+	c.evictStale(now)
+}
+
+func (c *restMapperCache) evictStale(now time.Time) {
+	cutoff := now.Add(-c.ttl).UnixNano()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for host, e := range c.entries {
+		if e.lastUsed.Load() < cutoff {
+			delete(c.entries, host)
+		}
+	}
 }
 
 func (c *restMapperCache) len() int {

--- a/internal/util/kube/restmapper_cache.go
+++ b/internal/util/kube/restmapper_cache.go
@@ -15,6 +15,7 @@
 package kube
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // restMapperCache holds one RESTMapper per remote cluster identity. A
@@ -62,16 +64,16 @@ type restMapperCache struct {
 	ttl             time.Duration
 	refreshInterval time.Duration
 	sweepInterval   time.Duration
+	maxEntries      int
 
-	lastSweep atomic.Int64
-	mu        sync.RWMutex
+	mu sync.Mutex
 }
 
-func newRESTMapperCache(ttl, refreshInterval, sweepInterval time.Duration) *restMapperCache {
-	return newRESTMapperCacheWithClock(ttl, refreshInterval, sweepInterval, time.Now)
+func newRESTMapperCache(ttl, refreshInterval, sweepInterval time.Duration, maxEntries int) *restMapperCache {
+	return newRESTMapperCacheWithClock(ttl, refreshInterval, sweepInterval, maxEntries, time.Now)
 }
 
-func newRESTMapperCacheWithClock(ttl, refreshInterval, sweepInterval time.Duration, nowFunc func() time.Time) *restMapperCache {
+func newRESTMapperCacheWithClock(ttl, refreshInterval, sweepInterval time.Duration, maxEntries int, nowFunc func() time.Time) *restMapperCache {
 	return &restMapperCache{
 		entries:         make(map[string]*restMapperEntry),
 		aliases:         make(map[string]string),
@@ -80,6 +82,7 @@ func newRESTMapperCacheWithClock(ttl, refreshInterval, sweepInterval time.Durati
 		ttl:             ttl,
 		refreshInterval: refreshInterval,
 		sweepInterval:   sweepInterval,
+		maxEntries:      maxEntries,
 	}
 }
 
@@ -89,7 +92,7 @@ type restMapperEntry struct {
 	// lastUsed, so an entry's absolute age keeps growing while it is in use.
 	createdAt time.Time
 	// rawFingerprint is the entry's current byte representation — the one the
-	// aliases index resolves. Mutated only under the cache's write lock, when a
+	// aliases index resolves. Mutated only under the cache's lock, when a
 	// promotion swaps it for a newer representation.
 	rawFingerprint string
 	lastUsed       atomic.Int64
@@ -114,30 +117,35 @@ const (
 	// until the process restarts. An aged entry is rebuilt on its next lookup.
 	restMapperRefreshInterval = 30 * time.Minute
 
-	// restMapperSweepInterval is how often eviction runs. It is driven by elapsed
-	// time rather than by cache misses: deleting a cluster produces no miss, so a
-	// miss-driven sweep would never reclaim a fleet that only shrinks.
+	// restMapperSweepInterval is the cadence of the sweeper runnable. TTL expiry
+	// is driven by elapsed time rather than by lookups: deleting a cluster
+	// produces no further lookups, so a lookup-driven sweep would never reclaim
+	// a fleet that only shrinks.
 	restMapperSweepInterval = 10 * time.Minute
+
+	// restMapperMaxEntries caps the cache. High identity churn within one TTL
+	// window must not grow the map without bound, and the cap also bounds
+	// retention in a binary that does not register the sweeper.
+	restMapperMaxEntries = 256
 )
 
-var sharedRESTMapperCache = newRESTMapperCache(restMapperTTL, restMapperRefreshInterval, restMapperSweepInterval)
+var sharedRESTMapperCache = newRESTMapperCache(restMapperTTL, restMapperRefreshInterval, restMapperSweepInterval, restMapperMaxEntries)
 
 func normalizeHost(host string) string { return strings.TrimRight(host, "/") }
 
 func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMapper, error) {
 	now := c.nowFunc()
-	c.maybeSweep(now)
 	rawFingerprint := fingerprint(kubeconfig)
 
-	c.mu.RLock()
+	c.mu.Lock()
 	if key, ok := c.aliases[rawFingerprint]; ok {
 		if entry, ok := c.entries[key]; ok && !entry.aged(now, c.refreshInterval) {
 			entry.lastUsed.Store(now.UnixNano())
-			c.mu.RUnlock()
+			c.mu.Unlock()
 			return entry.mapper, nil
 		}
 	}
-	c.mu.RUnlock()
+	c.mu.Unlock()
 
 	host := normalizeHost(cfg.Host)
 	canonicalFingerprint, err := c.canonicalize(kubeconfig)
@@ -164,10 +172,10 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 		return nil, fmt.Errorf("failed to create REST mapper for %s: %w", host, err)
 	}
 
-	// Re-check under the write lock: callers must converge on one mapper per
-	// cluster, or several would each run their own discovery. If the entry moved
-	// on while this build was in flight, a store would clobber newer credentials
-	// with older ones, so the loser keeps its own mapper and caches nothing.
+	// Re-check under the lock: concurrent lookups with equivalent kubeconfigs
+	// must converge on one mapper, or each would run its own discovery. Distinct
+	// identities use distinct keys, so a store here can never clobber another
+	// identity's mapper.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if entry, ok := c.entries[key]; ok && !entry.aged(now, c.refreshInterval) {
@@ -186,14 +194,41 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 	c.entries[key] = e
 	c.aliases[rawFingerprint] = key
 
+	// Inserts are rare (a new cluster, a rotation, an age refresh) so an O(n)
+	// scan for the least-recently-used entry beats maintaining LRU bookkeeping
+	// on every hit.
+	for len(c.entries) > c.maxEntries {
+		c.evictOldestLocked()
+	}
+
 	return mapper, nil
+}
+
+// evictOldestLocked removes the least-recently-used entry and its alias. Must
+// be called under the lock.
+func (c *restMapperCache) evictOldestLocked() {
+	var (
+		oldestKey string
+		oldest    int64
+		found     bool
+	)
+	for key, e := range c.entries {
+		if used := e.lastUsed.Load(); !found || used < oldest {
+			found = true
+			oldestKey, oldest = key, used
+		}
+	}
+	if found {
+		delete(c.aliases, c.entries[oldestKey].rawFingerprint)
+		delete(c.entries, oldestKey)
+	}
 }
 
 // promote makes rawFingerprint the entry's current byte representation, so its
 // later lookups take the fast path instead of canonicalizing again. The
 // previous representation's alias is dropped rather than kept: retaining every
 // representation ever seen would grow the index without bound on repeated
-// Secret rewrites. Must be called under the write lock.
+// Secret rewrites. Must be called under the lock.
 func (c *restMapperCache) promote(entry *restMapperEntry, key, rawFingerprint string) {
 	if entry.rawFingerprint == rawFingerprint {
 		return
@@ -223,18 +258,33 @@ func canonicalKubeconfigFingerprint(kubeconfig []byte) (string, error) {
 	return fingerprint(canonical), nil
 }
 
-func (c *restMapperCache) maybeSweep(now time.Time) {
-	last := c.lastSweep.Load()
-	if now.UnixNano()-last < int64(c.sweepInterval) {
-		return
-	}
-	// One sweeper at a time; a loser simply skips this round.
-	if !c.lastSweep.CompareAndSwap(last, now.UnixNano()) {
-		return
-	}
-
-	c.evictStale(now)
+// RESTMapperCacheSweeper returns the runnable that expires idle entries of the
+// shared RESTMapper cache.
+func RESTMapperCacheSweeper() manager.Runnable {
+	return &restMapperSweeper{cache: sharedRESTMapperCache}
 }
+
+// restMapperSweeper evicts idle entries on a fixed cadence, so that a fleet
+// that only shrinks releases its mappers, discovery data, transports, and
+// credential material even when no client is ever built again.
+type restMapperSweeper struct {
+	cache *restMapperCache
+}
+
+func (s *restMapperSweeper) Start(ctx context.Context) error {
+	ticker := time.NewTicker(s.cache.sweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			s.cache.evictStale(s.cache.nowFunc())
+		}
+	}
+}
+
+func (*restMapperSweeper) NeedLeaderElection() bool { return false }
 
 func (c *restMapperCache) evictStale(now time.Time) {
 	cutoff := now.Add(-c.ttl).UnixNano()
@@ -249,7 +299,7 @@ func (c *restMapperCache) evictStale(now time.Time) {
 }
 
 func (c *restMapperCache) len() int {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return len(c.entries)
 }

--- a/internal/util/kube/restmapper_cache.go
+++ b/internal/util/kube/restmapper_cache.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -101,7 +100,9 @@ type restMapperEntry struct {
 	// aliases index resolves. Mutated only under the cache's lock, when a
 	// promotion swaps it for a newer representation.
 	rawFingerprint string
-	lastUsed       atomic.Int64
+	// lastUsed is read and written only while the cache's mu is held, like
+	// every other mutable field here, so it needs no atomicity of its own.
+	lastUsed int64
 }
 
 // aged reports whether the entry has passed the absolute rebuild deadline. An
@@ -152,7 +153,7 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 	c.mu.Lock()
 	if key, ok := c.aliases[rawFingerprint]; ok {
 		if entry, ok := c.entries[key]; ok && !entry.aged(now, c.refreshInterval) {
-			entry.lastUsed.Store(now.UnixNano())
+			entry.lastUsed = now.UnixNano()
 			c.mu.Unlock()
 			return entry.mapper, entry.httpClient, nil
 		}
@@ -203,7 +204,7 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 		delete(c.aliases, old.rawFingerprint)
 	}
 	e := &restMapperEntry{mapper: mapper, httpClient: httpClient, rawFingerprint: rawFingerprint, createdAt: now}
-	e.lastUsed.Store(now.UnixNano())
+	e.lastUsed = now.UnixNano()
 	c.entries[key] = e
 	c.aliases[rawFingerprint] = key
 
@@ -226,9 +227,9 @@ func (c *restMapperCache) evictOldestLocked() {
 		found     bool
 	)
 	for key, e := range c.entries {
-		if used := e.lastUsed.Load(); !found || used < oldest {
+		if !found || e.lastUsed < oldest {
 			found = true
-			oldestKey, oldest = key, used
+			oldestKey, oldest = key, e.lastUsed
 		}
 	}
 	if found {
@@ -247,7 +248,7 @@ func (c *restMapperCache) lookupLocked(key, rawFingerprint string, now time.Time
 	if !ok || entry.aged(now, c.refreshInterval) {
 		return nil, nil, false
 	}
-	entry.lastUsed.Store(now.UnixNano())
+	entry.lastUsed = now.UnixNano()
 	c.promote(entry, key, rawFingerprint)
 
 	return entry.mapper, entry.httpClient, true
@@ -320,7 +321,7 @@ func (c *restMapperCache) evictStale(now time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for key, e := range c.entries {
-		if e.lastUsed.Load() < cutoff {
+		if e.lastUsed < cutoff {
 			delete(c.entries, key)
 			delete(c.aliases, e.rawFingerprint)
 		}

--- a/internal/util/kube/restmapper_cache.go
+++ b/internal/util/kube/restmapper_cache.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -88,6 +89,11 @@ func newRESTMapperCacheWithClock(ttl, refreshInterval, sweepInterval time.Durati
 
 type restMapperEntry struct {
 	mapper meta.RESTMapper
+	// httpClient is the client the mapper discovers through. It is handed out
+	// alongside the mapper so client.New reuses it instead of constructing a
+	// second one per object client, and so a mapper is never paired with
+	// another credential generation's transport.
+	httpClient *http.Client
 	// createdAt is set once at store time and never refreshed by hits, unlike
 	// lastUsed, so an entry's absolute age keeps growing while it is in use.
 	createdAt time.Time
@@ -133,7 +139,13 @@ var sharedRESTMapperCache = newRESTMapperCache(restMapperTTL, restMapperRefreshI
 
 func normalizeHost(host string) string { return strings.TrimRight(host, "/") }
 
-func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMapper, error) {
+// get returns the cached RESTMapper for the cluster identity the kubeconfig
+// describes, together with the HTTP client the mapper was built on, so the
+// caller can hand both to client.New and the object client shares the mapper's
+// transport instead of constructing its own. The two always come from the same
+// entry: a mapper must never be paired with another credential generation's
+// transport.
+func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMapper, *http.Client, error) {
 	now := c.nowFunc()
 	rawFingerprint := fingerprint(kubeconfig)
 
@@ -142,7 +154,7 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 		if entry, ok := c.entries[key]; ok && !entry.aged(now, c.refreshInterval) {
 			entry.lastUsed.Store(now.UnixNano())
 			c.mu.Unlock()
-			return entry.mapper, nil
+			return entry.mapper, entry.httpClient, nil
 		}
 	}
 	c.mu.Unlock()
@@ -150,38 +162,39 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 	host := normalizeHost(cfg.Host)
 	canonicalFingerprint, err := c.canonicalize(kubeconfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fingerprint kubeconfig for %s: %w", host, err)
+		return nil, nil, fmt.Errorf("failed to fingerprint kubeconfig for %s: %w", host, err)
 	}
 	key := host + "\x00" + canonicalFingerprint
 
 	c.mu.Lock()
-	if entry, ok := c.entries[key]; ok && !entry.aged(now, c.refreshInterval) {
-		entry.lastUsed.Store(now.UnixNano())
-		c.promote(entry, key, rawFingerprint)
+	if mapper, httpClient, ok := c.lookupLocked(key, rawFingerprint, now); ok {
 		c.mu.Unlock()
-		return entry.mapper, nil
+		return mapper, httpClient, nil
 	}
 	c.mu.Unlock()
 
+	cfg = rest.CopyConfig(cfg)
+	if cfg.UserAgent == "" {
+		cfg.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
 	httpClient, err := rest.HTTPClientFor(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP client for %s: %w", host, err)
+		return nil, nil, fmt.Errorf("failed to create HTTP client for %s: %w", host, err)
 	}
 	mapper, err := apiutil.NewDynamicRESTMapper(cfg, httpClient)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create REST mapper for %s: %w", host, err)
+		return nil, nil, fmt.Errorf("failed to create REST mapper for %s: %w", host, err)
 	}
 
 	// Re-check under the lock: concurrent lookups with equivalent kubeconfigs
 	// must converge on one mapper, or each would run its own discovery. Distinct
 	// identities use distinct keys, so a store here can never clobber another
-	// identity's mapper.
+	// identity's mapper. The loser returns the winner's pair, not a mix.
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if entry, ok := c.entries[key]; ok && !entry.aged(now, c.refreshInterval) {
-		entry.lastUsed.Store(now.UnixNano())
-		c.promote(entry, key, rawFingerprint)
-		return entry.mapper, nil
+	if winnerMapper, winnerClient, ok := c.lookupLocked(key, rawFingerprint, now); ok {
+		return winnerMapper, winnerClient, nil
 	}
 
 	// An aged predecessor keeps its slot's key but not its alias: the new entry
@@ -189,7 +202,7 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 	if old, ok := c.entries[key]; ok {
 		delete(c.aliases, old.rawFingerprint)
 	}
-	e := &restMapperEntry{mapper: mapper, rawFingerprint: rawFingerprint, createdAt: now}
+	e := &restMapperEntry{mapper: mapper, httpClient: httpClient, rawFingerprint: rawFingerprint, createdAt: now}
 	e.lastUsed.Store(now.UnixNano())
 	c.entries[key] = e
 	c.aliases[rawFingerprint] = key
@@ -201,7 +214,7 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 		c.evictOldestLocked()
 	}
 
-	return mapper, nil
+	return mapper, httpClient, nil
 }
 
 // evictOldestLocked removes the least-recently-used entry and its alias. Must
@@ -222,6 +235,22 @@ func (c *restMapperCache) evictOldestLocked() {
 		delete(c.aliases, c.entries[oldestKey].rawFingerprint)
 		delete(c.entries, oldestKey)
 	}
+}
+
+// lookupLocked returns the live pair for key, refreshing the entry's lastUsed
+// and promoting rawFingerprint to its current byte representation. Both the
+// canonical-hit path and the post-build re-check converge through it, so a
+// caller that lost a build race receives the winning entry's mapper and
+// transport together. Must be called under the lock.
+func (c *restMapperCache) lookupLocked(key, rawFingerprint string, now time.Time) (meta.RESTMapper, *http.Client, bool) {
+	entry, ok := c.entries[key]
+	if !ok || entry.aged(now, c.refreshInterval) {
+		return nil, nil, false
+	}
+	entry.lastUsed.Store(now.UnixNano())
+	c.promote(entry, key, rawFingerprint)
+
+	return entry.mapper, entry.httpClient, true
 }
 
 // promote makes rawFingerprint the entry's current byte representation, so its

--- a/internal/util/kube/restmapper_cache_test.go
+++ b/internal/util/kube/restmapper_cache_test.go
@@ -52,7 +52,7 @@ users:
 func TestRESTMapperCache(t *testing.T) {
 	newCache := func(t *testing.T) *restMapperCache {
 		t.Helper()
-		return newRESTMapperCache(restMapperTTL, restMapperSweepInterval)
+		return newRESTMapperCache(restMapperTTL, restMapperRefreshInterval, restMapperSweepInterval)
 	}
 
 	get := func(t *testing.T, c *restMapperCache, kubeconfig []byte) any {
@@ -117,7 +117,7 @@ func TestRESTMapperCache(t *testing.T) {
 		const ttl = time.Minute
 
 		var clock atomic.Int64
-		c := newRESTMapperCacheWithClock(ttl, time.Hour, func() time.Time {
+		c := newRESTMapperCacheWithClock(ttl, time.Hour, time.Hour, func() time.Time {
 			return time.Unix(0, clock.Load())
 		})
 
@@ -143,7 +143,7 @@ func TestRESTMapperCache(t *testing.T) {
 		const ttl = time.Minute
 
 		var clock atomic.Int64
-		c := newRESTMapperCacheWithClock(ttl, ttl/10, func() time.Time {
+		c := newRESTMapperCacheWithClock(ttl, time.Hour, ttl/10, func() time.Time {
 			return time.Unix(0, clock.Load())
 		})
 
@@ -163,6 +163,36 @@ func TestRESTMapperCache(t *testing.T) {
 
 		require.Same(t, first, again, "the live entry must be a hit, not a rebuild")
 		require.Equal(t, 1, c.len(), "a hit alone should have swept the idle entry")
+	})
+
+	t.Run("an aged mapper is rebuilt even while in constant use", func(t *testing.T) {
+		// Guards against constant use pinning a mapper forever: the dynamic
+		// mapper re-discovers only on a NoMatch, so a mapping it already knows
+		// would otherwise survive API removals until the process restarts. Every
+		// hit below refreshes lastUsed, so only createdAt can trigger the
+		// rebuild.
+		const refresh = time.Minute
+
+		var clock atomic.Int64
+		c := newRESTMapperCacheWithClock(time.Hour, refresh, time.Hour, func() time.Time {
+			return time.Unix(0, clock.Load())
+		})
+		kubeconfig := kubeconfigForHost(t, "https://a.example:6443", "u")
+
+		first := get(t, c, kubeconfig)
+		for i := range 9 {
+			clock.Store(int64(refresh) / 10 * int64(i+1))
+			require.Same(t, first, get(t, c, kubeconfig),
+				"a mapper younger than the refresh interval must be reused")
+		}
+
+		clock.Store(int64(refresh))
+		second := get(t, c, kubeconfig)
+		require.NotSame(t, first, second, "an aged mapper must be rebuilt despite recent use")
+		require.Equal(t, 1, c.len(), "the rebuild must replace the entry, not add one")
+
+		// The replacement's age starts at its own build time.
+		require.Same(t, second, get(t, c, kubeconfig))
 	})
 
 	t.Run("a slow build does not overwrite newer credentials", func(t *testing.T) {

--- a/internal/util/kube/restmapper_cache_test.go
+++ b/internal/util/kube/restmapper_cache_test.go
@@ -87,17 +87,78 @@ func TestRESTMapperCache(t *testing.T) {
 		require.Equal(t, 1, c.len())
 	})
 
-	t.Run("rotated credentials replace the mapper", func(t *testing.T) {
-		c := newCache(t)
-		host := "https://a.example:6443"
+	t.Run("rotated credentials rebuild the mapper and the old entry idles out", func(t *testing.T) {
+		const ttl = time.Minute
 
-		first := get(t, c, kubeconfigForHost(t, host, "u"))
-		second := get(t, c, kubeconfigForHost(t, host, "rotated"))
+		var clock atomic.Int64
+		c := newRESTMapperCacheWithClock(ttl, time.Hour, time.Hour, func() time.Time {
+			return time.Unix(0, clock.Load())
+		})
+		host := "https://a.example:6443"
 
 		// A mapper owns a discovery client with the old credentials baked in,
 		// so reusing it after a rotation would fail on the next refresh.
+		first := get(t, c, kubeconfigForHost(t, host, "u"))
+		second := get(t, c, kubeconfigForHost(t, host, "rotated"))
 		require.NotSame(t, first, second, "rotated credentials must rebuild the mapper")
-		require.Equal(t, 1, c.len(), "rotation must replace the entry, not add one")
+		require.Equal(t, 2, c.len(), "the superseded identity is kept until it idles out")
+
+		// Only the rotated identity is looked up from now on; the superseded
+		// entry ages past the TTL and is reclaimed by the sweep.
+		clock.Store(int64(2 * ttl))
+		require.Same(t, second, get(t, c, kubeconfigForHost(t, host, "rotated")))
+		c.evictStale(time.Unix(0, clock.Load()))
+		require.Equal(t, 1, c.len(), "the superseded identity must be swept once idle")
+	})
+
+	t.Run("two identities on one host keep their own mappers", func(t *testing.T) {
+		c := newCache(t)
+		host := "https://a.example:6443"
+		alice := kubeconfigForHost(t, host, "alice")
+		bob := kubeconfigForHost(t, host, "bob")
+
+		first := get(t, c, alice)
+		second := get(t, c, bob)
+		require.NotSame(t, first, second, "identities must not share a credentialed discovery client")
+
+		// Alternating identities must not evict each other: each keeps hitting
+		// the mapper it started with, without a single rebuild.
+		for range 5 {
+			require.Same(t, first, get(t, c, alice))
+			require.Same(t, second, get(t, c, bob))
+		}
+		require.Equal(t, 2, c.len())
+	})
+
+	t.Run("a rewritten kubeconfig canonicalizes once and swaps the alias", func(t *testing.T) {
+		c := newCache(t)
+		var canonicalizations atomic.Int64
+		c.canonicalize = func(kubeconfig []byte) (string, error) {
+			canonicalizations.Add(1)
+			return canonicalKubeconfigFingerprint(kubeconfig)
+		}
+
+		// Three byte representations of one identity, arriving one after the
+		// other the way Secret rewrites do. Each must canonicalize exactly once
+		// — on arrival — and then ride the raw fast path.
+		first := get(t, c, kubeconfigForHost(t, "https://a.example:6443", "u"))
+		for step, kubeconfig := range [][]byte{
+			kubeconfigForHost(t, "https://a.example:6443", "u"),
+			kubeconfigForHost(t, "https://a.example:6443/", "u"),
+			kubeconfigForHost(t, "https://a.example:6443//", "u"),
+		} {
+			for range 5 {
+				require.Same(t, first, get(t, c, kubeconfig),
+					"an equivalent representation must resolve to the existing mapper")
+			}
+			require.EqualValues(t, step+1, canonicalizations.Load(),
+				"only a representation's first lookup may canonicalize")
+		}
+
+		// Promotion swaps the entry's alias rather than accumulating one per
+		// representation, so the index stays pinned to the entry count.
+		require.Equal(t, 1, c.len())
+		require.Len(t, c.aliases, 1, "promotion must swap the alias, not retain old representations")
 	})
 
 	t.Run("distinct clusters get distinct mappers", func(t *testing.T) {
@@ -193,32 +254,6 @@ func TestRESTMapperCache(t *testing.T) {
 
 		// The replacement's age starts at its own build time.
 		require.Same(t, second, get(t, c, kubeconfig))
-	})
-
-	t.Run("a slow build does not overwrite newer credentials", func(t *testing.T) {
-		c := newCache(t)
-		host := "https://a.example:6443"
-
-		old := kubeconfigForHost(t, host, "old")
-		fresh := kubeconfigForHost(t, host, "fresh")
-
-		var newest any
-		// One-shot: cleared before the nested lookup so it does not re-enter.
-		c.setRaceHook(func() {
-			c.setRaceHook(nil)
-			newest = get(t, c, fresh)
-		})
-
-		oldCfg, err := clientcmd.RESTConfigFromKubeConfig(old)
-		require.NoError(t, err)
-		stale, err := c.get(oldCfg, old)
-		require.NoError(t, err)
-		require.NotNil(t, stale, "the losing caller still gets a usable mapper")
-		require.NotSame(t, newest, stale, "it uses its own credentials, not the cached ones")
-
-		require.Equal(t, 1, c.len())
-		require.Same(t, newest, get(t, c, fresh),
-			"the cached entry must still be the one built from the newer kubeconfig")
 	})
 
 	t.Run("concurrent lookups converge on one mapper", func(t *testing.T) {

--- a/internal/util/kube/restmapper_cache_test.go
+++ b/internal/util/kube/restmapper_cache_test.go
@@ -15,6 +15,7 @@
 package kube
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -52,7 +53,7 @@ users:
 func TestRESTMapperCache(t *testing.T) {
 	newCache := func(t *testing.T) *restMapperCache {
 		t.Helper()
-		return newRESTMapperCache(restMapperTTL, restMapperRefreshInterval, restMapperSweepInterval)
+		return newRESTMapperCache(restMapperTTL, restMapperRefreshInterval, restMapperSweepInterval, restMapperMaxEntries)
 	}
 
 	get := func(t *testing.T, c *restMapperCache, kubeconfig []byte) any {
@@ -91,7 +92,7 @@ func TestRESTMapperCache(t *testing.T) {
 		const ttl = time.Minute
 
 		var clock atomic.Int64
-		c := newRESTMapperCacheWithClock(ttl, time.Hour, time.Hour, func() time.Time {
+		c := newRESTMapperCacheWithClock(ttl, time.Hour, time.Hour, restMapperMaxEntries, func() time.Time {
 			return time.Unix(0, clock.Load())
 		})
 		host := "https://a.example:6443"
@@ -172,13 +173,12 @@ func TestRESTMapperCache(t *testing.T) {
 	})
 
 	t.Run("an idle cluster is evicted while an active one survives", func(t *testing.T) {
-		// Eviction policy is asserted by calling the sweep directly, with the
-		// sweep interval set beyond the test's lifetime so no lookup triggers one
-		// behind our back. Nothing here depends on wall-clock time.
+		// Asserts the eviction policy by calling the sweep directly, the way the
+		// sweeper runnable does. Nothing here depends on wall-clock time.
 		const ttl = time.Minute
 
 		var clock atomic.Int64
-		c := newRESTMapperCacheWithClock(ttl, time.Hour, time.Hour, func() time.Time {
+		c := newRESTMapperCacheWithClock(ttl, time.Hour, time.Hour, restMapperMaxEntries, func() time.Time {
 			return time.Unix(0, clock.Load())
 		})
 
@@ -197,33 +197,60 @@ func TestRESTMapperCache(t *testing.T) {
 		require.Same(t, first, again, "the in-use entry must survive the sweep")
 	})
 
-	t.Run("a hit alone reclaims an idle cluster", func(t *testing.T) {
-		// The final lookup has to be a genuine hit, which is what require.Same
-		// checks: asserting on c.len() alone would also pass if the sweep evicted
-		// the live entry and the lookup simply rebuilt it.
-		const ttl = time.Minute
-
+	t.Run("the sweeper reclaims idle entries without any lookup", func(t *testing.T) {
+		// A deleted cluster produces no further lookups, so expiry must not
+		// depend on one: after the last get below, only the running sweeper
+		// touches the cache. The injected clock jumps past the TTL; the ticker
+		// merely has to fire, so its interval is a real millisecond.
 		var clock atomic.Int64
-		c := newRESTMapperCacheWithClock(ttl, time.Hour, ttl/10, func() time.Time {
+		c := newRESTMapperCacheWithClock(time.Minute, time.Hour, time.Millisecond, restMapperMaxEntries, func() time.Time {
 			return time.Unix(0, clock.Load())
 		})
 
-		live := kubeconfigForHost(t, "https://live.example:6443", "u")
-		gone := kubeconfigForHost(t, "https://gone.example:6443", "u")
+		get(t, c, kubeconfigForHost(t, "https://gone.example:6443", "u"))
+		require.Equal(t, 1, c.len())
+		clock.Store(int64(2 * time.Minute))
 
-		first := get(t, c, live)
-		get(t, c, gone)
+		sweeper := &restMapperSweeper{cache: c}
+		require.False(t, sweeper.NeedLeaderElection(),
+			"every replica builds clients, so every replica must sweep")
+
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan error, 1)
+		go func() { done <- sweeper.Start(ctx) }()
+
+		require.Eventually(t, func() bool { return c.len() == 0 }, 10*time.Second, time.Millisecond,
+			"the sweeper must reclaim the idle entry with no lookup driving it")
+
+		cancel()
+		require.NoError(t, <-done, "the sweeper must stop cleanly on context cancellation")
+		require.Empty(t, c.aliases, "the entry's alias must be reclaimed with it")
+	})
+
+	t.Run("inserting past capacity evicts the least recently used", func(t *testing.T) {
+		var clock atomic.Int64
+		c := newRESTMapperCacheWithClock(time.Hour, time.Hour, time.Hour, 2, func() time.Time {
+			return time.Unix(0, clock.Load())
+		})
+
+		a := kubeconfigForHost(t, "https://a.example:6443", "u")
+		b := kubeconfigForHost(t, "https://b.example:6443", "u")
+		d := kubeconfigForHost(t, "https://d.example:6443", "u")
+
+		first := get(t, c, a)
+		clock.Store(1)
+		second := get(t, c, b)
+		clock.Store(2)
+		require.Same(t, first, get(t, c, a)) // a is now more recently used than b
+
+		clock.Store(3)
+		third := get(t, c, d) // over capacity: b is the LRU entry and must go
 		require.Equal(t, 2, c.len())
+		require.Len(t, c.aliases, 2, "the evicted entry's alias must go with it")
 
-		clock.Store(int64(ttl / 10 * 9))
-		require.Same(t, first, get(t, c, live), "no entry should have aged out yet")
-		require.Equal(t, 2, c.len())
-
-		clock.Store(int64(ttl / 2 * 3))
-		again := get(t, c, live)
-
-		require.Same(t, first, again, "the live entry must be a hit, not a rebuild")
-		require.Equal(t, 1, c.len(), "a hit alone should have swept the idle entry")
+		require.Same(t, first, get(t, c, a), "a recently used entry must survive the cap")
+		require.Same(t, third, get(t, c, d), "the newest entry must survive the cap")
+		require.NotSame(t, second, get(t, c, b), "the evicted identity must rebuild on return")
 	})
 
 	t.Run("an aged mapper is rebuilt even while in constant use", func(t *testing.T) {
@@ -235,7 +262,7 @@ func TestRESTMapperCache(t *testing.T) {
 		const refresh = time.Minute
 
 		var clock atomic.Int64
-		c := newRESTMapperCacheWithClock(time.Hour, refresh, time.Hour, func() time.Time {
+		c := newRESTMapperCacheWithClock(time.Hour, refresh, time.Hour, restMapperMaxEntries, func() time.Time {
 			return time.Unix(0, clock.Load())
 		})
 		kubeconfig := kubeconfigForHost(t, "https://a.example:6443", "u")

--- a/internal/util/kube/restmapper_cache_test.go
+++ b/internal/util/kube/restmapper_cache_test.go
@@ -16,7 +16,9 @@ package kube
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/clientcmd"
@@ -48,8 +50,9 @@ users:
 }
 
 func TestRESTMapperCache(t *testing.T) {
-	newCache := func() *restMapperCache {
-		return &restMapperCache{entries: make(map[string]restMapperEntry)}
+	newCache := func(t *testing.T) *restMapperCache {
+		t.Helper()
+		return newRESTMapperCache(restMapperTTL, restMapperSweepInterval)
 	}
 
 	get := func(t *testing.T, c *restMapperCache, kubeconfig []byte) any {
@@ -64,7 +67,7 @@ func TestRESTMapperCache(t *testing.T) {
 	}
 
 	t.Run("same cluster reuses one mapper", func(t *testing.T) {
-		c := newCache()
+		c := newCache(t)
 		kubeconfig := kubeconfigForHost(t, "https://a.example:6443", "u")
 
 		first := get(t, c, kubeconfig)
@@ -74,8 +77,18 @@ func TestRESTMapperCache(t *testing.T) {
 		require.Equal(t, 1, c.len())
 	})
 
+	t.Run("equivalent server URLs reuse one mapper", func(t *testing.T) {
+		c := newCache(t)
+
+		first := get(t, c, kubeconfigForHost(t, "https://a.example:6443", "u"))
+		second := get(t, c, kubeconfigForHost(t, "https://a.example:6443/", "u"))
+
+		require.Same(t, first, second)
+		require.Equal(t, 1, c.len())
+	})
+
 	t.Run("rotated credentials replace the mapper", func(t *testing.T) {
-		c := newCache()
+		c := newCache(t)
 		host := "https://a.example:6443"
 
 		first := get(t, c, kubeconfigForHost(t, host, "u"))
@@ -88,7 +101,7 @@ func TestRESTMapperCache(t *testing.T) {
 	})
 
 	t.Run("distinct clusters get distinct mappers", func(t *testing.T) {
-		c := newCache()
+		c := newCache(t)
 
 		a := get(t, c, kubeconfigForHost(t, "https://a.example:6443", "u"))
 		b := get(t, c, kubeconfigForHost(t, "https://b.example:6443", "u"))
@@ -97,8 +110,89 @@ func TestRESTMapperCache(t *testing.T) {
 		require.Equal(t, 2, c.len())
 	})
 
+	t.Run("an idle cluster is evicted while an active one survives", func(t *testing.T) {
+		// Eviction policy is asserted by calling the sweep directly, with the
+		// sweep interval set beyond the test's lifetime so no lookup triggers one
+		// behind our back. Nothing here depends on wall-clock time.
+		const ttl = time.Minute
+
+		var clock atomic.Int64
+		c := newRESTMapperCacheWithClock(ttl, time.Hour, func() time.Time {
+			return time.Unix(0, clock.Load())
+		})
+
+		live := kubeconfigForHost(t, "https://live.example:6443", "u")
+		gone := kubeconfigForHost(t, "https://gone.example:6443", "u")
+
+		first := get(t, c, live)
+		get(t, c, gone)
+		require.Equal(t, 2, c.len())
+
+		clock.Store(int64(2 * ttl))
+		again := get(t, c, live)
+		c.evictStale(time.Unix(0, clock.Load()))
+
+		require.Equal(t, 1, c.len(), "the idle entry should have been evicted")
+		require.Same(t, first, again, "the in-use entry must survive the sweep")
+	})
+
+	t.Run("a hit alone reclaims an idle cluster", func(t *testing.T) {
+		// The final lookup has to be a genuine hit, which is what require.Same
+		// checks: asserting on c.len() alone would also pass if the sweep evicted
+		// the live entry and the lookup simply rebuilt it.
+		const ttl = time.Minute
+
+		var clock atomic.Int64
+		c := newRESTMapperCacheWithClock(ttl, ttl/10, func() time.Time {
+			return time.Unix(0, clock.Load())
+		})
+
+		live := kubeconfigForHost(t, "https://live.example:6443", "u")
+		gone := kubeconfigForHost(t, "https://gone.example:6443", "u")
+
+		first := get(t, c, live)
+		get(t, c, gone)
+		require.Equal(t, 2, c.len())
+
+		clock.Store(int64(ttl / 10 * 9))
+		require.Same(t, first, get(t, c, live), "no entry should have aged out yet")
+		require.Equal(t, 2, c.len())
+
+		clock.Store(int64(ttl / 2 * 3))
+		again := get(t, c, live)
+
+		require.Same(t, first, again, "the live entry must be a hit, not a rebuild")
+		require.Equal(t, 1, c.len(), "a hit alone should have swept the idle entry")
+	})
+
+	t.Run("a slow build does not overwrite newer credentials", func(t *testing.T) {
+		c := newCache(t)
+		host := "https://a.example:6443"
+
+		old := kubeconfigForHost(t, host, "old")
+		fresh := kubeconfigForHost(t, host, "fresh")
+
+		var newest any
+		// One-shot: cleared before the nested lookup so it does not re-enter.
+		c.setRaceHook(func() {
+			c.setRaceHook(nil)
+			newest = get(t, c, fresh)
+		})
+
+		oldCfg, err := clientcmd.RESTConfigFromKubeConfig(old)
+		require.NoError(t, err)
+		stale, err := c.get(oldCfg, old)
+		require.NoError(t, err)
+		require.NotNil(t, stale, "the losing caller still gets a usable mapper")
+		require.NotSame(t, newest, stale, "it uses its own credentials, not the cached ones")
+
+		require.Equal(t, 1, c.len())
+		require.Same(t, newest, get(t, c, fresh),
+			"the cached entry must still be the one built from the newer kubeconfig")
+	})
+
 	t.Run("concurrent lookups converge on one mapper", func(t *testing.T) {
-		c := newCache()
+		c := newCache(t)
 		kubeconfig := kubeconfigForHost(t, "https://a.example:6443", "u")
 
 		const goroutines = 50
@@ -106,26 +200,31 @@ func TestRESTMapperCache(t *testing.T) {
 			wg      sync.WaitGroup
 			mu      sync.Mutex
 			mappers []any
+			errs    []error
 		)
 		wg.Add(goroutines)
 		for range goroutines {
 			go func() {
 				defer wg.Done()
 				cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
-				if err != nil {
-					return
-				}
-				m, err := c.get(cfg, kubeconfig)
-				if err != nil {
-					return
+				if err == nil {
+					var m any
+					m, err = c.get(cfg, kubeconfig)
+					if err == nil {
+						mu.Lock()
+						mappers = append(mappers, m)
+						mu.Unlock()
+						return
+					}
 				}
 				mu.Lock()
-				mappers = append(mappers, m)
+				errs = append(errs, err)
 				mu.Unlock()
 			}()
 		}
 		wg.Wait()
 
+		require.Empty(t, errs, "no concurrent lookup should fail")
 		require.Len(t, mappers, goroutines)
 		for _, m := range mappers {
 			require.Same(t, mappers[0], m, "all concurrent callers must receive the same mapper")

--- a/internal/util/kube/restmapper_cache_test.go
+++ b/internal/util/kube/restmapper_cache_test.go
@@ -16,12 +16,15 @@ package kube
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -56,13 +59,21 @@ func TestRESTMapperCache(t *testing.T) {
 		return newRESTMapperCache(restMapperTTL, restMapperRefreshInterval, restMapperSweepInterval, restMapperMaxEntries)
 	}
 
-	get := func(t *testing.T, c *restMapperCache, kubeconfig []byte) any {
+	getPair := func(t *testing.T, c *restMapperCache, kubeconfig []byte) (any, *http.Client) {
 		t.Helper()
 		cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
 		require.NoError(t, err)
-		m, err := c.get(cfg, kubeconfig)
+		m, httpClient, err := c.get(cfg, kubeconfig)
 		require.NoError(t, err)
 		require.NotNil(t, m)
+		require.NotNil(t, httpClient)
+
+		return m, httpClient
+	}
+
+	get := func(t *testing.T, c *restMapperCache, kubeconfig []byte) any {
+		t.Helper()
+		m, _ := getPair(t, c, kubeconfig)
 
 		return m
 	}
@@ -283,16 +294,88 @@ func TestRESTMapperCache(t *testing.T) {
 		require.Same(t, second, get(t, c, kubeconfig))
 	})
 
+	t.Run("the object client shares the mapper's HTTP client", func(t *testing.T) {
+		c := newCache(t)
+		kubeconfig := kubeconfigForHost(t, "https://a.example:6443", "u")
+
+		firstMapper, firstClient := getPair(t, c, kubeconfig)
+		againMapper, againClient := getPair(t, c, kubeconfig)
+		require.Same(t, firstMapper, againMapper)
+		require.Same(t, firstClient, againClient, "repeated lookups must reuse the cached HTTP client")
+
+		// A rotation gets its own pair: the new mapper must never ride the old
+		// credentials' transport, nor the other way around.
+		rotatedMapper, rotatedClient := getPair(t, c, kubeconfigForHost(t, "https://a.example:6443", "rotated"))
+		require.NotSame(t, firstMapper, rotatedMapper)
+		require.NotSame(t, firstClient, rotatedClient, "rotated credentials must get their own transport")
+	})
+
+	t.Run("the cached HTTP client sends the default Kubernetes user agent", func(t *testing.T) {
+		// The User-Agent is baked into the transport at build time: client-go
+		// adds its UA round tripper only if cfg.UserAgent is set at that moment,
+		// and controller-runtime's own defaulting never reaches a client that is
+		// handed to it prebuilt. Requests must not fall back to Go's default UA.
+		var got atomic.Value
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			got.Store(r.Header.Get("User-Agent"))
+		}))
+		defer srv.Close()
+
+		c := newCache(t)
+		_, httpClient := getPair(t, c, kubeconfigForHost(t, srv.URL, "u"))
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, rest.DefaultKubernetesUserAgent(), got.Load(),
+			"requests through the cached client must identify themselves as this process")
+	})
+
+	t.Run("a lookup losing the build race converges on the winner's pair", func(t *testing.T) {
+		// Deterministic version of the concurrent test below: the injected
+		// canonicalizer runs between the fast path and the locked re-check, so a
+		// competing store placed there is guaranteed to win the race, and the
+		// outer lookup must return the winner's mapper and transport rather than
+		// the pair it would have built.
+		c := newCache(t)
+		kubeconfig := kubeconfigForHost(t, "https://a.example:6443", "u")
+
+		var (
+			winnerMapper any
+			winnerClient *http.Client
+			raced        bool
+		)
+		c.canonicalize = func(kc []byte) (string, error) {
+			if !raced {
+				raced = true
+				winnerMapper, winnerClient = getPair(t, c, kc)
+			}
+			return canonicalKubeconfigFingerprint(kc)
+		}
+
+		loserMapper, loserClient := getPair(t, c, kubeconfig)
+
+		require.Same(t, winnerMapper, loserMapper, "the loser must adopt the winner's mapper")
+		require.Same(t, winnerClient, loserClient, "the loser must adopt the winner's transport, not its own build")
+		require.Equal(t, 1, c.len())
+	})
+
 	t.Run("concurrent lookups converge on one mapper", func(t *testing.T) {
 		c := newCache(t)
 		kubeconfig := kubeconfigForHost(t, "https://a.example:6443", "u")
 
+		type pair struct {
+			mapper     any
+			httpClient *http.Client
+		}
 		const goroutines = 50
 		var (
-			wg      sync.WaitGroup
-			mu      sync.Mutex
-			mappers []any
-			errs    []error
+			wg    sync.WaitGroup
+			mu    sync.Mutex
+			pairs []pair
+			errs  []error
 		)
 		wg.Add(goroutines)
 		for range goroutines {
@@ -300,11 +383,14 @@ func TestRESTMapperCache(t *testing.T) {
 				defer wg.Done()
 				cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
 				if err == nil {
-					var m any
-					m, err = c.get(cfg, kubeconfig)
+					var (
+						m any
+						h *http.Client
+					)
+					m, h, err = c.get(cfg, kubeconfig)
 					if err == nil {
 						mu.Lock()
-						mappers = append(mappers, m)
+						pairs = append(pairs, pair{mapper: m, httpClient: h})
 						mu.Unlock()
 						return
 					}
@@ -317,9 +403,11 @@ func TestRESTMapperCache(t *testing.T) {
 		wg.Wait()
 
 		require.Empty(t, errs, "no concurrent lookup should fail")
-		require.Len(t, mappers, goroutines)
-		for _, m := range mappers {
-			require.Same(t, mappers[0], m, "all concurrent callers must receive the same mapper")
+		require.Len(t, pairs, goroutines)
+		for _, p := range pairs {
+			require.Same(t, pairs[0].mapper, p.mapper, "all concurrent callers must receive the same mapper")
+			require.Same(t, pairs[0].httpClient, p.httpClient,
+				"build-race losers must return the winning entry's transport, not their own")
 		}
 		require.Equal(t, 1, c.len())
 	})

--- a/internal/util/kube/restmapper_cache_test.go
+++ b/internal/util/kube/restmapper_cache_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// kubeconfigForHost builds a kubeconfig for host, authenticating as user. The
+// mapper is lazy, so nothing is ever contacted; only the identity of the
+// resulting rest.Config matters here.
+func kubeconfigForHost(t *testing.T, host, user string) []byte {
+	t.Helper()
+
+	return []byte(`apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster:
+    server: ` + host + `
+contexts:
+- name: c
+  context:
+    cluster: c
+    user: ` + user + `
+current-context: c
+users:
+- name: ` + user + `
+  user:
+    token: ` + user + `-token
+`)
+}
+
+func TestRESTMapperCache(t *testing.T) {
+	newCache := func() *restMapperCache {
+		return &restMapperCache{entries: make(map[string]restMapperEntry)}
+	}
+
+	get := func(t *testing.T, c *restMapperCache, kubeconfig []byte) any {
+		t.Helper()
+		cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+		require.NoError(t, err)
+		m, err := c.get(cfg, kubeconfig)
+		require.NoError(t, err)
+		require.NotNil(t, m)
+
+		return m
+	}
+
+	t.Run("same cluster reuses one mapper", func(t *testing.T) {
+		c := newCache()
+		kubeconfig := kubeconfigForHost(t, "https://a.example:6443", "u")
+
+		first := get(t, c, kubeconfig)
+		for range 10 {
+			require.Same(t, first, get(t, c, kubeconfig), "a cached mapper must be reused verbatim")
+		}
+		require.Equal(t, 1, c.len())
+	})
+
+	t.Run("rotated credentials replace the mapper", func(t *testing.T) {
+		c := newCache()
+		host := "https://a.example:6443"
+
+		first := get(t, c, kubeconfigForHost(t, host, "u"))
+		second := get(t, c, kubeconfigForHost(t, host, "rotated"))
+
+		// A mapper owns a discovery client with the old credentials baked in,
+		// so reusing it after a rotation would fail on the next refresh.
+		require.NotSame(t, first, second, "rotated credentials must rebuild the mapper")
+		require.Equal(t, 1, c.len(), "rotation must replace the entry, not add one")
+	})
+
+	t.Run("distinct clusters get distinct mappers", func(t *testing.T) {
+		c := newCache()
+
+		a := get(t, c, kubeconfigForHost(t, "https://a.example:6443", "u"))
+		b := get(t, c, kubeconfigForHost(t, "https://b.example:6443", "u"))
+
+		require.NotSame(t, a, b)
+		require.Equal(t, 2, c.len())
+	})
+
+	t.Run("concurrent lookups converge on one mapper", func(t *testing.T) {
+		c := newCache()
+		kubeconfig := kubeconfigForHost(t, "https://a.example:6443", "u")
+
+		const goroutines = 50
+		var (
+			wg      sync.WaitGroup
+			mu      sync.Mutex
+			mappers []any
+		)
+		wg.Add(goroutines)
+		for range goroutines {
+			go func() {
+				defer wg.Done()
+				cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+				if err != nil {
+					return
+				}
+				m, err := c.get(cfg, kubeconfig)
+				if err != nil {
+					return
+				}
+				mu.Lock()
+				mappers = append(mappers, m)
+				mu.Unlock()
+			}()
+		}
+		wg.Wait()
+
+		require.Len(t, mappers, goroutines)
+		for _, m := range mappers {
+			require.Same(t, mappers[0], m, "all concurrent callers must receive the same mapper")
+		}
+		require.Equal(t, 1, c.len())
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
`DefaultClientFactory` and `DefaultClientFactoryWithRestConfig` build every regional and child cluster client without an explicit `Mapper`, so controller-runtime constructs a fresh dynamic discovery RESTMapper for each one. A fresh mapper performs a full API discovery against the target apiserver on its first `RESTMapping`, e.g. two requests, one of which carries the aggregated resource list for every group.

Because those clients are built per cluster per poll tick and per reconcile, then discarded, KCM re-discovers remote apiservers continuously. The sveltos ServiceSet poller runs every 10s and touches every ServiceSet on every tick, so discovery load against a regional apiserver scales with cluster count and never decays, even when the system is completely idle. `resolveChildClient` does the same against workload clusters on the reconcile path.

This PR caches the RESTMapper per target apiserver and passes it via `client.Options{Mapper: ...}`.

Measured while working on this, with a throwaway probe against a synthetic apiserver serving a 40-group discovery document, replaying 6 poll ticks × 30 clusters (60s at the poller's interval):

| | object GETs | discovery requests | discovery bytes |
|---|---|---|---|
| before | 180 | 540 | 1253.3 KB |
| after | 180 | 3 | 7.0 KB |

This is the same remedy as #2439, which fixed `gvrFromResourceReference` in the `StateManagementProvider` controller by building one `DeferredDiscoveryRESTMapper` at startup and reusing it.

This PR is also complementary to #2816, which already improved this path: its per-tick `rgnClients` map removed the repeated kubeconfig Secret read against the management cluster. This PR leaves that map in place and addresses a separate cost on the other side of the connection, the clients own RESTMapper, which is rebuilt whenever a client is, and so is unaffected by caching at tick scope.

**Which issue(s) this PR fixes**:
Fixes #3007