### PR TITLE
fix(ksm): ServiceTemplateChain upgrade skips intermediate versions

### DIFF
--- a/api/v1beta1/templatechain_common.go
+++ b/api/v1beta1/templatechain_common.go
@@ -17,7 +17,6 @@ package v1beta1
 import (
 	"fmt"
 	"slices"
-	"sort"
 )
 
 // TemplateChainSpec defines the desired state of *TemplateChain
@@ -149,7 +148,10 @@ func (s *TemplateChainSpec) findAllUpgradePaths(templateName string) ([][]Availa
 	return result, nil
 }
 
-// UpgradePaths returns shortest upgrade paths for the given template.
+// UpgradePaths returns one route per reachable destination for the given template,
+// hops listed in the order they must be applied. Where several routes lead to the
+// same destination the longest one is kept, so no hop is shortcut past.
+// A hop's Version falls back to its template name, so it is not always a semver.
 func (s *TemplateChainSpec) UpgradePaths(templateName string) ([]UpgradePath, error) {
 	allPaths, err := s.findAllUpgradePaths(templateName)
 	if err != nil {
@@ -173,7 +175,9 @@ func (s *TemplateChainSpec) UpgradePaths(templateName string) ([]UpgradePath, er
 		}
 	}
 
-	// Convert map back to slice
+	// Route order is hop order, so it is kept as-is: sorting by version string
+	// reorders hops wrongly ("1.10.0" precedes "1.9.0") and means nothing for the
+	// name fallback below.
 	result := make([]UpgradePath, 0, len(uniquePaths))
 	for _, path := range uniquePaths {
 		for i := range path {
@@ -181,9 +185,6 @@ func (s *TemplateChainSpec) UpgradePaths(templateName string) ([]UpgradePath, er
 				path[i].Version = path[i].Name
 			}
 		}
-		sort.Slice(path, func(i, j int) bool {
-			return path[i].Version < path[j].Version
-		})
 		result = append(result, UpgradePath{Versions: path})
 	}
 

--- a/api/v1beta1/templatechain_common_test.go
+++ b/api/v1beta1/templatechain_common_test.go
@@ -211,6 +211,35 @@ func TestTemplateChainSpec_TemplateUpgradePath(t *testing.T) {
 				{Versions: []AvailableUpgrade{{Name: "foo-0-2-0", Version: "foo-0-2-0"}, {Name: "foo-0-3-0", Version: "foo-0-3-0"}}},
 			},
 		},
