### PR TITLE
fix: stuck serviceset reconcile

### DIFF
--- a/internal/controller/adapters/sveltos/enqueue.go
+++ b/internal/controller/adapters/sveltos/enqueue.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
+	"github.com/K0rdent/kcm/internal/serviceset"
 	pollerutil "github.com/K0rdent/kcm/internal/util/poller"
 )
 
@@ -68,11 +69,11 @@ var enqueueStates = struct {
 //
 // Extracted from enqueueClusterSummary so unit tests can exercise the
 // state transitions directly with an injectable clock, without spinning
-// up envtest. `deployed` is a state-machine axis (the "we are done"
+// up envtest. `quiescent` is a state-machine axis (the "we are done"
 // arm), not a control-coupling flag.
 //
-//nolint:revive // deployed is an input axis of the state machine, not a caller-driven switch
-func (s *enqueueState) evaluate(now time.Time, summaryRV string, deployed bool) bool {
+//nolint:revive // quiescent is an input axis of the state machine, not a caller-driven switch
+func (s *enqueueState) evaluate(now time.Time, summaryRV string, quiescent bool) bool {
 	if s.lastSeenSummaryRV != summaryRV {
 		// A real sveltos-side change since we last looked. Enqueue,
 		// reset back-off, remember the new RV.
@@ -81,11 +82,9 @@ func (s *enqueueState) evaluate(now time.Time, summaryRV string, deployed bool) 
 		s.nextEligibleTime = now.Add(s.currentBackoff)
 		return true
 	}
-	if deployed {
-		// Quiescent — sveltos unchanged AND every service confirmed
-		// Deployed by the verifier. No health controller exists in this
-		// codebase, so ongoing pod-death detection is out of scope; we
-		// unquiesce automatically when sveltos next bumps CS RV.
+	if quiescent {
+		// No health controller exists in this codebase, so ongoing pod-death
+		// detection is out of scope; we unquiesce when sveltos next bumps CS RV.
 		return false
 	}
 	if now.Before(s.nextEligibleTime) {
@@ -101,6 +100,48 @@ func (s *enqueueState) evaluate(now time.Time, summaryRV string, deployed bool) 
 	}
 	s.nextEligibleTime = now.Add(s.currentBackoff)
 	return true
+}
+
+// Status.Deployed alone would be wrong here: both of its writers derive it from
+// per-service State, so it says nothing about whether the spec version has been
+// confirmed on cluster.
+func serviceSetSettled(serviceSet *kcmv1.ServiceSet) bool {
+	return serviceSet.Status.Deployed && stampConverged(serviceSet)
+}
+
+// A lagging stamp has to keep the poller awake: the stamp only advances inside a
+// ServiceSet reconcile, and it also makes FilterServiceDependencies lock the
+// service's dependents, which stops their spec from changing and so stops the
+// watch from firing. Quiescing there is self-sustaining.
+//
+// Spec is the authority for what must be accounted for — a status entry with no
+// spec counterpart is stale bookkeeping and must not hold convergence open.
+func stampConverged(serviceSet *kcmv1.ServiceSet) bool {
+	statusVersions := make(map[client.ObjectKey]*string, len(serviceSet.Status.Services))
+	for _, svc := range serviceSet.Status.Services {
+		statusVersions[serviceset.ServiceKey(svc.Namespace, svc.Name)] = svc.Version
+	}
+
+	for _, svc := range serviceSet.Spec.Services {
+		statusVersion, ok := statusVersions[serviceset.ServiceKey(svc.Namespace, svc.Name)]
+		if !ok {
+			return false
+		}
+		if !versionsEqual(svc.Version, statusVersion) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// A Helm status version is nil until the verifier first stamps it, and nil must
+// not compare equal to a spec version that is always set.
+func versionsEqual(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
 }
 
 // loadOrCreateEnqueueState returns the state for key, creating a fresh
@@ -140,11 +181,11 @@ func pruneEnqueueStates(seen map[client.ObjectKey]struct{}) {
 //  1. ClusterSummary.ResourceVersion advanced since last enqueue — a
 //     real sveltos-side change (apply, upgrade, patch). Enqueue and
 //     reset back-off to enqueueBaseBackoff.
-//  2. ServiceSet.Status.Deployed == true AND CS RV unchanged — the
-//     verifier confirmed every service is Deployed AND sveltos has not
-//     moved since then. Skip. There is no ongoing health controller in
-//     this codebase — the verifier's role in this PR is apply-time
-//     correctness, not continuous pod-death detection.
+//  2. Settled (see serviceSetSettled) AND CS RV unchanged — every service
+//     is Deployed, its spec version is stamped into status, and sveltos
+//     has not moved since then. Skip. There is no ongoing health
+//     controller in this codebase — the verifier's role in this PR is
+//     apply-time correctness, not continuous pod-death detection.
 //  3. Otherwise (in flight) — enqueue with exponentially-increasing
 //     back-off from enqueueBaseBackoff up to enqueueMaxBackoff. Any
 //     CS RV change resets to the base.
@@ -204,7 +245,7 @@ func enqueueClusterSummary(cl client.Client, systemNamespace string) pollerutil.
 			}
 
 			state := loadOrCreateEnqueueState(key)
-			if state.evaluate(now, summary.ResourceVersion, serviceSet.Status.Deployed) {
+			if state.evaluate(now, summary.ResourceVersion, serviceSetSettled(serviceSet)) {
 				logger.V(1).Info("Scheduling reconcile",
 					"service_set", key,
 					"cluster_summary", client.ObjectKeyFromObject(summary),

--- a/internal/controller/adapters/sveltos/enqueue_test.go
+++ b/internal/controller/adapters/sveltos/enqueue_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kcmv1 "github.com/K0rdent/kcm/api/v1beta1"
 )
 
 // TestEnqueueState_FirstSightEnqueuesAndSeedsRV asserts that a fresh
@@ -61,13 +63,13 @@ func TestEnqueueState_CSChangedResetsBackoff(t *testing.T) {
 		"back-off must reset to base on RV change")
 }
 
-// TestEnqueueState_QuiescentSkipsWhenDeployed asserts that a Deployed
-// ServiceSet with unchanged CS RV skips entirely, regardless of any
-// back-off state.
-func TestEnqueueState_QuiescentSkipsWhenDeployed(t *testing.T) {
+// TestEnqueueState_QuiescentSkipsWhenSettled asserts that a settled
+// ServiceSet (healthy AND stamp converged) with unchanged CS RV skips
+// entirely, regardless of any back-off state.
+func TestEnqueueState_QuiescentSkipsWhenSettled(t *testing.T) {
 	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
 	// Back-off long expired — a fixed-interval poller would enqueue here,
-	// but Status.Deployed==true and RV unchanged means there is nothing
+	// but settled on both axes with RV unchanged means there is nothing
 	// to verify.
 	s := &enqueueState{
 		lastSeenSummaryRV: "rv-1",
@@ -192,4 +194,157 @@ func TestPruneEnqueueStates_DropsUnseen(t *testing.T) {
 	_, droppedOK := enqueueStates.entries[dropped]
 	assert.True(t, keptOK, "seen entry must survive prune")
 	assert.False(t, droppedOK, "unseen entry must be dropped")
+}
+
+func TestEnqueueState_StampBehindKeepsPolling(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	s := &enqueueState{
+		lastSeenSummaryRV: "rv-1",
+		currentBackoff:    30 * time.Second,
+		nextEligibleTime:  now.Add(-time.Second),
+	}
+
+	got := s.evaluate(now, "rv-1", false)
+
+	assert.True(t, got, "healthy-but-unstamped SS must keep polling, not quiesce")
+	assert.Equal(t, 60*time.Second, s.currentBackoff,
+		"an unstamped SS follows the in-flight back-off schedule")
+	assert.Equal(t, now.Add(60*time.Second), s.nextEligibleTime,
+		"next-eligible must advance by the new back-off")
+}
+
+func TestEnqueueState_StampBehindThenSettledQuiesces(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	s := &enqueueState{
+		lastSeenSummaryRV: "rv-1",
+		currentBackoff:    30 * time.Second,
+		nextEligibleTime:  now.Add(-time.Second),
+	}
+
+	require.True(t, s.evaluate(now, "rv-1", false), "precondition: still polling while unstamped")
+
+	got := s.evaluate(now, "rv-1", true)
+
+	assert.False(t, got, "SS must quiesce once the stamp has converged")
+}
+
+// Regression test for the permanent-freeze bug: the poller's "we are done" input
+// was Status.Deployed alone, and a ServiceSet can be Deployed while its verifier
+// version stamp is still behind. The fixture is the observed lab state.
+func TestServiceSetSettled_HealthyButUnstampedIsNotSettled(t *testing.T) {
+	const ns = "k0rdent-apis"
+
+	ss := &kcmv1.ServiceSet{
+		Spec: kcmv1.ServiceSetSpec{Services: []kcmv1.ServiceWithValues{
+			{Name: "kacs-org-api", Namespace: ns, Version: new("1.1.0-rc.1.1")},
+		}},
+		Status: kcmv1.ServiceSetStatus{
+			Deployed: true,
+			Services: []kcmv1.ServiceState{
+				{Name: "kacs-org-api", Namespace: ns, Version: new("1.0.0"), State: kcmv1.ServiceStateDeployed},
+			},
+		},
+	}
+
+	require.True(t, ss.Status.Deployed, "fixture invariant: health axis reports done")
+	assert.False(t, serviceSetSettled(ss),
+		"a Deployed SS whose stamp is behind must not be treated as settled")
+}
+
+func TestServiceSetSettled_RequiresBothAxes(t *testing.T) {
+	const ns = "k0rdent-apis"
+
+	converged := []kcmv1.ServiceState{
+		{Name: "svc-a", Namespace: ns, Version: new("1.1.0"), State: kcmv1.ServiceStateDeployed},
+	}
+	spec := []kcmv1.ServiceWithValues{{Name: "svc-a", Namespace: ns, Version: new("1.1.0")}}
+
+	for _, tc := range []struct {
+		name     string
+		deployed bool
+		obs      []kcmv1.ServiceState
+		want     bool
+	}{
+		{name: "healthy and stamped", deployed: true, obs: converged, want: true},
+		{name: "stamped but not healthy", deployed: false, obs: converged, want: false},
+		{
+			name: "healthy but not stamped", deployed: true,
+			obs:  []kcmv1.ServiceState{{Name: "svc-a", Namespace: ns, Version: new("1.0.0")}},
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := &kcmv1.ServiceSet{
+				Spec:   kcmv1.ServiceSetSpec{Services: spec},
+				Status: kcmv1.ServiceSetStatus{Deployed: tc.deployed, Services: tc.obs},
+			}
+			assert.Equal(t, tc.want, serviceSetSettled(ss))
+		})
+	}
+}
+
+func TestStampConverged(t *testing.T) {
+	const ns = "k0rdent-apis"
+
+	for _, tc := range []struct {
+		name string
+		spec []kcmv1.ServiceWithValues
+		obs  []kcmv1.ServiceState
+		want bool
+	}{
+		{
+			name: "converged",
+			spec: []kcmv1.ServiceWithValues{{Name: "svc-a", Namespace: ns, Version: new("1.1.0")}},
+			obs:  []kcmv1.ServiceState{{Name: "svc-a", Namespace: ns, Version: new("1.1.0"), State: kcmv1.ServiceStateDeployed}},
+			want: true,
+		},
+		{
+			name: "status version behind spec",
+			spec: []kcmv1.ServiceWithValues{{Name: "svc-a", Namespace: ns, Version: new("1.1.0")}},
+			obs:  []kcmv1.ServiceState{{Name: "svc-a", Namespace: ns, Version: new("1.0.0"), State: kcmv1.ServiceStateDeployed}},
+			want: false,
+		},
+		{
+			name: "helm status version never stamped",
+			spec: []kcmv1.ServiceWithValues{{Name: "svc-a", Namespace: ns, Version: new("1.1.0")}},
+			obs:  []kcmv1.ServiceState{{Name: "svc-a", Namespace: ns, State: kcmv1.ServiceStateDeployed}},
+			want: false,
+		},
+		{
+			name: "desired service absent from status",
+			spec: []kcmv1.ServiceWithValues{
+				{Name: "svc-a", Namespace: ns, Version: new("1.1.0")},
+				{Name: "svc-b", Namespace: ns, Version: new("2.0.0")},
+			},
+			obs:  []kcmv1.ServiceState{{Name: "svc-a", Namespace: ns, Version: new("1.1.0")}},
+			want: false,
+		},
+		{
+			name: "stale status entry with no spec counterpart",
+			spec: []kcmv1.ServiceWithValues{{Name: "svc-a", Namespace: ns, Version: new("1.1.0")}},
+			obs: []kcmv1.ServiceState{
+				{Name: "svc-a", Namespace: ns, Version: new("1.1.0")},
+				{Name: "svc-gone", Namespace: ns, Version: new("0.9.0")},
+			},
+			want: true,
+		},
+		{
+			name: "namespace defaulting must still match",
+			spec: []kcmv1.ServiceWithValues{{Name: "svc-a", Version: new("1.1.0")}},
+			obs:  []kcmv1.ServiceState{{Name: "svc-a", Namespace: "default", Version: new("1.1.0")}},
+			want: true,
+		},
+		{
+			name: "no services desired",
+			want: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := &kcmv1.ServiceSet{
+				Spec:   kcmv1.ServiceSetSpec{Services: tc.spec},
+				Status: kcmv1.ServiceSetStatus{Services: tc.obs},
+			}
+			assert.Equal(t, tc.want, stampConverged(ss))
+		})
+	}
 }

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -372,16 +372,17 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClien
 	specVersions := make(map[client.ObjectKey]*string, len(serviceSet.Spec.Services))
 	for i := range serviceSet.Spec.Services {
 		svc := &serviceSet.Spec.Services[i]
-		specVersions[client.ObjectKey{Namespace: svc.Namespace, Name: svc.Name}] = svc.Version
+		specVersions[serviceset.ServiceKey(svc.Namespace, svc.Name)] = svc.Version
 	}
 
-	// Only the health pass reaches the target cluster; with no rules to
-	// evaluate, building the client would be pure cost.
-	var childClient client.Client
+	var assessServiceState func(serviceName, serviceNamespace string) (string, []metav1.Condition, error)
 	if len(rules) > 0 {
-		childClient, err = getChildClient(ctx, r.Client, rgnClient, serviceSet)
+		childClient, err := getChildClient(ctx, r.Client, rgnClient, serviceSet)
 		if err != nil {
 			return false, fmt.Errorf("get child cluster client: %w", err)
+		}
+		assessServiceState = func(serviceName, serviceNamespace string) (string, []metav1.Condition, error) {
+			return verifyHelmServiceOnCluster(ctx, childClient, rules, serviceName, serviceNamespace)
 		}
 	}
 
@@ -402,7 +403,7 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClien
 			continue
 		}
 
-		serviceKey := client.ObjectKey{Namespace: s.Namespace, Name: s.Name}
+		serviceKey := serviceset.ServiceKey(s.Namespace, s.Name)
 		currentHash := serviceHashes[serviceKey]
 
 		newState := s.State
@@ -432,7 +433,7 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClien
 		// runs. Gating the stamp on health rules is what let a lagging
 		// Status.Version freeze upgrades indefinitely.
 		if len(rules) > 0 {
-			verifierState, conds, err := verifyHelmServiceOnCluster(ctx, childClient, rules, s.Name, s.Namespace)
+			verifierState, conds, err := assessServiceState(s.Name, s.Namespace)
 			if err != nil {
 				errs = errors.Join(errs, fmt.Errorf("verify service %s/%s: %w", s.Namespace, s.Name, err))
 				continue

--- a/internal/controller/adapters/sveltos/serviceset_controller.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller.go
@@ -287,10 +287,17 @@ func (r *ServiceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // rules, and (c) decides the final state by combining sveltos's verdict
 // with the on-cluster verdict and the hash gate.
 //
-// Decision table (sveltos verdict, verifier verdict, hash) → final state.
-// State moves to Deployed only when BOTH signals agree; the stamp block
-// below then advances LastDeployedHash+Version only when they agree AND
-// the hash has actually moved:
+// The two passes are independent. Step (b) is skipped entirely when no rules
+// are loaded — sveltos's verdict then stands untouched — but the stamp still
+// runs, because "the spec version reached the cluster" is a fact about the
+// deploy, not about health, and withholding it strands FilterServiceDependencies
+// on a stale Status.Version.
+//
+// Decision table (sveltos verdict, verifier verdict, hash) → final state,
+// applicable only when rules are loaded. State moves to Deployed only when
+// BOTH signals agree; the stamp block below then advances
+// LastDeployedHash+Version only when they agree AND the hash has actually
+// moved:
 //
 //   - sveltos=*,            verifier!=Deployed            → Provisioning
 //     (downgrade —
@@ -349,12 +356,7 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClien
 	if err != nil {
 		return false, fmt.Errorf("load health rules: %w", err)
 	}
-	applyRuleLoadErrorCondition(serviceSet, loadErrs)
-
-	if len(rules) == 0 {
-		// No rules — keep sveltos-reported state.
-		return false, nil
-	}
+	applyRuleLoadErrorCondition(serviceSet, loadErrs, len(rules))
 
 	// Fingerprint inputs from sveltos's view.
 	summary, cc, profileKind, profileName, err := fetchHelmArtifactsForVerifier(ctx, rgnClient, serviceSet)
@@ -373,9 +375,14 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClien
 		specVersions[client.ObjectKey{Namespace: svc.Namespace, Name: svc.Name}] = svc.Version
 	}
 
-	childClient, err := getChildClient(ctx, r.Client, rgnClient, serviceSet)
-	if err != nil {
-		return false, fmt.Errorf("get child cluster client: %w", err)
+	// Only the health pass reaches the target cluster; with no rules to
+	// evaluate, building the client would be pure cost.
+	var childClient client.Client
+	if len(rules) > 0 {
+		childClient, err = getChildClient(ctx, r.Client, rgnClient, serviceSet)
+		if err != nil {
+			return false, fmt.Errorf("get child cluster client: %w", err)
+		}
 	}
 
 	l := ctrl.LoggerFrom(ctx)
@@ -398,6 +405,9 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClien
 		serviceKey := client.ObjectKey{Namespace: s.Namespace, Name: s.Name}
 		currentHash := serviceHashes[serviceKey]
 
+		newState := s.State
+		var newConds []metav1.Condition
+
 		// Combine sveltos's verdict with the verifier's on-cluster verdict:
 		//
 		//   1. Verifier says NOT healthy (unhealthy resources, or none found
@@ -416,25 +426,35 @@ func (r *ServiceSetReconciler) verifyServiceStates(ctx context.Context, rgnClien
 		//      promote from sveltos-Provisioning: the healthy pods may be
 		//      stale previous-version pods still running before a rollout
 		//      starts. We wait until sveltos itself confirms Deployed.
-		verifierState, conds, err := verifyHelmServiceOnCluster(ctx, childClient, rules, s.Name, s.Namespace)
-		if err != nil {
-			errs = errors.Join(errs, fmt.Errorf("verify service %s/%s: %w", s.Namespace, s.Name, err))
-			continue
-		}
+		//
+		// With no rules loaded none of that applies — we form no health opinion
+		// and sveltos's verdict stands untouched, while the stamp below still
+		// runs. Gating the stamp on health rules is what let a lagging
+		// Status.Version freeze upgrades indefinitely.
+		if len(rules) > 0 {
+			verifierState, conds, err := verifyHelmServiceOnCluster(ctx, childClient, rules, s.Name, s.Namespace)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("verify service %s/%s: %w", s.Namespace, s.Name, err))
+				continue
+			}
 
-		newState := s.State
-		var newConds []metav1.Condition
-		switch {
-		case verifierState != kcmv1.ServiceStateDeployed:
-			newState = kcmv1.ServiceStateProvisioning
-			newConds = conds
-		case s.State == kcmv1.ServiceStateProvisioning &&
-			currentHash != "" && currentHash == s.LastDeployedHash:
-			newState = kcmv1.ServiceStateDeployed
-		}
+			switch {
+			case verifierState != kcmv1.ServiceStateDeployed:
+				newState = kcmv1.ServiceStateProvisioning
+				newConds = conds
+			case s.State == kcmv1.ServiceStateProvisioning &&
+				currentHash != "" && currentHash == s.LastDeployedHash:
+				newState = kcmv1.ServiceStateDeployed
+			}
 
-		if newState == kcmv1.ServiceStateDeployed && currentHash == "" {
-			newState = kcmv1.ServiceStateProvisioning
+			if newState == kcmv1.ServiceStateDeployed && currentHash == "" {
+				newState = kcmv1.ServiceStateProvisioning
+				pendingStamp = true
+			}
+		} else if s.State == kcmv1.ServiceStateDeployed && currentHash == "" {
+			// Requeue to stamp later, but leave State alone — downgrading here
+			// would move Status.Deployed on the strength of an opinion we did
+			// not form.
 			pendingStamp = true
 		}
 

--- a/internal/controller/adapters/sveltos/serviceset_controller_test.go
+++ b/internal/controller/adapters/sveltos/serviceset_controller_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -1126,7 +1127,7 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 		// entry. Returns the service hash the verifier will compute from
 		// these artifacts — callers pre-seed LastDeployedHash to make the
 		// hash match or mismatch as required by the test case.
-		prepareVerifierArtifacts := func() string {
+		prepareVerifierArtifacts := func(withRules bool) string {
 			releaseNs = namespace.Name
 
 			By("targeting the reconciler at the ServiceSet's namespace for tier-1 rules", func() {
@@ -1164,18 +1165,20 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 				DeferCleanup(cl.Delete, d)
 			})
 
-			By("creating a namespace-global rules ConfigMap", func() {
-				cm := &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "verifier-hashgate-rules",
-						Namespace: namespace.Name,
-						Labels:    map[string]string{healthRuleTargetLabel: healthRuleTargetGlobal},
-					},
-					Data: map[string]string{healthRuleConfigMapDataKey: testRulesYAML},
-				}
-				Expect(cl.Create(ctx, cm)).To(Succeed())
-				DeferCleanup(cl.Delete, cm)
-			})
+			if withRules {
+				By("creating a namespace-global rules ConfigMap", func() {
+					cm := &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "verifier-hashgate-rules",
+							Namespace: namespace.Name,
+							Labels:    map[string]string{healthRuleTargetLabel: healthRuleTargetGlobal},
+						},
+						Data: map[string]string{healthRuleConfigMapDataKey: testRulesYAML},
+					}
+					Expect(cl.Create(ctx, cm)).To(Succeed())
+					DeferCleanup(cl.Delete, cm)
+				})
+			}
 
 			By("marking the StateManagementProvider ready and reconciling to create the Profile", func() {
 				stateManagementProvider.Status.Ready = true
@@ -1325,7 +1328,7 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 		}
 
 		It("Case A: promotes on hash match (unrelated apply demoted us)", func() {
-			expectedHash := prepareVerifierArtifacts()
+			expectedHash := prepareVerifierArtifacts(true)
 			// Sveltos-side hash equals what we last confirmed → the pods
 			// the verifier sees ARE the confirmed version → safe to
 			// promote back from the aggregate-demoted Provisioning.
@@ -1342,7 +1345,7 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 		})
 
 		It("Case B: does NOT promote when hash advanced (our real apply in progress)", func() {
-			_ = prepareVerifierArtifacts()
+			_ = prepareVerifierArtifacts(true)
 			// Sveltos-side hash has moved past what we last confirmed →
 			// sveltos is applying a new version of THIS service. The
 			// healthy pods the verifier just observed could be stale
@@ -1361,7 +1364,7 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 		})
 
 		It("Case C: stamps hash+version when both sveltos and verifier agree on new hash", func() {
-			expectedHash := prepareVerifierArtifacts()
+			expectedHash := prepareVerifierArtifacts(true)
 			// Sveltos already says Deployed, verifier confirms healthy,
 			// hash has advanced since last confirmed. This is the "both
 			// authoritative signals agree" intersection — safe to record
@@ -1377,6 +1380,44 @@ var _ = Describe("ServiceSet Controller integration tests", Ordered, func() {
 			Expect(svc.State).To(Equal(kcmv1.ServiceStateDeployed), "both agreed → stays Deployed")
 			Expect(svc.LastDeployedHash).To(Equal(expectedHash), "hash advances to sveltos-side fingerprint")
 			Expect(*svc.Version).To(Equal(specVersion), "version stamps to Spec.Services[i].Version")
+		})
+
+		// Regression test: the stamp used to be skipped entirely when no rules
+		// were configured, stranding Status.Version at the previous value.
+		// FilterServiceDependencies reads that field, so every dependent
+		// service stayed locked and the upgrade froze with everything green.
+		It("Case D: stamps hash+version with no rules configured", func() {
+			expectedHash := prepareVerifierArtifacts(false)
+			staleHash := "sha256:previous-confirmed-hash"
+			seedServiceStatus(kcmv1.ServiceStateDeployed, staleHash, "1.0.0")
+
+			pendingStamp, err := reconciler.verifyServiceStates(ctx, cl, &serviceSet)
+			Expect(err).To(Succeed())
+			Expect(pendingStamp).To(BeFalse(), "stamp fired this round — no requeue needed")
+
+			svc := serviceSet.Status.Services[0]
+			Expect(svc.State).To(Equal(kcmv1.ServiceStateDeployed), "sveltos's verdict stands untouched without rules")
+			Expect(svc.LastDeployedHash).To(Equal(expectedHash), "hash must advance even with no health opinion")
+			Expect(*svc.Version).To(Equal(specVersion), "version must stamp even with no health opinion")
+
+			cond := apimeta.FindStatusCondition(serviceSet.Status.Conditions, serviceSetHealthRulesCondition)
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Reason).To(Equal("NoRulesConfigured"), "must not read as AllRulesValid when there are none")
+		})
+
+		It("Case E: no rules leaves a Provisioning service alone and does not stamp", func() {
+			_ = prepareVerifierArtifacts(false)
+			staleHash := "sha256:previous-confirmed-hash"
+			seedServiceStatus(kcmv1.ServiceStateProvisioning, staleHash, "1.0.0")
+
+			pendingStamp, err := reconciler.verifyServiceStates(ctx, cl, &serviceSet)
+			Expect(err).To(Succeed())
+			Expect(pendingStamp).To(BeFalse(), "not Deployed, so nothing to stamp and nothing to requeue for")
+
+			svc := serviceSet.Status.Services[0]
+			Expect(svc.State).To(Equal(kcmv1.ServiceStateProvisioning), "no rules means no promotion")
+			Expect(svc.LastDeployedHash).To(Equal(staleHash), "stamp only fires on Deployed")
+			Expect(*svc.Version).To(Equal("1.0.0"), "stamp only fires on Deployed")
 		})
 	})
 })

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -959,7 +959,8 @@ func isNoMatchError(err error) bool {
 
 // serviceSetHealthRulesCondition is the ServiceSet-level condition the
 // verifier writes to surface health-rule load errors. Status=True when all
-// rule ConfigMaps parsed and compiled successfully; False when at least
+// rule ConfigMaps parsed and compiled successfully — with reason
+// NoRulesConfigured when there were none to parse at all; False when at least
 // one rule failed and the verifier had to skip it.
 const serviceSetHealthRulesCondition = "ServiceSetHealthRules"
 
@@ -975,16 +976,24 @@ const serviceSetHealthRulesCondition = "ServiceSetHealthRules"
 //
 // Both bounds protect against the same failure mode (misconfigured user
 // rules producing many error strings) via two independent mechanisms.
-func applyRuleLoadErrorCondition(serviceSet *kcmv1.ServiceSet, loadErrs []ruleLoadError) {
+func applyRuleLoadErrorCondition(serviceSet *kcmv1.ServiceSet, loadErrs []ruleLoadError, ruleKinds int) {
 	cond := metav1.Condition{
 		Type:               serviceSetHealthRulesCondition,
 		ObservedGeneration: serviceSet.Generation,
 	}
-	if len(loadErrs) == 0 {
+	switch {
+	// Zero rules produce zero load errors, so without this arm a cluster with
+	// no rules at all is indistinguishable from one whose rules all loaded —
+	// the reading that hid a stalled verifier behind a green condition.
+	case len(loadErrs) == 0 && ruleKinds == 0:
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = "NoRulesConfigured"
+		cond.Message = "No health rules configured; on-cluster service health is not verified"
+	case len(loadErrs) == 0:
 		cond.Status = metav1.ConditionTrue
 		cond.Reason = "AllRulesValid"
 		cond.Message = "All health rules loaded successfully"
-	} else {
+	default:
 		shown := loadErrs
 		truncated := 0
 		if len(shown) > maxRuleLoadErrorsInCondition {

--- a/internal/controller/adapters/sveltos/verify.go
+++ b/internal/controller/adapters/sveltos/verify.go
@@ -976,7 +976,7 @@ const serviceSetHealthRulesCondition = "ServiceSetHealthRules"
 //
 // Both bounds protect against the same failure mode (misconfigured user
 // rules producing many error strings) via two independent mechanisms.
-func applyRuleLoadErrorCondition(serviceSet *kcmv1.ServiceSet, loadErrs []ruleLoadError, ruleKinds int) {
+func applyRuleLoadErrorCondition(serviceSet *kcmv1.ServiceSet, loadErrs []ruleLoadError, ruleCount int) {
 	cond := metav1.Condition{
 		Type:               serviceSetHealthRulesCondition,
 		ObservedGeneration: serviceSet.Generation,
@@ -985,7 +985,7 @@ func applyRuleLoadErrorCondition(serviceSet *kcmv1.ServiceSet, loadErrs []ruleLo
 	// Zero rules produce zero load errors, so without this arm a cluster with
 	// no rules at all is indistinguishable from one whose rules all loaded —
 	// the reading that hid a stalled verifier behind a green condition.
-	case len(loadErrs) == 0 && ruleKinds == 0:
+	case len(loadErrs) == 0 && ruleCount == 0:
 		cond.Status = metav1.ConditionTrue
 		cond.Reason = "NoRulesConfigured"
 		cond.Message = "No health rules configured; on-cluster service health is not verified"

--- a/internal/controller/adapters/sveltos/verify_test.go
+++ b/internal/controller/adapters/sveltos/verify_test.go
@@ -1566,7 +1566,7 @@ func TestApplyRuleLoadErrorCondition_BoundsMessage(t *testing.T) {
 			})
 		}
 		ss := &kcmv1.ServiceSet{}
-		applyRuleLoadErrorCondition(ss, errs)
+		applyRuleLoadErrorCondition(ss, errs, 1)
 		require.Len(t, ss.Status.Conditions, 1)
 		msg := ss.Status.Conditions[0].Message
 		assert.Contains(t, msg, "ns/cm#0")
@@ -1584,7 +1584,7 @@ func TestApplyRuleLoadErrorCondition_BoundsMessage(t *testing.T) {
 		applyRuleLoadErrorCondition(ss, []ruleLoadError{{
 			Source: "ns/cm#huge",
 			Err:    errors.New(huge),
-		}})
+		}}, 1)
 		require.Len(t, ss.Status.Conditions, 1)
 		msg := ss.Status.Conditions[0].Message
 		// Cap+1 because the truncator appends "…" past the cap.
@@ -1595,9 +1595,17 @@ func TestApplyRuleLoadErrorCondition_BoundsMessage(t *testing.T) {
 
 	t.Run("no errors yields success condition", func(t *testing.T) {
 		ss := &kcmv1.ServiceSet{}
-		applyRuleLoadErrorCondition(ss, nil)
+		applyRuleLoadErrorCondition(ss, nil, 1)
 		require.Len(t, ss.Status.Conditions, 1)
 		assert.Equal(t, metav1.ConditionTrue, ss.Status.Conditions[0].Status)
 		assert.Equal(t, "AllRulesValid", ss.Status.Conditions[0].Reason)
+	})
+
+	t.Run("no rules is distinguishable from all rules valid", func(t *testing.T) {
+		ss := &kcmv1.ServiceSet{}
+		applyRuleLoadErrorCondition(ss, nil, 0)
+		require.Len(t, ss.Status.Conditions, 1)
+		assert.Equal(t, metav1.ConditionTrue, ss.Status.Conditions[0].Status)
+		assert.Equal(t, "NoRulesConfigured", ss.Status.Conditions[0].Reason)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes how the serviceset controller handles the serviceset reconciliation and re-queuing. So that the serviceset will be reconciled until it enters the state confirmed by corresponding sveltos objects - clustersummaries, clusterconfigurations, etc.
Aside from that this PR fixes the stale service status which was not properly updated in case there were no applicable health rules found.
