### PR TITLE
feat: add chain selector to access management

### DIFF
--- a/api/v1beta1/accessmanagement_types.go
+++ b/api/v1beta1/accessmanagement_types.go
@@ -50,9 +50,15 @@ type AccessRule struct {
 	// ClusterTemplateChains is the list of [ClusterTemplateChain] names whose ClusterTemplates
 	// will be distributed to all namespaces specified in TargetNamespaces.
 	ClusterTemplateChains []string `json:"clusterTemplateChains,omitempty"`
+	// ClusterTemplateChainSelector is the [k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector]
+	// used to list all matching [ClusterTemplateChain] objects.
+	ClusterTemplateChainSelector *metav1.LabelSelector `json:"clusterTemplateChainSelector,omitempty"`
 	// ServiceTemplateChains is the list of [ServiceTemplateChain] names whose ServiceTemplates
 	// will be distributed to all namespaces specified in TargetNamespaces.
 	ServiceTemplateChains []string `json:"serviceTemplateChains,omitempty"`
+	// ServiceTemplateChainSelector is the [k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector]
+	// used to list all matching [ServiceTemplateChain] objects.
+	ServiceTemplateChainSelector *metav1.LabelSelector `json:"serviceTemplateChainSelector,omitempty"`
 	// Credentials is the list of [Credential] names that will be distributed to all the
 	// namespaces specified in TargetNamespaces.
 	Credentials []string `json:"credentials,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -145,10 +145,20 @@ func (in *AccessRule) DeepCopyInto(out *AccessRule) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ClusterTemplateChainSelector != nil {
+		in, out := &in.ClusterTemplateChainSelector, &out.ClusterTemplateChainSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ServiceTemplateChains != nil {
 		in, out := &in.ServiceTemplateChains, &out.ServiceTemplateChains
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.ServiceTemplateChainSelector != nil {
+		in, out := &in.ServiceTemplateChainSelector, &out.ServiceTemplateChainSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Credentials != nil {
 		in, out := &in.Credentials, &out.Credentials

--- a/internal/controller/accessmanagement_controller.go
+++ b/internal/controller/accessmanagement_controller.go
@@ -23,8 +23,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -216,14 +219,65 @@ func (r *AccessManagementReconciler) collectSystemResources(ctx context.Context)
 	}, nil
 }
 
+// collectTemplateChains lists template chains matching selector in system namespace and merge
+// listed template chain names with the list of explicitly defined template chain names. Duplicates
+// are discarded.
+func (r *AccessManagementReconciler) collectTemplateChains(ctx context.Context, chains []string, sel *metav1.LabelSelector, kind string) ([]string, error) {
+	// fast-return if the selector is not defined
+	if sel == nil {
+		return chains, nil
+	}
+
+	var templateChainList client.ObjectList
+	switch kind {
+	case kcmv1.ClusterTemplateChainKind:
+		templateChainList = new(kcmv1.ClusterTemplateChainList{})
+	case kcmv1.ServiceTemplateChainKind:
+		templateChainList = new(kcmv1.ServiceTemplateChainList{})
+	default:
+		return nil, fmt.Errorf("unknown kind %s", kind)
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(sel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert selector: %w", err)
+	}
+	opts := new(client.ListOptions{LabelSelector: selector})
+	err = r.List(ctx, templateChainList, client.InNamespace(r.SystemNamespace), opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list %s objects: %w", kind, err)
+	}
+
+	matchingChains := make([]string, 0)
+	if err = apimeta.EachListItem(templateChainList, func(chain runtime.Object) error {
+		obj, ok := chain.(client.Object)
+		if !ok {
+			return errors.New("failed to convert runtime.Object to client.Object")
+		}
+		matchingChains = append(matchingChains, obj.GetName())
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to collect template chains: %w", err)
+	}
+	return sets.List(sets.New(chains...).Insert(matchingChains...)), nil
+}
+
 func (r *AccessManagementReconciler) processRuleResources(ctx context.Context, accessMgmt *kcmv1.AccessManagement, rule kcmv1.AccessRule, targetNamespace string, resources *amSystemResources, keeper *amResourceKeeper) error {
 	var errs error
 
-	if err := r.processTemplateChains(ctx, accessMgmt, rule.ClusterTemplateChains, targetNamespace, resources.ctChains, keeper.ctChains, kcmv1.ClusterTemplateChainKind); err != nil {
+	ctChains, err := r.collectTemplateChains(ctx, rule.ClusterTemplateChains, rule.ClusterTemplateChainSelector, kcmv1.ClusterTemplateChainKind)
+	if err != nil {
+		errs = errors.Join(errs, fmt.Errorf("failed to collect ClusterTemplateChains: %w", err))
+	}
+	if err := r.processTemplateChains(ctx, accessMgmt, ctChains, targetNamespace, resources.ctChains, keeper.ctChains, kcmv1.ClusterTemplateChainKind); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to process ClusterTemplateChains: %w", err))
 	}
 
-	if err := r.processTemplateChains(ctx, accessMgmt, rule.ServiceTemplateChains, targetNamespace, resources.stChains, keeper.stChains, kcmv1.ServiceTemplateChainKind); err != nil {
+	stChains, err := r.collectTemplateChains(ctx, rule.ServiceTemplateChains, rule.ServiceTemplateChainSelector, kcmv1.ServiceTemplateChainKind)
+	if err != nil {
+		errs = errors.Join(errs, fmt.Errorf("failed to collect ServiceTemplateChains: %w", err))
+	}
+	if err := r.processTemplateChains(ctx, accessMgmt, stChains, targetNamespace, resources.stChains, keeper.stChains, kcmv1.ServiceTemplateChainKind); err != nil {
 		errs = errors.Join(errs, fmt.Errorf("failed to process ServiceTemplateChains: %w", err))
 	}
 

--- a/internal/controller/management_controller.go
+++ b/internal/controller/management_controller.go
@@ -784,7 +784,7 @@ func (r *ManagementReconciler) getRelease(ctx context.Context, mgmt *kcmv1.Manag
 }
 
 func makeContainerdAuth(registry, user, pass string) ([]byte, error) {
-	registryHost := strings.Split(registry, "/")[0]
+	registryHost, _, _ := strings.Cut(registry, "/")
 	auth := map[string]any{
 		"auth": map[string]any{
 			"username": user,

--- a/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_accessmanagements.yaml
+++ b/templates/provider/kcm/templates/crds/k0rdent.mirantis.com_accessmanagements.yaml
@@ -65,6 +65,52 @@ spec:
                         items:
                           type: string
                         type: array
+                      clusterTemplateChainSelector:
+                        description: |-
+                          ClusterTemplateChainSelector is the [k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector]
+                          used to list all matching [ClusterTemplateChain] objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
                       clusterTemplateChains:
                         description: |-
                           ClusterTemplateChains is the list of [ClusterTemplateChain] names whose ClusterTemplates
@@ -86,6 +132,52 @@ spec:
                         items:
                           type: string
                         type: array
+                      serviceTemplateChainSelector:
+                        description: |-
+                          ServiceTemplateChainSelector is the [k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector]
+                          used to list all matching [ServiceTemplateChain] objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
                       serviceTemplateChains:
                         description: |-
                           ServiceTemplateChains is the list of [ServiceTemplateChain] names whose ServiceTemplates
@@ -187,6 +279,52 @@ spec:
                         items:
                           type: string
                         type: array
+                      clusterTemplateChainSelector:
+                        description: |-
+                          ClusterTemplateChainSelector is the [k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector]
+                          used to list all matching [ClusterTemplateChain] objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
                       clusterTemplateChains:
                         description: |-
                           ClusterTemplateChains is the list of [ClusterTemplateChain] names whose ClusterTemplates
@@ -208,6 +346,52 @@ spec:
                         items:
                           type: string
                         type: array
+                      serviceTemplateChainSelector:
+                        description: |-
+                          ServiceTemplateChainSelector is the [k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector]
+                          used to list all matching [ServiceTemplateChain] objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
                       serviceTemplateChains:
                         description: |-
                           ServiceTemplateChains is the list of [ServiceTemplateChain] names whose ServiceTemplates

--- a/test/e2e/functional_test.go
+++ b/test/e2e/functional_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -632,18 +633,18 @@ func waitForServiceDeployments(
 			stateMap[ss.Name] = ss
 		}
 
-		for i := len(services) - 1; i >= 0; i-- {
-			serviceState, ok := stateMap[services[i].Name]
+		for i, service := range slices.Backward(services) {
+			serviceState, ok := stateMap[service.Name]
 			if !ok {
 				continue
 			}
 
 			if serviceState.State != kcmv1.ServiceStateDeployed {
-				logs.Printf("Service %s in %s state: %s", services[i].Name, serviceState.State, serviceState.FailureMessage)
-				return fmt.Errorf("service %s in %s state: %s", services[i].Name, serviceState.State, serviceState.FailureMessage)
+				logs.Printf("Service %s in %s state: %s", service.Name, serviceState.State, serviceState.FailureMessage)
+				return fmt.Errorf("service %s in %s state: %s", service.Name, serviceState.State, serviceState.FailureMessage)
 			}
 
-			logs.Printf("Service %s is deployed", services[i].Name)
+			logs.Printf("Service %s is deployed", service.Name)
 			services = append(services[:i], services[i+1:]...)
 		}
 

--- a/test/util/exec/exec.go
+++ b/test/util/exec/exec.go
@@ -46,9 +46,7 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 }
 
 func handleCmdError(err error, command string) error {
-	var exitError *exec.ExitError
-
-	if errors.As(err, &exitError) {
+	if exitError, ok := errors.AsType[*exec.ExitError](err); ok {
 		return fmt.Errorf("%s failed with error: (%v): %s", command, err, string(exitError.Stderr))
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds template chain selectors to the AccessManagement. This is needed due to template chains immutability to make it possible to onboard new template chains without mutating singletone AccessManagement object.
