### PR TITLE
refactor: key the RESTMapper cache by digests and make its size configurable

### DIFF
--- a/internal/util/kube/restmapper_cache.go
+++ b/internal/util/kube/restmapper_cache.go
@@ -17,8 +17,11 @@ package kube
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -136,13 +139,45 @@ const (
 	// a fleet that only shrinks.
 	restMapperSweepInterval = 10 * time.Minute
 
-	// restMapperMaxEntries caps the cache. High identity churn within one TTL
-	// window must not grow the map without bound, and the cap also bounds
-	// retention in a binary that does not register the sweeper.
+	// restMapperMaxEntries caps the cache unless [restMapperCacheMaxEntriesEnvName]
+	// overrides it. High identity churn within one TTL window must not grow the
+	// map without bound, and the cap also bounds retention in a binary that
+	// does not register the sweeper.
 	restMapperMaxEntries = 256
+
+	// restMapperMaxConfigurableEntries is the largest cap an override may set,
+	// and must match the maximum of restMapperCacheMaxEntries in the chart
+	// values schemas so both configuration paths agree. A larger value is
+	// clamped rather than rejected: an operator asking for an oversized cache
+	// wants it big, and falling back to the small default could reintroduce
+	// the eviction churn the override exists to prevent.
+	restMapperMaxConfigurableEntries = 1_000_000
 )
 
-var sharedRESTMapperCache = newRESTMapperCache(restMapperTTL, restMapperRefreshInterval, restMapperSweepInterval, restMapperMaxEntries)
+// restMapperCacheMaxEntriesEnvName is the name of the env variable overriding
+// the shared RESTMapper cache's maximum entry count.
+const restMapperCacheMaxEntriesEnvName = "RESTMAPPER_CACHE_MAX_ENTRIES"
+
+var sharedRESTMapperCache = newRESTMapperCache(restMapperTTL, restMapperRefreshInterval, restMapperSweepInterval, restMapperCacheMaxEntriesFromEnv())
+
+// restMapperCacheMaxEntriesFromEnv resolves the shared cache's entry cap: the value of
+// [restMapperCacheMaxEntriesEnvName] when it holds a positive integer,
+// restMapperMaxEntries otherwise.
+func restMapperCacheMaxEntriesFromEnv() int {
+	raw, ok := os.LookupEnv(restMapperCacheMaxEntriesEnvName)
+	if !ok {
+		return restMapperMaxEntries
+	}
+	// On range overflow Atoi reports ErrRange but still returns the value
+	// saturated to MaxInt or MinInt, so letting that error through makes an
+	// oversized ask clamp below and a negative one fall back, the same as
+	// their in-range counterparts.
+	n, err := strconv.Atoi(raw)
+	if (err != nil && !errors.Is(err, strconv.ErrRange)) || n <= 0 {
+		return restMapperMaxEntries
+	}
+	return min(n, restMapperMaxConfigurableEntries)
+}
 
 func normalizeHost(host string) string { return strings.TrimRight(host, "/") }
 