+		// "1.10.0" precedes "1.9.0" lexicographically but comes after it in the chain.
+		"upgrade-path-hop-order": {
+			templateChainSpec: TemplateChainSpec{SupportedTemplates: []SupportedTemplate{
+				{
+					Name: "foo-1-8-0",
+					AvailableUpgrades: []AvailableUpgrade{
+						{Name: "foo-1-9-0", Version: "1.9.0"},
+					},
+				},
+				{
+					Name: "foo-1-9-0",
+					AvailableUpgrades: []AvailableUpgrade{
+						{Name: "foo-1-10-0", Version: "1.10.0"},
+					},
+				},
+				{
+					Name: "foo-1-10-0",
+				},
+			}},
+			templateName: "foo-1-8-0",
+			expectedUpgradePath: []UpgradePath{
+				{
+					Versions: []AvailableUpgrade{{Name: "foo-1-9-0", Version: "1.9.0"}},
+				},
+				{
+					Versions: []AvailableUpgrade{{Name: "foo-1-9-0", Version: "1.9.0"}, {Name: "foo-1-10-0", Version: "1.10.0"}},
+				},
+			},
+		},
 		"upgrade-path-4": {
 			templateChainSpec: TemplateChainSpec{SupportedTemplates: []SupportedTemplate{
 				{

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/Masterminds/semver/v3"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -556,47 +555,50 @@ func appendIfNotPresent(
 	return services
 }
 
-// minimumUpgradeStep returns the smallest available upgrade version for the named
-// service that falls within (currentVersion, desiredVersion]. Only upgrade paths
-// that actually contain the desired version are considered, avoiding dead-end branches.
-// Returns a zero-value AvailableUpgrade if no matching step is found in upgradePaths.
-func minimumUpgradeStep(upgradePaths []kcmv1.ServiceUpgradePaths, name, namespace, currentVersion, desiredVersion string) kcmv1.AvailableUpgrade {
-	current, err := semver.NewVersion(currentVersion)
-	if err != nil {
-		return kcmv1.AvailableUpgrade{}
-	}
-	desired, err := semver.NewVersion(desiredVersion)
-	if err != nil {
-		return kcmv1.AvailableUpgrade{}
-	}
-
-	var best kcmv1.AvailableUpgrade
-	var bestNext *semver.Version
+// nextUpgradeStep returns the next hop towards desiredTemplate, or a zero value if
+// no route reaches it.
+//
+// Routes are walked positionally and matched on template names rather than compared
+// by version: a chain may omit .version on its available upgrades, leaving the
+// version a copy of the template name, and comparing versions then found no step at
+// all and jumped straight to the desired template (#3042). Only routes that reach
+// desiredTemplate count, and the longest one wins, so dead-end branches are skipped
+// and no hop is shortcut past (#2693).
+func nextUpgradeStep(
+	upgradePaths []kcmv1.ServiceUpgradePaths,
+	name, namespace, currentTemplate, desiredTemplate string,
+) kcmv1.AvailableUpgrade {
+	var (
+		best    kcmv1.AvailableUpgrade
+		bestLen int
+	)
 
 	for _, path := range upgradePaths {
 		if path.Name != name || effectiveNamespace(path.Namespace) != effectiveNamespace(namespace) {
 			continue
 		}
-		for _, upgrade := range path.AvailableUpgrades {
-			// Only consider upgrade paths that can actually reach the desired version.
-			if !slices.ContainsFunc(upgrade.Versions, func(u kcmv1.AvailableUpgrade) bool {
-				v, err := semver.NewVersion(u.Version)
-				return err == nil && v.Equal(desired)
-			}) {
-				continue
+		// A route computed for another template cannot be positioned against this one.
+		if path.Template != "" && currentTemplate != "" && path.Template != currentTemplate {
+			continue
+		}
+		for _, route := range path.AvailableUpgrades {
+			target := slices.IndexFunc(route.Versions, func(u kcmv1.AvailableUpgrade) bool {
+				return u.Name == desiredTemplate
+			})
+			if target < 0 {
+				continue // this route cannot reach the desired template
 			}
 
-			for _, u := range upgrade.Versions {
-				v, err := semver.NewVersion(u.Version)
-				if err != nil {
-					continue
-				}
-				if v.Compare(current) > 0 && v.Compare(desired) <= 0 {
-					if bestNext == nil || v.Compare(bestNext) < 0 {
-						best = u
-						bestNext = v
-					}
-				}
+			// Hops up to and including the one the service already sits at are behind us.
+			next := 0
+			if at := slices.IndexFunc(route.Versions[:target], func(u kcmv1.AvailableUpgrade) bool {
+				return u.Name == currentTemplate
+			}); at >= 0 {
+				next = at + 1
+			}
+
+			if target+1 > bestLen {
+				best, bestLen = route.Versions[next], target+1
 			}
 		}
 	}
@@ -616,6 +618,7 @@ func ServicesToDeploy(
 	desiredVersions := make(map[client.ObjectKey]string)
 	desiredTemplates := make(map[client.ObjectKey]string)
 	deployedVersions := make(map[client.ObjectKey]string)
+	storedTemplates := make(map[client.ObjectKey]string)
 	upgradeAvailable := make(map[client.ObjectKey]bool)
 
 	for _, s := range filteredServices {
@@ -643,8 +646,9 @@ func ServicesToDeploy(
 		}
 
 		desiredVersion := desiredVersions[key]
+		storedTemplates[key] = svc.Template
 		upgradeAvailable[key] = svc.Version != nil && desiredVersion < *svc.Version ||
-			desiredVersionInUpgradePaths(upgradePaths, svc, desiredVersion)
+			desiredTemplateInUpgradePaths(upgradePaths, svc, desiredTemplates[key], desiredVersion)
 
 		for _, state := range serviceSet.Status.Services {
 			if state.State == kcmv1.ServiceStateDeployed &&
@@ -706,17 +710,20 @@ func ServicesToDeploy(
 			continue
 		}
 
-		// find the minimum valid upgrade step towards the desired version
-		currentVersion := deployedVersions[key]
-		minimumUpgrade := minimumUpgradeStep(upgradePaths, s.Name, s.Namespace, currentVersion, desiredVersion)
-		if minimumUpgrade.Version == "" {
-			minimumUpgrade = kcmv1.AvailableUpgrade{
+		// take the next hop the chain prescribes towards the desired template
+		nextUpgrade := nextUpgradeStep(upgradePaths, s.Name, s.Namespace, storedTemplates[key], desiredTemplate)
+		if nextUpgrade.Name == "" {
+			nextUpgrade = kcmv1.AvailableUpgrade{
 				Name:    desiredTemplate,
 				Version: desiredVersion,
 			}
+		} else if nextUpgrade.Version == nextUpgrade.Name {
+			// Only the template name, not a version: let ResolveServicesToApply read
+			// the real one off the hop's ServiceTemplate.
+			nextUpgrade.Version = ""
 		}
 
-		services = appendIfNotPresent(services, s, minimumUpgrade)
+		services = appendIfNotPresent(services, s, nextUpgrade)
 	}
 
 	return services
@@ -802,12 +809,25 @@ func ResolveServicesToApply(
 		return nil, fmt.Errorf("failed to determine upgrade paths: %w", err)
 	}
 
-	return ServicesToDeploy(upgradePaths, filteredServices, serviceSet), nil
+	servicesToDeploy := ServicesToDeploy(upgradePaths, filteredServices, serviceSet)
+
+	// A chain hop identifies its ServiceTemplate but carries no version of its own
+	// unless the chain sets one.
+	if err := ResolveServiceVersions(ctx, c, templateNamespace, servicesToDeploy); err != nil {
+		return nil, fmt.Errorf("failed to resolve versions for services to deploy: %w", err)
+	}
+
+	return servicesToDeploy, nil
 }
 
-func desiredVersionInUpgradePaths(
+// desiredTemplateInUpgradePaths reports whether the routes allow the service to
+// reach the desired template at all. Matching on the template name as well as the
+// version matters because a route's version may be a copy of the template name,
+// which never equals the version resolved from the ServiceTemplate (#3042).
+func desiredTemplateInUpgradePaths(
 	upgradePaths []kcmv1.ServiceUpgradePaths,
 	svc kcmv1.ServiceWithValues,
+	desiredTemplate string,
 	desiredVersion string,
 ) bool {
 	var res bool
@@ -822,7 +842,7 @@ func desiredVersionInUpgradePaths(
 		}
 		for _, upgradeList := range upgradePath.AvailableUpgrades {
 			if slices.ContainsFunc(upgradeList.Versions, func(c kcmv1.AvailableUpgrade) bool {
-				return c.Version == desiredVersion
+				return c.Name == desiredTemplate || c.Version == desiredVersion
 			}) {
 				return true
 			}

--- a/internal/serviceset/util.go
+++ b/internal/serviceset/util.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/Masterminds/semver/v3"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -606,6 +607,26 @@ func nextUpgradeStep(
 	return best
 }
 
+// isDowngrade reports whether desiredVersion is strictly older than currentVersion.
+// A ServiceTemplateChain only describes upgrades, so a downgrade is not gated by it.
+//
+// The comparison is semantic: lexicographically "1.10.0" sorts before "1.9.0", which
+// would read a real upgrade as a downgrade and let it past the chain gate. Either
+// version may legitimately not be a semver — ResolveServiceVersions falls back to the
+// ServiceTemplate name when the template carries no version — and then there is no
+// ordering to establish, so the chain decides.
+func isDowngrade(desiredVersion, currentVersion string) bool {
+	desired, err := semver.NewVersion(desiredVersion)
+	if err != nil {
+		return false
+	}
+	current, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		return false
+	}
+	return desired.LessThan(current)
+}
+
 // ServicesToDeploy computes the target ServiceWithValues for each service in
 // filteredServices (i.e. services whose dependencies are already satisfied),
 // taking into account in-flight upgrades and upgrade-path constraints.
@@ -647,7 +668,7 @@ func ServicesToDeploy(
 
 		desiredVersion := desiredVersions[key]
 		storedTemplates[key] = svc.Template
-		upgradeAvailable[key] = svc.Version != nil && desiredVersion < *svc.Version ||
+		upgradeAvailable[key] = svc.Version != nil && isDowngrade(desiredVersion, *svc.Version) ||
 			desiredTemplateInUpgradePaths(upgradePaths, svc, desiredTemplates[key], desiredVersion)
 
 		for _, state := range serviceSet.Status.Services {

--- a/internal/serviceset/util_test.go
+++ b/internal/serviceset/util_test.go
@@ -17,6 +17,7 @@ package serviceset
 import (
 	"testing"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,11 +35,11 @@ import (
 
 const testSystemNamespace = "test-system-ns"
 
-func TestMinimumUpgradeStep(t *testing.T) {
+func TestNextUpgradeStep(t *testing.T) {
 	t.Parallel()
 
-	// Shared upgrade paths: ingress-nginx with a two-hop path 4.11.5 → 4.12.3
-	// and a single-hop path directly to each version.
+	// Shared upgrade paths: ingress-nginx with a two-hop route 4.11.5 -> 4.12.3
+	// and a single-hop route directly to each version.
 	ingressUpgradePaths := []kcmv1.ServiceUpgradePaths{
 		{
 			Name: "ingress-nginx",
@@ -63,36 +64,59 @@ func TestMinimumUpgradeStep(t *testing.T) {
 		},
 	}
 
+	// #3042: availableUpgrades without .version, so nothing in the route is a semver.
+	stepwiseChain := kcmv1.TemplateChainSpec{SupportedTemplates: []kcmv1.SupportedTemplate{
+		{
+			Name:              "cert-manager-1-20-2",
+			AvailableUpgrades: []kcmv1.AvailableUpgrade{{Name: "cert-manager-1-20-3"}},
+		},
+		{
+			Name:              "cert-manager-1-20-3",
+			AvailableUpgrades: []kcmv1.AvailableUpgrade{{Name: "cert-manager-1-21-1"}},
+		},
+		{Name: "cert-manager-1-21-1"},
+	}}
+	stepwisePathsFrom := func(template string) []kcmv1.ServiceUpgradePaths {
+		routes, err := stepwiseChain.UpgradePaths(template)
+		require.NoError(t, err)
+		return []kcmv1.ServiceUpgradePaths{{
+			Name:              "cert-manager",
+			Namespace:         "cert-manager",
+			Template:          template,
+			AvailableUpgrades: routes,
+		}}
+	}
+
 	tests := map[string]struct {
 		upgradePaths    []kcmv1.ServiceUpgradePaths
 		name            string
 		namespace       string
-		current         string
-		desired         string
+		currentTemplate string
+		desiredTemplate string
 		expectedVersion string
 		expectedName    string
 	}{
 		"sequential upgrade enforced (dead branch fix)": {
 			upgradePaths:    ingressUpgradePaths,
 			name:            "ingress-nginx",
-			current:         "4.11.3",
-			desired:         "4.12.3",
+			currentTemplate: "ingress-nginx-4-11-3",
+			desiredTemplate: "ingress-nginx-4-12-3",
 			expectedVersion: "4.11.5",
 			expectedName:    "ingress-nginx-4-11-5",
 		},
 		"direct upgrade when no intermediate exists": {
 			upgradePaths:    ingressUpgradePaths,
 			name:            "ingress-nginx",
-			current:         "4.11.5",
-			desired:         "4.12.3",
+			currentTemplate: "ingress-nginx-4-11-5",
+			desiredTemplate: "ingress-nginx-4-12-3",
 			expectedVersion: "4.12.3",
 			expectedName:    "ingress-nginx-4-12-3",
 		},
 		"no valid upgrade": {
-			upgradePaths: ingressUpgradePaths,
-			name:         "ingress-nginx",
-			current:      "4.12.3",
-			desired:      "4.11.3",
+			upgradePaths:    ingressUpgradePaths,
+			name:            "ingress-nginx",
+			currentTemplate: "ingress-nginx-4-12-3",
+			desiredTemplate: "ingress-nginx-4-11-3",
 		},
 		// #2613: smallest candidate (2.0.0) is on a dead-end branch with no path
 		// to the desired version (3.0.0); the function must skip it and pick 3.0.0.
@@ -115,8 +139,8 @@ func TestMinimumUpgradeStep(t *testing.T) {
 				},
 			},
 			name:            "my-app",
-			current:         "1.0.0",
-			desired:         "3.0.0",
+			currentTemplate: "my-app-1-0-0",
+			desiredTemplate: "my-app-3-0-0",
 			expectedVersion: "3.0.0",
 			expectedName:    "my-app-3-0-0",
 		},
@@ -134,17 +158,57 @@ func TestMinimumUpgradeStep(t *testing.T) {
 					},
 				},
 			},
-			name:      "my-app",
-			namespace: "team-b",
-			current:   "1.0.0",
-			desired:   "2.0.0",
+			name:            "my-app",
+			namespace:       "team-b",
+			currentTemplate: "my-app-1-0-0",
+			desiredTemplate: "my-app-2-0-0",
+		},
+		"versionless chain steps through the intermediate template": {
+			upgradePaths:    stepwisePathsFrom("cert-manager-1-20-2"),
+			name:            "cert-manager",
+			namespace:       "cert-manager",
+			currentTemplate: "cert-manager-1-20-2",
+			desiredTemplate: "cert-manager-1-21-1",
+			expectedVersion: "cert-manager-1-20-3",
+			expectedName:    "cert-manager-1-20-3",
+		},
+		"versionless chain reaches the target from the intermediate template": {
+			upgradePaths:    stepwisePathsFrom("cert-manager-1-20-3"),
+			name:            "cert-manager",
+			namespace:       "cert-manager",
+			currentTemplate: "cert-manager-1-20-3",
+			desiredTemplate: "cert-manager-1-21-1",
+			expectedVersion: "cert-manager-1-21-1",
+			expectedName:    "cert-manager-1-21-1",
+		},
+		// 1.10.0 precedes 1.9.0 lexicographically but comes after it in the chain.
+		"route order wins over lexicographic order": {
+			upgradePaths: []kcmv1.ServiceUpgradePaths{
+				{
+					Name:     "my-app",
+					Template: "my-app-1-8-0",
+					AvailableUpgrades: []kcmv1.UpgradePath{
+						{
+							Versions: []kcmv1.AvailableUpgrade{
+								{Name: "my-app-1-9-0", Version: "1.9.0"},
+								{Name: "my-app-1-10-0", Version: "1.10.0"},
+							},
+						},
+					},
+				},
+			},
+			name:            "my-app",
+			currentTemplate: "my-app-1-8-0",
+			desiredTemplate: "my-app-1-10-0",
+			expectedVersion: "1.9.0",
+			expectedName:    "my-app-1-9-0",
 		},
 	}
 
 	for testName, tt := range tests {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
-			result := minimumUpgradeStep(tt.upgradePaths, tt.name, tt.namespace, tt.current, tt.desired)
+			result := nextUpgradeStep(tt.upgradePaths, tt.name, tt.namespace, tt.currentTemplate, tt.desiredTemplate)
 			require.Equal(t, tt.expectedVersion, result.Version)
 			require.Equal(t, tt.expectedName, result.Name)
 		})
@@ -512,6 +576,262 @@ func Test_ServicesToDeploy(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
 			f(t, tc)
+		})
+	}
+}
+
+// Test_ServicesToDeploy_StepwiseChain walks a 1.20.2 -> 1.20.3 -> 1.21.1 chain one
+// reconcile at a time. Regression test for #3042, where asking for 1.21.1 produced
+// a single upgrade straight from 1.20.2.
+func Test_ServicesToDeploy_StepwiseChain(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serviceName      = "cert-manager"
+		serviceNamespace = "cert-manager"
+	)
+
+	chain := kcmv1.TemplateChainSpec{SupportedTemplates: []kcmv1.SupportedTemplate{
+		{
+			Name:              "cert-manager-1-20-2",
+			AvailableUpgrades: []kcmv1.AvailableUpgrade{{Name: "cert-manager-1-20-3"}},
+		},
+		{
+			Name:              "cert-manager-1-20-3",
+			AvailableUpgrades: []kcmv1.AvailableUpgrade{{Name: "cert-manager-1-21-1"}},
+		},
+		{Name: "cert-manager-1-21-1"},
+	}}
+
+	// The user asks for the last version in the chain and never changes the request.
+	desiredServices := []kcmv1.Service{{
+		Name:          serviceName,
+		Namespace:     serviceNamespace,
+		Template:      "cert-manager-1-21-1",
+		Version:       "1.21.1",
+		TemplateChain: "chain-stepwise",
+	}}
+
+	// Mirrors ServicesUpgradePaths: routes are computed for the stored template.
+	upgradePathsFor := func(t *testing.T, storedTemplate string) []kcmv1.ServiceUpgradePaths {
+		t.Helper()
+		routes, err := chain.UpgradePaths(storedTemplate)
+		require.NoError(t, err)
+		return []kcmv1.ServiceUpgradePaths{{
+			Name:              serviceName,
+			Namespace:         serviceNamespace,
+			Template:          storedTemplate,
+			AvailableUpgrades: routes,
+		}}
+	}
+
+	serviceSetAt := func(storedTemplate, storedVersion, deployedVersion string) *kcmv1.ServiceSet {
+		return &kcmv1.ServiceSet{
+			Spec: kcmv1.ServiceSetSpec{Services: []kcmv1.ServiceWithValues{{
+				Name:      serviceName,
+				Namespace: serviceNamespace,
+				Template:  storedTemplate,
+				Version:   new(storedVersion),
+			}}},
+			Status: kcmv1.ServiceSetStatus{Services: []kcmv1.ServiceState{{
+				Name:      serviceName,
+				Namespace: serviceNamespace,
+				Version:   new(deployedVersion),
+				State:     kcmv1.ServiceStateDeployed,
+			}}},
+		}
+	}
+
+	tests := []struct {
+		description      string
+		storedTemplate   string
+		storedVersion    string
+		deployedVersion  string
+		expectedTemplate string
+		expectedVersion  string
+	}{
+		{
+			// Version is left for ResolveServicesToApply to resolve — see
+			// Test_ResolveServicesToApply_StepwiseChain.
+			description:      "first hop is the intermediate template, not the target",
+			storedTemplate:   "cert-manager-1-20-2",
+			storedVersion:    "1.20.2",
+			deployedVersion:  "1.20.2",
+			expectedTemplate: "cert-manager-1-20-3",
+			expectedVersion:  "",
+		},
+		{
+			description:      "the hop is held while it is still in flight",
+			storedTemplate:   "cert-manager-1-20-3",
+			storedVersion:    "1.20.3",
+			deployedVersion:  "1.20.2",
+			expectedTemplate: "cert-manager-1-20-3",
+			expectedVersion:  "1.20.3",
+		},
+		{
+			description:      "the target is taken once the intermediate hop is deployed",
+			storedTemplate:   "cert-manager-1-20-3",
+			storedVersion:    "1.20.3",
+			deployedVersion:  "1.20.3",
+			expectedTemplate: "cert-manager-1-21-1",
+			expectedVersion:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			actual := ServicesToDeploy(
+				upgradePathsFor(t, tc.storedTemplate),
+				desiredServices,
+				serviceSetAt(tc.storedTemplate, tc.storedVersion, tc.deployedVersion),
+			)
+			require.Len(t, actual, 1)
+			require.Equal(t, tc.expectedTemplate, actual[0].Template)
+			require.NotNil(t, actual[0].Version)
+			require.Equal(t, tc.expectedVersion, *actual[0].Version)
+		})
+	}
+}
+
+// Test_ResolveServicesToApply_StepwiseChain drives the full pipeline against a real
+// chain and its ServiceTemplates, so it covers the version the hop is recorded with
+// too. Regression test for #3042.
+func Test_ResolveServicesToApply_StepwiseChain(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespace    = "kcm-system"
+		cdName       = "test-cd"
+		chainName    = "chain-stepwise"
+		serviceName  = "cert-manager"
+		serviceNs    = "cert-manager"
+		templateFrom = "cert-manager-1-20-2"
+		templateVia  = "cert-manager-1-20-3"
+		templateTo   = "cert-manager-1-21-1"
+	)
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(kcmv1.AddToScheme(scheme))
+
+	serviceTemplate := func(name, version string) *kcmv1.ServiceTemplate {
+		return &kcmv1.ServiceTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: kcmv1.ServiceTemplateSpec{
+				Helm: &kcmv1.HelmSpec{
+					ChartSpec: &sourcev1.HelmChartSpec{Chart: serviceName, Version: version},
+				},
+			},
+			Status: kcmv1.ServiceTemplateStatus{
+				TemplateStatusCommon: kcmv1.TemplateStatusCommon{
+					TemplateValidationStatus: kcmv1.TemplateValidationStatus{Valid: true},
+				},
+			},
+		}
+	}
+
+	// No .version on the available upgrades: the shape the bug was reported with.
+	chain := &kcmv1.ServiceTemplateChain{
+		ObjectMeta: metav1.ObjectMeta{Name: chainName, Namespace: namespace},
+		Spec: kcmv1.TemplateChainSpec{SupportedTemplates: []kcmv1.SupportedTemplate{
+			{Name: templateFrom, AvailableUpgrades: []kcmv1.AvailableUpgrade{{Name: templateVia}}},
+			{Name: templateVia, AvailableUpgrades: []kcmv1.AvailableUpgrade{{Name: templateTo}}},
+			{Name: templateTo},
+		}},
+	}
+
+	cd := &kcmv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: cdName, Namespace: namespace},
+	}
+
+	// The user asks for the last version in the chain and never changes the request.
+	desiredServices := []kcmv1.Service{{
+		Name:          serviceName,
+		Namespace:     serviceNs,
+		Template:      templateTo,
+		TemplateChain: chainName,
+	}}
+
+	serviceSetAt := func(storedTemplate, storedVersion, deployedVersion string) *kcmv1.ServiceSet {
+		return &kcmv1.ServiceSet{
+			ObjectMeta: metav1.ObjectMeta{Name: cdName, Namespace: namespace},
+			Spec: kcmv1.ServiceSetSpec{
+				Cluster: cdName,
+				Services: []kcmv1.ServiceWithValues{{
+					Name:      serviceName,
+					Namespace: serviceNs,
+					Template:  storedTemplate,
+					Version:   new(storedVersion),
+				}},
+			},
+			Status: kcmv1.ServiceSetStatus{Services: []kcmv1.ServiceState{{
+				Name:      serviceName,
+				Namespace: serviceNs,
+				Template:  storedTemplate,
+				Version:   new(deployedVersion),
+				State:     kcmv1.ServiceStateDeployed,
+			}}},
+		}
+	}
+
+	tests := []struct {
+		description      string
+		storedTemplate   string
+		storedVersion    string
+		deployedVersion  string
+		expectedTemplate string
+		expectedVersion  string
+	}{
+		{
+			description:      "first hop is the intermediate template, not the target",
+			storedTemplate:   templateFrom,
+			storedVersion:    "1.20.2",
+			deployedVersion:  "1.20.2",
+			expectedTemplate: templateVia,
+			expectedVersion:  "1.20.3",
+		},
+		{
+			description:      "the hop is held while it is still in flight",
+			storedTemplate:   templateVia,
+			storedVersion:    "1.20.3",
+			deployedVersion:  "1.20.2",
+			expectedTemplate: templateVia,
+			expectedVersion:  "1.20.3",
+		},
+		{
+			description:      "the target is taken once the intermediate hop is deployed",
+			storedTemplate:   templateVia,
+			storedVersion:    "1.20.3",
+			deployedVersion:  "1.20.3",
+			expectedTemplate: templateTo,
+			expectedVersion:  "1.21.1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+			serviceSet := serviceSetAt(tc.storedTemplate, tc.storedVersion, tc.deployedVersion)
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(
+					chain, cd, serviceSet,
+					serviceTemplate(templateFrom, "1.20.2"),
+					serviceTemplate(templateVia, "1.20.3"),
+					serviceTemplate(templateTo, "1.21.1"),
+				).
+				WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetClusterIndexKey, kcmv1.ExtractServiceSetCluster).
+				WithIndex(&kcmv1.ServiceSet{}, kcmv1.ServiceSetMultiClusterServiceIndexKey, kcmv1.ExtractServiceSetMultiClusterService).
+				Build()
+
+			actual, err := ResolveServicesToApply(
+				t.Context(), cl, namespace, nil, cd, desiredServices, serviceSet)
+			require.NoError(t, err)
+			require.Len(t, actual, 1)
+			require.Equal(t, tc.expectedTemplate, actual[0].Template)
+			require.NotNil(t, actual[0].Version)
+			require.Equal(t, tc.expectedVersion, *actual[0].Version)
 		})
 	}
 }

--- a/internal/serviceset/util_test.go
+++ b/internal/serviceset/util_test.go
@@ -215,6 +215,35 @@ func TestNextUpgradeStep(t *testing.T) {
 	}
 }
 
+func Test_isDowngrade(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		desired  string
+		current  string
+		expected bool
+	}{
+		"downgrade":                      {desired: "1.9.0", current: "1.10.0", expected: true},
+		"upgrade":                        {desired: "1.10.0", current: "1.9.0", expected: false},
+		"same version":                   {desired: "1.9.0", current: "1.9.0", expected: false},
+		"downgrade within a minor":       {desired: "1.20.2", current: "1.20.3", expected: true},
+		"prerelease is older than final": {desired: "2.0.0-rc.1", current: "2.0.0", expected: true},
+		// ResolveServiceVersions falls back to the template name for a ServiceTemplate
+		// with no version, so an unparseable version is expected rather than exceptional.
+		"desired is a template name": {desired: "cert-manager-1-20-2", current: "1.21.1", expected: false},
+		"current is a template name": {desired: "1.20.2", current: "cert-manager-1-21-1", expected: false},
+		"both are template names":    {desired: "cert-manager-1-20-2", current: "cert-manager-1-21-1", expected: false},
+		"empty versions":             {desired: "", current: "", expected: false},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, isDowngrade(tt.desired, tt.current))
+		})
+	}
+}
+
 func Test_ServicesToDeploy(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A `ServiceTemplateChain` describing a multi-hop route (`1.20.2 -> 1.20.3 -> 1.21.1`) constrained which versions could be reached but not the route itself: asking for `1.21.1` produced a single helm upgrade straight from `1.20.2`, skipping `1.20.3`.

Root cause: `availableUpgrades[].version` is optional, and `UpgradePaths()` substitutes the ServiceTemplate name when it is unset. The step selection compared semvers, so it parsed none of those names, found no step, and fell back to deploying the desired template directly.

Changes:

- `UpgradePaths()` no longer sorts each route by version string. The order `findAllUpgradePaths` produces is the order the hops must be walked in; sorting reordered it (`1.10.0` precedes `1.9.0` lexicographically) and was meaningless for the name fallback.
- `minimumUpgradeStep` becomes `nextUpgradeStep`: it picks the next hop positionally within the route and matches on ServiceTemplate names rather than comparing versions. Dead-end branches are still skipped and the longest route to a destination still wins (#2693).
- `desiredVersionInUpgradePaths` becomes `desiredTemplateInUpgradePaths` and matches on the template name as well as the version.
- A hop whose version the chain did not set is resolved from its ServiceTemplate, so `.spec`/`.status` record a real chart version instead of a template name.

Chains that do set `version` behave as before — `name` is always populated.

Unit tests cover the fix at three levels: hop selection (`TestNextUpgradeStep`), the reconcile-by-reconcile walk (`Test_ServicesToDeploy_StepwiseChain`), and the full resolution pipeline against a real chain and its ServiceTemplates (`Test_ResolveServicesToApply_StepwiseChain`). All three fail on the unfixed code.

**Which issue(s) this PR fixes**:

Fixes #2062, #3042