--- a/internal/util/kube/restmapper_cache.go
+++ b/internal/util/kube/restmapper_cache.go
@@ -17,7 +17,6 @@ package kube
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strings"
@@ -52,14 +51,14 @@ import (
 // entry's single alias rather than accumulating every representation seen, so
 // len(aliases) == len(entries) always and the index cannot outgrow the cache.
 type restMapperCache struct {
-	entries map[string]*restMapperEntry
+	entries map[restMapperKey]*restMapperEntry
 	// aliases maps an entry's current raw kubeconfig fingerprint to its
 	// entries key.
-	aliases map[string]string
+	aliases map[[sha256.Size]byte]restMapperKey
 	nowFunc func() time.Time
 	// canonicalize is canonicalKubeconfigFingerprint, injectable so tests can
 	// count how often lookups leave the fast path.
-	canonicalize func([]byte) (string, error)
+	canonicalize func([]byte) ([sha256.Size]byte, error)
 
 	ttl             time.Duration
 	refreshInterval time.Duration
@@ -73,10 +72,17 @@ func newRESTMapperCache(ttl, refreshInterval, sweepInterval time.Duration, maxEn
 	return newRESTMapperCacheWithClock(ttl, refreshInterval, sweepInterval, maxEntries, time.Now)
 }
 
+// restMapperKey identifies one cluster identity: the normalized apiserver
+// host plus the canonical fingerprint of the kubeconfig addressing it.
+type restMapperKey struct {
+	host        string
+	fingerprint [sha256.Size]byte
+}
+
 func newRESTMapperCacheWithClock(ttl, refreshInterval, sweepInterval time.Duration, maxEntries int, nowFunc func() time.Time) *restMapperCache {
 	return &restMapperCache{
-		entries:         make(map[string]*restMapperEntry),
-		aliases:         make(map[string]string),
+		entries:         make(map[restMapperKey]*restMapperEntry),
+		aliases:         make(map[[sha256.Size]byte]restMapperKey),
 		nowFunc:         nowFunc,
 		canonicalize:    canonicalKubeconfigFingerprint,
 		ttl:             ttl,
@@ -99,7 +105,7 @@ type restMapperEntry struct {
 	// rawFingerprint is the entry's current byte representation — the one the
 	// aliases index resolves. Mutated only under the cache's lock, when a
 	// promotion swaps it for a newer representation.
-	rawFingerprint string
+	rawFingerprint [sha256.Size]byte
 	// lastUsed is read and written only while the cache's mu is held, like
 	// every other mutable field here, so it needs no atomicity of its own.
 	lastUsed int64
@@ -165,7 +171,7 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fingerprint kubeconfig for %s: %w", host, err)
 	}
-	key := host + "\x00" + canonicalFingerprint
+	key := restMapperKey{host: host, fingerprint: canonicalFingerprint}
 
 	c.mu.Lock()
 	if mapper, httpClient, ok := c.lookupLocked(key, rawFingerprint, now); ok {
@@ -222,7 +228,7 @@ func (c *restMapperCache) get(cfg *rest.Config, kubeconfig []byte) (meta.RESTMap
 // be called under the lock.
 func (c *restMapperCache) evictOldestLocked() {
 	var (
-		oldestKey string
+		oldestKey restMapperKey
 		oldest    int64
 		found     bool
 	)
@@ -243,7 +249,7 @@ func (c *restMapperCache) evictOldestLocked() {
 // canonical-hit path and the post-build re-check converge through it, so a
 // caller that lost a build race receives the winning entry's mapper and
 // transport together. Must be called under the lock.
-func (c *restMapperCache) lookupLocked(key, rawFingerprint string, now time.Time) (meta.RESTMapper, *http.Client, bool) {
+func (c *restMapperCache) lookupLocked(key restMapperKey, rawFingerprint [sha256.Size]byte, now time.Time) (meta.RESTMapper, *http.Client, bool) {
 	entry, ok := c.entries[key]
 	if !ok || entry.aged(now, c.refreshInterval) {
 		return nil, nil, false
@@ -259,7 +265,7 @@ func (c *restMapperCache) lookupLocked(key, rawFingerprint string, now time.Time
 // previous representation's alias is dropped rather than kept: retaining every
 // representation ever seen would grow the index without bound on repeated
 // Secret rewrites. Must be called under the lock.
-func (c *restMapperCache) promote(entry *restMapperEntry, key, rawFingerprint string) {
+func (c *restMapperCache) promote(entry *restMapperEntry, key restMapperKey, rawFingerprint [sha256.Size]byte) {
 	if entry.rawFingerprint == rawFingerprint {
 		return
 	}
@@ -268,22 +274,23 @@ func (c *restMapperCache) promote(entry *restMapperEntry, key, rawFingerprint st
 	c.aliases[rawFingerprint] = key
 }
 
-func fingerprint(data []byte) string {
-	sum := sha256.Sum256(data)
-	return hex.EncodeToString(sum[:])
+// fingerprint digests raw bytes into a comparable array, so it can serve as a
+// map key directly without a hex allocation on every lookup.
+func fingerprint(data []byte) [sha256.Size]byte {
+	return sha256.Sum256(data)
 }
 
-func canonicalKubeconfigFingerprint(kubeconfig []byte) (string, error) {
+func canonicalKubeconfigFingerprint(kubeconfig []byte) ([sha256.Size]byte, error) {
 	config, err := clientcmd.Load(kubeconfig)
 	if err != nil {
-		return "", err
+		return [sha256.Size]byte{}, err
 	}
 	for _, cluster := range config.Clusters {
 		cluster.Server = normalizeHost(cluster.Server)
 	}
 	canonical, err := clientcmd.Write(*config)
 	if err != nil {
-		return "", err
+		return [sha256.Size]byte{}, err
 	}
 	return fingerprint(canonical), nil
 }

--- a/internal/util/kube/restmapper_cache_test.go
+++ b/internal/util/kube/restmapper_cache_test.go
@@ -16,6 +16,7 @@ package kube
 
 import (
 	"context"
+	"crypto/sha256"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -145,7 +146,7 @@ func TestRESTMapperCache(t *testing.T) {
 	t.Run("a rewritten kubeconfig canonicalizes once and swaps the alias", func(t *testing.T) {
 		c := newCache(t)
 		var canonicalizations atomic.Int64
-		c.canonicalize = func(kubeconfig []byte) (string, error) {
+		c.canonicalize = func(kubeconfig []byte) ([sha256.Size]byte, error) {
 			canonicalizations.Add(1)
 			return canonicalKubeconfigFingerprint(kubeconfig)
 		}
@@ -347,7 +348,7 @@ func TestRESTMapperCache(t *testing.T) {
 			winnerClient *http.Client
 			raced        bool
 		)
-		c.canonicalize = func(kc []byte) (string, error) {
+		c.canonicalize = func(kc []byte) ([sha256.Size]byte, error) {
 			if !raced {
 				raced = true
 				winnerMapper, winnerClient = getPair(t, c, kc)

--- a/internal/util/kube/restmapper_cache_test.go
+++ b/internal/util/kube/restmapper_cache_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha256"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -28,6 +29,39 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+func TestRESTMapperCacheMaxEntriesFromEnv(t *testing.T) {
+	// The override guards against a fleet larger than the default cap turning
+	// every poll tick into an eviction cycle; anything that does not parse to a
+	// positive integer falls back to the compiled-in default.
+	for value, want := range map[string]int{
+		"1024":                  1024,
+		"1":                     1,
+		"":                      restMapperMaxEntries,
+		"0":                     restMapperMaxEntries,
+		"-5":                    restMapperMaxEntries,
+		"many":                  restMapperMaxEntries,
+		"256.5":                 restMapperMaxEntries,
+		"512x":                  restMapperMaxEntries,
+		"1e3":                   restMapperMaxEntries,
+		"1000000":               restMapperMaxConfigurableEntries,
+		"1000001":               restMapperMaxConfigurableEntries,
+		"9999999":               restMapperMaxConfigurableEntries,
+		"99999999999999999999":  restMapperMaxConfigurableEntries,
+		"-99999999999999999999": restMapperMaxEntries,
+	} {
+		t.Run("value "+value, func(t *testing.T) {
+			t.Setenv(restMapperCacheMaxEntriesEnvName, value)
+			require.Equal(t, want, restMapperCacheMaxEntriesFromEnv())
+		})
+	}
+
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv(restMapperCacheMaxEntriesEnvName, "sentinel") // registers restore of the prior value
+		require.NoError(t, os.Unsetenv(restMapperCacheMaxEntriesEnvName))
+		require.Equal(t, restMapperMaxEntries, restMapperCacheMaxEntriesFromEnv())
+	})
+}
 
 // kubeconfigForHost builds a kubeconfig for host, authenticating as user. The
 // mapper is lazy, so nothing is ever contacted; only the identity of the

--- a/templates/provider/kcm-regional/templates/deployment.yaml
+++ b/templates/provider/kcm-regional/templates/deployment.yaml
@@ -82,10 +82,18 @@ spec:
             name: metrics
             protocol: TCP
         {{- $proxy := $global.proxy | default dict }}
-        {{- if and $telController.proxy.enabled $proxy.secretName }}
+        {{- $proxyEnabled := and $telController.proxy.enabled $proxy.secretName }}
+        {{- if or $proxyEnabled $telController.restMapperCacheMaxEntries }}
         env:
+        {{- if $proxyEnabled }}
         - name: PROXY_SECRET
           value: {{ $proxy.secretName | quote }}
+        {{- end }}
+        {{- if $telController.restMapperCacheMaxEntries }}
+        - name: RESTMAPPER_CACHE_MAX_ENTRIES
+          {{- /* int64 first: values files decode numbers as float64, which quote would render in scientific notation from 1e6 up */}}
+          value: {{ $telController.restMapperCacheMaxEntries | int64 | quote }}
+        {{- end }}
         {{- end }}
         livenessProbe:
           httpGet:

--- a/templates/provider/kcm-regional/tests/telemetry_deployment_test.yaml
+++ b/templates/provider/kcm-regional/tests/telemetry_deployment_test.yaml
@@ -107,3 +107,45 @@ tests:
     asserts:
       - isNull:
           path: spec.template.spec.containers[0].env
+
+  - it: "cache size alone -> only the cache override is rendered"
+    set:
+      telemetry.controller.restMapperCacheMaxEntries: 512
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESTMAPPER_CACHE_MAX_ENTRIES
+            value: "512"
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 1
+
+  - it: "cache size at the schema maximum -> renders as an integer, not scientific notation"
+    set:
+      telemetry.controller.restMapperCacheMaxEntries: 1000000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESTMAPPER_CACHE_MAX_ENTRIES
+            value: "1000000"
+
+  - it: "proxy + cache size -> both entries share one env block"
+    set:
+      global.proxy.secretName: foobar
+      telemetry.controller.restMapperCacheMaxEntries: 512
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PROXY_SECRET
+            value: "foobar"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESTMAPPER_CACHE_MAX_ENTRIES
+            value: "512"
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 2

--- a/templates/provider/kcm-regional/values.schema.json
+++ b/templates/provider/kcm-regional/values.schema.json
@@ -243,6 +243,15 @@
                 }
               }
             },
+            "restMapperCacheMaxEntries": {
+              "description": "Overrides the maximum number of entries in the shared RESTMapper cache (default 256). Must be at least the number of cluster identities telemetry collects from, or short collection intervals rebuild mappers on every pass",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 1000000,
+              "minimum": 1
+            },
             "tolerations": {
               "description": "Tolerations to allow the pod to schedule on tainted nodes",
               "type": "array"

--- a/templates/provider/kcm-regional/values.yaml
+++ b/templates/provider/kcm-regional/values.yaml
@@ -20,6 +20,7 @@ telemetry: # @schema type: object; description: Telemetry collection configurati
       requests:
         cpu: 100m
         memory: 64Mi
+    restMapperCacheMaxEntries: null # @schema type: [integer, null]; minimum: 1; maximum: 1000000; description: Overrides the maximum number of entries in the shared RESTMapper cache (default 256). Must be at least the number of cluster identities telemetry collects from, or short collection intervals rebuild mappers on every pass
     nodeSelector: {} # @schema type: object; description: Node selector to constrain the pod to run on specific nodes
     affinity: {} # @schema type: object; description: Affinity rules for pod scheduling
     tolerations: [] # @schema type: array; description: Tolerations to allow the pod to schedule on tainted nodes

--- a/templates/provider/kcm/templates/deployment.yaml
+++ b/templates/provider/kcm/templates/deployment.yaml
@@ -86,6 +86,11 @@ spec:
         - name: ENABLE_PROVIDERS_RELOAD
           value: {{ .Values.enableProvidersReload | quote }}
         {{- end }}
+        {{- if .Values.controller.restMapperCacheMaxEntries }}
+        - name: RESTMAPPER_CACHE_MAX_ENTRIES
+          {{- /* int64 first: values files decode numbers as float64, which quote would render in scientific notation from 1e6 up */}}
+          value: {{ .Values.controller.restMapperCacheMaxEntries | int64 | quote }}
+        {{- end }}
         image: {{ if .Values.controller.globalRegistry }}
         {{- .Values.controller.globalRegistry }}/kcm-controller
         {{- else }}

--- a/templates/provider/kcm/tests/deployment_env_test.yaml
+++ b/templates/provider/kcm/tests/deployment_env_test.yaml
@@ -1,0 +1,38 @@
+suite: Manager deployment env rendering
+templates:
+  - templates/deployment.yaml
+
+tests:
+  - it: "defaults -> no RESTMapper cache override is rendered"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESTMAPPER_CACHE_MAX_ENTRIES
+          any: true
+
+  - it: "cache size set -> the override reaches the manager env"
+    set:
+      controller.restMapperCacheMaxEntries: 1024
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESTMAPPER_CACHE_MAX_ENTRIES
+            value: "1024"
+
+  - it: "cache size at the schema maximum -> renders as an integer, not scientific notation"
+    set:
+      controller.restMapperCacheMaxEntries: 1000000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RESTMAPPER_CACHE_MAX_ENTRIES
+            value: "1000000"
+
+  - it: "cache size above the schema maximum -> rejected by the values schema"
+    set:
+      controller.restMapperCacheMaxEntries: 2000000
+    asserts:
+      - failedTemplate: {}

--- a/templates/provider/kcm/values.schema.json
+++ b/templates/provider/kcm/values.schema.json
@@ -170,6 +170,15 @@
           "description": "Name of a Secret containing Registry Credentials (Auth) Data",
           "type": "string"
         },
+        "restMapperCacheMaxEntries": {
+          "description": "Overrides the maximum number of entries in the shared RESTMapper cache (default 256). Must be at least the number of simultaneously managed cluster identities, or the cache degrades to rebuilding mappers on every poll",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "maximum": 1000000,
+          "minimum": 1
+        },
         "templatesRepoURL": {
           "type": "string"
         },

--- a/templates/provider/kcm/values.yaml
+++ b/templates/provider/kcm/values.yaml
@@ -35,6 +35,7 @@ controller:
   defaultHelmTimeout: "" # @schema type: string; description: Specifies the timeout duration for Helm install or upgrade operations. If unset, Flux’s default value will be used
   capiClusterPollInterval: "1m" # @schema type: string; description: Polling interval for the periodic CAPI Cluster status check used by the ClusterDeployment controller. Set to "0" to disable the poller
   maxConcurrentReconciles: 10 # @schema type: integer; description: Specifies the maximum number of concurrent reconciles that will be run for each controller
+  restMapperCacheMaxEntries: null # @schema type: [integer, null]; minimum: 1; maximum: 1000000; description: Overrides the maximum number of entries in the shared RESTMapper cache (default 256). Must be at least the number of simultaneously managed cluster identities, or the cache degrades to rebuilding mappers on every poll
   logger: # @schema title: Logger Settings; description: Global controllers logger settings; type: object
     devel: false # @schema type: boolean; description: Development defaults(encoder=console,logLevel=debug,stackTraceLevel=warn) Production defaults(encoder=json,logLevel=info,stackTraceLevel=error)
     encoder: "" # @schema enum:[json, console, ""] ; type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up to #3008, addressing the two review suggestions deferred there.

Changes:

**1. Key the cache by raw sha256 digests**
Every factory call hashed the kubeconfig and then hex-encoded the digest, allocating a 64-byte string per lookup, and entry keys concatenated host, separator, and a second encoded digest. Fingerprints are now `[sha256.Size]byte` used directly as the alias keys, and the entries key is a `{host, fingerprint}` struct, as [suggested here](https://github.com/k0rdent/kcm/pull/3008#discussion_r3794682065).

**2. Make the cache size configurable**
A fleet with more simultaneously live cluster identities than the fixed 256-entry cap would turn every poll tick into an eviction cycle, rebuilding mappers and re-running discovery against the same apiservers the cache exists to protect.

The cap can now be overridden with the `RESTMAPPER_CACHE_MAX_ENTRIES` env var (falling back to 256 when unset or invalid), exposed as `controller.restMapperCacheMaxEntries` in the KCM chart and `telemetry.controller.restMapperCacheMaxEntries` in the regional chart. This approach was [suggested here](https://github.com/k0rdent/kcm/pull/3008#discussion_r3794707680).

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
Follow-up to #3008